### PR TITLE
test(countdown): stabilize timing-dependent describe blocks with fake timers

### DIFF
--- a/frontend/__tests__/components/Countdown.test.tsx
+++ b/frontend/__tests__/components/Countdown.test.tsx
@@ -182,6 +182,17 @@ describe('CountdownStatic', () => {
 });
 
 describe('calculateTimeRemaining', () => {
+  // CI flake fix: sem fake timers, Date.now() drift entre criação do futureDate
+  // e chamada de calculateTimeRemaining (que internamente também chama Date.now)
+  // causava hours=2 em vez de 3 quando o runner estava sob carga. Fake timers
+  // congela o clock entre as duas chamadas.
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('calculates days, hours, minutes, seconds correctly', () => {
     const futureDate = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000);
     const time = calculateTimeRemaining(futureDate);
@@ -239,6 +250,15 @@ describe('formatCountdown', () => {
 });
 
 describe('daysUntil', () => {
+  // Mesmo CI flake fix do describe calculateTimeRemaining — congela clock entre
+  // `new Date(Date.now() + ...)` e a chamada interna de Date.now() em daysUntil.
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('calculates days correctly', () => {
     const futureDate = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
     expect(daysUntil(futureDate)).toBe(3);


### PR DESCRIPTION
## Summary

Fix 2 describe blocks em `Countdown.test.tsx` que flakam em CI sob carga. Root cause: `calculateTimeRemaining` e `daysUntil` describes não usavam `jest.useFakeTimers()`. Sem isso, há drift entre `Date.now()` na criação do `futureDate` e a chamada interna dentro do método sob teste. Se o runner está saturado (como agora, com 100+ jobs queued), drift pode ultrapassar DAY/HOUR boundary e virar `hours=2` em vez de `3`.

Fix cirúrgico: 2 pares `beforeEach/afterEach` (10 linhas). Os outros describes do file (`Countdown`, `CountdownStatic`) JÁ usavam fake timers — esta PR apenas porta o pattern para os 2 que faltavam.

## Context

**Evidência empírica** (clever-beaver 2026-04-22):

```
FAILED tests/test_cancel_trial_token.py  -- not this one; this is Countdown test
Summary of all failing tests
FAIL __tests__/components/Countdown.test.tsx
  ● calculateTimeRemaining › calculates days, hours, minutes, seconds correctly
    expect(received).toBe(expected) // Object.is equality
    Expected: 3
    Received: 2
```

Confirmado intermitente em múltiplas runs:
- PR #463 FAIL 2× (runs 24755670651 e 24756477236)
- PR #466 pass uma vez mas risco alto sob saturation atual
- Local (máquina sem carga): 33/33 pass — flake só manifesta em CI

**Por que o fix é correto**:
- `jest.useFakeTimers()` congela `Date.now()` entre chamadas no mesmo tick
- Code sob teste usa `Date.now()` para computar diff → com timers fake, t1 - t0 = 0 sempre
- Outros describes do mesmo file já fazem isso (`Countdown`, `CountdownStatic`)

**Nota sobre CI saturation**: este fix sozinho não acelera a fila do GitHub Actions (cap de 20 concurrent jobs atingido pela cascata de sync-merges em 7 PRs simultâneos). Mas fixa a fonte de FAIL intermitente que amplifica rework quando a fila está congestionada.

## Testing Plan

- [x] Local: `npm test -- --testPathPattern='Countdown'` → **33/33 passes em 41.4s** (validado antes deste commit)
- [x] Diff restrito: apenas 1 arquivo (`frontend/__tests__/components/Countdown.test.tsx`), +20/-0
- [x] Sem touches em código de produção — 100% test-only
- [ ] CI post-merge: workflow Frontend Tests (PR Gate) passa consistentemente em PRs futuros

## Closes

- (nenhuma issue formal — pre-existing flake descoberto empiricamente durante Wave 3.1 do plan YOLO 2026-04-22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for countdown timer functionality by enhancing time control mechanisms in test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->