### PR TITLE
fix(tests): STORY-BTS-010a — billing, partners & feature flags (8 tests)

### DIFF
--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -175,7 +175,6 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "SECTOR_RED_FLAGS_ENABLED": "Sector-specific red flag detection",
     "PROXIMITY_CONTEXT_ENABLED": "Proximity context window for keyword matching",
     "ITEM_INSPECTION_ENABLED": "Item-level inspection for gray-zone contracts",
-    "FILTER_DEBUG_MODE": "Verbose filter debug logging (dev only)",
     # Term Search Quality
     "TERM_SEARCH_LLM_AWARE": "LLM-aware term search quality parity",
     "TERM_SEARCH_SYNONYMS": "Synonym expansion for term search",
@@ -212,6 +211,13 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "USER_FEEDBACK_ENABLED": "User feedback collection on search results",
     "USE_REDIS_CIRCUIT_BREAKER": "Redis-backed circuit breaker (vs in-memory)",
     "COMPRASGOV_CB_ENABLED": "ComprasGov circuit breaker enabled",
+    # A/B Testing
+    "ab_experiments_enabled": "A/B experiments framework (STORY-A/B)",
+    # Schema Contract (STORY-414)
+    "SCHEMA_CONTRACT_STRICT": "Strict schema contract validation for external responses (STORY-414)",
+    # Datalake Search Improvements
+    "TRIGRAM_FALLBACK_ENABLED": "Trigram fallback for datalake search (STORY-437)",
+    "EMBEDDING_ENABLED": "Semantic embedding search for datalake (STORY-438)",
 }
 
 
@@ -233,7 +239,6 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "SECTOR_RED_FLAGS_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-12"},
     "PROXIMITY_CONTEXT_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-12"},
     "ITEM_INSPECTION_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-12"},
-    "FILTER_DEBUG_MODE": {"owner": "search", "category": "debug", "lifecycle": "ops-toggle", "created": "2025-10"},
     # Term Search Quality — experimental, remove when graduated
     "TERM_SEARCH_LLM_AWARE": {"owner": "search", "category": "experimental", "lifecycle": "experimental", "created": "2026-01"},
     "TERM_SEARCH_SYNONYMS": {"owner": "search", "category": "experimental", "lifecycle": "experimental", "created": "2026-01"},
@@ -270,6 +275,14 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "USER_FEEDBACK_ENABLED": {"owner": "product", "category": "infra", "lifecycle": "permanent", "created": "2025-12"},
     "USE_REDIS_CIRCUIT_BREAKER": {"owner": "infra", "category": "infra", "lifecycle": "permanent", "created": "2025-12"},
     "COMPRASGOV_CB_ENABLED": {"owner": "infra", "category": "infra", "lifecycle": "permanent", "created": "2026-02"},
+    # A/B Testing
+    "ab_experiments_enabled": {"owner": "product", "category": "experimental", "lifecycle": "experimental", "created": "2026-03"},
+    # STORY-414: Schema contract gate
+    "SCHEMA_CONTRACT_STRICT": {"owner": "data", "category": "validation", "lifecycle": "experimental", "created": "2026-03"},
+    # STORY-437: Datalake search improvements
+    "TRIGRAM_FALLBACK_ENABLED": {"owner": "search", "category": "search", "lifecycle": "experimental", "created": "2026-03"},
+    # STORY-438: Semantic embeddings
+    "EMBEDDING_ENABLED": {"owner": "search", "category": "search", "lifecycle": "experimental", "created": "2026-03"},
 }
 
 

--- a/backend/tests/test_dunning.py
+++ b/backend/tests/test_dunning.py
@@ -579,9 +579,11 @@ async def test_require_active_plan_returns_402_for_blocked():
     )
 
     # has_master_access is imported from authorization inside require_active_plan
+    # BTS-010a Pattern 1: quota package split — patch at plan_auth.asyncio (where to_thread is called)
+    # and plan_auth.check_quota (where the lazy `from quota.plan_enforcement import check_quota` lands).
     with patch("authorization.has_master_access", new_callable=AsyncMock, return_value=False), \
-         patch("quota.check_quota", return_value=mock_quota_info), \
-         patch("quota.asyncio") as mock_asyncio:
+         patch("quota.plan_enforcement.check_quota", return_value=mock_quota_info), \
+         patch("quota.plan_auth.asyncio") as mock_asyncio:
 
         mock_asyncio.to_thread = AsyncMock(return_value=mock_quota_info)
 
@@ -618,9 +620,10 @@ async def test_require_active_plan_returns_402_for_grace_period():
         days_since_failure=16,
     )
 
+    # BTS-010a Pattern 1: quota package split — see comment on previous test.
     with patch("authorization.has_master_access", new_callable=AsyncMock, return_value=False), \
