### PR TITLE
fix(tests): STORY-BTS-008 — critical path & concurrency (18 tests)

### DIFF
--- a/backend/tests/test_concurrency_safety.py
+++ b/backend/tests/test_concurrency_safety.py
@@ -475,15 +475,21 @@ class TestPipelineOptimisticLocking:
 
     @patch("routes.pipeline._check_pipeline_write_access", _noop_check_pipeline_write_access)
     @patch("routes.pipeline._check_pipeline_read_access", _noop_check_pipeline_read_access)
-    def test_ac12_get_pipeline_returns_version(self):
-        """AC12: GET pipeline items includes version field in response."""
+    @patch("routes.pipeline.get_supabase")
+    def test_ac12_get_pipeline_returns_version(self, mock_get_sb):
+        """AC12: GET pipeline items includes version field in response.
+
+        ISSUE-021: list_pipeline uses get_supabase() (admin client) not get_user_db;
+        patch the source the route actually calls.
+        """
         sb = _mock_pipeline_sb()
         sb.execute.return_value = Mock(
             data=[SAMPLE_PIPELINE_ITEM],
             count=1,
         )
+        mock_get_sb.return_value = sb
 
-        client = _create_pipeline_client(mock_user_db=sb)
+        client = _create_pipeline_client()
         resp = client.get("/pipeline")
 
         assert resp.status_code == 200
@@ -552,34 +558,33 @@ class TestQuotaAtomicity:
 
     @patch("supabase_client.get_supabase")
     def test_ac26_fallback_creates_new_row(self, mock_get_sb):
-        """AC26: Quota fallback with nonexistent row creates with count=1."""
+        """AC26: When both atomic RPCs are unavailable, fail open.
+
+        The legacy last-resort upsert path was intentionally removed
+        (STORY-307 + BTS-001 finding). The contract now is fail-open:
+        return the current quota value from get_monthly_quota_used without
+        incrementing, never silently writing via a non-atomic upsert.
+        """
         from quota import increment_monthly_quota
 
         sb = MagicMock()
         mock_get_sb.return_value = sb
 
-        # Primary RPC fails
+        # Both atomic RPCs fail (e.g. fresh deploy before migrations)
         sb.rpc.return_value.execute.side_effect = [
             Exception("function increment_quota_atomic does not exist"),
-            # Fallback RPC also fails (function not deployed yet)
             Exception("function increment_quota_fallback_atomic does not exist"),
         ]
-
-        # Last-resort upsert path
-        sb.table.return_value = sb
-        sb.upsert.return_value = sb
-        sb.execute.return_value = Mock(data=[{"searches_count": 1}])
 
         with patch("quota.get_monthly_quota_used", return_value=1):
             result = increment_monthly_quota("user-new-quota", max_quota=50)
 
+        # Fail-open returns the current count untouched
         assert result == 1
 
-        # Verify upsert was called (creates row if not exists)
-        sb.upsert.assert_called_once()
-        upsert_args = sb.upsert.call_args[0][0]
-        assert upsert_args["searches_count"] == 1
-        assert upsert_args["user_id"] == "user-new-quota"
+        # The removed non-atomic upsert path MUST NOT be called — the whole
+        # point of STORY-307 was to eliminate read-modify-write races.
+        sb.upsert.assert_not_called()
 
     @patch("supabase_client.get_supabase")
     def test_ac15_no_read_modify_write_in_fallback(self, mock_get_sb):

--- a/backend/tests/test_crit004_correlation.py
+++ b/backend/tests/test_crit004_correlation.py
@@ -250,6 +250,7 @@ class TestJobQueueCorrelation:
         """AC15-AC16: llm_summary_job accepts **kwargs including _trace_id."""
         # Mock all dependencies at their source modules (deferred imports in job_queue)
         mock_resumo = MagicMock()
+        mock_resumo.resumo_executivo = "Test summary"
         mock_resumo.total_oportunidades = 0
         mock_resumo.valor_total = 0
         mock_resumo.model_dump.return_value = {"resumo_executivo": "Test"}
@@ -310,16 +311,26 @@ class TestAdminTraceEndpoint:
     def setup_method(self):
         from main import app
         from auth import require_auth
