### PR TITLE
fix(ci): migration-check dual-row output dedup (2-pass awk)

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -39,16 +39,32 @@ jobs:
           OUTPUT=$(supabase migration list --linked 2>&1)
           echo "$OUTPUT"
 
-          # Detect unapplied migrations: rows with Local value but empty Remote
-          # Supabase CLI outputs table with "Local | Remote | Time" columns
-          # An unapplied migration has content in Local but nothing in Remote
+          # Detect unapplied migrations: rows with Local value but empty Remote.
+          # Supabase CLI outputs table with "Local | Remote | Time" columns.
+          #
+          # NOTE (CONV-003c Abstract Coral session): recent Supabase CLI versions
+          # emit a DUAL-ROW per applied migration — the first row has both Local
+          # and Remote populated (truly applied), and a spurious second row has
+          # Local populated but Remote empty. A single-pass scan misclassifies
+          # the second row as "unapplied" and raises a false positive.
+          #
+          # The 2-pass scan below marks a migration as applied if ANY row for
+          # that Local value has a non-empty Remote. Truly unapplied migrations
+          # are those whose ALL rows have empty Remote.
           UNAPPLIED=$(echo "$OUTPUT" | awk -F'|' '
             NR > 2 {
               local = $1; gsub(/^[ \t]+|[ \t]+$/, "", local)
               remote = $2; gsub(/^[ \t]+|[ \t]+$/, "", remote)
-              if (local != "" && remote == "") print local
+              if (local == "") next
+              seen[local] = 1
+              if (remote != "") applied[local] = 1
             }
-          ')
+            END {
+              for (m in seen) {
+                if (!applied[m]) print m
+              }
+            }
+          ' | sort)
 
           # Also check for explicit "Not applied" text (older CLI versions)
           if [ -n "$UNAPPLIED" ] || echo "$OUTPUT" | grep -q "Not applied"; then


### PR DESCRIPTION
## Summary

Resolve falso-positivo crônico do workflow `Migration Check (Post-Merge Alert)` que listava ~11 migrations como "unapplied" quando de fato **todas estavam aplicadas em produção**.

## Context

Inspeção do log da run [24699091494](https://github.com/tjsasakifln/PNCP-poc/actions/runs/24699091494) revelou que versões recentes do Supabase CLI emitem **dual-row output** por migration aplicada em `supabase migration list --linked`:

\`\`\`
Local          | Remote         | Time (UTC)
20260414132000 | 20260414132000 | 2026-04-14 13:20:00    <- primeira row (aplicada)
20260414132000 |                | 2026-04-14 13:20:00    <- segunda row spurious
\`\`\`

O awk parser single-pass (linhas 45-51) classificava a **segunda row** como "unapplied" porque `remote == ""`, gerando 11 falsos positivos por run. Os handoffs `temporal-bonbon` e `bubbly-anchor` documentaram a suspeita; esta investigação confirmou empiricamente.

## Fix

Substitui o single-pass por **2-pass awk**:

1. **Pass 1:** coleta todo `Local` visto em `seen[]`; marca `applied[]` para qualquer `Local` cuja linha tenha `Remote` não-vazio.
2. **Pass 2 (END):** emite apenas `Locals` em `seen[]` mas não em `applied[]`.

Robusto contra qualquer ordenação de rows ou duplicação. Migrations verdadeiramente não-aplicadas (todas as rows com Remote vazio) continuam detectadas corretamente.

Bonus: output agora é ordenado (`| sort`) para logs CI determinísticos.

## Testing Plan

- [ ] `Migration Check (Post-Merge Alert)` workflow passa neste PR (primeiro run esperado verde após merge em main)
- [ ] Se houver migration genuinamente não-aplicada, ela é detectada (smoke test local: adicionar migration fake sem `supabase db push` → check retorna ela)
- [ ] STORY-414 AC3 schema contract validation continua funcionando (step seguinte não tocado)

## Closes

- Handoff followup: Abstract Coral session Frente B2
- Pending-issue documentado em `docs/sessions/2026-04/2026-04-20-temporal-bonbon-handoff.md` §Frente 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the accuracy of database migration detection in the CI/CD workflow to better validate deployment readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->