### PR TITLE
feat(seo-004): fix pricing schema on /planos + homepage AggregateOffer (Rich Results)

### DIFF
--- a/frontend/__tests__/planos/ProductSchema.test.tsx
+++ b/frontend/__tests__/planos/ProductSchema.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * STORY-SEO-004 AC6: ProductSchema emits valid JSON-LD with pricing
+ * that matches the shared source of truth in `lib/plan-pricing.ts`.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { ProductSchema } from "@/app/planos/components/ProductSchema";
+import {
+  PRO_PRICING,
+  CONSULTORIA_PRICING,
+  AGGREGATE_OFFER_BOUNDS,
+  getPriceValidUntil,
+} from "@/lib/plan-pricing";
+
+type OfferNode = {
+  "@type": "Offer";
+  price: string;
+  priceCurrency: string;
+  availability: string;
+  priceValidUntil: string;
+  category: string;
+  url: string;
+};
+
+type ProductNode = {
+  "@context": "https://schema.org";
+  "@type": "Product";
+  name: string;
+  description: string;
+  brand: { "@type": "Brand"; name: string };
+  offers: OfferNode[];
+};
+
+function extractSchemas(container: HTMLElement): ProductNode[] {
+  const scripts = Array.from(
+    container.querySelectorAll<HTMLScriptElement>('script[type="application/ld+json"]')
+  );
+  return scripts.map((s) => JSON.parse(s.textContent ?? "") as ProductNode);
+}
+
+describe("ProductSchema (STORY-SEO-004)", () => {
+  it("emits exactly 2 Product schemas (Pro + Consultoria)", () => {
+    const { container } = render(<ProductSchema />);
+    const schemas = extractSchemas(container);
+    expect(schemas).toHaveLength(2);
+    expect(schemas.map((s) => s.name)).toEqual(["SmartLic Pro", "SmartLic Consultoria"]);
+  });
+
+  it("each Product schema is well-formed JSON-LD with required fields", () => {
+    const { container } = render(<ProductSchema />);
+    const schemas = extractSchemas(container);
+
+    for (const schema of schemas) {
+      expect(schema["@context"]).toBe("https://schema.org");
+      expect(schema["@type"]).toBe("Product");
+      expect(schema.name).toBeTruthy();
+      expect(schema.description.length).toBeGreaterThan(20);
+      expect(schema.brand).toEqual({ "@type": "Brand", name: "SmartLic" });
+      expect(schema.offers).toHaveLength(3); // monthly + semiannual + annual
+    }
+  });
+
+  it("Pro offers match PRO_PRICING source of truth", () => {
+    const { container } = render(<ProductSchema />);
+    const [proSchema] = extractSchemas(container);
+
+    const priceByPeriod = Object.fromEntries(
+      proSchema.offers.map((o) => [o.category, Number(o.price)])
+    );
+
+    expect(priceByPeriod.monthly).toBe(PRO_PRICING.monthly.monthly);
+    expect(priceByPeriod.semiannual).toBe(PRO_PRICING.semiannual.monthly);
+    expect(priceByPeriod.annual).toBe(PRO_PRICING.annual.monthly);
+  });
+
+  it("Consultoria offers match CONSULTORIA_PRICING source of truth", () => {
+    const { container } = render(<ProductSchema />);
+    const [, consultoriaSchema] = extractSchemas(container);
+
+    const priceByPeriod = Object.fromEntries(
+      consultoriaSchema.offers.map((o) => [o.category, Number(o.price)])
+    );
+
+    expect(priceByPeriod.monthly).toBe(CONSULTORIA_PRICING.monthly.monthly);
+    expect(priceByPeriod.semiannual).toBe(CONSULTORIA_PRICING.semiannual.monthly);
+    expect(priceByPeriod.annual).toBe(CONSULTORIA_PRICING.annual.monthly);
+  });
+
+  it("all offers declare BRL currency, InStock availability, and priceValidUntil ≥ today", () => {
+    const { container } = render(<ProductSchema />);
+    const schemas = extractSchemas(container);
+    const today = new Date().toISOString().split("T")[0];
+
+    for (const schema of schemas) {
+      for (const offer of schema.offers) {
+        expect(offer.priceCurrency).toBe("BRL");
+        expect(offer.availability).toBe("https://schema.org/InStock");
+        expect(offer.priceValidUntil >= today).toBe(true);
+      }
+    }
+  });
+
+  it("offer prices are formatted with two decimal places (schema.org convention)", () => {
+    const { container } = render(<ProductSchema />);
+    const schemas = extractSchemas(container);
+
+    for (const schema of schemas) {
+      for (const offer of schema.offers) {
+        expect(offer.price).toMatch(/^\d+\.\d{2}$/);
+      }
+    }
+  });
+
+  it("AggregateOffer bounds agree with per-plan Offers", () => {
+    // Invariant documented in `lib/plan-pricing.ts`: AGGREGATE_OFFER_BOUNDS
+    // must cover all per-plan prices emitted by ProductSchema.
+    const { container } = render(<ProductSchema />);
+    const schemas = extractSchemas(container);
+    const allPrices = schemas.flatMap((s) => s.offers.map((o) => Number(o.price)));
+    expect(Math.min(...allPrices)).toBe(AGGREGATE_OFFER_BOUNDS.lowPrice);
+    expect(Math.max(...allPrices)).toBe(AGGREGATE_OFFER_BOUNDS.highPrice);
+    expect(allPrices).toHaveLength(AGGREGATE_OFFER_BOUNDS.offerCount);
+  });
+
+  it("getPriceValidUntil returns YYYY-MM-DD exactly 1 year ahead of input", () => {
+    const fixed = new Date("2026-04-21T12:00:00Z");
+    expect(getPriceValidUntil(fixed)).toBe("2027-04-21");
+  });
+});

