### PR TITLE
fix(tests): STORY-BTS-005 — consolidation & multi-source (16/19 + CRIT-054 regression flagged)

### DIFF
--- a/backend/tests/test_comprasgov_circuit_breaker.py
+++ b/backend/tests/test_comprasgov_circuit_breaker.py
@@ -188,11 +188,15 @@ class TestThresholdAlignment:
 
         try:
             # Re-import to get defaults
+            # pncp_client re-exports PNCP/PCP constants; COMPRASGOV constants live
+            # in config.pncp (source of truth) — no pncp_client re-export (TD-007 split).
             from pncp_client import (
                 PNCP_CIRCUIT_BREAKER_THRESHOLD,
                 PNCP_CIRCUIT_BREAKER_COOLDOWN,
                 PCP_CIRCUIT_BREAKER_THRESHOLD,
                 PCP_CIRCUIT_BREAKER_COOLDOWN,
+            )
+            from config import (
                 COMPRASGOV_CIRCUIT_BREAKER_THRESHOLD,
                 COMPRASGOV_CIRCUIT_BREAKER_COOLDOWN,
             )

--- a/backend/tests/test_consolidation_early_return.py
+++ b/backend/tests/test_consolidation_early_return.py
@@ -125,10 +125,14 @@ def _patch_health_registry():
 async def test_no_early_return_when_within_time():
     """4 UFs requested, 3 respond within 80s -> normal return (not early)."""
     # Records from 3 UFs — elapsed is under EARLY_RETURN_TIME_S
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     records = [
-        _make_record("SRC", "r1", uf="SP", cnpj="111", numero_edital="001"),
-        _make_record("SRC", "r2", uf="RJ", cnpj="222", numero_edital="002"),
-        _make_record("SRC", "r3", uf="MG", cnpj="333", numero_edital="003"),
+        _make_record("SRC", "r1", uf="SP", cnpj="111", numero_edital="001",
+                     objeto="Aquisição de uniformes escolares para rede municipal"),
+        _make_record("SRC", "r2", uf="RJ", cnpj="222", numero_edital="002",
+                     objeto="Contratação de serviços de pavimentação asfáltica urbana"),
+        _make_record("SRC", "r3", uf="MG", cnpj="333", numero_edital="003",
+                     objeto="Serviço de limpeza predial e manutenção hospitalar"),
     ]
 
     adapter = FakeAdapter("SRC", priority=1, records=records, delay=0)
