### PR TITLE
fix(ci): remove redundant pytest from backend-ci.yml

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -64,15 +64,9 @@ jobs:
           cd backend
           mypy . --config-file pyproject.toml || echo "::warning::mypy found type errors — review required"
 
-      - name: Run tests with coverage
-        run: |
-          cd backend
-          pytest --cov --cov-report=xml --cov-report=term --cov-fail-under=70
-
-      - name: Upload coverage to Codecov (optional)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./backend/coverage.xml
-          flags: backend
-          fail_ci_if_error: false
+      # STORY-CONV-003c (Abstract Coral session): pytest execution + codecov upload removed.
+      # This workflow is superseded by backend-tests.yml (see header note) for the PR-gate
+      # test matrix + coverage upload. Running pytest here hit PNCP live endpoints via
+      # integration tests with no timeout budget, producing spurious CI failures that did
+      # NOT reflect backend-tests.yml (authoritative gate). Lint/type/security scans above
+      # remain the responsibility of this workflow.


### PR DESCRIPTION
## Summary

O workflow `backend-ci.yml` declara-se **SUPERSEDED por `backend-tests.yml`** no header (linhas 1-5 — CRIT-038 PR gate é o gate autoritativo). Mas ele continuava rodando `pytest --cov --cov-fail-under=70` + codecov upload nas linhas 67-78 — duplicando o trabalho do workflow autoritativo, e sem timeout budget para integration tests que tocam PNCP live endpoints. Resultado: falhas espúrias pós-merge que **não refletiam** o status do PR gate real.

Este PR remove os dois steps redundantes. O workflow mantém suas responsabilidades declaradas: Trivy CRITICAL scan (bloqueante), ruff / mypy / pip-audit HIGH (advisory). Nenhuma execução de teste.

## Context

- Root cause: execução duplicada de pytest rodando integration tests sem timeout budget → PNCP live call timeout → spurious failure.
- PR gate real (backend-tests.yml) está VERDE em main há 5+ runs consecutivos. Este fix remove ruído que não bloqueia merge mas suja CI overview.
- Consistente com o principle do próprio arquivo: header diz "If you need to disable one, disable this file — NOT backend-tests.yml".

## Testing Plan

- [ ] `Backend CI (Security + Linting)` workflow passa neste PR
- [ ] Trivy CRITICAL scan continua bloqueante (se houver vuln, PR falha)
- [ ] ruff / mypy / pip-audit continuam advisory (continue-on-error preservado)

## Closes

- Handoff followup: Abstract Coral session Frente B1
- Referência: `docs/sessions/2026-04/2026-04-20-temporal-bonbon-handoff.md` (Migration Check diagnóstico paralelo, não resolvido na sessão anterior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal CI/workflow reorganization to streamline testing processes. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->