### PR TITLE
fix(ci): deploy smoke test false failure on 404 response

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -352,7 +352,10 @@ jobs:
           echo "=== POST Smoke Test (CRIT-080 — anti-SIGSEGV) ==="
           echo "Validating POST requests not returning 502 (jemalloc/Sentry SIGSEGV guard)..."
 
-          HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "${BACKEND_URL}/debug/post-test" 2>&1 || echo "000")
+          # CRIT-080: anti-SIGSEGV guard. Use -s (not -sf) so curl prints
+          # http_code even on 4xx instead of failing + triggering `|| echo "000"`,
+          # which concatenated to "404000" and broke the >=500 arithmetic.
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${BACKEND_URL}/debug/post-test" 2>&1 || echo "000")
           echo "POST /debug/post-test → HTTP $HTTP_CODE"
 
           if [ "$HTTP_CODE" -ge 500 ] || [ "$HTTP_CODE" = "000" ]; then


### PR DESCRIPTION
## Summary

Fix 1-char bug no workflow \`deploy.yml\` que causava **false failure em todo deploy em main** desde a introdução do CRIT-080 anti-SIGSEGV guard.

## Context

Deploy to Production workflow (run 24695912413) falhou no step \"Production Smoke Tests\" com:
\`\`\`
POST /debug/post-test → HTTP 404000
##[error]POST endpoint retornou 404000 — possível SIGSEGV/502!
\`\`\`

**HTTP 404000 não existe.** Bug analisado:
- \`curl -sf\` faz curl falhar em 4xx com exit 22
- \`-w \"%{http_code}\"\` já emitiu \"404\" no stdout antes do fail
- \`|| echo \"000\"\` trigga, anexando \"000\"
- \`HTTP_CODE=\"404000\"\`, passa \`-ge 500\` → false error

**Deploy real sucedeu** (Backend/Frontend Railway + Migrations todos SUCCESS). Só o smoke test reportou falha cosmética.

## Changes

\`.github/workflows/deploy.yml\` linha 355:
- \`curl -sf\` → \`curl -s\` (drop -f flag)
- Agora 4xx não trigga fallback; só 5xx ou conexão caída (000) produzem erro real

## Testing Plan

- [x] Análise do log real (run 24695925413) confirmando a concatenação \"404\" + \"000\"
- [x] Valor esperado pós-fix: HTTP 404 (endpoint removido por segurança) → passa \`-ge 500\` check
- [ ] Próximo deploy em main validará que o smoke test passa

## Closes

N/A — fix de workflow CI pré-existente. Libera 1 failing workflow em main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)