### PR TITLE
fix(tests): STORY-BTS-001 — quota & plan capabilities realignment (9 tests)

### DIFF
--- a/backend/tests/test_plan_capabilities.py
+++ b/backend/tests/test_plan_capabilities.py
@@ -94,8 +94,15 @@ class TestPlanCapabilities:
         assert set(PLAN_NAMES.keys()) == set(PLAN_CAPABILITIES.keys())
 
     def test_plan_prices_exist_for_paid_plans(self):
-        """PLAN_PRICES should have prices for all paid plans."""
-        paid_plans = {"consultor_agil", "maquina", "sala_guerra", "smartlic_pro"}
+        """PLAN_PRICES should have prices for all paid plans (including BIZ-001 founding + BIZ-002 consultoria)."""
+        paid_plans = {
+            "consultor_agil",
+            "maquina",
+            "sala_guerra",
+            "smartlic_pro",
+            "founding_member",  # STORY-BIZ-001
+            "consultoria",  # STORY-BIZ-002
+        }
         assert set(PLAN_PRICES.keys()) == paid_plans
 
     def test_upgrade_suggestions_valid(self):
@@ -138,9 +145,10 @@ class TestMonthlyQuotaHelpers:
 
     def test_get_quota_reset_date_handles_december(self):
         """Reset date should roll over to next year if current month is December."""
-        with patch("quota.datetime") as mock_datetime:
+        # TD-007 split: get_quota_reset_date lives in quota.quota_atomic after the
+        # package refactor — patch the datetime symbol bound in that submodule.
+        with patch("quota.quota_atomic.datetime") as mock_datetime:
             # Mock current date as December 15, 2025
-            # get_quota_reset_date() uses datetime.now(timezone.utc)
             mock_datetime.now.return_value = datetime(2025, 12, 15, tzinfo=timezone.utc)
             # Allow datetime(...) constructor calls to work normally
             mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
@@ -226,24 +234,29 @@ class TestIncrementMonthlyQuota:
     @patch("supabase_client.get_supabase")
     @patch("quota.get_monthly_quota_used")
     def test_fallback_increments_existing_quota(self, mock_get_used, mock_get_supabase):
