### PR TITLE
fix(tests): deterministic signature tampering (kills 3.11 flake)

### DIFF
--- a/backend/tests/test_cancel_trial_token.py
+++ b/backend/tests/test_cancel_trial_token.py
@@ -160,9 +160,19 @@ class TestCreateAndVerifyToken:
         assert exc.value.reason == "expired"
 
     def test_invalid_signature_rejected(self):
+        # Flipping a single last char is flaky: HMAC-SHA256 base64url uses
+        # 43 chars × 6 bits = 258 bits for a 256-bit signature — the last
+        # char has 2 padding bits. Chars in the base64url alphabet that share
+        # the same top-4 bits (e.g. "A"/"B", "C"/"D") decode to IDENTICAL
+        # bytes after padding strip, so a naive flip may yield the same
+        # signature bytes ~6.25% of the time → test passes/fails by chance.
+        #
+        # Deterministic fix: replace the entire signature with "A"*len — this
+        # produces all-zero decoded bytes which cannot possibly be a valid
+        # HMAC-SHA256 output for the given (header, payload, secret) tuple.
         token = create_cancel_trial_token(USER_ID)
-        # Flip last char to break signature
-        tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+        header, payload, signature = token.split(".")
+        tampered = f"{header}.{payload}.{'A' * len(signature)}"
 
         with pytest.raises(TrialCancelTokenError) as exc:
             verify_cancel_trial_token(tampered)


### PR DESCRIPTION
## Summary

Addresses DEBT-CI-3.11-flaky-trial-cancel-token — killing the sole flaky test blocking CI green baseline.

**Root cause (empirical, sessão prancy-pudding 2026-04-21):**
HMAC-SHA256 signatures encoded as 43-char base64url use 258 bits for 256 bits of data — the last char carries 2 padding bits. Chars in the base64url alphabet that share the same top-4 bits (A/B, C/D, etc.) decode to IDENTICAL bytes after padding strip.

The previous test flipped only the last char:

\`\`\`python
tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
\`\`\`

When \`token[-1]\` happened to be in an ambiguous char group (~6.25% probability over the 64-char alphabet), the flip produced decode-equivalent signatures → verification passed → test failed with \`DID NOT RAISE TrialCancelTokenError\`. Python 3.11 CI hit this sometimes; 3.12 mostly didn't (JWT generation is determinstic within a run but iat/exp timestamps vary across runs, producing different last chars).

**Fix:** replace the entire signature with \`"A" * len(signature)\` — all-zero decoded bytes cannot possibly equal a valid HMAC-SHA256 output for the given (header, payload, secret) tuple. Deterministic.

## Testing Plan

- [x] Local validation: \`TrialCancelTokenError raised with reason=invalid_signature\` ✓
- [ ] CI Backend Tests (3.11) matrix passes
- [ ] CI Backend Tests (3.12) matrix passes
- [ ] Test coverage preserved — scenario "signature tampered → rejection" still exercised

## Closes

- DEBT-CI-3.11-flaky-trial-cancel-token (docs/stories/DEBT-CI-3.11-flaky-trial-cancel-token.story.md)

Unblocks: PR #453 (SEO-006 web-vitals), PR #455 (SEO-001 sitemap observability), Dependabot batch (#417, #418, #419, #420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)