### PR TITLE
feat(conv-003): STORY-CONV-003 AC2 — backend signup com Stripe PaymentElement

### DIFF
--- a/backend/routes/auth_signup.py
+++ b/backend/routes/auth_signup.py
@@ -1,0 +1,262 @@
+"""POST /v1/auth/signup — Backend signup with Stripe trial (STORY-CONV-003a AC1).
+
+Flow:
+
+1. Pydantic validates email + password + optional Stripe PM id.
+2. Rate-limit the caller IP (3 req / 10 min) to deter multi-account abuse.
+3. Create the Supabase auth user via `auth.admin.create_user` (server-side
+   trigger `handle_new_user` populates the `profiles` row).
+4. If `stripe_payment_method_id` was provided and the feature is wired up,
+   call `services.stripe_signup.create_customer_and_subscription` and
+   persist the resulting ids on `profiles` (UPDATE, not INSERT — the
+   trigger already created the row).
+5. Return `SignupResponse` with `trial_end_ts` (Stripe trial_end when a
+   subscription exists; otherwise now + 14d).
+
+Failure policy (STORY-CONV-003a AC2): if Stripe fails AFTER the Supabase
+user was created, we log + mark profile `subscription_status='payment_failed'`
+and return 200 with `stripe_customer_id=None`. The user can access the app
+during the grace period (SUBSCRIPTION_GRACE_DAYS) and billing
+reconciliation can retry asynchronously.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from rate_limiter import require_rate_limit, SIGNUP_RATE_LIMIT_PER_10MIN
+from schemas.common import validate_password
+from schemas.user import SignupRequest, SignupResponse
+from services.stripe_signup import (
+    StripeSignupError,
+    create_customer_and_subscription,
+)
+from utils.disposable_emails import is_disposable_email
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth-signup"])
+
+
+def _compute_local_trial_end_ts(days: int = 14) -> int:
+    """Return Unix seconds for now + `days` (fallback when no Stripe sub)."""
+    return int((datetime.now(timezone.utc) + timedelta(days=days)).timestamp())
+
+
+def _get_supabase():
+    """Lazy supabase client for test patchability.
+
+    Tests patch ``routes.auth_signup.get_supabase`` per CLAUDE.md testing
+    guidance — import inside the function so the patch target exists at
+    call time.
+    """
+    from supabase_client import get_supabase
+
+    return get_supabase()
+
+
+def _update_profile_with_stripe(
+    sb,
+    user_id: str,
+    *,
+    customer_id: Optional[str],
+    subscription_id: Optional[str],
+    pm_id: Optional[str],
+    subscription_status: str,
+    company: Optional[str] = None,
+) -> None:
+    """UPDATE profiles row with Stripe ids. Non-fatal on failure.
+
+    The `handle_new_user` trigger already INSERTed the profile — we just
+    patch the Stripe columns. We swallow DB errors so billing recon can
+    pick up the divergence later (STORY-314) instead of 500-ing the user.
+    """
+    updates: dict = {}
+    if customer_id is not None:
+        updates["stripe_customer_id"] = customer_id
+    if subscription_id is not None:
+        updates["stripe_subscription_id"] = subscription_id
+    if pm_id is not None:
+        updates["stripe_default_pm_id"] = pm_id
+    if subscription_status:
+        updates["subscription_status"] = subscription_status
+    if company:
+        updates["company"] = company
+
+    if not updates:
+        return
+
+    try:
+        sb.table("profiles").update(updates).eq("id", user_id).execute()
+    except Exception:  # noqa: BLE001 — intentional broad catch
+        logger.exception(
+            "profiles update failed post-signup (user_id=%s***) — billing recon will retry",
+            user_id[:8],
+        )
+
+
+@router.post("/signup", response_model=SignupResponse)
+async def signup(
+    request: Request,
+    body: SignupRequest,
+    _rl=Depends(require_rate_limit(SIGNUP_RATE_LIMIT_PER_10MIN, 600)),
+) -> SignupResponse:
+    """STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.
+
+    Returns 200 with `SignupResponse`. Error modes:
+
+    - 400: disposable email domain or weak password.
+    - 400: invalid `stripe_payment_method_id` shape (Pydantic regex).
+    - 409: email already registered (detected via Supabase error).
+    - 500: Supabase auth.create_user failed (NOT Stripe — Stripe fails open).
+    """
+
+    email = body.email.lower().strip()
+
+    # Defense-in-depth: frontend already validates, but stop disposable
+    # domains here too (MED-SEC-001 pattern in auth_email.py).
+    if is_disposable_email(email):
+        raise HTTPException(
+            status_code=400,
+            detail="Este provedor de email não é aceito. Use um email corporativo ou pessoal.",
+        )
+
+    is_valid_pw, pw_err = validate_password(body.password)
+    if not is_valid_pw:
+        raise HTTPException(status_code=400, detail=pw_err)
+
+    sb = _get_supabase()
+
+    # 1. Create the Supabase auth user. The handle_new_user trigger inserts
+    #    the matching profiles row synchronously inside the transaction.
+    try:
+        user_metadata = {}
+        if body.full_name:
+            user_metadata["full_name"] = body.full_name
+        if body.company:
+            user_metadata["company"] = body.company
+
+        auth_result = sb.auth.admin.create_user(
+            {
+                "email": email,
+                "password": body.password,
+                "email_confirm": False,  # user must confirm via email link
+                "user_metadata": user_metadata,
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 — normalize Supabase SDK errors
+        message = str(exc).lower()
+        if "already" in message or "exists" in message or "duplicate" in message:
+            raise HTTPException(
+                status_code=409,
+                detail="Email já cadastrado. Faça login ou recupere sua senha.",
+            ) from exc
+        logger.error("Supabase create_user failed: %s", type(exc).__name__)
+        raise HTTPException(
+            status_code=500,
+            detail="Erro ao criar conta. Tente novamente em instantes.",
+        ) from exc
+
+    user = getattr(auth_result, "user", None) or auth_result.get("user") if isinstance(auth_result, dict) else getattr(auth_result, "user", None)
+    if user is None:
+        logger.error("Supabase create_user returned no user object")
+        raise HTTPException(status_code=500, detail="Erro ao criar conta.")
+
+    user_id = str(getattr(user, "id", None) or user["id"])
+
+    # Audit (non-blocking). Lazy import so tests can inject a stub
+    # (see tests/test_auth_signup_ratelimit.py pattern).
+    try:
+        import audit
+
+        if hasattr(audit, "log_audit_event"):
+            audit.log_audit_event(
+                event_type="auth.signup",
+                details={
+                    "user_id": user_id,
+                    "has_payment_method": bool(body.stripe_payment_method_id),
+                },
+                level="INFO",
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug("Audit log failed for signup", exc_info=True)
+
+    # 2. No card → legacy trial path. Compute local trial_end and return.
+    if not body.stripe_payment_method_id:
+        _update_profile_with_stripe(
+            sb,
+            user_id,
+            customer_id=None,
+            subscription_id=None,
+            pm_id=None,
+            subscription_status="free_trial",
+            company=body.company,
+        )
+        return SignupResponse(
+            user_id=user_id,
+            email=email,
+            trial_end_ts=_compute_local_trial_end_ts(),
+            stripe_customer_id=None,
+            stripe_subscription_id=None,
+            subscription_status="free_trial",
+            requires_email_confirmation=True,
+        )
+
+    # 3. Card path → Stripe Customer + Subscription with 14d trial.
+    try:
+        stripe_result = create_customer_and_subscription(
+            email=email,
+            payment_method_id=body.stripe_payment_method_id,
+            user_id=user_id,
+        )
+    except StripeSignupError as exc:
+        # Fail open per AC2 line 33. Still mark profile for recon.
+        logger.warning(
+            "Stripe signup failed; user %s*** created without subscription (step=%s)",
+            user_id[:8],
+            exc.step,
+        )
+        _update_profile_with_stripe(
+            sb,
+            user_id,
+            customer_id=exc.customer_id,  # may be set if failure happened post-customer
+            subscription_id=None,
+            pm_id=None,
+            subscription_status="payment_failed",
+            company=body.company,
+        )
+        return SignupResponse(
+            user_id=user_id,
+            email=email,
+            trial_end_ts=_compute_local_trial_end_ts(),
+            stripe_customer_id=exc.customer_id,
+            stripe_subscription_id=None,
+            subscription_status="payment_failed",
+            requires_email_confirmation=True,
+        )
+
+    _update_profile_with_stripe(
+        sb,
+        user_id,
+        customer_id=stripe_result["customer_id"],
+        subscription_id=stripe_result["subscription_id"],
+        pm_id=stripe_result["default_pm_id"],
+        subscription_status="trialing",
+        company=body.company,
+    )
+
+    trial_end_ts = stripe_result["trial_end_ts"] or _compute_local_trial_end_ts()
+
+    return SignupResponse(
+        user_id=user_id,
+        email=email,
+        trial_end_ts=trial_end_ts,
+        stripe_customer_id=stripe_result["customer_id"],
+        stripe_subscription_id=stripe_result["subscription_id"],
+        subscription_status="trialing",
+        requires_email_confirmation=True,
+    )

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -1,7 +1,7 @@
 """User profile, onboarding, and auth-related schemas."""
 
 from enum import Enum
-from pydantic import BaseModel, Field, model_validator, field_validator
+from pydantic import BaseModel, EmailStr, Field, model_validator, field_validator
 from typing import Any, Dict, List, Optional
 
 
@@ -289,3 +289,75 @@ class DeleteAccountResponse(BaseModel):
     """Response for DELETE /me."""
     success: bool
     message: str
+
+
+# ---------------------------------------------------------------------------
+# STORY-CONV-003a: Signup with Stripe trial
+# ---------------------------------------------------------------------------
+
+class SignupRequest(BaseModel):
+    """Request body for POST /v1/auth/signup (STORY-CONV-003a AC1).
+
+    `stripe_payment_method_id` is optional during rollout — when present, the
+    backend creates a Stripe Customer + Subscription with 14-day trial and
+    attaches the PaymentMethod. When absent, a Supabase user is created and
+    the trial is tracked locally (legacy path).
+    """
+
+    email: EmailStr = Field(
+        ...,
+        description="User email (must be valid format, max 320 chars)",
+        max_length=320,
+    )
+    password: str = Field(
+        ...,
+        min_length=8,
+        max_length=200,
+        description="Password (min 8 chars — Supabase enforces complexity)",
+    )
+    stripe_payment_method_id: Optional[str] = Field(
+        default=None,
+        max_length=255,
+        pattern=r"^pm_[A-Za-z0-9_]+$",
+        description="Stripe PaymentMethod ID (pm_...) from frontend PaymentElement",
+    )
+    full_name: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Optional display name, propagated to profiles.full_name",
+    )
+    company: Optional[str] = Field(
+        default=None,
+        max_length=200,
+        description="Optional company name, stored in profiles.company",
+    )
+
+
+class SignupResponse(BaseModel):
+    """Response body for POST /v1/auth/signup (STORY-CONV-003a AC3)."""
+
+    user_id: str = Field(..., description="Supabase auth.users.id UUID")
+    email: EmailStr = Field(..., description="Confirmed user email")
+    trial_end_ts: Optional[int] = Field(
+        default=None,
+        description=(
+            "Unix epoch seconds when trial ends. Sourced from Stripe when "
+            "subscription created; otherwise computed locally (now + 14d)."
+        ),
+    )
+    stripe_customer_id: Optional[str] = Field(
+        default=None,
+        description="Stripe Customer ID (cus_...) if card was attached",
+    )
+    stripe_subscription_id: Optional[str] = Field(
+        default=None,
+        description="Stripe Subscription ID (sub_...) if card was attached",
+    )
+    subscription_status: str = Field(
+        default="trialing",
+        description="Subscription status: trialing | free_trial | payment_failed",
+    )
+    requires_email_confirmation: bool = Field(
+        default=True,
+        description="Whether Supabase requires email confirmation before login",
+    )

--- a/backend/services/stripe_signup.py
+++ b/backend/services/stripe_signup.py
@@ -1,0 +1,256 @@
+"""Stripe integration for signup flow (STORY-CONV-003a AC1).
+
+Encapsulates the "cartão obrigatório no trial" path:
+
+1. Create Stripe Customer for the new user.
+2. Attach the PaymentMethod coming from the frontend PaymentElement.
+3. Set it as the Customer's default invoice payment method.
+4. Create a Subscription with `trial_period_days=14` and
+   `default_payment_method=pm_id` so Stripe auto-charges at trial end.
+
+All Stripe calls use idempotency keys derived from `signup-{email}-{utc_date}`
+to keep retries safe. The service does **not** touch Supabase — the caller
+(route) is responsible for persisting `stripe_customer_id`,
+`stripe_subscription_id`, `stripe_default_pm_id` on the `profiles` row.
+
+Failure policy (AC2 line 33): callers MUST catch `StripeSignupError` and
+still let the user log in — trial is tracked locally via the 14-day grace
+period, and billing reconciliation (STORY-314) can retry later.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional, TypedDict
+
+import stripe
+
+logger = logging.getLogger(__name__)
+
+
+class StripeSignupError(Exception):
+    """Raised when any Stripe signup step fails.
+
+    The route handler catches this and returns a 200 signup response with
+    `stripe_customer_id=None` so the user can still access the app during
+    the grace period.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        step: str,
+        stripe_code: Optional[str] = None,
+        customer_id: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.step = step
+        self.stripe_code = stripe_code
+        self.customer_id = customer_id
+
+
+class SignupStripeResult(TypedDict):
+    """Return shape from `create_customer_and_subscription`."""
+
+    customer_id: str
+    subscription_id: str
+    trial_end_ts: Optional[int]
+    default_pm_id: str
+
+
+def _build_idempotency_key(email: str, step: str) -> str:
+    """Generate a deterministic idempotency key.
+
+    Format: ``signup-{step}-{email_lower}-{utc_date}``.
+    Stripe accepts up to 255 chars — email-derived keys stay well under that.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return f"signup-{step}-{email.strip().lower()}-{today}"
+
+
+def _require_api_key() -> str:
+    """Fetch the Stripe secret key from env or raise."""
+    api_key = os.getenv("STRIPE_SECRET_KEY")
+    if not api_key:
+        raise StripeSignupError(
+            "STRIPE_SECRET_KEY not configured",
+            step="config",
+        )
+    return api_key
+
+
+def _require_price_id() -> str:
+    """Fetch the Stripe price id for SmartLic Pro trial subscription."""
+    price_id = (
+        os.getenv("STRIPE_SMARTLIC_PRO_PRICE_ID")
+        or os.getenv("STRIPE_PRICE_ID_SMARTLIC_PRO_MONTHLY")
+    )
+    if not price_id:
+        raise StripeSignupError(
+            "STRIPE_SMARTLIC_PRO_PRICE_ID not configured",
+            step="config",
+        )
+    return price_id
+
+
+def create_customer_and_subscription(
+    email: str,
+    payment_method_id: str,
+    *,
+    trial_period_days: int = 14,
+    user_id: Optional[str] = None,
+) -> SignupStripeResult:
+    """Run the full Stripe signup dance and return identifiers.
+
+    Steps (each idempotency-keyed):
+
+    1. `stripe.Customer.create(email=email, payment_method=pm_id, invoice_settings=...)`
+    2. `stripe.PaymentMethod.attach(pm_id, customer=cus_id)`
+    3. `stripe.Customer.modify(cus_id, invoice_settings.default_payment_method=pm_id)`
+    4. `stripe.Subscription.create(..., trial_period_days=14, default_payment_method=pm_id)`
+
+    Args:
+        email: New user's email (becomes Stripe Customer.email).
+        payment_method_id: Stripe PaymentMethod ID (`pm_...`) collected from
+            the frontend PaymentElement.
+        trial_period_days: Free trial length. Defaults to 14 per AC1.
+        user_id: Optional Supabase user id, stored in Customer metadata.
+
+    Returns:
+        SignupStripeResult with `customer_id`, `subscription_id`,
+        `trial_end_ts` (Unix seconds; may be None if Stripe omits it), and
+        `default_pm_id`.
+
+    Raises:
+        StripeSignupError: on any Stripe failure. Inspect `.step` and
+            `.stripe_code` to classify — the route should fail open (create
+            user but skip subscription) when this fires.
+    """
+
+    if not payment_method_id or not payment_method_id.startswith("pm_"):
+        raise StripeSignupError(
+            f"Invalid payment_method_id: {payment_method_id!r}",
+            step="validate",
+        )
+
+    api_key = _require_api_key()
+    price_id = _require_price_id()
+
+    # 1. Create the Customer (idempotent by email+date).
+    try:
+        customer = stripe.Customer.create(
+            email=email,
+            metadata={"user_id": user_id} if user_id else {},
+            api_key=api_key,
+            idempotency_key=_build_idempotency_key(email, "customer"),
+        )
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "Stripe customer creation failed: email=%s*** code=%s",
+            email[:3],
+            getattr(exc, "code", None),
+        )
+        raise StripeSignupError(
+            f"Failed to create Stripe customer: {exc}",
+            step="customer_create",
+            stripe_code=getattr(exc, "code", None),
+        ) from exc
+
+    customer_id = customer["id"] if isinstance(customer, dict) else customer.id
+
+    # 2. Attach PM to the customer.
+    try:
+        stripe.PaymentMethod.attach(
+            payment_method_id,
+            customer=customer_id,
+            api_key=api_key,
+            idempotency_key=_build_idempotency_key(email, "pm_attach"),
+        )
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "Stripe PM attach failed: customer=%s*** pm=%s*** code=%s",
+            customer_id[:6],
+            payment_method_id[:6],
+            getattr(exc, "code", None),
+        )
+        raise StripeSignupError(
+            f"Failed to attach payment method: {exc}",
+            step="pm_attach",
+            stripe_code=getattr(exc, "code", None),
+            customer_id=customer_id,
+        ) from exc
+
+    # 3. Set as default PM on the customer (for invoice charges post-trial).
+    try:
+        stripe.Customer.modify(
+            customer_id,
+            invoice_settings={"default_payment_method": payment_method_id},
+            api_key=api_key,
+            idempotency_key=_build_idempotency_key(email, "customer_default_pm"),
+        )
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "Stripe customer default-PM modify failed: customer=%s*** code=%s",
+            customer_id[:6],
+            getattr(exc, "code", None),
+        )
+        raise StripeSignupError(
+            f"Failed to set default payment method: {exc}",
+            step="customer_default_pm",
+            stripe_code=getattr(exc, "code", None),
+            customer_id=customer_id,
+        ) from exc
+
+    # 4. Create the Subscription with trial.
+    try:
+        subscription = stripe.Subscription.create(
+            customer=customer_id,
+            items=[{"price": price_id}],
+            trial_period_days=trial_period_days,
+            default_payment_method=payment_method_id,
+            metadata={
+                "plan_id": "smartlic_pro",
+                "source": "signup_with_card",
+                "user_id": user_id or "",
+            },
+            api_key=api_key,
+            idempotency_key=_build_idempotency_key(email, "subscription"),
+        )
+    except stripe.error.StripeError as exc:
+        logger.error(
+            "Stripe subscription create failed: customer=%s*** code=%s",
+            customer_id[:6],
+            getattr(exc, "code", None),
+        )
+        raise StripeSignupError(
+            f"Failed to create subscription: {exc}",
+            step="subscription_create",
+            stripe_code=getattr(exc, "code", None),
+            customer_id=customer_id,
+        ) from exc
+
+    subscription_id = (
+        subscription["id"] if isinstance(subscription, dict) else subscription.id
+    )
+    trial_end_ts = (
+        subscription.get("trial_end")
+        if isinstance(subscription, dict)
+        else getattr(subscription, "trial_end", None)
+    )
+
+    logger.info(
+        "Stripe signup successful: customer=%s*** subscription=%s*** trial_end=%s",
+        customer_id[:6],
+        subscription_id[:6],
+        trial_end_ts,
+    )
+
+    return SignupStripeResult(
+        customer_id=customer_id,
+        subscription_id=subscription_id,
+        trial_end_ts=int(trial_end_ts) if trial_end_ts else None,
+        default_pm_id=payment_method_id,
+    )

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -23,6 +23,7 @@ from routes.emails import router as emails_router
 from routes.pipeline import router as pipeline_router
 from routes.onboarding import router as onboarding_router
 from routes.auth_email import router as auth_email_router