-        app.dependency_overrides[require_auth] = lambda: {
+        from admin import require_admin
+        admin_user = {
             "sub": "test-user-id",
+            "id": "test-user-id",
             "email": "test@example.com",
+            "is_admin": True,
+            "is_master": True,
         }
+        app.dependency_overrides[require_auth] = lambda: admin_user
+        # Route uses Depends(require_admin) — override that too so tests
+        # can hit /v1/admin/search-trace without a real admin token.
+        app.dependency_overrides[require_admin] = lambda: admin_user
         self.client = TestClient(app)
 
     def teardown_method(self):
         from main import app
         from auth import require_auth
+        from admin import require_admin
         app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
 
     @patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=None)
     @patch("job_queue.get_job_result", new_callable=AsyncMock, return_value=None)
@@ -369,7 +380,9 @@ class TestAdminTraceEndpoint:
     def test_trace_endpoint_requires_auth(self):
         from main import app
         from auth import require_auth
+        from admin import require_admin
         app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(require_admin, None)
 
         resp = self.client.get("/v1/admin/search-trace/no-auth")
         # Without auth override, should fail

--- a/backend/tests/test_crit046_pool_exhaustion.py
+++ b/backend/tests/test_crit046_pool_exhaustion.py
@@ -174,9 +174,13 @@ class TestHttpxPoolConfiguration:
     """AC3/AC4: Test _configure_httpx_pool configures limits and timeouts."""
 
     def test_configure_httpx_pool_sets_limits(self):
-        """Pool configured with max_connections=50, max_keepalive=20."""
+        """Pool configured with the production defaults from supabase_client (DEBT-018)."""
         import httpx
-        from supabase_client import _configure_httpx_pool
+        from supabase_client import (
+            _configure_httpx_pool,
+            _POOL_MAX_CONNECTIONS,
+            _POOL_MAX_KEEPALIVE,
+        )
 
         # Create a mock supabase client with a real httpx session
         mock_client = Mock()
@@ -191,10 +195,11 @@ class TestHttpxPoolConfiguration:
         new_session = mock_client.postgrest.session
         assert isinstance(new_session, httpx.Client)
 
-        # Verify the transport has the correct limits
+        # Verify the transport has the correct limits matching module constants
+        # (env-tunable via SUPABASE_POOL_MAX_CONNECTIONS / SUPABASE_POOL_MAX_KEEPALIVE).
         transport = new_session._transport
-        assert transport._pool._max_connections == 50
-        assert transport._pool._max_keepalive_connections == 20
+        assert transport._pool._max_connections == _POOL_MAX_CONNECTIONS
+        assert transport._pool._max_keepalive_connections == _POOL_MAX_KEEPALIVE
 
     def test_configure_httpx_pool_sets_timeout(self):
         """Timeout configured as 30s total, 10s connect."""
@@ -471,12 +476,14 @@ class TestPoolConstants:
     """Verify CRIT-046 constants are correctly defined."""
 
     def test_pool_max_connections(self):
+        """DEBT-018 lowered the default to 25 (env-tunable via SUPABASE_POOL_MAX_CONNECTIONS)."""
         from supabase_client import _POOL_MAX_CONNECTIONS
-        assert _POOL_MAX_CONNECTIONS == 50
+        assert _POOL_MAX_CONNECTIONS == 25
 
     def test_pool_max_keepalive(self):
+        """DEBT-018 lowered the default to 10 (env-tunable via SUPABASE_POOL_MAX_KEEPALIVE)."""
         from supabase_client import _POOL_MAX_KEEPALIVE
-        assert _POOL_MAX_KEEPALIVE == 20
+        assert _POOL_MAX_KEEPALIVE == 10
 
     def test_pool_timeout(self):
         from supabase_client import _POOL_TIMEOUT

--- a/backend/tests/test_crit050_pipeline_hardening.py
+++ b/backend/tests/test_crit050_pipeline_hardening.py
@@ -386,7 +386,7 @@ class TestAC15Stage4CrashPartialResponse:
     @pytest.mark.asyncio
     @patch("pipeline.stages.persist.quota")
     @patch("pipeline.stages.execute.get_from_cache_cascade", new_callable=AsyncMock, return_value=None)
