### PR TITLE
feat(conv-003c): AC3 welcome_to_pro + AC5 runbook + AC7 cancel frontend

### DIFF
--- a/backend/templates/emails/billing.py
+++ b/backend/templates/emails/billing.py
@@ -78,6 +78,87 @@ def render_payment_confirmation_email(
     )
 
 
+def render_welcome_to_pro_email(
+    user_name: str,
+    plan_name: str,
+    amount: str,
+    next_renewal_date: str,
+    billing_period: str = "mensal",
+) -> str:
+    """Render first-charge-after-trial welcome email (STORY-CONV-003c AC3).
+
+    Distinct from `render_payment_confirmation_email` (used for renewals):
+    celebrates the trial → paid conversion, reminds the user of key
+    features, and links to account/support. Prevents "confusion about why
+    I was charged" support tickets that typically drive chargebacks in
+    the first billing cycle post-trial.
+    """
+    body = f"""
+    <h1 style="color: {SMARTLIC_GREEN}; font-size: 22px; margin: 0 0 16px;">
+      Bem-vindo ao SmartLic Pro, {user_name}!
+    </h1>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Seu trial de 14 dias terminou e o primeiro pagamento foi processado.
+      Você agora tem acesso completo aos recursos do {plan_name}.
+    </p>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="background-color: #f8faf8; border-radius: 8px; border: 1px solid #e8f5e9; margin: 0 0 24px;">
+      <tr>
+        <td style="padding: 20px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="color: #888; font-size: 13px; padding: 6px 0;">Plano ativo</td>
+              <td align="right" style="color: #333; font-size: 15px; font-weight: 600; padding: 6px 0;">{plan_name}</td>
+            </tr>
+            <tr>
+              <td style="color: #888; font-size: 13px; padding: 6px 0;">Cobrança de hoje</td>
+              <td align="right" style="color: #333; font-size: 15px; font-weight: 600; padding: 6px 0;">{amount}</td>
+            </tr>
+            <tr>
+              <td style="color: #888; font-size: 13px; padding: 6px 0;">Periodicidade</td>
+              <td align="right" style="color: #333; font-size: 15px; padding: 6px 0;">{billing_period.capitalize()}</td>
+            </tr>
+            <tr>
+              <td style="color: #888; font-size: 13px; padding: 6px 0;">Próxima renovação</td>
+              <td align="right" style="color: #333; font-size: 15px; padding: 6px 0;">{next_renewal_date}</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+
+    <h2 style="color: #333; font-size: 18px; margin: 24px 0 12px;">O que você pode fazer agora</h2>
+    <ul style="color: #555; font-size: 15px; line-height: 1.7; margin: 0 0 20px; padding-left: 20px;">
+      <li>Buscas ilimitadas em PNCP + ComprasGov + PCP v2</li>
+      <li>Análise de viabilidade 4 fatores com IA</li>
+      <li>Pipeline Kanban de oportunidades</li>
+      <li>Relatórios Excel + resumo executivo</li>
+    </ul>
+
+    <p style="text-align: center; margin: 16px 0;">
+      <a href="{FRONTEND_URL}/buscar"
+         class="btn"
+         style="display: inline-block; padding: 14px 32px; background-color: {SMARTLIC_GREEN}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
+        Abrir SmartLic Pro
+      </a>
+    </p>
+
+    <p style="color: #888; font-size: 13px; line-height: 1.6; margin: 32px 0 0; text-align: center;">
+      Precisa de ajuda? Responda este email ou acesse
+      <a href="{FRONTEND_URL}/ajuda" style="color: {SMARTLIC_GREEN};">smartlic.tech/ajuda</a>.<br>
+      Gerencie assinatura em
+      <a href="{FRONTEND_URL}/conta" style="color: {SMARTLIC_GREEN};">smartlic.tech/conta</a>.
+    </p>
+    """
+
+    return email_base(
+        title=f"Bem-vindo ao SmartLic Pro — {plan_name}",
+        body_html=body,
+        is_transactional=True,
+    )
+
+
 def render_subscription_expiring_email(
     user_name: str,
     plan_name: str,

--- a/backend/tests/test_welcome_to_pro_email.py
+++ b/backend/tests/test_welcome_to_pro_email.py
@@ -1,0 +1,145 @@
+"""Tests for welcome_to_pro email (STORY-CONV-003c AC3).
+
+Asserts that:
+  - `render_welcome_to_pro_email` renders lifecycle-aware copy distinct
+    from the renewal template.
+  - `_send_payment_confirmation_email` branches on
+    `is_first_charge_after_trial` and dispatches the correct category
+    tag + subject.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestRenderWelcomeToPro:
+    def test_contains_trial_end_and_plan(self):
+        from templates.emails.billing import render_welcome_to_pro_email
+
+        html = render_welcome_to_pro_email(
+            user_name="Founder B2G",
+            plan_name="SmartLic Pro",
+            amount="R$ 397,00",
+            next_renewal_date="20/05/2026",
+            billing_period="mensal",
+        )
+
+        # Lifecycle-aware content:
+        assert "Bem-vindo ao SmartLic Pro" in html
+        assert "trial de 14 dias terminou" in html
+        assert "Founder B2G" in html
+        assert "R$ 397,00" in html
+        assert "20/05/2026" in html
+        assert "SmartLic Pro" in html
+        # Must link to account + support (reduces support tickets)
+        assert "/conta" in html
+        assert "/ajuda" in html
+
+    def test_distinguishable_from_renewal_template(self):
+        """Post-trial welcome must NOT just duplicate the generic renewal
+        confirmation copy — if they rendered the same, detecting
+        trial→paid conversion has no user-visible value."""
+        from templates.emails.billing import (
+            render_payment_confirmation_email,
+            render_welcome_to_pro_email,
+        )
+
+        renewal = render_payment_confirmation_email(
+            user_name="X",
+            plan_name="SmartLic Pro",
+            amount="R$ 397,00",
+            next_renewal_date="20/05/2026",
+        )
+        welcome = render_welcome_to_pro_email(
+            user_name="X",
+            plan_name="SmartLic Pro",
+            amount="R$ 397,00",
+            next_renewal_date="20/05/2026",
+        )
+        assert renewal != welcome
+        assert "Bem-vindo" in welcome
+        assert "Bem-vindo" not in renewal
+
+
+class TestInvoiceHandlerBranching:
+    """Verify _send_payment_confirmation_email chooses the right template
+    based on is_first_charge_after_trial."""
+
+    def test_trial_branch_uses_welcome_subject_and_tag(self):
+        from webhooks.handlers import invoice as invoice_module
+
+        sb = MagicMock()
+        profile_result = MagicMock()
+        profile_result.data = {"email": "a@b.com", "full_name": "A B"}
+        sb.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = profile_result
+
+        invoice_data = {
+            "amount_paid": 39700,
+            "lines": {"data": [{"plan": {"interval": "month", "interval_count": 1}}]},
+        }
+
+        with patch("email_service.send_email_async") as mock_send:
+            invoice_module._send_payment_confirmation_email(
+                sb,
+                user_id="u-1",
+                plan_id="smartlic_pro",
+                invoice_data=invoice_data,
+                new_expires="2026-05-04T00:00:00+00:00",
+                is_first_charge_after_trial=True,
+            )
+            mock_send.assert_called_once()
+            kwargs = mock_send.call_args.kwargs
+            assert "Bem-vindo ao SmartLic Pro" in kwargs["subject"]
+            assert kwargs["tags"] == [{"name": "category", "value": "welcome_to_pro"}]
+            assert "Bem-vindo" in kwargs["html"]
+
+    def test_renewal_branch_uses_generic_confirmation(self):
+        from webhooks.handlers import invoice as invoice_module
+
+        sb = MagicMock()
+        profile_result = MagicMock()
+        profile_result.data = {"email": "c@d.com", "full_name": "C D"}
+        sb.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = profile_result
+
+        invoice_data = {
+            "amount_paid": 39700,
+            "lines": {"data": [{"plan": {"interval": "month", "interval_count": 1}}]},
+        }
+
+        with patch("email_service.send_email_async") as mock_send:
+            invoice_module._send_payment_confirmation_email(
+                sb,
+                user_id="u-2",
+                plan_id="smartlic_pro",
+                invoice_data=invoice_data,
+                new_expires="2026-05-04T00:00:00+00:00",
+                is_first_charge_after_trial=False,
+            )
+            mock_send.assert_called_once()
+            kwargs = mock_send.call_args.kwargs
+            assert "Pagamento confirmado" in kwargs["subject"]
+            assert kwargs["tags"] == [{"name": "category", "value": "payment_confirmation"}]
+            # Must NOT include trial→paid copy on renewals
+            assert "trial de 14 dias terminou" not in kwargs["html"]
+
+    def test_default_is_renewal_branch(self):
+        """Backward compatibility: callers not passing the new flag fall
+        back to the renewal template."""
+        from webhooks.handlers import invoice as invoice_module
+
+        sb = MagicMock()
+        profile_result = MagicMock()
+        profile_result.data = {"email": "e@f.com", "full_name": "E F"}
+        sb.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = profile_result
+
+        with patch("email_service.send_email_async") as mock_send:
+            invoice_module._send_payment_confirmation_email(
+                sb,
+                user_id="u-3",
+                plan_id="smartlic_pro",
+                invoice_data={"amount_paid": 0},
+                new_expires="2026-05-04T00:00:00+00:00",
+            )
+            kwargs = mock_send.call_args.kwargs
+            assert kwargs["tags"] == [
+                {"name": "category", "value": "payment_confirmation"}
+            ]

--- a/backend/webhooks/handlers/invoice.py
+++ b/backend/webhooks/handlers/invoice.py
@@ -54,18 +54,19 @@ async def handle_invoice_payment_succeeded(sb, event: stripe.Event) -> None:
 
     new_expires = (datetime.now(timezone.utc) + timedelta(days=duration_days)).isoformat()
 
-    # STORY-309 AC11: Check if this was a recovery from dunning (subscription was past_due)
-    # STORY-CONV-003c AC3: Also detect trialing→active transition for trial_converted_auto event
+    # STORY-309 AC11 + STORY-CONV-003c AC3: Detect prior status to branch the
+    # post-charge path — dunning recovery email vs welcome_to_pro (first charge
+    # after trial) vs standard renewal confirmation — and to emit the
+    # trial_converted_auto analytics event when applicable.
     was_past_due = False
     was_trialing = False
     try:
         profile_check = sb.table("profiles").select("subscription_status").eq("id", user_id).single().execute()
-        if profile_check.data:
-            prior_status = profile_check.data.get("subscription_status")
-            if prior_status == "past_due":
-                was_past_due = True
-            elif prior_status == "trialing":
-                was_trialing = True
+        prior_status = (profile_check.data or {}).get("subscription_status")
+        if prior_status == "past_due":
+            was_past_due = True
+        elif prior_status == "trialing":
+            was_trialing = True
     except Exception as e:
         logger.warning(f"Failed to check prior subscription status for user_id={user_id}: {e}")
 
@@ -85,8 +86,17 @@ async def handle_invoice_payment_succeeded(sb, event: stripe.Event) -> None:
 
     await invalidate_user_caches(user_id, f"Annual renewal processed, new_expires={new_expires[:10]}")
 
-    # STORY-225 AC12: Send payment confirmation email
-    _send_payment_confirmation_email(sb, user_id, plan_id, invoice_data, new_expires)
+    # STORY-225 AC12 + STORY-CONV-003c AC3: Send confirmation email.
+    # Trial→paid conversion uses `welcome_to_pro` (first charge after
+    # trial); renewals use the generic `payment_confirmation` template.
+    _send_payment_confirmation_email(
+        sb,
+        user_id,
+        plan_id,
+        invoice_data,
+        new_expires,
+        is_first_charge_after_trial=was_trialing,
+    )
 
     # STORY-309 AC11: Send recovery email if was in dunning
     if was_past_due:
@@ -265,11 +275,29 @@ async def handle_payment_action_required(sb, event: stripe.Event) -> None:
 # Email helpers (fire-and-forget)
 # ============================================================================
 
-def _send_payment_confirmation_email(sb, user_id: str, plan_id: str, invoice_data: dict, new_expires: str) -> None:
-    """Send payment confirmation email (AC12). Never raises."""
+def _send_payment_confirmation_email(
+    sb,
+    user_id: str,
+    plan_id: str,
+    invoice_data: dict,
+    new_expires: str,
+    *,
+    is_first_charge_after_trial: bool = False,
+) -> None:
+    """Send payment confirmation email (AC12 + CONV-003c AC3). Never raises.
+
+    ``is_first_charge_after_trial`` selects the welcome-to-pro template
+    (lifecycle-aware copy) over the generic renewal confirmation. The
+    trial→paid moment is where chargebacks cluster for SaaS — explicit
+    acknowledgement of what the user is paying for reduces "eu não sabia
+    que ia cobrar" tickets.
+    """
     try:
         from email_service import send_email_async
-        from templates.emails.billing import render_payment_confirmation_email
+        from templates.emails.billing import (
+            render_payment_confirmation_email,
+            render_welcome_to_pro_email,
+        )
         from quota import PLAN_NAMES
 
         profile = sb.table("profiles").select("email, full_name").eq("id", user_id).single().execute()
@@ -305,20 +333,37 @@ def _send_payment_confirmation_email(sb, user_id: str, plan_id: str, invoice_dat
         except Exception:
             renewal_date = new_expires[:10]
 
-        html = render_payment_confirmation_email(
-            user_name=name,
-            plan_name=plan_name,
-            amount=amount,
-            next_renewal_date=renewal_date,
-            billing_period=billing_period,
-        )
+        if is_first_charge_after_trial:
+            html = render_welcome_to_pro_email(
+                user_name=name,
+                plan_name=plan_name,
+                amount=amount,
+                next_renewal_date=renewal_date,
+                billing_period=billing_period,
+            )
+            subject = f"Bem-vindo ao SmartLic Pro — {plan_name}"
+            category = "welcome_to_pro"
+        else:
+            html = render_payment_confirmation_email(
+                user_name=name,
+                plan_name=plan_name,
+                amount=amount,
+                next_renewal_date=renewal_date,
+                billing_period=billing_period,
+            )
+            subject = f"Pagamento confirmado — {plan_name}"
+            category = "payment_confirmation"
         send_email_async(
             to=email,
-            subject=f"Pagamento confirmado — {plan_name}",
+            subject=subject,
             html=html,
-            tags=[{"name": "category", "value": "payment_confirmation"}],
+            tags=[{"name": "category", "value": category}],
         )
-        logger.info(f"Payment confirmation email queued for user_id={user_id}")
+        logger.info(
+            "Confirmation email queued (user_id=%s, category=%s)",
+            user_id,
+            category,
+        )
     except Exception as e:
         logger.warning(f"Failed to send payment confirmation email: {e}")
 

--- a/docs/runbooks/trial-card-rollback.md
+++ b/docs/runbooks/trial-card-rollback.md
@@ -1,0 +1,142 @@
+# Runbook — Trial Card Rollback
+
+**Story:** STORY-CONV-003c AC5
+**Related:** STORY-CONV-003a (backend signup + Stripe), STORY-CONV-003b (frontend PaymentElement + A/B rollout)
+**Last updated:** 2026-04-20
+
+---
+
+## Quando acionar este runbook
+
+Dispare rollback do coleta-de-cartão quando QUALQUER um destes triggers for observado em produção:
+
+| Trigger | Threshold | Fonte |
+|---------|-----------|-------|
+| **Conversion rate drop** | Queda ≥50% em 7 dias vs baseline pré-rollout | Mixpanel funnel `signup_attempted → signup_completed` por `rollout_branch` |
+| **Chargeback rate** | > 1% dos signups com cartão em 30 dias | Stripe dashboard `balance.dispute_funds_withdrawn` |
+| **Payment failure spike** | > 20% dos `signup_completed` com `subscription_status=payment_failed` em 24h | `smartlic_trial_charge_failed_total` Prometheus / Sentry tag `signup_payment_failed` |
+| **Suporte overwhelmed** | > 5 tickets/dia sobre "cobrança indevida" ou "cartão debitado no trial" | Email/chat inbox |
+| **Regulatório** | Notificação Procon/ANS/CDC ou órgão equivalente | Legal escalation |
+
+**Escalação imediata (P0 — sem espera por consenso):**
+- Chargeback > 2% ou fraud detected por Stripe Radar → rollback **agora** + freeze novos signups até causa raiz.
+
+---
+
+## Ação de rollback — 30 segundos
+
+### Passo 1 — Desligar o A/B rollout
+
+```bash
+# Railway (frontend service)
+railway variables set NEXT_PUBLIC_TRIAL_REQUIRE_CARD_ROLLOUT_PCT=0 \
+  --service smartlic-frontend
+```
+
+A branch `card` lê essa env var em runtime via `useRolloutBranch.ts` (hash % 100 < pct). `PCT=0` força TODOS os novos signups para o branch `legacy` (Supabase direct, sem cartão).
+
+> **Nota:** Next.js `NEXT_PUBLIC_*` vars são inlineadas no build. Em staging/prod o frontend precisa re-deploy para que a var nova seja lida — OU o código lê `process.env` em runtime (nosso caso via `readRolloutPctFromEnv`). Validate com `curl` em passo 4.
+
+### Passo 2 — Validar que o rollout caiu a zero
+
+Dentro de 5 minutos da env var set:
+
+```bash
+# Mixpanel (via API ou dashboard)
+# Query: últimas 30min, filtro event=signup_completed, breakdown por rollout_branch
+# Esperado: rollout_branch=legacy counts crescendo, rollout_branch=card → 0
+```
+
+Alternativa via curl em /signup:
+
+```bash
+# Deve retornar HTML sem <div data-testid="signup-step-2-card">
+curl -s https://smartlic.tech/signup | grep -c 'data-testid="signup-step-2-card"'
+# Esperado: 0
+```
+
+### Passo 3 — Signups em trialing ativo NÃO são afetados
+
+- Usuários que já completaram signup com cartão mantêm sua subscription Stripe `trialing` normalmente.
+- Stripe continua o charge em D+14 conforme agendado.
+- **NÃO cancelar subscriptions existentes** — isso geraria refunds desnecessários e confusão.
+- Se a causa raiz exigir cancelamento em massa, seguir sub-processo "Mass cancel" abaixo (requires user approval).
+
+### Passo 4 — Comunicação
+
+- Post em `#incidents-live` (Slack) com: trigger observado, timestamp, env var alterada, impacto estimado.
+- Update status page se impacto for user-visible (`smartlic.tech/status`).
+- Abrir issue no backlog `INCIDENT-trial-card-rollback-{YYYY-MM-DD}` com link para este runbook.
+
+---
+
+## Root cause investigation
+
+Após rollback estabilizar, investigar em paralelo:
+
+1. **Stripe Dashboard > Payments** — filtrar `metadata.flow=pre_signup_trial` últimos 7 dias. Identificar padrões (issuer declines, CVV mismatches, 3DS failures).
+2. **Sentry** — filtro tag `signup_payment_failed` + breadcrumb `stripe.SetupIntent.create` + `stripe.Subscription.create`.
+3. **Mixpanel** — funnel completeness `signup_attempted → trial_card_captured → signup_completed` por `rollout_branch`. Gaps apontam onde usuários caem.
+4. **Backend logs (Railway)** — grep `StripeSignupError` + `step=` para triangular qual sub-passo falha (customer_create, pm_attach, subscription_create).
+5. **Chargeback codes Stripe** — se rollback foi por chargeback, classificar por `reason` (fraudulent, product_not_received, subscription_canceled). "Fraudulent" = fraud signal; "product_not_received" = UX (usuários esqueceram que assinaram).
+
+---
+
+## Mass cancel — apenas sob escalação explícita
+
+**Pré-requisitos:** user (founder) autoriza por escrito (Slack/email); causa raiz identificada e documentada.
+
+```python
+# backend/scripts/mass_cancel_trials.py (não commitado — criar ad-hoc)
+import stripe
+from datetime import datetime, timezone, timedelta
+
+stripe.api_key = os.environ["STRIPE_SECRET_KEY"]
+
+# Buscar subscriptions trialing criadas em window do incidente
+start = datetime(2026, X, X, tzinfo=timezone.utc)
+end = datetime(2026, X, X, tzinfo=timezone.utc)
+
+subs = stripe.Subscription.list(
+    status="trialing",
+    created={"gte": int(start.timestamp()), "lte": int(end.timestamp())},
+    limit=100,
+)
+
+for sub in subs.auto_paging_iter():
+    # Log antes de cancelar — audit trail
+    print(f"Cancelling {sub.id} (customer={sub.customer}, trial_end={sub.trial_end})")
+    stripe.Subscription.cancel(sub.id)
+```
+
+**Pós mass cancel:**
+- Email de esclarecimento para todos os usuários afetados (template `trial_cancelled_by_incident.html` — criar).
+- Atualizar `profiles.subscription_status='canceled_incident'` via backfill SQL.
+- Postmortem 5-why em `docs/postmortems/YYYY-MM-DD-trial-card-incident.md`.
+
+---
+
+## Re-rollout (quando voltar)
+
+Após root cause fix + 7 dias estabilizado:
+
+1. Staging: `NEXT_PUBLIC_TRIAL_REQUIRE_CARD_ROLLOUT_PCT=100` durante 48h com equipe testando signups.
+2. Prod canary: `PCT=5` por 72h. Monitorar funnel + chargebacks diários.
+3. Prod ratchet: 5→15→30→50 em incrementos de 7 dias cada, com GO/NO-GO daily review.
+4. Parar ratchet se qualquer trigger acima for observado.
+
+---
+
+## Observabilidade esperada (AC4 — a ser shipado)
+
+- Prometheus: `smartlic_trial_signup_with_card_total{branch}`, `smartlic_trial_cancel_before_charge_total`, `smartlic_trial_auto_converted_total`, `smartlic_trial_charge_failed_total`
+- Mixpanel events: `trial_card_captured`, `trial_cancelled_before_charge`, `trial_converted_auto`, `trial_charge_failed`
+- Dashboard admin: `/admin/billing/trial-funnel` (deferido — STORY-CONV-003c AC4)
+
+Até o dashboard chegar, usar queries Mixpanel manuais via dashboard.mixpanel.com + Stripe Dashboard para dispute rate.
+
+---
+
+## Change log
+
+- **2026-04-20** — Runbook criado (@dev flickering-llama session, Opus 4.7). Ainda sem incidentes — doc preventivo antes do primeiro rollout em prod.

--- a/frontend/__tests__/conta/cancel-trial.test.tsx
+++ b/frontend/__tests__/conta/cancel-trial.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * STORY-CONV-003c AC7: cancel-trial page render tests.
+ *
+ * Scope: fetch + render happy/error/already-cancelled paths. The POST
+ * cancel flow is asserted via click → fetch stub verification.
+ */
+/** @jest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/navigation BEFORE importing the component under test.
+const mockPush = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
+import CancelTrialPage from "../../app/conta/cancelar-trial/page";
+
+function mockFetch(...responses: Array<{ ok: boolean; status?: number; body: unknown }>) {
+  const impls = responses.map((r) => async () => ({
+    ok: r.ok,
+    status: r.status ?? (r.ok ? 200 : 500),
+    json: async () => r.body,
+  }));
+  (global as any).fetch = jest.fn().mockImplementation(() => impls.shift()!());
+}
+
+describe("CancelTrialPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    (global as any).fetch = undefined;
+  });
+
+  it("shows error when token query param is missing", async () => {
+    mockGet.mockReturnValue("");
+    render(<CancelTrialPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("cancel-trial-error")).toHaveTextContent(
+        /Token de cancelamento ausente/i,
+      ),
+    );
+  });
+
+  it("renders confirmation UI after a valid token returns trial info", async () => {
+    mockGet.mockReturnValue("jwt.valid.token");
+    mockFetch({
+      ok: true,
+      body: {
+        user_id: "u-1",
+        email: "founder@b2g.com",
+        plan_name: "SmartLic Pro",
+        trial_end_ts: Math.floor(Date.now() / 1000) + 86_400,
+        already_cancelled: false,
+      },
+    });
+    render(<CancelTrialPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("cancel-trial-confirm")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/founder@b2g\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/SmartLic Pro/)).toBeInTheDocument();
+  });
+
+  it("short-circuits to already-cancelled view when backend says so", async () => {
+    mockGet.mockReturnValue("jwt.old.token");
+    mockFetch({
+      ok: true,
+      body: {
+        user_id: "u-1",
+        email: "x@y.com",
+        plan_name: "Consultoria",
+        trial_end_ts: Math.floor(Date.now() / 1000) + 3600,
+        already_cancelled: true,
+      },
+    });
+    render(<CancelTrialPage />);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("cancel-trial-already-cancelled"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces 410/400 token errors with the backend message", async () => {
+    mockGet.mockReturnValue("jwt.expired.token");
+    mockFetch({ ok: false, status: 410, body: { detail: "Token expirado" } });
+    render(<CancelTrialPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("cancel-trial-error")).toHaveTextContent(
+        "Token expirado",
+      ),
+    );
+  });
+
+  it("POSTs { token } on confirm and redirects to /confirmado on success", async () => {
+    mockGet.mockReturnValue("jwt.valid.token");
+    mockFetch(
+      {
+        ok: true,
+        body: {
+          user_id: "u-1",
+          email: "a@b.com",
+          plan_name: "SmartLic Pro",
+          trial_end_ts: Math.floor(Date.now() / 1000) + 86_400,
+          already_cancelled: false,
+        },
+      },
+      {
+        ok: true,
+        body: { cancelled: true, access_until: "2026-05-04T00:00:00Z", already_cancelled: false },
+      },
+    );
+    render(<CancelTrialPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("cancel-trial-submit")).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByTestId("cancel-trial-submit"));
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/conta/cancelar-trial/confirmado"),
+    );
+
+    // Verify POST payload
+    const postCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(postCall[0]).toBe("/api/conta/cancelar-trial");
+    expect(postCall[1].method).toBe("POST");
+    expect(JSON.parse(postCall[1].body)).toEqual({ token: "jwt.valid.token" });
+  });
+});

--- a/frontend/app/api/conta/cancelar-trial/route.ts
+++ b/frontend/app/api/conta/cancelar-trial/route.ts
@@ -1,0 +1,19 @@
+/**
+ * Cancel-trial proxy (STORY-CONV-003c AC7).
+ *
+ * GET  /api/conta/cancelar-trial?token=<jwt> → backend returns trial
+ *      metadata (no state mutation).
+ * POST /api/conta/cancelar-trial with { token } → backend executes
+ *      Stripe.Subscription.cancel + DB state transition. Idempotent.
+ *
+ * Anonymous (no auth header) — the JWT token is the credential. Backend
+ * validates signature, TTL (48h), action claim, and user existence.
+ */
+import { createProxyRoute } from "../../../../lib/create-proxy-route";
+
+export const { GET, POST } = createProxyRoute({
+  backendPath: "/v1/conta/cancelar-trial",
+  methods: ["GET", "POST"],
+  requireAuth: false,
+  errorMessage: "Link de cancelamento inválido ou expirado.",
+});

--- a/frontend/app/conta/cancelar-trial/confirmado/page.tsx
+++ b/frontend/app/conta/cancelar-trial/confirmado/page.tsx
@@ -1,0 +1,47 @@
+/**
+ * /conta/cancelar-trial/confirmado — success page shown after a one-click
+ * trial cancellation succeeds (STORY-CONV-003c AC7).
+ */
+import Link from "next/link";
+
+export const metadata = {
+  title: "Trial cancelada — SmartLic",
+  // Prevent indexing — this page is only valid via redirect.
+  robots: { index: false, follow: false },
+};
+
+export default function CancelTrialConfirmadoPage() {
+  return (
+    <main className="p-6 max-w-md mx-auto" data-testid="cancel-trial-confirmado">
+      <h1 className="text-2xl font-semibold text-ink mb-3">Trial cancelada ✓</h1>
+      <p className="text-sm text-ink-secondary mb-4">
+        Nenhuma cobrança será feita. Você mantém acesso até o fim do período
+        de trial. Nenhum dado da sua conta foi apagado.
+      </p>
+      <p className="text-sm text-ink-secondary mb-4">
+        Se mudou de ideia, basta reativar a assinatura a partir da sua conta
+        — mantemos seus dados por 30 dias.
+      </p>
+      <div className="flex flex-col gap-2">
+        <Link
+          href="/buscar"
+          className="py-2 px-4 text-center bg-brand-blue text-white rounded-input"
+        >
+          Continuar usando SmartLic
+        </Link>
+        <Link
+          href="/conta"
+          className="py-2 px-4 text-center border border-ink-secondary rounded-input text-ink"
+        >
+          Minha conta
+        </Link>
+        <Link
+          href="/ajuda"
+          className="py-2 px-4 text-center text-ink-secondary text-sm"
+        >
+          Precisa de ajuda?
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/conta/cancelar-trial/page.tsx
+++ b/frontend/app/conta/cancelar-trial/page.tsx
@@ -1,0 +1,192 @@
+/**
+ * /conta/cancelar-trial — one-click cancel page (STORY-CONV-003c AC7).
+ *
+ * Arrives via link in the D-1 trial email (AC1) — token is signed by the
+ * backend with TRIAL_CANCEL_JWT_SECRET (48h TTL, action="cancel_trial").
+ *
+ * Flow:
+ * 1. GET /api/conta/cancelar-trial?token=<jwt> → fetches trial metadata
+ *    (user email, plan_name, trial_end_ts, already_cancelled).
+ * 2. Show "Confirmar cancelamento" — explicit confirm prevents accidental
+ *    cancel from link previews / browser prefetch.
+ * 3. POST /api/conta/cancelar-trial with { token } — backend cancels
+ *    Stripe subscription (no proration, access keeps until trial_end_ts).
+ * 4. Redirect to /conta/cancelar-trial/confirmado on success.
+ */
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import Link from "next/link";
+
+type TrialInfo = {
+  user_id: string;
+  email: string;
+  plan_name: string;
+  trial_end_ts: number;
+  already_cancelled: boolean;
+};
+
+function CancelTrialView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [info, setInfo] = useState<TrialInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!token) {
+        setError("Token de cancelamento ausente. Abra o link do email original.");
+        setLoading(false);
+        return;
+      }
+      try {
+        const res = await fetch(
+          `/api/conta/cancelar-trial?token=${encodeURIComponent(token)}`,
+        );
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body?.detail ?? `Erro ${res.status}`);
+        }
+        const data: TrialInfo = await res.json();
+        if (!cancelled) {
+          setInfo(data);
+          setError(null);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Link de cancelamento inválido ou expirado.");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const handleCancel = async () => {
+    if (!token || submitting) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/conta/cancelar-trial", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.detail ?? `Erro ${res.status}`);
+      }
+      toast.success("Trial cancelada com sucesso.");
+      router.push("/conta/cancelar-trial/confirmado");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Não foi possível cancelar agora. Tente novamente em instantes.";
+      setError(msg);
+      toast.error(msg);
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 text-center text-ink-secondary" data-testid="cancel-trial-loading">
+        Validando link de cancelamento…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 max-w-md mx-auto" data-testid="cancel-trial-error">
+        <h1 className="text-xl font-semibold text-ink mb-3">Link inválido</h1>
+        <p role="alert" className="text-sm text-red-700 bg-red-50 p-3 rounded mb-4">
+          {error}
+        </p>
+        <p className="text-sm text-ink-secondary">
+          Se você chegou aqui pelo email, o link pode ter expirado (48h). Abra{" "}
+          <Link href="/conta" className="underline">
+            sua conta
+          </Link>{" "}
+          para cancelar manualmente, ou responda o email para suporte.
+        </p>
+      </div>
+    );
+  }
+
+  if (!info) return null;
+
+  const trialEnd = new Date(info.trial_end_ts * 1000).toLocaleDateString("pt-BR");
+
+  if (info.already_cancelled) {
+    return (
+      <div className="p-6 max-w-md mx-auto" data-testid="cancel-trial-already-cancelled">
+        <h1 className="text-xl font-semibold text-ink mb-3">Trial já cancelada</h1>
+        <p className="text-sm text-ink-secondary mb-4">
+          Sua trial do plano <strong>{info.plan_name}</strong> já foi cancelada. Você mantém
+          acesso até {trialEnd}.
+        </p>
+        <Link
+          href="/buscar"
+          className="inline-block py-2 px-4 bg-brand-blue text-white rounded-input"
+        >
+          Continuar usando SmartLic
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-md mx-auto" data-testid="cancel-trial-confirm">
+      <h1 className="text-xl font-semibold text-ink mb-3">Cancelar trial</h1>
+      <p className="text-sm text-ink-secondary mb-4">
+        Você está cancelando a trial de <strong>{info.plan_name}</strong> para a conta{" "}
+        <strong>{info.email}</strong>.
+      </p>
+      <div className="mb-4 p-3 bg-surface-1 rounded-input text-xs text-ink-secondary space-y-1">
+        <p>
+          ✓ Nenhuma cobrança será feita em {trialEnd}.
+        </p>
+        <p>
+          ✓ Você continua com acesso completo até {trialEnd}.
+        </p>
+        <p>
+          ✓ Nenhum dado da sua conta será apagado — você pode reativar depois.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Link
+          href="/buscar"
+          className="flex-1 text-center py-2 px-4 border border-ink-secondary rounded-input text-ink"
+        >
+          Manter assinatura
+        </Link>
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={submitting}
+          className="flex-1 py-2 px-4 bg-red-600 text-white rounded-input disabled:opacity-50"
+          data-testid="cancel-trial-submit"
+        >
+          {submitting ? "Cancelando…" : "Confirmar cancelamento"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function CancelTrialPage() {
+  // useSearchParams requires a Suspense boundary in Next 14+ App Router.
+  return (
+    <Suspense fallback={<div className="p-6 text-center">Carregando…</div>}>
+      <CancelTrialView />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary

- Entrega **AC3** (welcome_to_pro email no trial→paid first charge), **AC5** (runbook rollback) e **AC7** (frontend `/conta/cancelar-trial` page) da STORY-CONV-003c.
- AC1 (cron D-1 email) e AC4 (observability dashboard) deferidos para follow-up: AC1 depende de `services.trial_cancel_token` (shipado em PR #431); AC4 útil apenas quando houver baseline de signups pagos.

## Changes

### Backend — AC3
- `templates/emails/billing.py::render_welcome_to_pro_email` distinguível do renewal template (copy lifecycle-aware, links conta + suporte).
- `webhooks/handlers/invoice.py::handle_invoice_payment_succeeded` detecta `prior_status == "trialing"` → passa `is_first_charge_after_trial=True` ao `_send_payment_confirmation_email` que ramifica template + subject + Resend category.
- 5 testes backend (`test_welcome_to_pro_email.py`).

### Docs — AC5
- `docs/runbooks/trial-card-rollback.md`: triggers quantificados (chargeback >1%, conv drop >50%/7d, payment fail spike >20%/24h), ação de 30s, validação, root-cause checklist, mass-cancel sub-processo (gate user approval), re-rollout canário.

### Frontend — AC7
- `app/conta/cancelar-trial/page.tsx` + `confirmado/page.tsx` — UI de cancelamento em um clique consumindo endpoints do PR #431.
- `app/api/conta/cancelar-trial/route.ts` — proxy GET+POST.
- 5 testes frontend (token ausente, válido, already-cancelled, expirado, submit+redirect).

## Testing Plan

- [x] Backend tests: `pytest tests/test_welcome_to_pro_email.py` (5/5)
- [x] Frontend tests: `npx jest __tests__/conta/` (5/5)
- [ ] Staging smoke (pós-#431 merge): clicar no link /conta/cancelar-trial?token=<jwt-mock> → UI carrega metadata + POST cancela subscription Stripe
- [ ] Staging smoke: disparar Stripe webhook `invoice.payment_succeeded` em conta com `prior_status=trialing` → email chega com subject `Bem-vindo ao SmartLic Pro`

## Dependências

- **AC7 frontend** assume que PR #431 (CONV-003c AC2 — endpoints `/v1/conta/cancelar-trial` GET+POST) foi merged em main. Até lá a rota retorna 404 via proxy — **não é regressão**, página é nova e não linkada em nenhum fluxo ativo ainda.
- **AC1 cron** shipa em PR separado quando PR #431 em main.

## Closes (parcial)

STORY-CONV-003c AC3, AC5, AC7. AC1 + AC4 em follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)