### PR TITLE
fix(ci): DEBT-CI-storybook — babel-loader para TS/TSX stories

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,6 +1,13 @@
 import type { StorybookConfig } from "@storybook/react-webpack5";
 import path from "path";
 
+// DEBT-CI-storybook: o builder webpack5 puro do Storybook não inclui loader
+// TypeScript — stories .tsx falhavam com "Module parse failed: Unexpected token"
+// ao encontrar type imports. Tentar @storybook/nextjs v8.6 não funciona no projeto
+// porque Next 16 removeu next/config (dependência interna do preset).
+//
+// Solução: registrar babel-loader com preset-typescript + preset-react (todos
+// já em node_modules via next/react deps). Custo zero em tempo de instalação.
 const config: StorybookConfig = {
   stories: [
     "../components/**/*.stories.@(ts|tsx)",
@@ -22,6 +29,32 @@ const config: StorybookConfig = {
         "@": path.resolve(__dirname, ".."),
       };
     }
+    config.module = config.module || {};
+    config.module.rules = config.module.rules || [];
+    config.module.rules.push({
+      test: /\.(ts|tsx)$/,
+      exclude: /node_modules/,
+      use: [
+        {
+          loader: require.resolve("babel-loader"),
+          options: {
+            babelrc: false,
+            configFile: false,
+            presets: [
+              [
+                require.resolve("@babel/preset-env"),
+                { targets: { esmodules: true } },
+              ],
+              [
+                require.resolve("@babel/preset-react"),
+                { runtime: "automatic" },
+              ],
+              require.resolve("@babel/preset-typescript"),
+            ],
+          },
+        },
+      ],
+    });
     return config;
   },
 };


### PR DESCRIPTION
## Summary

Fix do cluster **Storybook Build** que falhava em 100% dos PRs que tocavam `frontend/components/` ou `frontend/app/**/components/`. Impacto empírico: 4+ PRs recentes (#447, #452, #453, #455) com este check vermelho.

## Root Cause (diagnóstico empírico)

`npm run build-storybook` local reproduziu o erro:

```
Module parse failed: Unexpected token (2:12)
File was processed with these loaders:
 * @storybook/csf-plugin/dist/webpack-loader.js
 * @storybook/builder-webpack5/dist/loaders/export-order-loader.js
You may need an additional loader to handle the result of these loaders.
> import type { Meta, StoryObj } from "@storybook/react";
```

`@storybook/react-webpack5` builder puro **não inclui loader TypeScript**. Stories .tsx falhavam no webpack parse de type imports.

## Alternativas avaliadas

1. **`@storybook/nextjs` v8.6.18** (já instalado) — **FALHOU**: `Error: Cannot find module 'next/config'`. Next 16 removeu esse module; @storybook/nextjs v8.6 ainda depende dele.
2. **swc-loader** — não instalado; adicionar criaria diff em `package.json` + `package-lock.json` (churn maior).
3. **babel-loader com presets existentes** — ✅ **ESCOLHIDO**. Todos presets (`@babel/preset-env`, `@babel/preset-react`, `@babel/preset-typescript`) já em `node_modules/` via deps transitivas de next/react.

## Implementation

`webpackFinal` em `.storybook/main.ts` adiciona rule para `.ts`/`.tsx`:

```ts
{
  test: /\.(ts|tsx)$/,
  exclude: /node_modules/,
  use: [{
    loader: require.resolve("babel-loader"),
    options: {
      babelrc: false,
      configFile: false,
      presets: [
        [require.resolve("@babel/preset-env"), { targets: { esmodules: true } }],
        [require.resolve("@babel/preset-react"), { runtime: "automatic" }],
        require.resolve("@babel/preset-typescript"),
      ],
    },
  }],
}
```

**Zero novos pacotes instalados.** Diff = 1 arquivo, 33 linhas adicionadas.

## Testing Plan

- [x] `npm run build-storybook` local SUCCESS (1.45 min, output em `storybook-static/`)
- [ ] CI: `Storybook Build` workflow verde neste PR
- [ ] Chromatic Visual Regression downstream continua passing

## Closes

- `DEBT-CI-storybook-ts-loader.story.md` — AC1, AC2, AC3 atendidos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development build configuration to provide improved TypeScript and React component support in the component story environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->