### PR TITLE
fix(seo-001): serialize sitemap/4.xml backend fetches — unblocks 10k entity URLs

### DIFF
--- a/frontend/__tests__/app/sitemap-parallel-fetch.test.ts
+++ b/frontend/__tests__/app/sitemap-parallel-fetch.test.ts
@@ -1,17 +1,19 @@
 /**
  * @jest-environment node
  *
- * Regression test for HTTP 524 sitemap timeout fix.
+ * Regression test for sitemap fetch behavior.
  *
- * Bug: sitemap() chamava endpoints do backend sequencialmente, somando latência →
- * Railway/Cloudflare retornava HTTP 524.
+ * Historical context:
+ *  - v1 (pre-SEO-460): awaits sequenciais → somou latência → HTTP 524.
+ *  - v2 (SEO-460): Promise.all paraleliza + AbortSignal.timeout(15000).
+ *  - v3 (#458, 2026-04-21): awaits sequenciais DE NOVO — 6 fetches paralelos
+ *    saturavam o backend em produção (todos timeoutavam simultaneamente em ~30s+),
+ *    resultando em sitemap/4.xml vazio. Serialização + ISR 1h (revalidate=3600)
+ *    move o custo para 1 request/h por shard (amortizado entre crawlers).
  *
- * Fix: Promise.all() paraleliza as chamadas; AbortSignal.timeout(15000) limita cada
- * fetch a 15s individualmente.
- *
- * Com o Sitemap Index (SEO-460), os endpoints ficam distribuídos por sub-sitemap:
+ * Por sub-sitemap:
  *  - id:2 → /v1/sitemap/licitacoes-indexable (1 endpoint)
- *  - id:4 → 6 endpoints de entidades em Promise.all
+ *  - id:4 → 6 endpoints de entidades em awaits sequenciais
  */
 
 // Mock fetch globally (node env pattern — see __tests__/api/buscar.test.ts)
@@ -76,7 +78,7 @@ function makeFastFetchMock() {
   );
 }
 
