### PR TITLE
feat(conv-003a): scaffolding — migration profiles.stripe_default_pm_id

### DIFF
--- a/docs/stories/2026-04/EPIC-REVENUE-2026-Q2/STORY-CONV-003a-backend-stripe-signup.story.md
+++ b/docs/stories/2026-04/EPIC-REVENUE-2026-Q2/STORY-CONV-003a-backend-stripe-signup.story.md
@@ -95,3 +95,10 @@ Prerequisite para CONV-003b (frontend 2-step) e CONV-003c (webhooks completos + 
 ## Change Log
 
 - **2026-04-19** — @sm (River): Sub-story criada a partir da decomposição de STORY-CONV-003. Status Ready.
+- **2026-04-20** — @dev (Wave 3 session): **Partial scaffolding shipped** — DB foundation only.
+  - AC2 partial: migration `supabase/migrations/20260420000003_add_profiles_stripe_default_pm_id.sql` + down pareado cria coluna nullable `profiles.stripe_default_pm_id` (TEXT) + índice parcial `idx_profiles_stripe_default_pm_id WHERE NOT NULL`. Column unused até AC1 ligar backend writes.
+  - Colunas `stripe_customer_id` e `stripe_subscription_id` já existiam em `profiles` (migration 001, não precisam novo ADD COLUMN).
+  - Test stubs (AC5) **NÃO criados** — Zero Quarentena policy (EPIC-BTS): stubs `pytest.mark.skip` com rota ainda inexistente geram ruído. Tests reais serão escritos na sessão AC1 junto com o código de produção.
+  - Route/schema (AC1/AC3/AC4) **NÃO iniciados** — endpoint `/v1/auth/signup` ainda não existe (signup atual é Supabase Auth direto do frontend). Criação do endpoint + lógica Stripe + webhook é trabalho de 3-4h próxima sessão com founder hands (advisor guidance: evitar Stripe integration via agente).
+  - Status permanece `Ready` — scaffolding não começa InProgress; AC1 ainda é o trabalho principal.
+  - Decisão estratégica: commit separado da migration permite CI exercitar o `deploy.yml` auto-apply path sem acoplamento a código Stripe pendente.

--- a/supabase/migrations/20260420000003_add_profiles_stripe_default_pm_id.down.sql
+++ b/supabase/migrations/20260420000003_add_profiles_stripe_default_pm_id.down.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- Down migration: 20260420000003_add_profiles_stripe_default_pm_id
+-- Story: STORY-CONV-003a
+-- Date: 2026-04-20
+--
+-- Reverts addition of profiles.stripe_default_pm_id column and its index.
+-- Safe to run: column is nullable, no foreign keys, no triggers depend on it.
+-- ============================================================================
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.idx_profiles_stripe_default_pm_id;
+
+ALTER TABLE public.profiles
+    DROP COLUMN IF EXISTS stripe_default_pm_id;
+
+COMMIT;

--- a/supabase/migrations/20260420000003_add_profiles_stripe_default_pm_id.sql
+++ b/supabase/migrations/20260420000003_add_profiles_stripe_default_pm_id.sql
@@ -1,0 +1,41 @@
+-- ============================================================================
+-- Migration: 20260420000003_add_profiles_stripe_default_pm_id
+-- Story: STORY-CONV-003a — Backend Signup + Stripe Customer + Subscription
+-- Date: 2026-04-20
+--
+-- Purpose:
+--   Adds `stripe_default_pm_id` column to profiles so the signup+card flow
+--   (CONV-003a AC2) can persist the Stripe PaymentMethod ID that was attached
+--   to the Customer and set as the subscription's default PM.
+--
+--   `profiles.stripe_customer_id` and `profiles.stripe_subscription_id` already
+--   exist (migration 001). This migration only adds the PM reference so trial
+--   expiry can charge the card without round-tripping Stripe's Customer API.
+--
+--   Column is nullable because (a) legacy profiles have no card, and (b) the
+--   cartão-obrigatório flow is rolled out gradually via feature flag
+--   TRIAL_REQUIRE_CARD_ROLLOUT_PCT (introduced in CONV-003b).
+--
+-- Scaffolding-only migration: CONV-003a full Stripe integration (AC1/AC4) is
+-- deferred to the next session. This migration is safe to ship now because
+-- the column is nullable and unused until backend writes to it.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.profiles
+    ADD COLUMN IF NOT EXISTS stripe_default_pm_id TEXT;
+
+COMMENT ON COLUMN public.profiles.stripe_default_pm_id IS
+    'STORY-CONV-003a: Stripe PaymentMethod ID attached to the Customer and '
+    'used as the subscription default payment method. Set at signup when '
+    'TRIAL_REQUIRE_CARD_ROLLOUT_PCT is active; null for legacy users and '
+    'users who signed up before the feature flag was enabled.';
+
+-- Partial index for billing reconciliation (most profiles won't have a PM
+-- during rollout ramp-up).
+CREATE INDEX IF NOT EXISTS idx_profiles_stripe_default_pm_id
+    ON public.profiles (stripe_default_pm_id)
+    WHERE stripe_default_pm_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Partial scaffolding for STORY-CONV-003a (Backend Signup + Stripe Customer + Subscription). Ships the DB foundation ahead of the full Stripe integration session so the column is live when AC1/AC3/AC4 land next.

## What ships here

- **Migration `20260420000003_add_profiles_stripe_default_pm_id.sql`** — adds `stripe_default_pm_id TEXT NULL` to `profiles` + partial index `WHERE stripe_default_pm_id IS NOT NULL` for billing reconciliation during rollout ramp-up
- **Paired `.down.sql`** per STORY-6.2 policy — safe DROP COLUMN (column is nullable, no FKs, no triggers)
- **Story Change Log update** documenting scoping decisions

## What this is NOT

- Route `/v1/auth/signup` — **not created** (doesn't exist yet; current signup is Supabase Auth direct from frontend). Endpoint creation is part of AC1.
- Stripe client calls (`Customer.create`, `PaymentMethod.attach`, `Subscription.create`) — **reserved for founder session** (advisor guidance: avoid high-variance Stripe integration via agent)
- Webhook handler `customer.subscription.trial_will_end` — part of AC4
- Test stubs — **NOT created** per Zero Quarentena policy (EPIC-BTS). Real tests written alongside AC1 production code next session.

## Why ship this alone

Unlocks the auto-apply path via `deploy.yml` without coupling to pending Stripe work. Next session starts with the column live in prod, can focus purely on integration logic + tests (~3-4h founder hands estimate).

## Closes

- STORY-CONV-003a (partial — AC2 scaffolding only; AC1/AC3/AC4/AC5 remain Ready for next session)

## Testing Plan

- [ ] CI migration-gate workflow validates down.sql pairing and SQL lint
- [ ] CI migration-check workflow confirms no prior unapplied migrations
- [ ] `deploy.yml` auto-apply succeeds post-merge (migrations shipped idempotent via `IF NOT EXISTS`)
- [ ] Smoke check post-deploy: `\d public.profiles` shows new column in Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)