+from routes.auth_signup import router as auth_signup_router
 from routes.health import router as cache_health_router
 from routes.health_core import router as health_core_router
 from routes.feedback import router as feedback_router
@@ -76,6 +77,7 @@ _v1_routers = [
     analytics_router, oauth_router, export_sheets_router,
     search_router, user_router, billing_router, sessions_router, plans_router,
     emails_router, pipeline_router, onboarding_router, auth_email_router,
+    auth_signup_router,
     cache_health_router, feedback_router, auth_check_router, bid_analysis_router,
     alerts_router, trial_emails_router, mfa_router, org_router, partners_router,
     sectors_public_router, reports_router, blog_stats_router, metrics_api_router,

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -8984,6 +8984,141 @@
         "title": "SharedAnalisePublic",
         "type": "object"
       },
+      "SignupRequest": {
+        "description": "Request body for POST /v1/auth/signup (STORY-CONV-003a AC1).\n\n`stripe_payment_method_id` is optional during rollout \u2014 when present, the\nbackend creates a Stripe Customer + Subscription with 14-day trial and\nattaches the PaymentMethod. When absent, a Supabase user is created and\nthe trial is tracked locally (legacy path).",
+        "properties": {
+          "company": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional company name, stored in profiles.company",
+            "title": "Company"
+          },
+          "email": {
+            "description": "User email (must be valid format, max 320 chars)",
+            "format": "email",
+            "maxLength": 320,
+            "title": "Email",
+            "type": "string"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional display name, propagated to profiles.full_name",
+            "title": "Full Name"
+          },
+          "password": {
+            "description": "Password (min 8 chars \u2014 Supabase enforces complexity)",
+            "maxLength": 200,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string"
+          },
+          "stripe_payment_method_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "pattern": "^pm_[A-Za-z0-9_]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stripe PaymentMethod ID (pm_...) from frontend PaymentElement",
+            "title": "Stripe Payment Method Id"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "SignupRequest",
+        "type": "object"
+      },
+      "SignupResponse": {
+        "description": "Response body for POST /v1/auth/signup (STORY-CONV-003a AC3).",
+        "properties": {
+          "email": {
+            "description": "Confirmed user email",
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "requires_email_confirmation": {
+            "default": true,
+            "description": "Whether Supabase requires email confirmation before login",
+            "title": "Requires Email Confirmation",
+            "type": "boolean"
+          },
+          "stripe_customer_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stripe Customer ID (cus_...) if card was attached",
+            "title": "Stripe Customer Id"
+          },
+          "stripe_subscription_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stripe Subscription ID (sub_...) if card was attached",
+            "title": "Stripe Subscription Id"
+          },
+          "subscription_status": {
+            "default": "trialing",
+            "description": "Subscription status: trialing | free_trial | payment_failed",
+            "title": "Subscription Status",
+            "type": "string"
+          },
+          "trial_end_ts": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Unix epoch seconds when trial ends. Sourced from Stripe when subscription created; otherwise computed locally (now + 14d).",
+            "title": "Trial End Ts"
+          },
+          "user_id": {
+            "description": "Supabase auth.users.id UUID",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "email"
+        ],
+        "title": "SignupResponse",
+        "type": "object"
+      },
       "SitemapCnpjsResponse": {
         "properties": {
           "cnpjs": {
@@ -13987,6 +14122,48 @@
         "summary": "Resend Confirmation",
         "tags": [
           "auth-email"
+        ]
+      }
+    },
+    "/v1/auth/signup": {
+      "post": {
+        "description": "STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.\n\nReturns 200 with `SignupResponse`. Error modes:\n\n- 400: disposable email domain or weak password.\n- 400: invalid `stripe_payment_method_id` shape (Pydantic regex).\n- 409: email already registered (detected via Supabase error).\n- 500: Supabase auth.create_user failed (NOT Stripe \u2014 Stripe fails open).",
+        "operationId": "signup_v1_auth_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignupResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Signup",
+        "tags": [
+          "auth-signup"
         ]
       }
     },

--- a/backend/tests/test_signup_with_card.py
+++ b/backend/tests/test_signup_with_card.py
@@ -1,0 +1,433 @@
+"""STORY-CONV-003a AC5: POST /v1/auth/signup — tests with Stripe PM.
+
+Mock targets:
+    - `services.stripe_signup.stripe` for Stripe SDK calls.
+    - `routes.auth_signup.get_supabase` is monkey-patched via the module's
+      `_get_supabase` helper (patch `routes.auth_signup._get_supabase`).
+    - `audit.log_audit_event` is injected by the autouse fixture below
+      (mirrors tests/test_auth_signup_ratelimit.py pattern).
+
+These tests NEVER hit real Stripe — all `stripe.Customer.create`,
+`stripe.PaymentMethod.attach`, `stripe.Customer.modify`,
+`stripe.Subscription.create` calls are patched.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Eagerly import the module so `patch("routes.auth_signup.X")` resolves.
+import routes.auth_signup as _auth_signup_module  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _mock_audit():
+    """Inject audit.log_audit_event if missing (matches rate-limit tests)."""
+    import audit
+
+    if not hasattr(audit, "log_audit_event"):
+        audit.log_audit_event = lambda **kwargs: None
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _stripe_env():
+    """Provide Stripe env vars so service doesn't early-abort."""
+    with patch.dict(
+        os.environ,
+        {
+            "STRIPE_SECRET_KEY": "sk_test_signup_xxx",
+            "STRIPE_SMARTLIC_PRO_PRICE_ID": "price_test_pro_monthly",
+        },
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_rate_limit():
+    """Default: rate limiter allows all requests (tests don't exercise limits)."""
+    async def _allow(key, max_req, window):
+        return (True, 0)
+
+    with patch("rate_limiter._flexible_limiter") as mock_limiter, \
+         patch("config.get_feature_flag", return_value=False):
+        mock_limiter.check_rate_limit = AsyncMock(side_effect=_allow)
+        yield
+
+
+class _FakeChain:
+    """Minimal chainable Supabase mock that records updates."""
+
+    def __init__(self, sink):
+        self.sink = sink
+
+    def update(self, payload):
+        self.sink["update_payload"] = payload
+        return self
+
+    def eq(self, *a, **kw):
+        self.sink.setdefault("eq_calls", []).append((a, kw))
+        return self
+
+    def execute(self):
+        self.sink["executed"] = True
+        return SimpleNamespace(data=[])
+
+
+def _make_supabase(user_id: str = "usr-uuid-1", raise_on_create: Exception | None = None):
+    """Build a Supabase client mock with auth.admin.create_user + table().update."""
+    sb = MagicMock()
+    profile_sink: dict = {}
+
+    # auth.admin.create_user
+    if raise_on_create is not None:
+        sb.auth.admin.create_user.side_effect = raise_on_create
+    else:
+        created_user = SimpleNamespace(id=user_id, email="placeholder")
+        sb.auth.admin.create_user.return_value = SimpleNamespace(user=created_user)
+
+    # table().update().eq().execute()
+    sb.table.return_value = _FakeChain(profile_sink)
+    sb._profile_sink = profile_sink
+    return sb
+
+
+def _make_app():
+    from routes.auth_signup import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/v1")
+    return app
+
+
+def _stripe_obj(**kwargs):
+    """Dict-with-attr-access (matches real Stripe SDK objects)."""
+
+    class _O(dict):
+        def __getattr__(self, name):
+            try:
+                return self[name]
+            except KeyError:
+                raise AttributeError(name)
+
+    return _O(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Happy path: PM + Stripe succeeds
+# ---------------------------------------------------------------------------
+
+class TestSignupWithValidPM:
+    """AC1+AC2+AC3: PM provided → Stripe Customer + Subscription created."""
+
+    def test_creates_customer_and_subscription(self):
+        sb = _make_supabase(user_id="usr-001")
+
+        with patch("routes.auth_signup._get_supabase", return_value=sb), \
+             patch("services.stripe_signup.stripe") as mock_stripe:
+
+            mock_stripe.Customer.create.return_value = _stripe_obj(id="cus_test_001")
+            mock_stripe.PaymentMethod.attach.return_value = _stripe_obj(id="pm_test_001")
+            mock_stripe.Customer.modify.return_value = _stripe_obj(id="cus_test_001")
+            mock_stripe.Subscription.create.return_value = _stripe_obj(
+                id="sub_test_001",
+                trial_end=1_800_000_000,
+            )
+            # Real class for exception catching
+            import stripe as stripe_real
+            mock_stripe.error = stripe_real.error
+
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "newuser@company.com",
+                        "password": "Abcd1234!",
+                        "stripe_payment_method_id": "pm_test_001",
+                    },
+                )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["user_id"] == "usr-001"
+        assert body["email"] == "newuser@company.com"
+        assert body["stripe_customer_id"] == "cus_test_001"
+        assert body["stripe_subscription_id"] == "sub_test_001"
+        assert body["trial_end_ts"] == 1_800_000_000
+        assert body["subscription_status"] == "trialing"
+
+        # Profile update should have persisted Stripe ids.
+        payload = sb._profile_sink["update_payload"]
+        assert payload["stripe_customer_id"] == "cus_test_001"
+        assert payload["stripe_subscription_id"] == "sub_test_001"
+        assert payload["stripe_default_pm_id"] == "pm_test_001"
+        assert payload["subscription_status"] == "trialing"
+
+    def test_idempotency_keys_are_set_per_step(self):
+        """AC1: every Stripe call must carry a deterministic idempotency key."""
+        sb = _make_supabase(user_id="usr-002")
+
+        with patch("routes.auth_signup._get_supabase", return_value=sb), \
+             patch("services.stripe_signup.stripe") as mock_stripe:
+
+            mock_stripe.Customer.create.return_value = _stripe_obj(id="cus_002")
+            mock_stripe.PaymentMethod.attach.return_value = _stripe_obj(id="pm_002")
+            mock_stripe.Customer.modify.return_value = _stripe_obj(id="cus_002")
+            mock_stripe.Subscription.create.return_value = _stripe_obj(
+                id="sub_002",
+                trial_end=1_810_000_000,
+            )
+            import stripe as stripe_real
+            mock_stripe.error = stripe_real.error
+
+            with TestClient(_make_app()) as client:
+                client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "idem@company.com",
+                        "password": "Abcd1234!",
+                        "stripe_payment_method_id": "pm_002",
+                    },
+                )
+
+        # All four Stripe mutations must receive idempotency_key kwargs.
+        for call_name, call_obj in [
+            ("Customer.create", mock_stripe.Customer.create),
+            ("PaymentMethod.attach", mock_stripe.PaymentMethod.attach),
+            ("Customer.modify", mock_stripe.Customer.modify),
+            ("Subscription.create", mock_stripe.Subscription.create),
+        ]:
+            assert call_obj.called, f"{call_name} must be called"
+            _, kwargs = call_obj.call_args
+            assert "idempotency_key" in kwargs, f"{call_name} missing idempotency_key"
+            assert "signup-" in kwargs["idempotency_key"]
+            assert "idem@company.com" in kwargs["idempotency_key"]
+
+
+# ---------------------------------------------------------------------------
+# Legacy path: no PM → user created, local trial
+# ---------------------------------------------------------------------------
+
+class TestSignupWithoutPM:
+    """AC2 fallback: legacy trial path (no card required)."""
+
+    def test_creates_user_only_and_returns_local_trial_end(self):
+        sb = _make_supabase(user_id="usr-legacy-1")
+
+        with patch("routes.auth_signup._get_supabase", return_value=sb), \
+             patch("services.stripe_signup.stripe") as mock_stripe:
+            # mock_stripe must still exist but must NOT be called.
+            import stripe as stripe_real
+            mock_stripe.error = stripe_real.error
+
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "legacy@company.com",
+                        "password": "Abcd1234!",
+                        # stripe_payment_method_id omitted
+                    },
+                )
+
+            assert mock_stripe.Customer.create.call_count == 0
+            assert mock_stripe.Subscription.create.call_count == 0
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["user_id"] == "usr-legacy-1"
+        assert body["stripe_customer_id"] is None
+        assert body["stripe_subscription_id"] is None
+        assert body["subscription_status"] == "free_trial"
+        assert body["trial_end_ts"] is not None  # local +14d
+        # ~14d window is 14*86400 = 1_209_600 seconds; loose upper bound.
+        import time
+        assert body["trial_end_ts"] > int(time.time())
+        assert body["trial_end_ts"] < int(time.time()) + 15 * 86400
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+class TestSignupFailureModes:
+    """AC5 failure modes."""
+
+    def test_invalid_pm_shape_returns_422(self):
+        """Pydantic regex rejects non-`pm_` ids at the boundary (422)."""
+        sb = _make_supabase()
+        with patch("routes.auth_signup._get_supabase", return_value=sb):
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "bad@company.com",
+                        "password": "Abcd1234!",
+                        "stripe_payment_method_id": "not_a_real_pm_id",
+                    },
+                )
+        assert resp.status_code == 422
+
+    def test_weak_password_returns_400(self):
+        sb = _make_supabase()
+        with patch("routes.auth_signup._get_supabase", return_value=sb):
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={"email": "weak@company.com", "password": "Abcdefgh"},
+                )
+        # weak password returns 400 from validate_password (service-level)
+        assert resp.status_code == 400
+
+    def test_duplicate_email_returns_409(self):
+        """Supabase create_user raises "user already exists" → 409."""
+        sb = _make_supabase(raise_on_create=Exception("User already registered"))
+        with patch("routes.auth_signup._get_supabase", return_value=sb):
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={"email": "dup@company.com", "password": "Abcd1234!"},
+                )
+        assert resp.status_code == 409
+
+    def test_stripe_timeout_fails_open_marks_payment_failed(self):
+        """AC2 line 33: Stripe failure after user → 200 with payment_failed."""
+        sb = _make_supabase(user_id="usr-timeout-1")
+
+        with patch("routes.auth_signup._get_supabase", return_value=sb), \
+             patch("services.stripe_signup.stripe") as mock_stripe:
+
+            import stripe as stripe_real
+            mock_stripe.error = stripe_real.error
+            # Customer.create succeeds — so exc.customer_id should be set.
+            mock_stripe.Customer.create.return_value = _stripe_obj(id="cus_to_001")
+            # PaymentMethod.attach raises Stripe timeout.
+            mock_stripe.PaymentMethod.attach.side_effect = stripe_real.error.APIConnectionError(
+                "timeout contacting Stripe"
+            )
+
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "timeout@company.com",
+                        "password": "Abcd1234!",
+                        "stripe_payment_method_id": "pm_to_001",
+                    },
+                )
+
+        # Signup still succeeds — user can log in during grace period.
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["user_id"] == "usr-timeout-1"
+        assert body["stripe_subscription_id"] is None
+        assert body["subscription_status"] == "payment_failed"
+        # customer_id captured from the successful first step
+        assert body["stripe_customer_id"] == "cus_to_001"
+
+        # Profile was marked for recon.
+        payload = sb._profile_sink["update_payload"]
+        assert payload["subscription_status"] == "payment_failed"
+
+    def test_stripe_card_declined_fails_open(self):
+        """card_declined on Subscription.create → 200 payment_failed."""
+        sb = _make_supabase(user_id="usr-cd-1")
+
+        with patch("routes.auth_signup._get_supabase", return_value=sb), \
+             patch("services.stripe_signup.stripe") as mock_stripe:
+
+            import stripe as stripe_real
+            mock_stripe.error = stripe_real.error
+            mock_stripe.Customer.create.return_value = _stripe_obj(id="cus_cd_1")
+            mock_stripe.PaymentMethod.attach.return_value = _stripe_obj(id="pm_cd_1")
+            mock_stripe.Customer.modify.return_value = _stripe_obj(id="cus_cd_1")
+            mock_stripe.Subscription.create.side_effect = stripe_real.error.CardError(
+                "Your card was declined.", param="card", code="card_declined"
+            )
+
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "cd@company.com",
+                        "password": "Abcd1234!",
+                        "stripe_payment_method_id": "pm_cd_1",
+                    },
+                )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["subscription_status"] == "payment_failed"
+        assert body["stripe_subscription_id"] is None
+
+    def test_disposable_email_returns_400(self):
+        """MED-SEC-001: disposable domain blocked even for signup endpoint."""
+        sb = _make_supabase()
+        with patch("routes.auth_signup._get_supabase", return_value=sb), \
+             patch("routes.auth_signup.is_disposable_email", return_value=True):
+            with TestClient(_make_app()) as client:
+                resp = client.post(
+                    "/v1/auth/signup",
+                    json={
+                        "email": "trash@mailinator.com",
+                        "password": "Abcd1234!",
+                    },
+                )
+        assert resp.status_code == 400
+        assert "email" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Service-level tests (no FastAPI) for idempotency-key format
+# ---------------------------------------------------------------------------
+
+class TestStripeSignupService:
+    """Direct coverage of `services/stripe_signup.py` helpers."""
+
+    def test_missing_secret_key_raises(self):
+        from services.stripe_signup import (
+            StripeSignupError,
+            create_customer_and_subscription,
+        )
+        with patch.dict(os.environ, {"STRIPE_SECRET_KEY": ""}, clear=False):
+            # Explicitly remove so env helper sees absence.
+            os.environ.pop("STRIPE_SECRET_KEY", None)
+            with pytest.raises(StripeSignupError) as ei:
+                create_customer_and_subscription(
+                    email="nokey@company.com",
+                    payment_method_id="pm_nokey_1",
+                )
+            assert ei.value.step == "config"
+
+    def test_invalid_pm_prefix_raises_validate_step(self):
+        from services.stripe_signup import (
+            StripeSignupError,
+            create_customer_and_subscription,
+        )
+        with pytest.raises(StripeSignupError) as ei:
+            create_customer_and_subscription(
+                email="noprefix@company.com",
+                payment_method_id="garbage_id",
+            )
+        assert ei.value.step == "validate"
+
+    def test_idempotency_key_is_stable_for_same_email_same_day(self):
+        from services.stripe_signup import _build_idempotency_key
+
+        k1 = _build_idempotency_key("User@Company.COM", "customer")
+        k2 = _build_idempotency_key("user@company.com", "customer")
+        # Case-insensitive email normalization.
+        assert k1 == k2
+        assert k1.startswith("signup-customer-")
+        assert "user@company.com" in k1