-describe('sitemap() — parallel fetch regression (HTTP 524 fix)', () => {
+describe('sitemap() — fetch behavior (signal + serialization)', () => {
   beforeEach(() => {
     (global.fetch as jest.Mock).mockReset();
   });
@@ -110,12 +112,13 @@ describe('sitemap() — parallel fetch regression (HTTP 524 fix)', () => {
     }
   });
 
-  it('sub-sitemap id:4 inicia todos os 6 fetches antes de qualquer resposta resolver (Promise.all)', async () => {
+  it('sub-sitemap id:4 serializa os 6 fetches (um por vez) para proteger backend de saturação', async () => {
+    // #458: código mudou de Promise.all → awaits sequenciais.
+    // Garantia: no máximo 1 fetch em voo a qualquer momento; o próximo só inicia
+    // após o anterior resolver. Isso previne o 6-way saturation que causava
+    // sitemap/4.xml vazio em produção.
     const initiated: string[] = [];
-    let releaseAll!: () => void;
-    const gate = new Promise<void>((res) => {
-      releaseAll = res;
-    });
+    const resolvers: Array<() => void> = [];
 
     (global.fetch as jest.Mock).mockImplementation(
       (url: string | URL | Request) => {
@@ -123,10 +126,14 @@ describe('sitemap() — parallel fetch regression (HTTP 524 fix)', () => {
         const endpoint = ENTITY_ENDPOINTS.find((e) => urlStr.includes(e));
         if (endpoint) {
           initiated.push(endpoint);
-          return gate.then(() => ({
-            ok: true,
-            json: () => Promise.resolve(PAYLOAD_BY_ENDPOINT[endpoint]),
-          })) as Promise<Response>;
+          return new Promise<Response>((resolve) => {
+            resolvers.push(() =>
+              resolve({
+                ok: true,
+                json: () => Promise.resolve(PAYLOAD_BY_ENDPOINT[endpoint]),
+              } as Response),
+            );
+          });
         }
         return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response);
       },
@@ -135,14 +142,23 @@ describe('sitemap() — parallel fetch regression (HTTP 524 fix)', () => {
     const sitemap = await importSitemapFresh();
     const sitemapPromise = sitemap({ id: 4 });
 
-    // Flush microtasks para que Promise.all dispare todos os fetches
-    for (let i = 0; i < 20; i++) await Promise.resolve();
+    const flush = async () => {
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+    };
 
-    // Com Promise.all: todos os 6 devem estar em voo antes de qualquer resposta resolver
-    // Com sequential awaits (bug original): apenas 1 teria sido iniciado
-    expect(initiated.length).toBe(6);
+    // Serial: após microtasks iniciais, APENAS 1 fetch em voo
+    await flush();
+    expect(initiated.length).toBe(1);
 
-    releaseAll();
+    // Resolve cada um → próximo inicia; contagem avança 1 a 1
+    for (let step = 1; step < ENTITY_ENDPOINTS.length; step++) {
+      resolvers[step - 1]();
+      await flush();
+      expect(initiated.length).toBe(step + 1);
+    }
+
+    // Resolve o último para completar a promise
+    resolvers[ENTITY_ENDPOINTS.length - 1]();
     await sitemapPromise;
   });
 });

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -672,22 +672,14 @@ export default async function sitemap(props: { id: Promise<string> }): Promise<M
     // Lowest crawl priority — Google processes these last.
     // -----------------------------------------------------------------------
     case 4: {
-      // Parallelizar todas as chamadas ao backend — cada helper tem AbortSignal.timeout(15000).
-      const [
-        cnpjList,
-        contratosOrgaoList,
-        orgaoList,
-        fornecedoresCnpjList,
-        municipiosList,
-        itensList,
-      ] = await Promise.all([
-        fetchSitemapCnpjs(),
-        fetchContratosOrgaoIndexable(),
-        fetchSitemapOrgaos(),
-        fetchSitemapFornecedoresCnpj(),
-        fetchSitemapMunicipios(),
-        fetchSitemapItens(),
-      ]);
+      // 6 fetches paralelos saturavam o backend (todos timeoutavam em ~30s+) → sitemap vazio em produção.
+      // Serializados: 5-7s cada, total ~30-45s, dentro do orçamento de runtime ISR.
+      const cnpjList = await fetchSitemapCnpjs();
+      const contratosOrgaoList = await fetchContratosOrgaoIndexable();
+      const orgaoList = await fetchSitemapOrgaos();
+      const fornecedoresCnpjList = await fetchSitemapFornecedoresCnpj();
+      const municipiosList = await fetchSitemapMunicipios();
+      const itensList = await fetchSitemapItens();
 
       // SEO-PLAYBOOK Onda 1: CNPJ pages from datalake (≥1 bid, ~4k-5k URLs)
       const cnpjRoutes: MetadataRoute.Sitemap = cnpjList.map((cnpj) => ({

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -191,6 +191,15 @@ async function fetchSitemapOrgaos(): Promise<string[]> {
  * id:3 — Content/blog pages (~500 URLs, sem backend)
  * id:4 — Entity pages (~10k+ URLs, backend: cnpjs, orgaos, fornecedores)
  */
+/**
+ * ISR 1h — uma regeneração por hora cobre N crawler requests (Google + Bing + Yandex).
+ * Sem isso, cada hit em sitemap/4.xml disparava 6 fetches sequenciais ao backend
+ * (~30-45s) — sob carga de múltiplos crawlers simultâneos, o backend saturaria
+ * novamente mesmo com a serialização deste PR. ISR move o custo para 1 request/h
+ * por shard em vez de 1 request por crawler-hit.
+ */
+export const revalidate = 3600;
+
 export async function generateSitemaps() {
   return [
     { id: 0 }, // Core static pages


### PR DESCRIPTION
## Summary

Hotfix crítico para **STORY-SEO-001 AC2**. Após merge do PR #455 (sitemap observability), validação empírica revelou que `sitemap/4.xml` em produção estava **vazio** (0 URLs) apesar de `BACKEND_URL` estar corretamente setado em Railway.

## Root Cause

6 fetches paralelos em `Promise.all` saturavam o backend:

```
# Sequencial (um endpoint):
curl /v1/sitemap/cnpjs  →  HTTP 200 em 7.0s  (85KB)

# Paralelo (6 endpoints simultaneous):
curl .../cnpjs            →  HTTP=000 timeout 30s+
curl .../contratos-orgao  →  HTTP=000 timeout 30s+
curl .../orgaos           →  HTTP=000 timeout 30s+
curl .../fornecedores     →  HTTP=000 timeout 30s+
curl .../municipios       →  HTTP=000 timeout 30s+
curl .../itens            →  HTTP=000 timeout 30s+
```

Log Railway frontend confirma: `TIMEOUT_ERR (23)` em `.next/server/app/sitemap/[__metadata_id__]/route.js`.

Cada fetch com `AbortSignal.timeout(15000)` cai no `catch` silencioso → retorna `[]` → shard 4 vazio.

## Fix

Serializar os 6 `await`s no handler `case 4` de `frontend/app/sitemap.ts`. Cada fetch ~5-7s, total ~30-45s — dentro do orçamento de runtime ISR.

Backend concurrency root cause fica para investigação futura (candidato a STORY-TD: pool workers / query optimization `pncp_supplier_contracts`).

## Revenue impact

- Desbloqueia ~10k entity URLs no sitemap shard 4
- Cumpre AC2 do EPIC-SEO-2026-04 STORY-SEO-001
- Contribui diretamente para meta do Success Criteria: `smartlic_sitemap_urls_count{shard="4"} > 5000`

## Testing Plan

- [x] Typecheck `npx tsc --noEmit` limpo
- [x] Diagnóstico empírico: curl single (200 OK) vs curl paralelo (timeout cascata)
- [ ] CI: Backend Tests + Frontend Tests verdes
- [ ] Pós-deploy: `curl -sL https://smartlic.tech/sitemap/4.xml | grep -c '<url>'` ≥ 5000
- [ ] GSC: re-submeter sitemap após validação

## Closes

- Task de investigação em `docs/sessions/2026-04/2026-04-21-prancy-pudding-handoff.md` AC1/AC2 (SEO-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated sitemap data loading to run sequentially for more reliable generation.

* **Performance**
  * Added hourly caching so sitemap pages refresh at most once per hour, reducing backend load.

* **Tests**
  * Revised sitemap tests to validate serialized fetch behavior and ensure fetch ordering and timeouts are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->