@@ -163,13 +167,18 @@ async def test_early_return_triggers_on_timeout_threshold():
     Elapsed > early_return_time AND >= 80% -> early return with is_partial=True.
     """
     # Source A: returns records for SP, RJ, MG quickly
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     records_a = [
-        _make_record("SRC_A", "a1", uf="SP", cnpj="111", numero_edital="001"),
-        _make_record("SRC_A", "a2", uf="RJ", cnpj="222", numero_edital="002"),
-        _make_record("SRC_A", "a3", uf="MG", cnpj="333", numero_edital="003"),
+        _make_record("SRC_A", "a1", uf="SP", cnpj="111", numero_edital="001",
+                     objeto="Aquisição de uniformes escolares para rede municipal"),
+        _make_record("SRC_A", "a2", uf="RJ", cnpj="222", numero_edital="002",
+                     objeto="Contratação de serviços de pavimentação asfáltica urbana"),
+        _make_record("SRC_A", "a3", uf="MG", cnpj="333", numero_edital="003",
+                     objeto="Serviço de limpeza predial e manutenção hospitalar"),
     ]
     # Source B: very slow, would return BA but won't finish in time
-    records_b = [_make_record("SRC_B", "b1", uf="BA", cnpj="444", numero_edital="004")]
+    records_b = [_make_record("SRC_B", "b1", uf="BA", cnpj="444", numero_edital="004",
+                              objeto="Fornecimento de medicamentos para unidade de saúde")]
 
     adapter_a = FakeAdapter("SRC_A", priority=1, records=records_a, delay=0)
     adapter_b = FakeAdapter("SRC_B", priority=2, records=records_b, delay=10)
@@ -335,13 +344,18 @@ async def test_ufs_completed_and_pending_lists():
 async def test_filter_ranking_on_collected_results_only():
     """When early return triggers, dedup/legacy conversion runs on available data only."""
     # Source A: 3 UFs fast
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     records_a = [
-        _make_record("SRC_A", "a1", uf="SP", cnpj="111", numero_edital="001"),
-        _make_record("SRC_A", "a2", uf="RJ", cnpj="222", numero_edital="002"),
-        _make_record("SRC_A", "a3", uf="MG", cnpj="333", numero_edital="003"),
+        _make_record("SRC_A", "a1", uf="SP", cnpj="111", numero_edital="001",
+                     objeto="Aquisição de uniformes escolares para rede municipal"),
+        _make_record("SRC_A", "a2", uf="RJ", cnpj="222", numero_edital="002",
+                     objeto="Contratação de serviços de pavimentação asfáltica urbana"),
+        _make_record("SRC_A", "a3", uf="MG", cnpj="333", numero_edital="003",
+                     objeto="Serviço de limpeza predial e manutenção hospitalar"),
     ]
     # Source B: 1 UF extremely slow
-    records_b = [_make_record("SRC_B", "b1", uf="BA", cnpj="444", numero_edital="004")]
+    records_b = [_make_record("SRC_B", "b1", uf="BA", cnpj="444", numero_edital="004",
+                              objeto="Fornecimento de medicamentos para unidade de saúde")]
 
     adapter_a = FakeAdapter("SRC_A", priority=1, records=records_a, delay=0)
     adapter_b = FakeAdapter("SRC_B", priority=2, records=records_b, delay=10)

--- a/backend/tests/test_consolidation_multisource.py
+++ b/backend/tests/test_consolidation_multisource.py
@@ -188,12 +188,14 @@ async def test_different_procurements_from_different_sources_both_kept():
     """
     AC30: Different procurements from different sources → both kept.
     """
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     pncp_record = create_procurement(
         source_id="PNCP-111",
         source_name="PNCP",
         cnpj="11.111.111/0001-11",
         numero_edital="001/2025",
         ano="2025",
+        objeto="Aquisição de uniformes escolares para rede municipal",
     )
     pcp_record = create_procurement(
         source_id="PCP-222",
@@ -201,6 +203,7 @@ async def test_different_procurements_from_different_sources_both_kept():
         cnpj="22.222.222/0001-22",
         numero_edital="002/2025",
         ano="2025",
+        objeto="Contratação de serviços de pavimentação asfáltica urbana",
     )
 
     pncp_adapter = MockSourceAdapter(code="PNCP", name="PNCP", records=[pncp_record])
@@ -378,12 +381,14 @@ async def test_both_adapters_succeed_is_partial_false():
     """
     AC31: Both adapters succeed → all results merged, is_partial=False.
     """
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     pncp_record = create_procurement(
         source_id="PNCP-1",
         source_name="PNCP",
         cnpj="11.111.111/0001-11",
         numero_edital="001/2025",
         ano="2025",
+        objeto="Aquisição de uniformes escolares para rede municipal",
     )
     pcp_record = create_procurement(
         source_id="PCP-1",
@@ -391,6 +396,7 @@ async def test_both_adapters_succeed_is_partial_false():
         cnpj="22.222.222/0001-22",
         numero_edital="002/2025",
         ano="2025",
+        objeto="Contratação de serviços de pavimentação asfáltica urbana",
     )
 
     pncp_adapter = MockSourceAdapter(code="PNCP", name="PNCP", records=[pncp_record])
@@ -499,13 +505,16 @@ async def test_partial_failure_one_of_three_sources_fails():
     """
     AC31: 1 out of 3 sources fails → partial results with is_partial=True.
     """
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     pncp_record = create_procurement(
         source_id="PNCP-1", source_name="PNCP", cnpj="11.111.111/0001-11",
-        numero_edital="001/2025", ano="2025"
+        numero_edital="001/2025", ano="2025",
+        objeto="Aquisição de uniformes escolares para rede municipal",
     )
     portal_record = create_procurement(
         source_id="PORTAL-1", source_name="Portal", cnpj="22.222.222/0001-22",
-        numero_edital="002/2025", ano="2025"
+        numero_edital="002/2025", ano="2025",
+        objeto="Contratação de serviços de pavimentação asfáltica urbana",
     )
 
     pncp_adapter = MockSourceAdapter(code="PNCP", name="PNCP", records=[pncp_record])
@@ -807,21 +816,25 @@ async def test_timeout_with_partial_records_salvaged():
     Requires async generator yielding records before timeout.
     """
     # Create a slow adapter that yields 2 records then times out