--- a/backend/webhooks/handlers/subscription.py
+++ b/backend/webhooks/handlers/subscription.py
@@ -294,6 +294,88 @@ async def handle_subscription_deleted(sb, event: stripe.Event) -> None:
     _send_cancellation_email(sb, user_id, local_sub)
 
 
+async def handle_subscription_trial_will_end(sb, event: stripe.Event) -> None:
+    """
+    Handle customer.subscription.trial_will_end event (STORY-CONV-003a AC4).
+
+    Stripe fires this 3 days before trial_end. Used to:
+    - Dedup via Redis (7-day TTL) against duplicate Stripe retries
+    - Emit Sentry breadcrumb for observability
+    - Log a structured event; email/notification is a future story
+
+    Never raises — webhook acks must be idempotent. Non-fatal errors logged.
+    """
+    event_id = getattr(event, "id", None) or event.get("id", "unknown")
+    subscription_data = event.data.object
+    stripe_sub_id = (
+        subscription_data.get("id")
+        if isinstance(subscription_data, dict)
+        else subscription_data.id
+    )
+    stripe_customer_id = (
+        subscription_data.get("customer")
+        if isinstance(subscription_data, dict)
+        else getattr(subscription_data, "customer", None)
+    )
+
+    # Redis dedup (7-day TTL) — best-effort. If Redis is down, proceed anyway:
+    # duplicate handling is safe (log + breadcrumb only, no side effects).
+    try:
+        from redis_pool import get_redis_pool
+
+        redis = await get_redis_pool()
+        dedup_key = f"trial_will_end:{event_id}"
+        existing = await redis.get(dedup_key)
+        if existing:
+            logger.info(
+                f"trial_will_end already processed: event_id={event_id[:16]}***"
+            )
+            return
+        await redis.setex(dedup_key, _TRIAL_WILL_END_DEDUP_TTL_S, "1")
+    except Exception:
+        logger.warning(
+            "Redis dedup check failed for trial_will_end — proceeding", exc_info=True
+        )
+
+    # Resolve local user_id for logs/breadcrumb
+    user_id: str = ""
+    try:
+        sub_result = (
+            sb.table("user_subscriptions")
+            .select("user_id")
+            .eq("stripe_subscription_id", stripe_sub_id)
+            .limit(1)
+            .execute()
+        )
+        if sub_result.data:
+            user_id = sub_result.data[0]["user_id"]
+    except Exception:
+        logger.debug("user_subscriptions lookup failed (non-fatal)", exc_info=True)
+
+    logger.info(
+        "Trial ending in 3 days: subscription_id=%s, customer_id=%s, user_id=%s",
+        (stripe_sub_id or "")[:16] + "***",
+        (stripe_customer_id or "")[:8] + "***" if stripe_customer_id else "unknown",
+        (user_id or "unknown")[:8] + ("***" if user_id else ""),
+    )
+
+    # Sentry breadcrumb — best-effort, never raises.
+    try:
+        import sentry_sdk
+
+        sentry_sdk.add_breadcrumb(
+            category="billing",
+            message="customer.subscription.trial_will_end",
+            level="info",
+            data={
+                "subscription_id": (stripe_sub_id or "")[:16] + "***",
+                "user_id": (user_id or "unknown")[:8] + ("***" if user_id else ""),
+            },
+        )
+    except Exception:
+        pass
+
+
 # ============================================================================
 # Helpers (fire-and-forget)
 # ============================================================================

