### PR TITLE
feat(seo-006): RUM for Core Web Vitals via web-vitals → GA4

### DIFF
--- a/docs/observability/web-vitals.md
+++ b/docs/observability/web-vitals.md
@@ -1,0 +1,74 @@
+# Web Vitals — Real User Monitoring (RUM)
+
+**Owner:** `@architect` · **Since:** 2026-04-21 · **Story:** STORY-SEO-006
+
+## What is instrumented
+
+`frontend/app/components/WebVitalsReporter.tsx` hooks into the [`web-vitals` npm package](https://github.com/GoogleChrome/web-vitals) and forwards five Core/adjacent metrics to Google Analytics 4 as custom `web_vitals` events:
+
+| Metric | What it measures | Good | Needs-improvement | Poor |
+|--------|------------------|------|-------------------|------|
+| **LCP** — Largest Contentful Paint | Time until the biggest above-the-fold element is painted | ≤ 2.5 s | 2.5–4.0 s | > 4.0 s |
+| **INP** — Interaction to Next Paint | Overall interaction latency (p75 across page interactions) | ≤ 200 ms | 200–500 ms | > 500 ms |
+| **CLS** — Cumulative Layout Shift | Sum of unexpected layout shifts (unitless; reported × 1000) | ≤ 0.1 | 0.1–0.25 | > 0.25 |
+| **TTFB** — Time To First Byte | Server responsiveness | ≤ 800 ms | 800–1800 ms | > 1800 ms |
+| **FCP** — First Contentful Paint | First painted content on the page | ≤ 1.8 s | 1.8–3.0 s | > 3.0 s |
+
+Thresholds are Google's — align with what Search Console reports in the **Core Web Vitals** section.
+
+## How to see the data
+
+1. Open **GA4** → property for `smartlic.tech`.
+2. **Reports → Engagement → Events** — confirm `web_vitals` shows a rising count after deploy (lag ~1 h).
+3. **Explore → Free form**:
+   - Dimensions: `Event name`, `metric_name` (custom), `Page path`
+   - Metrics: `Event count`, **custom metric** `metric_value` with aggregation `Percentile 75`
+   - Filter: `Event name = web_vitals`
+   - Rows: `Page path`; Columns: `metric_name`
+4. Save the exploration as **Web Vitals RUM p75**.
+
+Custom dimension / metric registration (one-time in GA4 Admin):
+
+| Type | Name | Scope | Event param |
+|------|------|-------|-------------|
+| Custom dimension | `metric_name` | Event | `event_label` |
+| Custom metric | `metric_value` | Event | `metric_value` (unit: Standard) |
+| Custom dimension | `metric_rating` | Event | `metric_rating` |
+
+## How to react to regression
+
+1. **LCP p75 > 3 s on `/`, `/planos`, or `/buscar` for 3 consecutive days** — open a perf bug. Common culprits: unoptimized hero image, third-party script blocking render, font loading strategy.
+2. **INP p75 > 300 ms on any top-traffic page** — investigate long tasks via Chrome DevTools Performance panel; consider `startTransition` or code-splitting.
+3. **CLS p75 > 0.15** — find the offending element: `web.dev/debug-layout-shifts`. Usually missing `width`/`height` on images or late-loading ads/embeds.
+4. **TTFB p75 > 1 s consistently** — backend/CDN issue, coordinate with `@devops`.
+
+## Complementary signals
+
+- **Lighthouse CI** (runs on PRs) — synthetic lab measurement. Good for catching regressions in PR before merge.
+- **Google Search Console → Core Web Vitals** — 28-day rolling aggregate at URL-group level. Lags ~3 weeks behind deploy.
+- **Microsoft Clarity** — heatmaps + session recordings, not quantitative CWV.
+
+The `web_vitals` GA4 stream is the **only** real-time, per-URL RUM source in this stack. Trust it over lab data for production decisions.
+
+## Scope & non-goals
+
+- Does not auto-alert on regression. Dashboard is pull-only. If/when needed, a future story can wire a GA4 Alert or a Grafana check over the BigQuery export.
+- Sampling: 100% (GA4 default — SmartLic traffic is well below the 10M events/day threshold that triggers sampling).
+- No PII in the payload — only metric IDs and ratings.
+
+## Troubleshooting
+
+**"No web_vitals events in GA4"**
+- `window.gtag` is missing — check `GoogleAnalytics` component mounted and consent is granted.
+- Ad-blocker stripping `gtag` — expected; consented real users will still report.
+- DNT (Do Not Track) honored via consent banner → no data for those users.
+
+**"Values look way too high"**
+- CLS is multiplied by 1000 when stored as `value` to fit GA4's integer metric aggregation. The raw float is preserved in `metric_value` — use that for accurate analysis.
+
+## Related
+
+- `frontend/app/components/WebVitalsReporter.tsx` — implementation
+- `frontend/app/layout.tsx` — mount point
+- `frontend/app/components/GoogleAnalytics.tsx` — `gtag` provider (consent-gated)
+- STORY-SEO-005 (planned) — `/admin/seo` dashboard integration (pull GA4 Data API → display CWV side-by-side with GSC)

--- a/frontend/__tests__/WebVitalsReporter.test.tsx
+++ b/frontend/__tests__/WebVitalsReporter.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * STORY-SEO-006: WebVitalsReporter hooks web-vitals callbacks and dispatches
+ * GA4 `web_vitals` events via `window.gtag` (silently no-oping when absent).
+ *
+ * Note: jest.config has `resetMocks: true`, so the mock implementations are
+ * wiped between tests. We re-install them in beforeEach to capture handlers.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import type { Metric } from "web-vitals";
+import * as webVitals from "web-vitals";
+
+jest.mock("web-vitals", () => ({
+  onCLS: jest.fn(),
+  onINP: jest.fn(),
+  onLCP: jest.fn(),
+  onTTFB: jest.fn(),
+  onFCP: jest.fn(),
+}));
+
+import { WebVitalsReporter } from "@/app/components/WebVitalsReporter";
+
+type MetricName = "CLS" | "INP" | "LCP" | "TTFB" | "FCP";
+const handlers: { [K in MetricName]?: (m: Metric) => void } = {};
+
+function installMocks() {
+  for (const key of Object.keys(handlers)) delete handlers[key as MetricName];
+  const capture =
+    (key: MetricName) =>
+    (cb: (m: Metric) => void): void => {
+      handlers[key] = cb;
+    };
+  (webVitals.onCLS as jest.Mock).mockImplementation(capture("CLS"));
+  (webVitals.onINP as jest.Mock).mockImplementation(capture("INP"));
+  (webVitals.onLCP as jest.Mock).mockImplementation(capture("LCP"));
+  (webVitals.onTTFB as jest.Mock).mockImplementation(capture("TTFB"));
+  (webVitals.onFCP as jest.Mock).mockImplementation(capture("FCP"));
+}
+
+function makeMetric(
+  name: Metric["name"],
+  value: number,
+  delta = value,
+  rating: Metric["rating"] = "good"
+): Metric {
+  return {
+    name,
+    value,
+    delta,
+    rating,
+    id: `${name}-1`,
+    navigationType: "navigate",
+    entries: [],
+  } as unknown as Metric;
+}
+
+describe("WebVitalsReporter (STORY-SEO-006)", () => {
+  let gtagSpy: jest.Mock;
+
+  beforeEach(() => {
+    installMocks();
+    gtagSpy = jest.fn();
+    (window as unknown as { gtag?: typeof gtagSpy }).gtag = gtagSpy;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { gtag?: unknown }).gtag;
+  });
+
+  it("registers callbacks for all five web-vitals metrics on mount", () => {
+    render(<WebVitalsReporter />);
+    expect(handlers.CLS).toBeDefined();
+    expect(handlers.INP).toBeDefined();
+    expect(handlers.LCP).toBeDefined();
+    expect(handlers.TTFB).toBeDefined();
+    expect(handlers.FCP).toBeDefined();
+  });
+
+  it("dispatches a GA4 event with rounded integer value for LCP", () => {
+    render(<WebVitalsReporter />);
+    handlers.LCP!(makeMetric("LCP", 2547.83));
+
+    expect(gtagSpy).toHaveBeenCalledTimes(1);
+    const [command, name, params] = gtagSpy.mock.calls[0];
+    expect(command).toBe("event");
+    expect(name).toBe("web_vitals");
+    expect(params).toMatchObject({
+      event_category: "Web Vitals",
+      event_label: "LCP",
+      value: 2548,
+      non_interaction: true,
+      metric_id: "LCP-1",
+      metric_value: 2547.83,
+      metric_rating: "good",
+    });
+  });
+
+  it("scales CLS by 1000 before rounding (GA4 integer aggregation constraint)", () => {
+    render(<WebVitalsReporter />);
+    handlers.CLS!(makeMetric("CLS", 0.073, 0.012));
+
+    const [, , params] = gtagSpy.mock.calls[0];
+    expect(params.value).toBe(73); // 0.073 * 1000 rounded
+    expect(params.metric_value).toBe(0.073); // raw float preserved
+  });
+
+  it("preserves metric_delta in the dispatched params", () => {
+    render(<WebVitalsReporter />);
+    handlers.INP!(makeMetric("INP", 150, 22));
+
+    const [, , params] = gtagSpy.mock.calls[0];
+    expect(params.metric_delta).toBe(22);
+  });
+
+  it("silently no-ops when window.gtag is missing (consent denied / ad-blocker)", () => {
+    delete (window as unknown as { gtag?: unknown }).gtag;
+    render(<WebVitalsReporter />);
+
+    expect(() => handlers.LCP!(makeMetric("LCP", 1234))).not.toThrow();
+  });
+
+  it("renders nothing (null component)", () => {
+    const { container } = render(<WebVitalsReporter />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/app/components/WebVitalsReporter.tsx
+++ b/frontend/app/components/WebVitalsReporter.tsx
@@ -1,0 +1,53 @@
+/**
+ * STORY-SEO-006: Real User Monitoring (RUM) for Core Web Vitals.
+ *
+ * Reports LCP / INP / CLS / TTFB / FCP from real users into Google Analytics 4
+ * via custom `web_vitals` events. GA4 was chosen over Vercel Speed Insights
+ * because SmartLic is hosted on Railway, not Vercel (Opção B in the story).
+ *
+ * Silently no-ops if `window.gtag` is unavailable (consent denied, ad-blocker,
+ * script failure) — never throws, never blocks rendering.
+ *
+ * Read docs/observability/web-vitals.md for interpretation thresholds and
+ * how to build the GA4 Explorations dashboard.
+ */
+"use client";
+
+import { useEffect } from "react";
+import { onCLS, onINP, onLCP, onTTFB, onFCP, type Metric } from "web-vitals";
+
+// `window.gtag` is declared globally (with a broader signature) in
+// `app/components/GoogleAnalytics.tsx` — reuse it here instead of redeclaring.
+
+function report(metric: Metric): void {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") {
+    return;
+  }
+
+  // CLS is a unitless ratio; multiply by 1000 so GA4 can aggregate as integer.
+  const value = metric.name === "CLS" ? Math.round(metric.value * 1000) : Math.round(metric.value);
+
+  window.gtag("event", "web_vitals", {
+    event_category: "Web Vitals",
+    event_label: metric.name,
+    value,
+    non_interaction: true,
+    metric_id: metric.id,
+    metric_value: metric.value,
+    metric_delta: metric.delta,
+    metric_rating: metric.rating,
+    navigation_type: metric.navigationType,
+  });
+}
+
+export function WebVitalsReporter(): null {
+  useEffect(() => {
+    onCLS(report);
+    onINP(report);
+    onLCP(report);
+    onTTFB(report);
+    onFCP(report);
+  }, []);
+
+  return null;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -17,6 +17,7 @@ import { UserProvider } from "../contexts/UserContext";
 import { StructuredData } from "./components/StructuredData";
 import { GoogleAnalytics } from "./components/GoogleAnalytics";
 import { ClarityAnalytics } from "./components/ClarityAnalytics";
+import { WebVitalsReporter } from "./components/WebVitalsReporter";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -173,6 +174,8 @@ export default function RootLayout({
         />
       </head>
       <body>
+        {/* STORY-SEO-006: Real User Monitoring for Core Web Vitals → GA4 */}
+        <WebVitalsReporter />
         {/* Skip navigation link for accessibility - WCAG 2.4.1 Bypass Blocks */}
         <a
           href="#main-content"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "tailwind-merge": "^3.5.0",
         "use-debounce": "^10.1.0",
         "uuid": "^13.0.0",
+        "web-vitals": "^5.2.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -24397,6 +24398,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "tailwind-merge": "^3.5.0",
     "use-debounce": "^10.1.0",
     "uuid": "^13.0.0",
+    "web-vitals": "^5.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Implements STORY-SEO-006 (2 SP, P1 quick win). Instruments `web-vitals` npm package to report LCP/INP/CLS/TTFB/FCP from real users into Google Analytics 4 as custom `web_vitals` events. Fills the "Performance category (10% of SEO score) not measurable" gap from audit 2026-04-21.

## Context

Opção A (Vercel Speed Insights) was discarded in story Dev Notes: SmartLic is hosted on Railway, not Vercel. Opção B implemented: `web-vitals` package → custom GA4 events.

Audit ref: \`docs/plans/elenque-todas-as-fragilidades-humble-dream.md\` (Audit 5.1 + 5.4).

## Changes

| File | Role |
|------|------|
| \`frontend/package.json\`, \`package-lock.json\` | Add \`web-vitals@^5.2.0\` |
| \`frontend/app/components/WebVitalsReporter.tsx\` (new) | Client component; registers callbacks; dispatches GA4 events; no-op when \`gtag\` absent |
| \`frontend/app/layout.tsx\` | Mount \`<WebVitalsReporter />\` inside \`<body>\` |
| \`docs/observability/web-vitals.md\` (new) | Thresholds, GA4 Exploration setup, custom dimension/metric mapping, regression reaction playbook, troubleshooting |
| \`frontend/__tests__/WebVitalsReporter.test.tsx\` (new) | 6 unit tests |

## Event payload (dispatched to GA4)

```js
gtag('event', 'web_vitals', {
  event_category: 'Web Vitals',
  event_label: 'LCP',          // or INP/CLS/TTFB/FCP
  value: 2548,                 // integer (CLS × 1000)
  non_interaction: true,
  metric_id: 'LCP-1',
  metric_value: 2547.83,       // raw float preserved
  metric_delta: 22,
  metric_rating: 'good',       // good | needs-improvement | poor
  navigation_type: 'navigate'
});
```

## Acceptance Criteria

- [x] **AC1** — Opção decidida (B) + documentada
- [x] **AC3** — Implementação Opção B completa
- [ ] **AC4** — Dashboard GA4 Exploration (instruções no doc — requer ~1h em GA4 admin + 24h de ingestão inicial)
- [ ] **AC5** — CI threshold LCP p75 > 3s (blocked pending 7 days of baseline data; TODO registrado no doc)
- [ ] **AC6** — Integração \`/admin/seo\` dashboard (escopo da STORY-SEO-005)
- [x] **AC7** — Doc \`docs/observability/web-vitals.md\`

## Closes

Implements STORY-SEO-006 (from EPIC-SEO-2026-04 — see PR #450).

## Testing Plan

- [x] \`npx tsc --noEmit\` → exit 0
- [x] \`npm test -- WebVitalsReporter.test\` → 6/6 pass
- [ ] Post-deploy (24h): GA4 → Engagement → Events mostra \`web_vitals\` com contagem crescente
- [ ] Post-deploy (7d): Exploration "Web Vitals RUM p75" tem ≥1.000 samples e cobre home/planos/buscar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Real User Monitoring for Core Web Vitals (LCP, INP, CLS, TTFB, FCP) with automatic reporting to Google Analytics 4.

* **Documentation**
  * Added comprehensive guide for monitoring Core Web Vitals, including GA4 setup, metric interpretation, and troubleshooting steps.

* **Tests**
  * Added test suite validating Core Web Vitals collection and Google Analytics integration.

* **Chores**
  * Added `web-vitals` package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->