+    # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
     async def slow_fetch_generator():
         # Yield 2 records quickly
         yield create_procurement(
             source_id="SLOW-1", source_name="SlowSource", cnpj="10.000.000/0001-10",
-            numero_edital="001/2025", ano="2025"
+            numero_edital="001/2025", ano="2025",
+            objeto="Aquisição de uniformes escolares para rede municipal",
         )
         yield create_procurement(
             source_id="SLOW-2", source_name="SlowSource", cnpj="20.000.000/0001-20",
-            numero_edital="002/2025", ano="2025"
+            numero_edital="002/2025", ano="2025",
+            objeto="Contratação de serviços de pavimentação asfáltica urbana",
         )
         # Then hang indefinitely
         await asyncio.sleep(100)
         yield create_procurement(
             source_id="SLOW-3", source_name="SlowSource", cnpj="30.000.000/0001-30",
-            numero_edital="003/2025", ano="2025"
+            numero_edital="003/2025", ano="2025",
+            objeto="Serviço de limpeza predial e manutenção hospitalar",
         )
 
     class SlowAdapter(SourceAdapter):

--- a/backend/tests/test_harden010_comprasgov_disable.py
+++ b/backend/tests/test_harden010_comprasgov_disable.py
@@ -18,16 +18,22 @@ class TestAC1FeatureFlag:
         from config import COMPRASGOV_ENABLED
         assert COMPRASGOV_ENABLED is False
 
-    @patch.dict("os.environ", {"COMPRASGOV_ENABLED": "true"})
     def test_env_var_enables(self):
         """Setting COMPRASGOV_ENABLED=true enables the flag."""
+        # CIG-BE config split (TD-007): COMPRASGOV_ENABLED source of truth is
+        # config.pncp; reload that first, then config package re-exports it.
+        # Cleanup must happen AFTER patch.dict exits, so module state matches real env.
         import importlib
+        import os
+        import config.pncp
         import config
-        importlib.reload(config)
-        try:
-            assert config.COMPRASGOV_ENABLED is True
-        finally:
+        with patch.dict("os.environ", {"COMPRASGOV_ENABLED": "true"}):
+            importlib.reload(config.pncp)
             importlib.reload(config)
+            assert config.COMPRASGOV_ENABLED is True
+        # After patch.dict exits: env restored — reload to match
+        importlib.reload(config.pncp)
+        importlib.reload(config)
 
     def test_registered_in_feature_flag_registry(self):
         """Flag is in _FEATURE_FLAG_REGISTRY for runtime toggles."""
@@ -74,9 +80,12 @@ class TestAC3StartupWarning:
             for msg in caplog.messages
         )
 
-    @patch("config.COMPRASGOV_ENABLED", True)
+    @patch("config.pncp.COMPRASGOV_ENABLED", True)
     def test_no_warning_when_enabled(self, caplog):
         """log_feature_flags() does NOT warn when ComprasGov is enabled."""
+        # log_feature_flags() does `from config.pncp import COMPRASGOV_ENABLED`
+        # fresh at call-time — patch MUST target the source of truth module
+        # (config.pncp), not the re-export (config).
         from config import log_feature_flags
         with caplog.at_level(logging.WARNING, logger="config"):
             log_feature_flags()
@@ -90,19 +99,23 @@ class TestAC3StartupWarning:
 # AC4: Easy to re-enable via env var
 # ---------------------------------------------------------------------------
 class TestAC4ReEnable:
-    @patch.dict("os.environ", {"COMPRASGOV_ENABLED": "true"})
     def test_reenable_via_env_var(self):
         """Setting COMPRASGOV_ENABLED=true re-enables ComprasGov."""
