### PR TITLE
fix(ci): install pydantic[email] in migration-check for schema contract

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -99,8 +99,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Supabase Python client
-        run: pip install supabase --quiet
+      - name: Install Supabase Python client + schema deps
+        # email-validator is needed because backend/schemas/__init__.py imports
+        # user.py which uses pydantic.EmailStr. Without it, schemas.contract
+        # fails at import time with ModuleNotFoundError before --validate runs.
+        run: pip install supabase 'pydantic[email]' --quiet
 
       - name: Validate schema contract
         id: schema_contract


### PR DESCRIPTION
## Summary

- Post-#466 migration-check was still failing in main (see runs 24777046801, 24777067812, 24777161709)
- Root cause: `ModuleNotFoundError: No module named 'email_validator'` when `python -m schemas.contract --validate` imports `backend/schemas/user.py` (uses `pydantic.EmailStr`)
- PR #466 fixed the working-directory but left the install step thin (`pip install supabase` only)

## Context

- Schema contract validator requires the backend schemas package to import cleanly
- `EmailStr` needs the `pydantic[email]` extra, which pulls in `email-validator`
- Backend pins it at `pydantic[email]==2.12.5` (backend/requirements.txt) — workflow now matches

## Testing Plan

- [x] Diff reviewed: single-line add of `'pydantic[email]'` to the pip install
- [x] Root-cause confirmed via failing run log (24777161709) — traceback ends at `import email_validator` in pydantic.networks
- [ ] CI run on this PR should pass Backend Tests (PR Gate) + Frontend Tests (PR Gate)
- [ ] Post-merge: Migration Check (Post-Merge Alert) should turn green in main

## Closes

- Follow-up to #466 for CRIT-050 migration gate chain
- Unblocks Wave 1 gate (CI 100% verde in main) for plan abundant-reddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow dependencies to ensure schema validation executes without import errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->