-         patch("quota.check_quota", return_value=mock_quota_info), \
-         patch("quota.asyncio") as mock_asyncio:
+         patch("quota.plan_enforcement.check_quota", return_value=mock_quota_info), \
+         patch("quota.plan_auth.asyncio") as mock_asyncio:
 
         mock_asyncio.to_thread = AsyncMock(return_value=mock_quota_info)
 

--- a/backend/tests/test_feature_flags_admin.py
+++ b/backend/tests/test_feature_flags_admin.py
@@ -129,8 +129,10 @@ class TestUpdateFeatureFlag:
     @patch("routes.feature_flags._redis_get_override", new_callable=AsyncMock, return_value=None)
     def test_update_flag_redis_unavailable_falls_back_to_memory(self, mock_get, mock_set, client):
         """When Redis is unavailable, should fall back to in-memory storage."""
+        # BTS-010a: FILTER_DEBUG_MODE was removed from _FEATURE_FLAG_REGISTRY;
+        # use DIGEST_ENABLED (ops-toggle, still in registry) as replacement fixture.
         resp = client.patch(
-            "/admin/feature-flags/FILTER_DEBUG_MODE",
+            "/admin/feature-flags/DIGEST_ENABLED",
             json={"value": True},
         )
         assert resp.status_code == 200
@@ -176,14 +178,16 @@ class TestUpdateFeatureFlag:
     @patch("routes.feature_flags._redis_get_override", new_callable=AsyncMock, return_value=None)
     def test_update_flag_stores_in_memory(self, mock_get, mock_set, client):
         """After update, in-memory override should be set."""
+        # BTS-010a: FILTER_DEBUG_MODE was removed from _FEATURE_FLAG_REGISTRY;
+        # use DIGEST_ENABLED (ops-toggle, still in registry) as replacement fixture.
         from routes.feature_flags import _runtime_overrides
 
         resp = client.patch(
-            "/admin/feature-flags/FILTER_DEBUG_MODE",
+            "/admin/feature-flags/DIGEST_ENABLED",
             json={"value": True},
         )
         assert resp.status_code == 200
-        assert _runtime_overrides.get("FILTER_DEBUG_MODE") is True
+        assert _runtime_overrides.get("DIGEST_ENABLED") is True
 
     @patch("routes.feature_flags._redis_set_override", new_callable=AsyncMock, return_value=True)
     @patch("routes.feature_flags._redis_get_override", new_callable=AsyncMock, return_value=None)


### PR DESCRIPTION
## Summary
STORY-BTS-010a — Fix 8 billing, partners & feature flags test failures (Wave 2 BTS). **Triage overscoped:** claimed 14, empirical baseline = 8 (test_partners + test_harden028_stripe_events_purge already green).

Root-cause clusters:
1. **Dunning patch target drift (Wave 1 Pattern 1, TD-007 split):** `quota.asyncio` → `quota.plan_auth.asyncio`; `quota.check_quota` → `quota.plan_enforcement.check_quota` (2 tests in `test_dunning.py`).
2. **Feature flag registry drift:** 4 new flags added (`ab_experiments_enabled`, `SCHEMA_CONTRACT_STRICT`, `TRIGRAM_FALLBACK_ENABLED`, `EMBEDDING_ENABLED`); 1 removed (`FILTER_DEBUG_MODE`). Metadata tables in `routes/feature_flags.py` synced + test fixtures adapted (6 tests across `test_feature_flag_matrix.py` + `test_feature_flags_admin.py`).

Minimal production touch: `backend/routes/feature_flags.py` metadata-only (`_FLAG_DESCRIPTIONS` + `_FLAG_LIFECYCLE` tables) to satisfy `TestAllFlagsHaveDescription` invariant enforcing metadata tracks `_FEATURE_FLAG_REGISTRY`. Zero behavior change; `config/features.py` (true SoT) untouched.

Files modified:
- `backend/tests/test_dunning.py` (2 patch target redirects)
- `backend/tests/test_feature_flags_admin.py` (2 fixture adaptations — ops-toggle flag swap)
- `backend/routes/feature_flags.py` (metadata registry sync)

## Testing Plan
- [x] `pytest tests/test_partners.py tests/test_dunning.py tests/test_harden028_stripe_events_purge.py tests/test_feature_flag_matrix.py tests/test_feature_flags_admin.py --timeout=20` → 122 pass in 19.68s (was 8 failing)
- [x] Regression check: all 116 feature-flag-adjacent tests still pass
- [x] No skip/xfail added

## Closes
Part of EPIC-BTS-2026Q2 Wave 2. Closes STORY-BTS-010a (Billing, Partners & Feature Flags).