--- a/backend/webhooks/handlers/subscription.py
+++ b/backend/webhooks/handlers/subscription.py
@@ -2,8 +2,10 @@
 Subscription webhook handlers.
 
 Events:
+- customer.subscription.created
 - customer.subscription.updated
 - customer.subscription.deleted
+- customer.subscription.trial_will_end (STORY-CONV-003a AC4)
 """
 
 import stripe
@@ -12,6 +14,10 @@ from log_sanitizer import get_sanitized_logger
 from webhooks.handlers._shared import invalidate_user_caches
 
 logger = get_sanitized_logger(__name__)
+
+
+# STORY-CONV-003a AC4: Redis dedup TTL for trial_will_end events (7 days).
+_TRIAL_WILL_END_DEDUP_TTL_S = 7 * 24 * 3600
 
 
 async def handle_subscription_updated(sb, event: stripe.Event) -> None:

--- a/backend/webhooks/stripe.py
+++ b/backend/webhooks/stripe.py
@@ -46,6 +46,7 @@ from webhooks.handlers.subscription import (  # noqa: F401
     handle_subscription_created as _handle_subscription_created,
     handle_subscription_updated as _handle_subscription_updated,
     handle_subscription_deleted as _handle_subscription_deleted,
+    handle_subscription_trial_will_end as _handle_subscription_trial_will_end,
     _mark_partner_referral_churned,
     _send_cancellation_email,
 )
@@ -197,6 +198,9 @@ async def stripe_webhook(request: Request):
                 await _handle_subscription_updated(sb, event)
             elif event.type == "customer.subscription.deleted":
                 await _handle_subscription_deleted(sb, event)
+            elif event.type == "customer.subscription.trial_will_end":
+                # STORY-CONV-003a AC4: Stripe fires 3d before trial_end.
+                await _handle_subscription_trial_will_end(sb, event)
             elif event.type == "invoice.payment_succeeded":
                 await _handle_invoice_payment_succeeded(sb, event)
             elif event.type == "invoice.payment_failed":

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -1761,6 +1761,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/auth/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Signup
+         * @description STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.
+         *
+         *     Returns 200 with `SignupResponse`. Error modes:
+         *
+         *     - 400: disposable email domain or weak password.
+         *     - 400: invalid `stripe_payment_method_id` shape (Pydantic regex).
+         *     - 409: email already registered (detected via Supabase error).
+         *     - 500: Supabase auth.create_user failed (NOT Stripe — Stripe fails open).
+         */
+        post: operations["signup_v1_auth_signup_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/auth/status": {
         parameters: {
             query?: never;
@@ -2622,6 +2649,30 @@ export interface paths {
         get: operations["fornecedores_stats_v1_fornecedores__setor___uf__stats_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Founding Checkout
+         * @description Create a founding-customer Stripe Checkout Session with FOUNDING30 applied.
+         *
+         *     Side effects:
+         *     - Inserts a `founding_leads` row with `checkout_status='pending'`.
+         *     - Later webhook events (`checkout.session.completed` / `expired`) update it.
+         */
+        post: operations["founding_checkout_v1_founding_checkout_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6780,6 +6831,26 @@ export interface components {
             /** Uf */
             uf: string;
         };
+        /** FoundingCheckoutRequest */
+        FoundingCheckoutRequest: {
+            /** Cnpj */
+            cnpj: string;
+            /** Email */
+            email: string;
+            /** Motivo */
+            motivo: string;
+            /** Nome */
+            nome: string;
+            /** Razao Social */
+            razao_social?: string | null;
+        };
+        /** FoundingCheckoutResponse */
+        FoundingCheckoutResponse: {
+            /** Checkout Url */
+            checkout_url: string;
+            /** Lead Id */
+            lead_id: string;
+        };
         /**
          * GoogleSheetsExportHistory
          * @description Schema for individual export history entry.
@@ -8592,6 +8663,87 @@ export interface components {
              * @default 0
              */
             view_count: number;
+        };
+        /**
+         * SignupRequest
+         * @description Request body for POST /v1/auth/signup (STORY-CONV-003a AC1).
+         *
+         *     `stripe_payment_method_id` is optional during rollout — when present, the
+         *     backend creates a Stripe Customer + Subscription with 14-day trial and
+         *     attaches the PaymentMethod. When absent, a Supabase user is created and
+         *     the trial is tracked locally (legacy path).
+         */
+        SignupRequest: {
+            /**
+             * Company
+             * @description Optional company name, stored in profiles.company
+             */
+            company?: string | null;
+            /**
+             * Email
+             * Format: email
+             * @description User email (must be valid format, max 320 chars)
+             */
+            email: string;
+            /**
+             * Full Name
+             * @description Optional display name, propagated to profiles.full_name
+             */
+            full_name?: string | null;
+            /**
+             * Password
+             * @description Password (min 8 chars — Supabase enforces complexity)
+             */
+            password: string;
+            /**
+             * Stripe Payment Method Id
+             * @description Stripe PaymentMethod ID (pm_...) from frontend PaymentElement
+             */
+            stripe_payment_method_id?: string | null;
+        };
+        /**
+         * SignupResponse
+         * @description Response body for POST /v1/auth/signup (STORY-CONV-003a AC3).
+         */
+        SignupResponse: {
+            /**
+             * Email
+             * Format: email
+             * @description Confirmed user email
+             */
+            email: string;
+            /**
+             * Requires Email Confirmation
+             * @description Whether Supabase requires email confirmation before login
+             * @default true
+             */
+            requires_email_confirmation: boolean;
+            /**
+             * Stripe Customer Id
+             * @description Stripe Customer ID (cus_...) if card was attached
+             */
+            stripe_customer_id?: string | null;
+            /**
+             * Stripe Subscription Id
+             * @description Stripe Subscription ID (sub_...) if card was attached
+             */
+            stripe_subscription_id?: string | null;
+            /**
+             * Subscription Status
+             * @description Subscription status: trialing | free_trial | payment_failed
+             * @default trialing
+             */
+            subscription_status: string;
+            /**
+             * Trial End Ts
+             * @description Unix epoch seconds when trial ends. Sourced from Stripe when subscription created; otherwise computed locally (now + 14d).
+             */
+            trial_end_ts?: number | null;
+            /**
+             * User Id
+             * @description Supabase auth.users.id UUID
+             */
+            user_id: string;
         };
         /** SitemapCnpjsResponse */
         SitemapCnpjsResponse: {
@@ -11471,6 +11623,39 @@ export interface operations {
             };
         };
     };
+    signup_v1_auth_signup_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignupRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     auth_status_v1_auth_status_get: {
         parameters: {
             query: {
@@ -12644,6 +12829,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FornecedoresStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_checkout_v1_founding_checkout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FoundingCheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingCheckoutResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

Ships backend side of the "cartão obrigatório no trial" conversion lever (STORY-CONV-003 AC1-AC5).

**Benchmark impact:** +170% trial→paid conversion (18% → 48% industry benchmark). This is the highest-ROI story in EPIC-REVENUE-2026-Q2.

## What's included

- `schemas/user.py`: new `SignupRequest` + `SignupResponse` with optional `stripe_payment_method_id` (`pm_...` regex) and `trial_end_ts` Unix seconds.
- `services/stripe_signup.py`: 4-step Stripe dance (Customer → PM attach → default PM → Subscription with `trial_period_days=14`). Every call carries a deterministic `idempotency_key` so retries are safe. All Stripe errors funnel into `StripeSignupError(step=..., stripe_code=...)`.
- `routes/auth_signup.py`: `POST /v1/auth/signup`. Disposable-email block + password complexity + rate limiter (`SIGNUP_RATE_LIMIT_PER_10MIN`). **Fails open** per AC2 line 33 — if Stripe errors after Supabase user exists, profile is marked `subscription_status='payment_failed'` and billing recon (STORY-314) retries later.
- `webhooks/handlers/subscription.py`: `handle_subscription_trial_will_end` with Redis dedup (7-day TTL) + Sentry breadcrumb + PII-safe log. Never raises.
- `webhooks/stripe.py`: dispatcher now routes `customer.subscription.trial_will_end` to the new handler.
- `tests/test_signup_with_card.py` (433 lines, 4 test classes): happy path with PM, legacy no-PM path, Stripe failure modes, idempotency key verification.

## Closes

- STORY-CONV-003 AC1 (schema + endpoint)
- STORY-CONV-003 AC2 (backend Stripe signup + fail-open)
- STORY-CONV-003 AC3 (response shape with trial_end_ts)
- STORY-CONV-003 AC4 (trial_will_end webhook handler wire-up)
- STORY-CONV-003 AC5 (test coverage — 10 test cases)

AC1 (frontend 2-step PaymentElement) and AC6+ (feature flag rollout, rollback doc) remain open — planned for next session.

## Dependencies

- **Blocked by PR #408** (CONV-003a scaffolding migration `profiles.stripe_default_pm_id`). Once #408 merges, rebase will drop the duplicate scaffolding commit automatically.

## Testing Plan

- [ ] CI Backend Tests (PR Gate) passa — main está vermelha hoje; este PR espera merge-train estabilizar
- [ ] `pytest backend/tests/test_signup_with_card.py --timeout=30 -xvs` local (4 test classes, ~10 test cases)
- [ ] Review humano de `services/stripe_signup.py` (idempotency keys) e `routes/auth_signup.py` (fail-open behavior)
- [ ] Staging smoke test: `curl -X POST https://api.smartlic.tech/v1/auth/signup -d '{"email":"test+signup@example.com","password":"Abcd1234!","stripe_payment_method_id":"pm_card_visa"}'`
- [ ] Validar webhook `customer.subscription.trial_will_end` via Stripe CLI: `stripe trigger customer.subscription.trial_will_end`

## Rollout notes

- `stripe_payment_method_id` é optional no Pydantic — rollout feature-flag gated no frontend (AC3), então o backend aceita requests sem card (legacy path) durante a fase A/B.
- "Fail to last known plan" preservado: errors em Supabase update durante signup são swallowed, billing recon decide o próximo passo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)