### PR TITLE
fix(deploy): correct Railway monorepo root directory config

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -8,7 +8,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
-watchPatterns = ["backend/**"]
+watchPatterns = ["**"]
 
 [deploy]
 startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -132,8 +132,12 @@ git pull origin main
 
 ### Step 1.3: Deploy Backend
 
-1. **Deploy from Local:**
+1. **Deploy from Local (Monorepo):**
    ```bash
+   # From the repository root — sends only the backend/ folder
+   railway up backend --path-as-root --service bidiq-backend
+
+   # Or from the backend directory
    cd backend
    railway up
    ```
@@ -142,6 +146,11 @@ git pull origin main
    ```bash
    git push origin main  # Triggers automatic deployment
    ```
+
+   **⚠️ Monorepo Note:** When using GitHub auto-deploy, configure each
+   service's **Root Directory** in the Railway Dashboard:
+   - `bidiq-backend` → Root Directory: `/backend`
+   - `bidiq-frontend` → Root Directory: `/frontend`
 
 2. **Monitor Deployment:**
    - Watch logs in Railway dashboard under "Deployments" tab
@@ -196,10 +205,16 @@ open $BACKEND_URL/docs
    vercel login
    ```
 
-2. **Deploy:**
+2. **Deploy to Vercel:**
    ```bash
    cd frontend
    vercel --prod
+   ```
+
+   **Alternative — Deploy frontend to Railway (instead of Vercel):**
+   ```bash
+   # From the repository root
+   railway up frontend --path-as-root --service bidiq-frontend
    ```
 
    - Select "Link to existing project" or "Create new project"

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -8,6 +8,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
+watchPatterns = ["**"]
 
 [deploy]
 healthcheckPath = "/"


### PR DESCRIPTION
## Context
Railway monorepo deploy fails because `watchPatterns` in backend/railway.toml uses `backend/**` which is incorrect when the service's root directory is already set to `/backend`. Frontend was also missing watch patterns entirely. DEPLOYMENT.md lacked monorepo-specific CLI commands.

## Changes
- Fix `backend/railway.toml`: change `watchPatterns` from `["backend/**"]` to `["**"]` (paths are relative to root directory)
- Add `watchPatterns = ["**"]` to `frontend/railway.toml` for selective rebuilds
- Add `railway up <dir> --path-as-root --service <name>` commands to `docs/DEPLOYMENT.md`
- Document Root Directory dashboard configuration for GitHub auto-deploy

## Testing Plan
- [x] Backend tests passing (226 passed, 3 skipped)
- [ ] Manual validation: deploy backend via `railway up backend --path-as-root`
- [ ] Manual validation: deploy frontend via `railway up frontend --path-as-root`

## Risks & Rollback
Low risk — config-only changes. Revert commit if Railway behavior differs from documented patterns.

## Closes
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)