+        # CIG-BE config split (TD-007): reload config.pncp first (source of truth)
+        # Cleanup happens AFTER patch.dict exits so module state matches real env.
         import importlib
+        import config.pncp
         import config
-        importlib.reload(config)
-        try:
+        with patch.dict("os.environ", {"COMPRASGOV_ENABLED": "true"}):
+            importlib.reload(config.pncp)
+            importlib.reload(config)
             assert config.COMPRASGOV_ENABLED is True
             from source_config.sources import SourceConfig
             sc = SourceConfig.from_env()
             assert sc.compras_gov.enabled is True
-        finally:
-            importlib.reload(config)
+        # After patch.dict exits: env restored — reload to match
+        importlib.reload(config.pncp)
+        importlib.reload(config)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_multisource_orchestration.py
+++ b/backend/tests/test_multisource_orchestration.py
@@ -333,9 +333,16 @@ class TestDegradedMode:
     @pytest.mark.asyncio
     async def test_not_partial_when_all_sources_succeed(self):
         """is_partial=False when all sources return data successfully."""
-        records_a = [_make_record("SOURCE_A", "a1", cnpj="111")]
+        # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) fuzzy match
+        records_a = [_make_record(
+            "SOURCE_A", "a1", cnpj="111",
+            objeto="Aquisição de uniformes escolares para rede municipal",
+        )]
         records_b = [
-            _make_record("SOURCE_B", "b1", cnpj="222", numero_edital="002")
+            _make_record(
+                "SOURCE_B", "b1", cnpj="222", numero_edital="002",
+                objeto="Contratação de serviços de pavimentação asfáltica urbana",
+            )
         ]
 
         adapters = {

--- a/backend/tests/test_pcp_timeout_isolation.py
+++ b/backend/tests/test_pcp_timeout_isolation.py
@@ -113,10 +113,12 @@ class TestPcpTimeoutIsolation:
         """When PCP times out, PNCP data should be returned as partial."""
         from consolidation import ConsolidationService
 
+        # Use distinct objects to avoid TITLE-PREFIX-DEDUP (ISSUE-027) collapsing
+        # "Uniforme escolar tipo A" / "tipo B" (same 60-char prefix + 0.85 jaccard)
         pncp_records = [
-            _make_unified("PNCP", "pncp-001", "Uniforme escolar tipo A"),
-            _make_unified("PNCP", "pncp-002", "Uniforme escolar tipo B"),
-            _make_unified("PNCP", "pncp-003", "Jaleco hospitalar"),
+            _make_unified("PNCP", "pncp-001", "Aquisição de uniformes escolares tipo A para rede municipal"),
+            _make_unified("PNCP", "pncp-002", "Contratação de pavimentação asfáltica urbana zona sul"),
+            _make_unified("PNCP", "pncp-003", "Fornecimento de jalecos hospitalares para unidade básica"),
         ]
 
         adapters = {
@@ -281,6 +283,7 @@ class TestPcpTimeoutIsolation:
                 record_count=2,
                 duration_ms=1500,
                 error=None,
+                skipped_reason=None,
             ),
             SimpleNamespace(
                 source_code="PORTAL_COMPRAS",
@@ -288,13 +291,16 @@ class TestPcpTimeoutIsolation:
                 record_count=0,
                 duration_ms=30000,
                 error="PCP timed out",
+                skipped_reason=None,
             ),
         ]
+        mock_result.ufs_completed = ["SP"]
+        mock_result.ufs_pending = []
 
         with patch("consolidation.ConsolidationService") as MockCS, \
              patch("source_config.sources.get_source_config") as mock_config, \
              patch("pipeline.stages.execute.enriquecer_com_status_inferido") as mock_enrich, \
-             patch("pipeline.cache_manager._supabase_save_cache", new_callable=AsyncMock), \
+             patch("cache.manager.save_to_cache_per_uf", new_callable=AsyncMock), \
              patch("pipeline.stages.validate._supabase_get_cache", new_callable=AsyncMock, return_value=None):
 
             mock_svc = AsyncMock()

