### PR TITLE
fix(deploy): fix frontend Dockerfile and align tests with runtime BACKEND_URL

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 
 # Install dependencies
-RUN npm ci --only=production=false
+RUN npm ci
 
 # Stage 2: Build
 FROM node:20-alpine AS builder
@@ -23,8 +23,6 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Set build-time environment variables
-ARG NEXT_PUBLIC_BACKEND_URL
-ENV NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL
 ENV NEXT_TELEMETRY_DISABLED=1
 
 # Build the application

--- a/frontend/__tests__/api/buscar.test.ts
+++ b/frontend/__tests__/api/buscar.test.ts
@@ -151,8 +151,8 @@ describe("POST /api/buscar", () => {
     const response = await POST(request);
     const data = await response.json();
 
-    expect(response.status).toBe(500);
-    expect(data.message).toBe("Erro interno do servidor");
+    expect(response.status).toBe(503);
+    expect(data.message).toContain("Backend indisponível");
   });
 
   it("should cache Excel buffer with download ID", async () => {
@@ -232,9 +232,9 @@ describe("POST /api/buscar", () => {
     setTimeoutSpy.mockRestore();
   });
 
-  it("should use NEXT_PUBLIC_BACKEND_URL from environment", async () => {
-    const originalEnv = process.env.NEXT_PUBLIC_BACKEND_URL;
-    process.env.NEXT_PUBLIC_BACKEND_URL = "http://custom:9000";
+  it("should use BACKEND_URL from environment", async () => {
+    const originalEnv = process.env.BACKEND_URL;
+    process.env.BACKEND_URL = "http://custom:9000";
 
     const mockBackendResponse = {
       resumo: {
@@ -270,7 +270,7 @@ describe("POST /api/buscar", () => {
     );
 
     // Restore
-    process.env.NEXT_PUBLIC_BACKEND_URL = originalEnv;
+    process.env.BACKEND_URL = originalEnv;
   });
 
   it("should handle invalid UFs type", async () => {

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -20,6 +20,6 @@ restartPolicyMaxRetries = 3
 # Environment Variables (Set in Railway Dashboard)
 # =============================================================================
 # REQUIRED:
-#   - NEXT_PUBLIC_BACKEND_URL (URL do backend service)
+#   - BACKEND_URL (Runtime URL of backend service, e.g. https://bidiq-backend.up.railway.app)
 #   - PORT (Auto-injected by Railway)
 # =============================================================================


### PR DESCRIPTION
## Context
Issue #75 — The frontend Dockerfile used a deprecated `npm ci` flag and referenced `NEXT_PUBLIC_BACKEND_URL` as a build-time arg, but the application code (`app/api/buscar/route.ts`) reads `BACKEND_URL` at runtime. Two tests were also stale (expecting wrong status code and wrong env var name).

## Changes
- Remove deprecated `--only=production=false` flag from `npm ci`
- Remove unused `NEXT_PUBLIC_BACKEND_URL` build arg from Dockerfile (not needed since API routes use server-side `BACKEND_URL` at runtime)
- Update `railway.toml` to document correct `BACKEND_URL` env var
- Fix test expecting 500 → 503 for network errors (matches actual route behavior)
- Fix test referencing `NEXT_PUBLIC_BACKEND_URL` → `BACKEND_URL`

## Testing Plan
- [x] All 94 frontend tests passing
- [x] All 226 backend tests passing (no regressions)
- [ ] Docker build validation (Docker not available locally — CI will validate)

## Risks & Rollback
Low risk — removes unused build arg and fixes test alignment. Revert single commit if issues arise.

## Closes
Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)