-        """Should increment quota via fallback when RPC unavailable.
-        STORY-307: Updated — fallback now tries atomic RPC first, then upsert.
-        get_monthly_quota_used is called once (after upsert), not twice.
+        """When both atomic RPCs are unavailable the function fails open.
+
+        Evolution:
+          - STORY-307 (historical): legacy manual upsert served as 3rd fallback.
+          - Post-TD-007: upsert path was removed; the function now returns the
+            current monthly count (via facade lookup) so a missing RPC never
+            blocks a user. This mirrors the behaviour in quota_atomic.py
+            lines 120-127 ("fail-open" branch).
         """
         # Both RPCs fail (functions not available)
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
         mock_sb.rpc.return_value.execute.side_effect = Exception("function does not exist")
 
-        # Fallback: get_monthly_quota_used called once after upsert
+        # Fail-open path: get_monthly_quota_used is consulted via the quota
+        # facade to report the current (unmodified) count back to the caller.
         mock_get_used.return_value = 24
 
         result = increment_monthly_quota("user-123")
 
         assert result == 24
-
-        # Verify upsert was called as last-resort fallback
-        mock_sb.table.return_value.upsert.assert_called_once()
+        # Legacy upsert was removed — verify it is NOT invoked anymore.
+        mock_sb.table.return_value.upsert.assert_not_called()
 
     @patch("supabase_client.get_supabase")
     def test_creates_new_record_via_rpc(self, mock_get_supabase):
@@ -265,7 +278,7 @@ class TestCheckQuota:
     """Test check_quota function."""
 
     @patch("supabase_client.get_supabase")
-    @patch("quota.get_monthly_quota_used")
+    @patch("quota.plan_enforcement.get_monthly_quota_used")
     def test_free_trial_user_within_trial_period(self, mock_get_used, mock_get_supabase):
         """FREE trial user within trial period and under quota should be allowed."""
         mock_get_used.return_value = 1  # Under 1000-search limit (STORY-264)
@@ -291,15 +304,21 @@ class TestCheckQuota:
         assert result.trial_expires_at is not None
 
     @patch("supabase_client.get_supabase")
-    @patch("quota.get_monthly_quota_used")
+    @patch("quota.plan_enforcement.get_monthly_quota_used")
     def test_trial_expired_blocks_user(self, mock_get_used, mock_get_supabase):
-        """Expired trial should block user."""
+        """Expired trial beyond the 48h grace window should block the user.
+
+        Note: production added a 48h trial grace period (TRIAL_GRACE_HOURS=48,
+        TRIAL_GRACE_MAX_SEARCHES=3). To assert the hard-block path we push the
+        expiration well beyond that window (3 days ago) — inside the grace
+        window the user would instead see the "usou suas 3 buscas" message.
+        """
         mock_get_used.return_value = 5
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
 
-        # Mock expired trial
-        past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        # Mock trial expired more than 48h ago (hard block, not grace)
+        past_date = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = [
             {
                 "id": "sub-123",
@@ -313,9 +332,9 @@ class TestCheckQuota:
         assert result.allowed is False
         assert "trial expirou" in result.error_message.lower()
 
-    @patch("quota.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
+    @patch("quota.plan_enforcement.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
     @patch("supabase_client.get_supabase")
-    @patch("quota.get_monthly_quota_used")
+    @patch("quota.plan_enforcement.get_monthly_quota_used")
     def test_consultor_agil_within_quota(self, mock_get_used, mock_get_supabase, mock_get_caps):
         """Consultor Ágil user within quota should be allowed."""
         mock_get_used.return_value = 23  # Under 50 limit
@@ -337,9 +356,9 @@ class TestCheckQuota:
         assert result.quota_used == 23
         assert result.quota_remaining == 27  # 50 - 23
 
-    @patch("quota.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
+    @patch("quota.plan_enforcement.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
     @patch("supabase_client.get_supabase")
-    @patch("quota.get_monthly_quota_used")
+    @patch("quota.plan_enforcement.get_monthly_quota_used")
     def test_quota_exhausted_blocks_user(self, mock_get_used, mock_get_supabase, mock_get_caps):
         """User who exhausted monthly quota should be blocked."""
         mock_get_used.return_value = 50  # At limit
@@ -360,9 +379,9 @@ class TestCheckQuota:
         assert "50 análises este mês" in result.error_message
         assert result.quota_remaining == 0
 
-    @patch("quota.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
+    @patch("quota.plan_enforcement.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
     @patch("supabase_client.get_supabase")
-    @patch("quota.get_monthly_quota_used")
+    @patch("quota.plan_enforcement.get_monthly_quota_used")
     def test_maquina_plan_has_excel_enabled(self, mock_get_used, mock_get_supabase, mock_get_caps):
         """Máquina plan should have allow_excel=True."""
         mock_get_used.return_value = 100
@@ -383,9 +402,9 @@ class TestCheckQuota:
         assert result.capabilities["allow_excel"] is True
         assert result.capabilities["max_history_days"] == 365
 
-    @patch("quota.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
+    @patch("quota.plan_enforcement.get_plan_capabilities", return_value=PLAN_CAPABILITIES)
     @patch("supabase_client.get_supabase")
-    @patch("quota.get_monthly_quota_used")
+    @patch("quota.plan_enforcement.get_monthly_quota_used")
     def test_sala_guerra_highest_limits(self, mock_get_used, mock_get_supabase, mock_get_caps):
         """Sala de Guerra should have highest limits."""
         mock_get_used.return_value = 500
@@ -501,8 +520,15 @@ class TestPlanPricing:
         assert "free_trial" not in PLAN_PRICES
 
     def test_all_paid_plans_have_prices(self):
-        """All paid plans must have prices."""
-        paid_plans = {"consultor_agil", "maquina", "sala_guerra", "smartlic_pro"}
+        """All paid plans must have prices (including BIZ-001 founding + BIZ-002 consultoria)."""
+        paid_plans = {
+            "consultor_agil",
+            "maquina",
+            "sala_guerra",
+            "smartlic_pro",
+            "founding_member",  # STORY-BIZ-001
+            "consultoria",  # STORY-BIZ-002
+        }
         assert set(PLAN_PRICES.keys()) == paid_plans
 
     def test_prices_contain_currency_symbol(self):


### PR DESCRIPTION
## Summary

Implements **STORY-BTS-001** (EPIC-BTS-2026Q2 Wave 1 P0) — realigns 9 failing tests in `backend/tests/test_plan_capabilities.py` with post-TD-007 quota package layout + new paid plans (founding_member, consultoria) + 48h trial grace period.

## Scope correction

Story triage claimed 35 failures across 3 files. Re-inspection on `main` (2026-04-19) shows:

- `tests/test_quota.py` — **41/41 PASS** (0 failing; cited 22 were already fixed by ambient CIG waves)
- `tests/test_plan_capabilities.py` — **9 failing** (targeted by this PR)
- `tests/test_quota_race_condition.py` — **14/14 PASS** (0 failing; cited 5 were already fixed)

Net reduction of failing tests from the 208-baseline gate: **9 tests**. Counting reconciliation documented in Change Log of the story file.

## Root cause by sub-group (AC3)

### 1. New paid plans (2 tests — update expected set)

`PLAN_PRICES` now includes `founding_member` (STORY-BIZ-001) and `consultoria` (STORY-BIZ-002). Tests asserting the exact set broke.

### 2. Patch target drift post TD-007 (5 tests)

`backend/quota/plan_enforcement.py` eagerly imports `get_monthly_quota_used` and `get_plan_capabilities` from submodules. Patching the facade attribute (`quota.get_monthly_quota_used`) does not reach the locally-bound name in `plan_enforcement` — mocks become silent no-ops.

| Before | After |
|--------|-------|
| `patch("quota.get_monthly_quota_used")` | `patch("quota.plan_enforcement.get_monthly_quota_used")` |
| `patch("quota.get_plan_capabilities")` | `patch("quota.plan_enforcement.get_plan_capabilities")` |
| `patch("quota.datetime")` | `patch("quota.quota_atomic.datetime")` |

### 3. Production behaviour changed (2 tests)

- `increment_monthly_quota` removed the manual upsert fallback (fail-open returns current count). Test rewritten to match new contract.
- `check_quota` added a 48h trial grace period. Test pushes `past_date` to 3 days back to exit grace and hit the hard-block path.

## Changes

- `backend/tests/test_plan_capabilities.py` — 9 tests updated (patch targets + assertion contracts + expanded paid plan set)

## Testing Plan

- [x] `pytest backend/tests/test_quota.py backend/tests/test_plan_capabilities.py backend/tests/test_quota_race_condition.py --timeout=30 -v` — **99/99 PASS locally**
- [x] AC5 NEGATIVE: `grep -nE '@pytest\\.mark\\.(skip|xfail)|pytest\\.skip\\(' ...` returns empty (Zero Quarentena preserved)
- [ ] CI `Backend Tests (3.11)` and `(3.12)` show 9 fewer failures vs baseline (208 → 199)
- [ ] No regressions in other test files (backend coverage ≥ 70% preserved)

## Closes

Implements STORY-BTS-001 (EPIC-BTS-2026Q2, Wave 1 P0).

Note: Story file lives in PR #394 (epic docs) and its Status `Ready → InReview` update will happen in a follow-up docs commit once PR #394 is merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)