### PR TITLE
fix(ci): Load Test 404 root cause — locustfile rota /api/buscar → /buscar

### DIFF
--- a/backend/locustfile.py
+++ b/backend/locustfile.py
@@ -70,7 +70,7 @@ health_check_times = []
 @events.request.add_listener
 def on_request(request_type, name, response_time, response_length, exception, **kwargs):
     """Track custom metrics per endpoint."""
-    if name == "/api/buscar":
+    if name == "/buscar":
         search_times.append(response_time)
     elif name.startswith("/api/download"):
         download_times.append(response_time)
@@ -89,7 +89,7 @@ def on_test_stop(environment, **kwargs):
     print("=" * 80)
 
     if search_times:
-        print("\n📊 Search Endpoint (/api/buscar):")
+        print("\n📊 Search Endpoint (/buscar):")
         print(f"   Requests: {len(search_times)}")
         print(f"   Avg: {sum(search_times) / len(search_times):.0f}ms")
         print(f"   Min: {min(search_times):.0f}ms")
@@ -162,9 +162,9 @@ class SmartLicUser(HttpUser):
         }
 
         with self.client.post(
-            "/api/buscar",
+            "/buscar",
             json=payload,
-            name="/api/buscar",
+            name="/buscar",
             catch_response=True
         ) as response:
             if response.status_code == 200:
@@ -259,9 +259,9 @@ class StressTestUser(HttpUser):
         }
 
         with self.client.post(
-            "/api/buscar",
+            "/buscar",
             json=payload,
-            name="/api/buscar",
+            name="/buscar",
             catch_response=True,
         ) as response:
             if response.status_code not in [200, 422, 504]:


### PR DESCRIPTION
## Summary

Load Test - Backend API workflow has been failing with 100% of requests returning HTTP 404. Root cause: `backend/locustfile.py` targets `/api/buscar` but FastAPI mounts `routes/search/__init__.py:170` at path `/buscar` (no `/api/` prefix). Frontend uses `/api/buscar` via Next.js proxy (`frontend/app/api/buscar/route.ts`), but locust hits the backend directly via `--host=http://localhost:8000`, bypassing that proxy.

## Context

**Misdiagnosed for weeks:**
- PR #444 fixed a different bug (`StressTestUser` missing `catch_response=True`)
- Documented as "pre-existing 100% failure" in ≥3 session handoffs (`docs/sessions/2026-04/`)
- Blocked 5 Dependabot PRs (#413, #417, #418, #419, #420) via PR gate
- Blocked PR #447 merge

**Empirical evidence** from run `24705189641` (PR #447):
```
POST /api/buscar    43    43(100.00%)
POST /api/buscar   139   139(100.00%)
POST /api/buscar   269   269(100.00%)
   Unexpected status: 404
```

## Change

6 substitutions in `backend/locustfile.py`:
- Line 73: `if name == "/api/buscar":` → `/buscar`
- Line 92: stats print string
- Lines 165, 167 (`SmartLicUser.search_bids`): POST `/api/buscar` + `name=` → `/buscar`
- Lines 262, 264 (`StressTestUser.aggressive_search`): POST `/api/buscar` + `name=` → `/buscar`

Zero behavior change in Locust contract; only corrects the target URL.

## Closes

- Unblocks #447 (Load Test failure)
- Unblocks Dependabot #413, #417, #418, #419, #420

## Testing Plan

- [ ] CI run: "Load Test - Backend API" must PASS (≤1% failure rate baseline)
- [ ] Post-merge: `gh pr checks 447` shows Load Test → PASS
- [ ] Post-merge: Dependabot PRs listed above auto-merge via label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search endpoint routing to ensure accurate request tracking and performance metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->