### PR TITLE
fix(ci): migration-check awk filter stderr leakage from Supabase CLI

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -56,6 +56,10 @@ jobs:
               local = $1; gsub(/^[ \t]+|[ \t]+$/, "", local)
               remote = $2; gsub(/^[ \t]+|[ \t]+$/, "", remote)
               if (local == "") next
+              # Filter out stderr leakage (e.g. "Connecting to remote database...",
+              # "Skipping migration README.md...") that lack pipe separators —
+              # real migration rows always have a 14-digit timestamp in Local.
+              if (local !~ /^[0-9]{14}$/) next
               seen[local] = 1
               if (remote != "") applied[local] = 1
             }


### PR DESCRIPTION
## Summary

Fixes false positive in migration-check workflow: `supabase migration list --linked 2>&1` leaks stderr lines (e.g. `Connecting to remote database...`, `Skipping migration README.md...`) that lack pipe separators. The awk parser was treating these as rows with empty remote → classifying as unapplied migrations.

Empirical evidence from run [24703292240](https://github.com/tjsasakifln/PNCP-poc/actions/runs/24703292240) log shows UNAPPLIED containing stderr strings:

```
Unapplied migrations:
Connecting to remote database...
Skipping migration 006a_update_profiles_plan_type_constraint.sql...
Skipping migration 006b_search_sessions_service_role_policy.sql...
Skipping migration README.md...
```

## Fix

Add `if (local !~ /^[0-9]{14}$/) next` — real migration rows always have a 14-digit timestamp, so any line failing that pattern is stderr noise. Preserves dual-row dedup logic from PR #441 (Abstract Coral session).

## Testing Plan

- [x] Local simulation: applied migrations + stderr leak → `UNAPPLIED=''` (PASS)
- [x] Local simulation: real unapplied (no dual-row) → `UNAPPLIED='20260414131000'` (PASS)
- [ ] CI validates on this PR's own push-to-main run (Migration Check is scheduled + workflow_dispatch, not PR-triggered, but will run on merge)

## Closes

Part of baseline CI green effort (sessão floofy-sparkle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration scan accuracy by filtering out non-migration entries from validation results, reducing false positives in the migration check process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->