### PR TITLE
fix(deploy): resolve Railway healthcheck timeout (#73)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,9 +28,9 @@ COPY . .
 # Expose port (Railway injects PORT env var)
 EXPOSE 8000
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+# Health check - uses $PORT for compatibility with Railway's port injection
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen(f'http://localhost:{os.environ.get(\"PORT\", \"8000\")}/health')" || exit 1
 
 # Run with uvicorn - Railway will inject $PORT
-CMD uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -53,7 +53,10 @@ app.add_middleware(
     allow_headers=["*"],  # Allow all headers for development
 )
 
-logger.info("FastAPI application initialized with CORS middleware")
+logger.info(
+    "FastAPI application initialized — PORT=%s",
+    os.getenv("PORT", "8000"),
+)
 
 
 @app.get("/")

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -13,7 +13,7 @@ watchPatterns = ["**"]
 [deploy]
 startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
-healthcheckTimeout = 60
+healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 


### PR DESCRIPTION
## Context
Railway backend deploy fails because the Docker HEALTHCHECK probes `localhost:8000` while Railway injects a different `$PORT`, causing all health check attempts to hit a closed port and timeout.

## Changes
- **Dockerfile**: HEALTHCHECK now reads `$PORT` env var dynamically instead of hardcoded 8000
- **Dockerfile**: CMD uses exec form (`["sh", "-c", ...]`) for reliable `$PORT` expansion
- **Dockerfile**: Increased `start-period` from 10s → 30s to allow heavy Python imports
- **railway.toml**: Increased `healthcheckTimeout` from 60s → 120s
- **main.py**: Startup log now includes PORT value for deploy diagnostics

## Testing Plan
- [x] All 226 backend tests passing (0 failures)
- [ ] Manual validation: deploy to Railway and verify `/health` returns 200
- [ ] Verify startup logs show correct PORT in Railway dashboard

## Risks & Rollback
Low risk — changes only affect Docker healthcheck and Railway config. Rollback: revert this PR.

## Closes
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)