### PR TITLE
fix(ci): locustfile StressTestUser missing catch_response=True

### DIFF
--- a/backend/locustfile.py
+++ b/backend/locustfile.py
@@ -258,7 +258,12 @@ class StressTestUser(HttpUser):
             "setor": "UNIFORMES",
         }
 
-        with self.client.post("/api/buscar", json=payload, name="/api/buscar") as response:
+        with self.client.post(
+            "/api/buscar",
+            json=payload,
+            name="/api/buscar",
+            catch_response=True,
+        ) as response:
             if response.status_code not in [200, 422, 504]:
                 print(f"   Unexpected status: {response.status_code}")
 


### PR DESCRIPTION
## Summary

Fix one-liner: `StressTestUser.stress_search` em \`backend/locustfile.py\` usa um \`with self.client.post(...) as response\` block mas **não passa** \`catch_response=True\` — Locust exige esse flag para o with-block ou levanta \`locust.exception.LocustError\` em cada iteração.

Consequência: o workflow **Load Test - Backend API** falha com ~200+ linhas de erro por minuto de execução em TODOS os PRs + runs on main.

## Context

Verificação empírica do run [24700999295](https://github.com/tjsasakifln/PNCP-poc/actions/runs/24700999295/job/72243990608):

\`\`\`
[2026-04-21 02:35:50,921] runnervmeorf1/ERROR/locust.user.task:
In order to use a with-block for requests, you must also pass
catch_response=True
  raise LocustError("In order to use a with-block for requests,
  you must also pass catch_response=True")
\`\`\`

Os outros métodos no mesmo arquivo (linhas 137, 164, 214) já têm o flag. Foi um oversight na adição do \`StressTestUser\` — não um bug novo.

## Fix

Adiciona \`catch_response=True\` como keyword arg na chamada \`self.client.post\` do \`stress_search\` (linha 261). 6 linhas de diff (reformatação multi-linha por conta do arg extra).

## Testing Plan

- [ ] Load Test - Backend API workflow passa neste PR (era FAILURE antes)
- [ ] Demais workflows (Backend Tests, Frontend Tests, CodeQL, Dep Scan) passam (não afetados)
- [x] Regression: nada foi alterado além do flag; outros StressTestUser methods e SmartLicUser methods intocados

## Closes

- Abstract Coral session CI cleanup — completa objetivo "CI 100% verde na main com baseline em zero testes falhando"
- Desbloqueia Load Test como sinal confiável para mudanças de performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)