### PR TITLE
fix(tests): STORY-BTS-006 — search pipeline & async flow (13/15)

### DIFF
--- a/backend/tests/test_progressive_delivery.py
+++ b/backend/tests/test_progressive_delivery.py
@@ -166,12 +166,17 @@ class TestBackgroundResultsStore:
         assert result is None
 
     def test_ttl_expiry(self):
-        """Results older than TTL should not be served."""
+        """Results older than TTL should not be served.
+
+        STORY-362 AC1 raised in-memory _RESULTS_TTL from 600s to 3600s.
+        Import the current value so this test tracks the source of truth.
+        """
+        from routes.search_state import _RESULTS_TTL
         resp = _make_response()
         store_background_results("test-ttl-001", resp)
 
-        # Manually expire entry
-        _background_results["test-ttl-001"]["stored_at"] = time.time() - 700  # > 600s TTL
+        # Manually expire entry (any offset > _RESULTS_TTL)
+        _background_results["test-ttl-001"]["stored_at"] = time.time() - (_RESULTS_TTL + 100)
 
         result = get_background_results("test-ttl-001")
         assert result is None

--- a/backend/tests/test_progressive_results_295.py
+++ b/backend/tests/test_progressive_results_295.py
@@ -86,12 +86,22 @@ class FakeAdapter(SourceAdapter):
 async def test_fast_source_emits_partial_before_slow_completes():
     """AC15: When one source is fast and another is slow, on_source_done
     is called for the fast source BEFORE the slow source finishes."""
+    # STORY-BTS-006: Use distinct objetos per record to avoid title-prefix
+    # cross-org dedup (added to consolidation.dedup post-STORY-295). The test
+    # asserts raw record counts, not dedup behavior — which is covered by
+    # dedicated dedup tests.
     fast_records = [
-        _make_record("FAST", f"fast-{i}", cnpj=f"111{i:04d}", numero_edital=f"{i:03d}")
+        _make_record(
+            "FAST", f"fast-{i}", cnpj=f"111{i:04d}", numero_edital=f"{i:03d}",
+            objeto=f"Material de limpeza fast {i}",
+        )
         for i in range(5)
     ]
     slow_records = [
-        _make_record("SLOW", f"slow-{i}", cnpj=f"222{i:04d}", numero_edital=f"{i:03d}")
+        _make_record(
+            "SLOW", f"slow-{i}", cnpj=f"222{i:04d}", numero_edital=f"{i:03d}",
+            objeto=f"Material de limpeza slow {i}",
+        )
         for i in range(3)
     ]
 
@@ -187,8 +197,12 @@ async def test_partial_results_timing_under_10s():
 @pytest.mark.asyncio
 async def test_one_source_fails_others_deliver():
     """AC16: If one source fails, results from other sources are still delivered."""
+    # STORY-BTS-006: Distinct objetos to avoid title-prefix cross-org dedup.
     ok_records = [
-        _make_record("OK_SOURCE", f"ok-{i}", cnpj=f"111{i:04d}", numero_edital=f"{i:03d}")
+        _make_record(
+            "OK_SOURCE", f"ok-{i}", cnpj=f"111{i:04d}", numero_edital=f"{i:03d}",
+            objeto=f"Material de limpeza ok {i}",
+        )
         for i in range(3)
     ]
 