--- a/frontend/app/components/StructuredData.tsx
+++ b/frontend/app/components/StructuredData.tsx
@@ -8,6 +8,8 @@
  * so async loading via next/script adds unnecessary overhead and delays
  * structured data availability for crawlers.
  */
+import { AGGREGATE_OFFER_BOUNDS, getPriceValidUntil } from "@/lib/plan-pricing";
+
 export function StructuredData() {
   // Organization Schema — AC6 + STORY-439 AC4: Trust completeness (taxID, founder, addressLocality)
   const organizationSchema = {
@@ -82,10 +84,12 @@ export function StructuredData() {
     operatingSystem: 'Web',
     offers: {
       '@type': 'AggregateOffer',
-      lowPrice: '1599.00',
-      highPrice: '1999.00',
-      priceCurrency: 'BRL',
-      offerCount: 3,
+      lowPrice: AGGREGATE_OFFER_BOUNDS.lowPrice.toFixed(2),
+      highPrice: AGGREGATE_OFFER_BOUNDS.highPrice.toFixed(2),
+      priceCurrency: AGGREGATE_OFFER_BOUNDS.priceCurrency,
+      offerCount: AGGREGATE_OFFER_BOUNDS.offerCount,
+      priceValidUntil: getPriceValidUntil(),
+      availability: 'https://schema.org/InStock',
     },
     description: 'Avaliação de viabilidade de licitações públicas com critérios objetivos. Filtragem por setor, região e modalidade. Relatórios Excel e pipeline de oportunidades.',
     screenshot: 'https://smartlic.tech/api/og',

--- a/frontend/app/planos/components/ProductSchema.tsx
+++ b/frontend/app/planos/components/ProductSchema.tsx
@@ -1,0 +1,82 @@
+/**
+ * JSON-LD Product schema for /planos page (STORY-SEO-004).
+ *
+ * Emits 2 Products (SmartLic Pro + Consultoria), each with 3 Offers
+ * (monthly, semiannual, annual), matching the billing periods shown in the UI.
+ *
+ * Rich Results eligibility requires: name, offers, brand, description,
+ * priceValidUntil, availability. Aligned with schema.org/Product spec.
+ */
+import {
+  CONSULTORIA_PRICING,
+  PRO_PRICING,
+  PricingTable,
+  getPriceValidUntil,
+} from "@/lib/plan-pricing";
+
+const SITE_URL = "https://smartlic.tech";
+
+type ProductSpec = {
+  name: string;
+  description: string;
+  pricing: PricingTable;
+  urlQueryKey: string;
+};
+
+const PRODUCTS: ProductSpec[] = [
+  {
+    name: "SmartLic Pro",
+    description:
+      "Inteligência de decisão em licitações públicas para empresas B2G: avaliação de viabilidade, filtragem setorial, pipeline e exportação Excel.",
+    pricing: PRO_PRICING,
+    urlQueryKey: "pro",
+  },
+  {
+    name: "SmartLic Consultoria",
+    description:
+      "Plano Consultoria SmartLic: até 5 usuários, 5.000 análises/mês, dashboard consolidado e suporte dedicado para consultorias e assessorias de licitação.",
+    pricing: CONSULTORIA_PRICING,
+    urlQueryKey: "consultoria",
+  },
+];
+
+function buildProductSchema(product: ProductSpec, priceValidUntil: string): Record<string, unknown> {
+  const offers = Object.entries(product.pricing).map(([period, entry]) => ({
+    "@type": "Offer",
+    price: entry.monthly.toFixed(2),
+    priceCurrency: "BRL",
+    availability: "https://schema.org/InStock",
+    priceValidUntil,
+    category: period,
+    url: `${SITE_URL}/planos?plan=${product.urlQueryKey}&period=${period}`,
+  }));
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: product.name,
+    description: product.description,
+    brand: {
+      "@type": "Brand",
+      name: "SmartLic",
+    },
+    offers,
+  };
+}
+
+export function ProductSchema() {
+  const priceValidUntil = getPriceValidUntil();
+  const schemas = PRODUCTS.map((p) => buildProductSchema(p, priceValidUntil));
+
+  return (
+    <>
+      {schemas.map((schema, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/app/planos/page.tsx
+++ b/frontend/app/planos/page.tsx
@@ -21,8 +21,10 @@ import { PlanStatusBanners } from "./components/PlanStatusBanners";
 import { PlanProCard } from "./components/PlanProCard";
 import { PlanConsultoriaCard } from "./components/PlanConsultoriaCard";
 import { PlanFAQ } from "./components/PlanFAQ";
+import { ProductSchema } from "./components/ProductSchema";
 import { buttonVariants } from "../../components/ui/button";
 import { trackViewItem, trackBeginCheckout } from "../components/GoogleAnalytics";
+import { PRO_PRICING, CONSULTORIA_PRICING } from "@/lib/plan-pricing";
 import type { components } from "../api-types.generated";
 
 // STORY-2.1 (EPIC-TD-2026Q2): Profile shape is a subset of the backend
@@ -30,12 +32,9 @@ import type { components } from "../api-types.generated";
 // callers can pass the full response unchanged.
 type UserProfile = Partial<components["schemas"]["UserProfileResponse"]>;
 
-// STORY-360 AC2: Static fallback pricing (source of truth: backend GET /v1/plans -> Stripe)
-const PRICING_FALLBACK: Record<BillingPeriod, { monthly: number; total: number; period: string; discount?: number }> = {
-  monthly: { monthly: 397, total: 397, period: "mês" },
-  semiannual: { monthly: 357, total: 2142, period: "semestre", discount: 10 },
-  annual: { monthly: 297, total: 3564, period: "ano", discount: 25 },
-};
+// STORY-360 AC2 + STORY-SEO-004: pricing source of truth lives in `lib/plan-pricing.ts`
+// (consumed here and by ProductSchema.tsx to keep JSON-LD in sync with UI).
+const PRICING_FALLBACK = PRO_PRICING;
 
 // GTM-002: Features list
 const FEATURES = [
@@ -48,11 +47,7 @@ const FEATURES = [
   { text: "Filtragem com 1.000+ regras", detail: "Precisão setorial para seu mercado" },
 ];
 
-const CONSULTORIA_PRICING_FALLBACK: Record<BillingPeriod, { monthly: number; total: number; period: string; discount?: number }> = {
-  monthly: { monthly: 997, total: 997, period: "mês" },
-  semiannual: { monthly: 897, total: 5382, period: "semestre", discount: 10 },
-  annual: { monthly: 797, total: 9564, period: "ano", discount: 20 },
-};
+const CONSULTORIA_PRICING_FALLBACK = CONSULTORIA_PRICING;
 
 const CONSULTORIA_FEATURES = [
   { text: "Até 5 usuários", detail: "Sua equipe inteira em uma só conta" },
@@ -302,6 +297,7 @@ export default function PlanosPage() {
 
   return (
     <div className="min-h-screen bg-[var(--canvas)]">
+      <ProductSchema />
       <LandingNavbar />
 
       {/* Stripe redirect overlay */}

--- a/frontend/lib/plan-pricing.ts
+++ b/frontend/lib/plan-pricing.ts
@@ -1,0 +1,52 @@
+/**
+ * Single source of truth for plan pricing across the frontend.
+ *
+ * Runtime fallback when backend `GET /v1/plans` is unavailable; also feeds
+ * structured data (JSON-LD Product/Offer schemas) and Rich Results.
+ *
+ * Backend canonical source: `plan_billing_periods` table (synced from Stripe).
+ * Keep these values in sync with STORY-277/360 pricing policy.
+ */
+
+export type BillingPeriod = "monthly" | "semiannual" | "annual";
+
+export interface PricingEntry {
+  /** Monthly cost at this billing cadence (R$). */
+  monthly: number;
+  /** Total billed at cadence (R$): monthly × periods. */
+  total: number;
+  /** Human-readable period label ("mês", "semestre", "ano"). */
+  period: string;
+  /** Discount percentage vs monthly cadence, if any. */
+  discount?: number;
+}
+
+export type PricingTable = Record<BillingPeriod, PricingEntry>;
+
+export const PRO_PRICING: PricingTable = {
+  monthly: { monthly: 397, total: 397, period: "mês" },
+  semiannual: { monthly: 357, total: 2142, period: "semestre", discount: 10 },
+  annual: { monthly: 297, total: 3564, period: "ano", discount: 25 },
+};
+
+export const CONSULTORIA_PRICING: PricingTable = {
+  monthly: { monthly: 997, total: 997, period: "mês" },
+  semiannual: { monthly: 897, total: 5382, period: "semestre", discount: 10 },
+  annual: { monthly: 797, total: 9564, period: "ano", discount: 20 },
+};
+
+/** Stable min/max across both tiers, for AggregateOffer schema. */
+export const AGGREGATE_OFFER_BOUNDS = {
+  lowPrice: Math.min(PRO_PRICING.annual.monthly, CONSULTORIA_PRICING.annual.monthly),
+  highPrice: Math.max(PRO_PRICING.monthly.monthly, CONSULTORIA_PRICING.monthly.monthly),
+  // 2 tiers × 3 periods each
+  offerCount: 6,
+  priceCurrency: "BRL" as const,
+};
+
+/** ISO-8601 date one year from `now`, used for Offer.priceValidUntil. */
+export function getPriceValidUntil(now: Date = new Date()): string {
+  const next = new Date(now);
+  next.setFullYear(next.getFullYear() + 1);
+  return next.toISOString().split("T")[0];
+}


### PR DESCRIPTION
## Summary

Implements STORY-SEO-004 (2 SP, P1 quick win). Fixes two SEO bugs on structured data:

1. **SoftwareApplication** schema on homepage declared lowPrice=R\$1599 / highPrice=R\$1999 — roughly **4× the real pricing** (R\$297–R\$997). Google SERP "Software" rich snippet could show wrong values, decaying CTR.
2. **/planos** page did not emit Product JSON-LD per plan → not eligible for Google Merchant Listings / pricing-table SERP enhancements / SGE comparisons.

## Context

Real pricing (per STORY-277/360 policy, source: \`plan_billing_periods\`):
- **SmartLic Pro**: R\$397/mo (monthly), R\$357/mo (semiannual -10%), R\$297/mo (annual -25%)
- **Consultoria**: R\$997/mo (monthly), R\$897/mo (semiannual -10%), R\$797/mo (annual -20%)

Audit reference: \`docs/plans/elenque-todas-as-fragilidades-humble-dream.md\` (Audit 3.2 + 3.3).

## Changes

| File | Role |
|------|------|
| \`frontend/lib/plan-pricing.ts\` (new) | Single source of truth for Pro & Consultoria pricing; schema-ready \`AGGREGATE_OFFER_BOUNDS\` and \`getPriceValidUntil()\` helpers |
| \`frontend/app/planos/components/ProductSchema.tsx\` (new) | Emits 2 Product JSON-LD nodes × 3 Offers each (monthly, semiannual, annual) |
| \`frontend/app/components/StructuredData.tsx\` | AggregateOffer now reads from \`AGGREGATE_OFFER_BOUNDS\`; adds \`priceValidUntil\` + \`availability: InStock\` |
| \`frontend/app/planos/page.tsx\` | Imports pricing from SSoT module (replaces inline duplicates); renders \`<ProductSchema />\` |
| \`frontend/__tests__/planos/ProductSchema.test.tsx\` (new) | 8 unit tests |

## Acceptance Criteria

- [x] **AC1** — lowPrice=297, highPrice=997, offerCount=6 in SoftwareApplication
- [x] **AC2** — priceValidUntil + availability added
- [x] **AC3** — ProductSchema emits 2 Products × 3 Offers each
- [x] **AC4** — Source of truth centralized in \`lib/plan-pricing.ts\`
- [ ] **AC5** — Rich Results Test PASS (manual step post-deploy; see Testing Plan)
- [x] **AC6** — Unit test validates prices match SSoT + JSON valid

## Closes

Implements STORY-SEO-004 (from EPIC-SEO-2026-04 — see PR #450).

## Testing Plan

- [x] \`npx tsc --noEmit\` → exit 0 (clean)
- [x] \`npm test -- ProductSchema.test\` → 8/8 pass
- [ ] Post-deploy: Rich Results Test on \`https://smartlic.tech\` → SoftwareApplication rich snippet shows R\$297 as lowPrice
- [ ] Post-deploy: Rich Results Test on \`https://smartlic.tech/planos\` → 2 Products detected with valid Offers
- [ ] 2-3 weeks post-deploy: GSC Enhancements → Merchant Listings reports 2 valid URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced pricing pages with structured data markup (JSON-LD) to improve search engine visibility and enable rich search results.
  * Centralized pricing configuration as single source of truth for all plan pricing across the application.

* **Improvements**
  * Updated product schema to include stock availability status and price validity dates.

* **Tests**
  * Added comprehensive test suite for product schema generation, validation, and price consistency verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->