-    @patch("pipeline.cache_manager._supabase_save_cache", new_callable=AsyncMock)
+    @patch("cache.manager.save_to_cache_per_uf", new_callable=AsyncMock)
     @patch("pipeline.stages.validate._supabase_get_cache", new_callable=AsyncMock, return_value=None)
     @patch("pipeline.cache_manager.get_fallback_cache", new_callable=AsyncMock, return_value=None)
     async def test_stage_filter_exception_uses_fallback_resumo(

--- a/backend/tests/test_crit057_filter_time_budget.py
+++ b/backend/tests/test_crit057_filter_time_budget.py
@@ -5,7 +5,7 @@ marking unclassified items as pending_review instead of blocking the pipeline.
 """
 
 import time
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 
 def _make_lic(objeto: str = "Aquisicao de equipamentos de construcao civil para obras publicas", valor: float = 100_000.0) -> dict:
@@ -32,115 +32,142 @@ def _fake_sector():
 
 
 class TestCrit057BatchBudgetGuard:
-    """AC1/AC2: Budget guard inside batch zero-match loop."""
+    """AC1/AC2: Budget guard inside batch zero-match loop.
 
-    @patch("config.LLM_ZERO_MATCH_ENABLED", True)
+    The batch zero-match classifier and its budget guard moved out of the
+    synchronous filter into the async ``classify_zero_match_job`` ARQ job
+    (see ``backend/jobs/queue/jobs.py``). These tests exercise the job
+    directly so the AC still has coverage post-architectural-move.
+    """
+
+    def _run_job(self, candidates: list[dict]):
+        """Run classify_zero_match_job to completion synchronously for test assertions."""
+        import asyncio
+        from jobs.queue.jobs import classify_zero_match_job
+
+        async def _noop_store(*args, **kwargs):
+            return None
+
+        with patch("jobs.queue.result_store.store_zero_match_results", side_effect=_noop_store), \
+             patch("progress.get_tracker", new_callable=AsyncMock, return_value=None):
+            return asyncio.run(
+                classify_zero_match_job(
+                    ctx={},
+                    search_id="crit057-test",
+                    candidates=candidates,
+                    setor="engenharia",
+                    sector_name="Engenharia",
+                )
+            )
+
     @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 5)
     @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 0.05)  # Very short budget to trigger
     @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 100)
     def test_budget_exceeded_marks_pending_review(self):
         """Budget of 0.05s + slow LLM batches -> interrupts, marks rest as pending_review."""
-        from filter import aplicar_todos_filtros
-
-        # Create 20 items (4 batches of 5)
         licitacoes = [_make_lic(f"Equipamento de construcao civil numero {i:03d} para obra publica") for i in range(20)]
 
-        call_count = 0
-
-        def slow_classify_batch(items, setor_name=None, setor_id=None, termos_busca=None):
-            nonlocal call_count
-            call_count += 1
+        def slow_classify_batch(items, setor_name=None, setor_id=None, search_id=None):
             time.sleep(0.1)  # Each batch takes 100ms, budget is 50ms
             return [{"is_primary": True, "confidence": 60, "evidence": []}] * len(items)
 
-        with patch("llm_arbiter._classify_zero_match_batch", slow_classify_batch), \
-             patch("llm_arbiter.classify_contract_primary_match", return_value={"is_primary": False}), \
-             patch("sectors.get_sector") as mock_sector:
-            mock_sector.return_value = _fake_sector()
+        with patch("llm_arbiter._classify_zero_match_batch", slow_classify_batch):
+            result = self._run_job(licitacoes)
 
-            resultado, stats = aplicar_todos_filtros(
-                licitacoes=licitacoes,
-                ufs_selecionadas={"SP"},
-                setor="engenharia",
-            )
-
-        # Budget should have been exceeded
-        assert stats.get("zero_match_budget_exceeded", 0) > 0, \
-            f"Expected budget exceeded items, got stats: {stats}"
-        # Some items should be pending_review
+        # Some items should be pending_review with the budget-exceeded reason.
         pending = [lic for lic in licitacoes if lic.get("_pending_review")]
-        assert len(pending) > 0, "Expected some items marked as pending_review"
-        # Pending items should have correct reason
-        for lic in pending:
-            assert lic["_pending_review_reason"] == "zero_match_budget_exceeded"
+        assert len(pending) > 0, f"Expected pending_review items, got result: {result}"
+        budget_pending = [
+            lic for lic in pending
+            if lic.get("_pending_review_reason") == "zero_match_budget_exceeded"
+        ]
+        assert len(budget_pending) > 0, (
+            "Expected at least one item with "
+            "_pending_review_reason='zero_match_budget_exceeded'"
+        )
+        for lic in budget_pending:
             assert lic["_relevance_source"] == "pending_review"
+        assert result["pending"] > 0
 
-    @patch("config.LLM_ZERO_MATCH_ENABLED", True)
     @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 5)
     @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)  # Very high budget -- never triggers
     @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 100)
     def test_high_budget_classifies_all(self):
         """Budget of 999s + 10 items -> classifies all normally."""
-        from filter import aplicar_todos_filtros
-
         licitacoes = [_make_lic(f"Servico de engenharia e construcao civil numero {i:03d} para obras") for i in range(10)]
 
-        def fast_classify_batch(items, setor_name=None, setor_id=None, termos_busca=None):
+        call_count = 0
+
+        def fast_classify_batch(items, setor_name=None, setor_id=None, search_id=None):
+            nonlocal call_count
+            call_count += 1
             return [{"is_primary": True, "confidence": 65, "evidence": ["match"]}] * len(items)
 
-        with patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
-             patch("llm_arbiter.classify_contract_primary_match", return_value={"is_primary": False}), \
-             patch("sectors.get_sector") as mock_sector:
-            mock_sector.return_value = _fake_sector()
+        with patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch):
+            result = self._run_job(licitacoes)
 
-            resultado, stats = aplicar_todos_filtros(
-                licitacoes=licitacoes,
-                ufs_selecionadas={"SP"},
-                setor="engenharia",
-            )
-
-        # No budget exceeded
-        assert stats.get("zero_match_budget_exceeded", 0) == 0
-        # All should be classified
-        assert stats.get("llm_zero_match_calls", 0) == 10
-        pending = [lic for lic in licitacoes if lic.get("_pending_review")]
-        assert len(pending) == 0, "No items should be pending_review with high budget"
+        # All 10 items classified, no budget-exceeded pending reviews.
+        assert result["status"] == "completed"
+        assert result["total_classified"] == 10
+        assert result["approved"] == 10
+        assert result["pending"] == 0
+        assert call_count == 2  # 10 items / batch_size 5 = 2 calls
+        budget_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_budget_exceeded"
+        ]
+        assert len(budget_pending) == 0
 
 
 class TestCrit057Metrics:
-    """AC3: Prometheus metric observed correctly."""
+    """AC3: Prometheus metric observed correctly.
 
-    @patch("config.LLM_ZERO_MATCH_ENABLED", True)
+    Post-architectural-move the job emits ``ZERO_MATCH_JOB_DURATION`` from
+    ``classify_zero_match_job`` rather than the filter observing a
+    ``FILTER_ZERO_MATCH_DURATION`` counter in-line.
+    """
+
     @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 10)
     @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
     @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 100)
     def test_metric_observed_on_completion(self):
-        """FILTER_ZERO_MATCH_DURATION metric is observed after classification."""
-        from filter import aplicar_todos_filtros
+        """ZERO_MATCH_JOB_DURATION metric is observed after classification."""
+        import asyncio
+        from jobs.queue.jobs import classify_zero_match_job
 
         licitacoes = [_make_lic(f"Servico especializado de construcao civil item {i:03d} para obras") for i in range(5)]
 
-        def fast_batch(items, setor_name=None, setor_id=None, termos_busca=None):
+        def fast_batch(items, setor_name=None, setor_id=None, search_id=None):
             return [{"is_primary": True, "confidence": 60, "evidence": []}] * len(items)
 
         mock_metric = MagicMock()
-        with patch("llm_arbiter._classify_zero_match_batch", fast_batch), \
-             patch("llm_arbiter.classify_contract_primary_match", return_value={"is_primary": False}), \
-             patch("metrics.FILTER_ZERO_MATCH_DURATION", mock_metric), \
-             patch("sectors.get_sector") as mock_sector:
-            mock_sector.return_value = _fake_sector()
+        mock_status = MagicMock()
 
-            aplicar_todos_filtros(
-                licitacoes=licitacoes,
-                ufs_selecionadas={"SP"},
-                setor="engenharia",
+        async def _noop_store(*args, **kwargs):
+            return None
+
+        with patch("llm_arbiter._classify_zero_match_batch", fast_batch), \
+             patch("metrics.ZERO_MATCH_JOB_DURATION", mock_metric), \
+             patch("metrics.ZERO_MATCH_JOB_STATUS", mock_status), \
+             patch("jobs.queue.result_store.store_zero_match_results", side_effect=_noop_store), \
+             patch("progress.get_tracker", new_callable=AsyncMock, return_value=None):
+            asyncio.run(
+                classify_zero_match_job(
+                    ctx={},
+                    search_id="crit057-metrics",
+                    candidates=licitacoes,
+                    setor="engenharia",
+                    sector_name="Engenharia",
+                )
             )
 
-        # Metric should have been observed
-        mock_metric.labels.assert_called()
-        call_kwargs = mock_metric.labels.call_args[1]
-        assert call_kwargs["mode"] == "batch"
-        assert call_kwargs["budget_exceeded"] == "false"
+        # Job duration metric observed exactly once (on happy-path exit).
+        mock_metric.observe.assert_called_once()
+        # Status counter labelled as completed on success.
+        mock_status.labels.assert_any_call(status="completed")
 
 
 class TestCrit057SearchContext:
@@ -188,7 +215,14 @@ class TestCrit057FilterStatsSchema:
 
 
 class TestCrit057ConfigVar:
-    """AC1: FILTER_ZERO_MATCH_BUDGET_S config variable."""
+    """AC1: FILTER_ZERO_MATCH_BUDGET_S config variable.
+
+    Pattern 3 (see docs/sessions/2026-04/2026-04-19-bts-wave1-handoff.md):
+    FILTER_ZERO_MATCH_BUDGET_S is parsed in ``config/features.py`` and
+    only re-exported by the ``config`` package root. Reloading ``config``
+    alone does NOT re-trigger ``os.getenv`` — we must reload
+    ``config.features`` (the source of truth).
+    """
 
     def test_default_value(self):
         """Default budget is 30 seconds."""
@@ -196,19 +230,22 @@ class TestCrit057ConfigVar:
         import os
         old = os.environ.pop("FILTER_ZERO_MATCH_BUDGET_S", None)
         try:
-            import config
-            importlib.reload(config)
-            assert config.FILTER_ZERO_MATCH_BUDGET_S == 30.0
+            from config import features
+            importlib.reload(features)
+            assert features.FILTER_ZERO_MATCH_BUDGET_S == 30.0
         finally:
             if old is not None:
                 os.environ["FILTER_ZERO_MATCH_BUDGET_S"] = old
-            importlib.reload(config)
+            from config import features as _features_final
+            importlib.reload(_features_final)
 
     def test_env_override(self):
         """Budget can be overridden via env var."""
         import importlib
         with patch.dict("os.environ", {"FILTER_ZERO_MATCH_BUDGET_S": "15"}):
-            import config
-            importlib.reload(config)
-            assert config.FILTER_ZERO_MATCH_BUDGET_S == 15.0
-            importlib.reload(config)
+            from config import features
+            importlib.reload(features)
+            assert features.FILTER_ZERO_MATCH_BUDGET_S == 15.0
+        # Restore the module to its ambient default after the patch context exits.
+        from config import features as _features_final
+        importlib.reload(_features_final)

--- a/backend/tests/test_job_queue.py
+++ b/backend/tests/test_job_queue.py
@@ -422,6 +422,7 @@ class TestLlmSummaryJob:
         from job_queue import llm_summary_job
 
         mock_resumo = MagicMock()
+        mock_resumo.resumo_executivo = "Test summary R$ 50.000,00"
         mock_resumo.total_oportunidades = 5
         mock_resumo.valor_total = 100000
         mock_resumo.model_dump = MagicMock(return_value={
@@ -451,6 +452,7 @@ class TestLlmSummaryJob:
         from job_queue import llm_summary_job
 
         mock_fallback = MagicMock()
+        mock_fallback.resumo_executivo = "Fallback summary"
         mock_fallback.total_oportunidades = 2
         mock_fallback.valor_total = 0
         mock_fallback.model_dump = MagicMock(return_value={"resumo_executivo": "Fallback"})
@@ -469,6 +471,7 @@ class TestLlmSummaryJob:
         from job_queue import llm_summary_job
 
         mock_resumo = MagicMock()
+        mock_resumo.resumo_executivo = "Test summary"
         mock_resumo.total_oportunidades = 1
         mock_resumo.valor_total = 0
         mock_resumo.model_dump = MagicMock(return_value={"resumo_executivo": "Test"})
@@ -491,6 +494,7 @@ class TestLlmSummaryJob:
         from job_queue import llm_summary_job
 
         mock_resumo = MagicMock()
+        mock_resumo.resumo_executivo = "LLM-generated text"
         mock_resumo.total_oportunidades = 999
         mock_resumo.valor_total = 999999
         mock_resumo.model_dump = MagicMock(return_value={})

--- a/backend/tests/test_revalidation_quota_cache.py
+++ b/backend/tests/test_revalidation_quota_cache.py
@@ -316,26 +316,31 @@ class TestT5_RevalidationNoUserQuota:
 
     @pytest.mark.asyncio
     async def test_do_revalidation_never_calls_quota(self):
-        """_do_revalidation does not call any quota functions."""
+        """_do_revalidation does not call any quota functions.
+
+        Patches target `cache.swr` (where _do_revalidation lives) and
+        `cache.manager.save_to_cache` (lazy-imported inside the function).
+        Patching the `search_cache` re-export facade does not reach the
+        call sites inside cache.swr — that was the old drift causing
+        the test to hang on the real asyncio.Lock.
+        """
         mock_results = [{"id": "reval-1"}]
         mock_sources = ["PNCP", "COMPRAS_GOV"]
 
+        import asyncio as _asyncio
+        real_lock = _asyncio.Lock()
+
         with (
             patch(
-                "search_cache._fetch_multi_source_for_revalidation",
+                "cache.swr._fetch_multi_source_for_revalidation",
                 new_callable=AsyncMock,
                 return_value=(mock_results, mock_sources),
             ),
-            patch("search_cache.save_to_cache", new_callable=AsyncMock) as mock_save,
-            patch("search_cache._clear_revalidating", new_callable=AsyncMock),
-            patch("search_cache._get_revalidation_lock") as mock_lock,
+            patch("cache.manager.save_to_cache", new_callable=AsyncMock) as mock_save,
+            patch("cache.swr._clear_revalidating", new_callable=AsyncMock),
+            patch("cache.swr._get_revalidation_lock", return_value=real_lock),
             patch("config.REVALIDATION_TIMEOUT", 60),
         ):
-            lock_instance = AsyncMock()
-            lock_instance.__aenter__ = AsyncMock(return_value=None)
-            lock_instance.__aexit__ = AsyncMock(return_value=None)
-            mock_lock.return_value = lock_instance
-
             import search_cache
             search_cache._active_revalidations = 1
 


### PR DESCRIPTION
## Summary
STORY-BTS-008 — Fix 18/18 critical path & concurrency test failures (Wave 2 BTS). Triage match: 18 claimed = 18 actual. **No production bugs detected** — all drift from intentional production changes.

9 root-cause clusters (A-I):
- **A. DEBT-018 pool defaults:** `PIPELINE_POOL_SIZE` 50 → 25, `PIPELINE_MAX_OVERFLOW` 20 → 10 (env-tunable).
- **B. Batch zero-match architectural move:** budget guard moved filter → async job `classify_zero_match_job`. Rewrote 3 tests to exercise job path.
- **C. Wave 1 Pattern 3:** reload `config.features` (SoT) not `config` (re-export facade).
- **D. Wave 1 Pattern 5:** `_supabase_save_cache` → `save_to_cache_per_uf` (cache.manager split).
- **E. Mock hygiene:** `_ground_truth_summary` runs regex on MagicMock → needed `mock.resumo_executivo = "text"`.
- **F. Auth gate:** `/v1/admin/search-trace` uses `require_admin`; tests only overrode `require_auth` (403 fix).
- **G. Admin DB client:** Pipeline GET uses `get_supabase()` (ISSUE-021), not `get_user_db`.
- **H. STORY-307 contract change:** quota upsert fallback intentionally removed (fail-open contract enforced).
- **I. Patch at call site:** `search_cache.*` patches don't reach `cache.swr._do_revalidation`; was hanging on real `asyncio.Lock`.

Files modified (7 test files, zero production code).

## Testing Plan
- [x] `pytest tests/test_crit046_pool_exhaustion.py tests/test_crit057_filter_time_budget.py tests/test_crit050_pipeline_hardening.py tests/test_crit004_correlation.py tests/test_concurrency_safety.py tests/test_revalidation_quota_cache.py tests/test_job_queue.py --timeout=15` → 162 pass (was 18 failing + hang)
- [x] No skip/xfail added
- [x] Confirmed no production race conditions underlying failures (per-cluster analysis)

## Closes
Part of EPIC-BTS-2026Q2 Wave 2. Closes STORY-BTS-008 (Critical Path & Concurrency).