--- a/backend/tests/test_search_async.py
+++ b/backend/tests/test_search_async.py
@@ -118,7 +118,7 @@ class TestT1AsyncReturns202:
 
                 client = TestClient(app)
                 response = client.post(
-                    "/buscar",
+                    "/v1/buscar",
                     json={
                         "ufs": ["SP"],
                         "data_inicial": "2026-02-01",
@@ -158,7 +158,7 @@ class TestT2WorkerProcesses:
         with patch("pipeline.worker.executar_busca_completa", new_callable=AsyncMock, return_value=mock_busca_response), \
              patch("progress.get_tracker", new_callable=AsyncMock, return_value=mock_tracker), \
              patch("progress.remove_tracker", new_callable=AsyncMock), \
-             patch("job_queue.persist_job_result", new_callable=AsyncMock) as mock_persist, \
+             patch("jobs.queue.result_store.persist_job_result", new_callable=AsyncMock) as mock_persist, \
              patch("middleware.search_id_var"), \
              patch("middleware.request_id_var"), \
              patch("metrics.SEARCH_JOB_DURATION") as mock_metric:
@@ -197,7 +197,7 @@ class TestT3SSEDelivery:
         with patch("pipeline.worker.executar_busca_completa", new_callable=AsyncMock, return_value=mock_busca_response), \
              patch("progress.get_tracker", new_callable=AsyncMock, return_value=mock_tracker), \
              patch("progress.remove_tracker", new_callable=AsyncMock), \
-             patch("job_queue.persist_job_result", new_callable=AsyncMock), \
+             patch("jobs.queue.result_store.persist_job_result", new_callable=AsyncMock), \
              patch("middleware.search_id_var"), \
              patch("middleware.request_id_var"), \
              patch("metrics.SEARCH_JOB_DURATION") as mock_metric:
@@ -383,7 +383,7 @@ class TestT6QuotaInPOST:
 
                 client = TestClient(app)
                 response = client.post(
-                    "/buscar",
+                    "/v1/buscar",
                     json={
                         "ufs": ["SP"],
                         "data_inicial": "2026-02-01",
@@ -482,7 +482,7 @@ class TestT7AsyncReturnsImmediately:
                 client = TestClient(app)
                 start = time.time()
                 response = client.post(
-                    "/buscar",
+                    "/v1/buscar",
                     json={
                         "ufs": ["SP", "RJ", "MG", "BA", "RS"],
                         "data_inicial": "2026-02-01",
@@ -654,7 +654,7 @@ class TestT10Heartbeat:
         with patch("pipeline.worker.executar_busca_completa", new_callable=AsyncMock, return_value=mock_busca_response) as mock_exec, \
              patch("progress.get_tracker", new_callable=AsyncMock, return_value=mock_tracker), \
              patch("progress.remove_tracker", new_callable=AsyncMock), \
-             patch("job_queue.persist_job_result", new_callable=AsyncMock), \
+             patch("jobs.queue.result_store.persist_job_result", new_callable=AsyncMock), \
              patch("middleware.search_id_var"), \
              patch("middleware.request_id_var"), \
              patch("metrics.SEARCH_JOB_DURATION") as mock_metric:
@@ -694,9 +694,12 @@ class TestFeatureFlagConfig:
         assert SEARCH_ASYNC_ENABLED is False
 
     def test_async_timeout_constant(self):
-        """STORY-292: _ASYNC_SEARCH_TIMEOUT replaces SEARCH_ASYNC_WAIT_TIMEOUT."""
+        """STORY-292 / AC9: _ASYNC_SEARCH_TIMEOUT replaces SEARCH_ASYNC_WAIT_TIMEOUT.
+
+        Raised from 120s to 240s to accommodate tamanhoPagina=50 per-UF latency.
+        """
         from routes.search import _ASYNC_SEARCH_TIMEOUT
-        assert _ASYNC_SEARCH_TIMEOUT == 120
+        assert _ASYNC_SEARCH_TIMEOUT == 240
 
 
 class TestSearchQueuedResponse:

--- a/backend/tests/test_search_contracts.py
+++ b/backend/tests/test_search_contracts.py
@@ -380,15 +380,16 @@ class TestStatusEndpointContract:
             "started_at": "2026-01-01T00:00:00Z",
         }
 
-        with patch("routes.search_status.get_tracker", new_callable=AsyncMock, return_value=None):
-            with patch("routes.search_status.get_state_machine", return_value=None):
-                with patch("routes.search_status.get_search_status", new_callable=AsyncMock, return_value=mock_status):
-                    with patch("job_queue.get_job_result", new_callable=AsyncMock, return_value=None):
-                        async with AsyncClient(
-                            transport=ASGITransport(app=app),
-                            base_url="http://test",
-                        ) as client:
-                            resp = await client.get(f"/v1/search/{search_id}/status")
+        with patch("routes.search_status._verify_search_ownership", new_callable=AsyncMock):
+            with patch("routes.search_status.get_tracker", new_callable=AsyncMock, return_value=None):
+                with patch("routes.search_status.get_state_machine", return_value=None):
+                    with patch("routes.search_status.get_search_status", new_callable=AsyncMock, return_value=mock_status):
+                        with patch("job_queue.get_job_result", new_callable=AsyncMock, return_value=None):
+                            async with AsyncClient(
+                                transport=ASGITransport(app=app),
+                                base_url="http://test",
+                            ) as client:
+                                resp = await client.get(f"/v1/search/{search_id}/status")
 
         assert resp.status_code == 200
         data = resp.json()
@@ -452,15 +453,16 @@ class TestStatusEndpointContract:
             "excel_status": "ready",
         }
 
-        with patch("routes.search_status.get_tracker", new_callable=AsyncMock, return_value=None):
-            with patch("routes.search_status.get_state_machine", return_value=None):
-                with patch("routes.search_status.get_search_status", new_callable=AsyncMock, return_value=mock_status):
-                    with patch("job_queue.get_job_result", new_callable=AsyncMock, return_value=mock_excel):
-                        async with AsyncClient(
-                            transport=ASGITransport(app=app),
-                            base_url="http://test",
-                        ) as client:
-                            resp = await client.get(f"/v1/search/{search_id}/status")
+        with patch("routes.search_status._verify_search_ownership", new_callable=AsyncMock):
+            with patch("routes.search_status.get_tracker", new_callable=AsyncMock, return_value=None):
+                with patch("routes.search_status.get_state_machine", return_value=None):
+                    with patch("routes.search_status.get_search_status", new_callable=AsyncMock, return_value=mock_status):
+                        with patch("job_queue.get_job_result", new_callable=AsyncMock, return_value=mock_excel):
+                            async with AsyncClient(
+                                transport=ASGITransport(app=app),
+                                base_url="http://test",
+                            ) as client:
+                                resp = await client.get(f"/v1/search/{search_id}/status")
 
         assert resp.status_code == 200
         data = resp.json()
@@ -498,11 +500,15 @@ class TestBackwardCompatImports:
         assert callable(_persist_results_to_redis)
 
     def test_can_import_async_search_functions(self):
-        """AC10: Async search functions importable from routes.search."""
+        """AC10: Async search functions importable from routes.search.
+
+        AC9: _ASYNC_SEARCH_TIMEOUT raised from 120s to 240s to accommodate
+        tamanhoPagina=50 per-UF latency.
+        """
         from routes.search import (
             _ASYNC_SEARCH_TIMEOUT,
         )
-        assert _ASYNC_SEARCH_TIMEOUT == 120
+        assert _ASYNC_SEARCH_TIMEOUT == 240
 
     def test_can_import_status_endpoints(self):
         """AC10: Status endpoint functions importable from routes.search."""

--- a/backend/tests/test_search_pipeline_generate_persist.py
+++ b/backend/tests/test_search_pipeline_generate_persist.py
@@ -270,7 +270,12 @@ class TestConvertToLicitacaoItems:
         assert item.link == "https://pncp.gov.br/app/editais/123"
 
     def test_missing_optional_fields(self):
-        """Handles missing optional fields with graceful defaults."""
+        """Handles missing optional fields with graceful defaults.
+
+        LicitacaoItem.valor is Optional[float] so a missing
+        ``valorTotalEstimado`` maps to ``None`` (not 0.0) — the frontend
+        treats None as "value unknown" rather than "value zero".
+        """
         lic = {
             "objetoCompra": "Servicos gerais",
             "nomeOrgao": "Orgao Teste",
@@ -279,7 +284,7 @@ class TestConvertToLicitacaoItems:
         result = _convert_to_licitacao_items([lic])
         assert len(result) == 1
         item = result[0]
-        assert item.valor == 0.0
+        assert item.valor is None
         assert item.municipio is None
         assert item.modalidade is None
         assert item.data_publicacao is None
@@ -345,7 +350,12 @@ class TestStageGenerate:
              patch("pipeline.stages.generate.upload_excel"):
             await pipeline.stage_generate(ctx)
 
-        mock_resumo.assert_called_once_with(lics, sector_name="Vestuario")
+        mock_resumo.assert_called_once_with(
+            lics,
+            sector_name="Vestuario",
+            termos_busca=None,
+            setor_id="vestuario",
+        )
         assert ctx.response is not None
         assert ctx.response.resumo.resumo_executivo == resumo.resumo_executivo
         # Actual totals override LLM values


### PR DESCRIPTION
## Summary
STORY-BTS-006 — Fix 13/15 search pipeline & async flow test failures (Wave 2 BTS). Triage match: 13 scope failures = 13 fixed.

Root-cause clusters (A-H):
- **A. Route path migration (Pattern 5):** `/buscar` → `/v1/buscar` — all search routes now only mount under `/v1/` (consistent with other existing tests).
- **B. Async timeout tightening:** `_ASYNC_SEARCH_TIMEOUT` raised 120s → 240s (STORY-292 AC9, tamanhoPagina=50 latency).
- **C. Persist job result moved (Pattern 1):** `persist_job_result` → `jobs.queue.result_store`; `search_job` imports lazily — patch at source.
- **D. Ownership gate added:** `_verify_search_ownership` gate added to `/v1/search/{id}/status` — patch out in contract tests.
- **E. Shape drift:** `LicitacaoItem.valor` default `0.0` → `None`.
- **F. Signature extended:** `gerar_resumo()` extended with `termos_busca` + `setor_id` kwargs.
- **G. Dedup:** Consolidation added TITLE-PREFIX-DEDUP — fake records needed unique objetos.
- **H. Constant updated:** `_RESULTS_TTL` 600s → 3600s (STORY-362 AC1) — test now imports constant instead of hard-coding.

## Out-of-scope (deferred, not failing in this PR)
1. `test_precision_recall_datalake::test_datalake_precision_recall[vestuario]` — recall 34% < 70%. Ground truth auto-labeled pre-ISSUE-029; requires regenerating `benchmark_ground_truth.json` via `scripts/build_benchmark_from_datalake.py` (data-engineer scope).
2. `test_precision_recall_benchmark::TestVestuario::test_epi_protecao_approved` — same ISSUE-029 tightening.
3. `test_precision_recall_benchmark::TestCrossSectorCollisions::test_cross_sector_collision_rate` — combinatorial regex test timeouts >15s (pre-existing slow benchmark).

Files modified (5 test files, zero production code).

## Testing Plan
- [x] `pytest tests/test_search_async.py tests/test_search_contracts.py tests/test_search_pipeline_generate_persist.py tests/test_progressive_results_295.py tests/test_progressive_delivery.py --timeout=15` → 92 pass in 51s
- [x] No skip/xfail added
- [x] 3 deferred tests documented for data-engineer follow-up

## Closes
Part of EPIC-BTS-2026Q2 Wave 2. Closes STORY-BTS-006 (partial — 2 precision/recall + 1 slow benchmark deferred to data-engineer follow-up).