--- a/backend/tests/test_portal_compras_client.py
+++ b/backend/tests/test_portal_compras_client.py
@@ -455,7 +455,8 @@ class TestNormalize:
         assert record.source_id == "pcp_12345"
         assert record.source_name == "PORTAL_COMPRAS"
         assert "uniformes profissionais" in record.objeto
-        assert record.valor_estimado == 0.0  # v2 has no value data
+        # UX-401 AC1: PCP v2 listing has no value data — normalized to None (not 0.0)
+        assert record.valor_estimado is None
         assert record.orgao == "Secretaria de Administração"
         assert record.uf == "SP"
         assert record.municipio == "Campinas"
@@ -478,10 +479,11 @@ class TestNormalize:
         assert record.objeto == "Aquisição de equipamentos de TI"
 
     def test_normalize_value_is_zero(self, adapter):
-        """Test normalize sets valor_estimado=0.0 (v2 has no value data)."""
+        """Test normalize sets valor_estimado=None (UX-401 AC1: v2 has no value data)."""
         raw = _make_v2_record(1)
         record = adapter.normalize(raw)
-        assert record.valor_estimado == 0.0
+        # UX-401 AC1: PCP v2 listing has no value data — normalized to None (not 0.0)
+        assert record.valor_estimado is None
 
     def test_normalize_missing_id_raises_error(self, adapter):
         """Test normalize raises SourceParseError when codigoLicitacao missing."""


### PR DESCRIPTION
## Summary
STORY-BTS-005 — Fix 16/19 consolidation & multi-source test failures (Wave 2 BTS). Triage match: 19 claimed = 19 actual. **3 tests deferred — production regression CRIT-054 detected.**

Root-cause clusters (fixed):
- **A. TITLE-PREFIX-DEDUP collisions (ISSUE-027):** New dedup layer (first 60 chars + jaccard ≥ 0.85) collapsed test records sharing default `objeto="Test procurement"` / `"Material de limpeza"`. Parametrized distinct objetos per record, following existing `test_same_cnpj_different_edital_both_kept` pattern (8 tests).
- **B. Patch drift TD-007/TD-008 (Wave 1 Pattern I):** `_supabase_save_cache` → `cache.manager.save_to_cache_per_uf`; `COMPRASGOV_*` constants moved from `pncp_client` to `config`; new `SourceResult.skipped_reason` attribute required by production (3 tests).
- **C. UX-401 AC1:** PCP v2 intentionally normalizes missing `valor_estimado` to `None`, not `0.0` (2 tests).
- **D. `config.pncp` facade + reload cleanup (Wave 1 Pattern 3):** `log_feature_flags()` re-imports fresh → must patch at source-of-truth module. Reload cleanup moved AFTER `patch.dict` context exits (3 tests).

## ⚠️ Production regression detected (out-of-scope, new story opened)
**CRIT-054 (3 tests blocked):** DEBT-201 refactor (`filter.py` → `filter/pipeline.py`) silently dropped the PCP v2 `desconhecido`/`todos` pass-through elif branch (present at `bf6ab7cc:backend/filter.py:2385-2395`). Tests in `test_crit054_pcp_status_mapping.py` validate correct contract; production is broken. Needs follow-up story to restore:
- Port elif branch into `filter/pipeline.py` ~line 137-140 (after `status_inferido == status_lower` check)
- Restore `FILTER_PASSTHROUGH_TOTAL` metric
- Restore `_status_unconfirmed` marker

Guardrail held: did not edit production, did not skip/xfail, did not relax assertions.

Files modified (7 test files, zero production code).

## Testing Plan
- [x] `pytest tests/test_consolidation_multisource.py tests/test_consolidation_early_return.py tests/test_multisource_orchestration.py tests/test_pcp_timeout_isolation.py tests/test_portal_compras_client.py tests/test_comprasgov_circuit_breaker.py tests/test_harden010_comprasgov_disable.py --timeout=20` → 195 pass, 0 fail
- [x] CRIT-054 tests documented as blocked pending production fix (new story)
- [x] No skip/xfail added

## Closes
Part of EPIC-BTS-2026Q2 Wave 2. Closes STORY-BTS-005 (partial — 3 CRIT-054 tests deferred to CRIT-054-filter-passthrough-regression story).
