### PR TITLE
fix(ci): mkdir before supabase init in migration-validate

### DIFF
--- a/.github/workflows/migration-validate.yml
+++ b/.github/workflows/migration-validate.yml
@@ -31,8 +31,13 @@ jobs:
 
       - name: Start Supabase local
         run: |
-          supabase init --workdir /tmp/supabase-test || true
-          cp -r supabase/migrations /tmp/supabase-test/supabase/migrations
+          # Supabase CLI's --workdir flag chdirs BEFORE init and fails if the
+          # target doesn't exist, so create it explicitly and init in-place.
+          mkdir -p /tmp/supabase-test
+          cd /tmp/supabase-test
+          supabase init --yes
+          cd "$GITHUB_WORKSPACE"
+          cp -r supabase/migrations/. /tmp/supabase-test/supabase/migrations/
           cd /tmp/supabase-test
           supabase start
 


### PR DESCRIPTION
## Summary

- Validate Migration Sequence has been failing on every PR touching migrations (observed on #470 run 24758683981)
- Root cause: Supabase CLI's `--workdir /tmp/supabase-test` chdirs BEFORE init, fails because dir doesn't exist
- Downstream: `cp -r supabase/migrations ...` then fails with "No such file or directory"

## Context

Before: `supabase init --workdir /tmp/supabase-test || true` — the `|| true` masked the init failure, leaving the dir un-initialized. The `cp` and `cd` steps then fell over.

After: `mkdir -p /tmp/supabase-test && cd ... && supabase init --yes` — dir exists, init runs in place, migrations copy into the dir created by init, no flag quirks.

## Testing Plan

- [x] Root-cause confirmed via failing log (PR #470 job 72437409855): `failed to change workdir: chdir /tmp/supabase-test: no such file or directory`
- [ ] CI on this PR should pass Validate Migration Sequence (this PR touches a workflow but not a migration, so the path-filter won't run it — validate via re-running on #470 post-merge)
- [ ] Post-merge: Trigger workflow_dispatch on migration-validate.yml to confirm on main
- [ ] #470 Validate Migration Sequence should turn green once its branch rebases onto main with this fix

## Closes

- Unblocks Wave 1.6 (PR triage) for plan abundant-reddy
- Part of the broader CI green effort (CRIT-050 migration chain + post-#407 drift sweep tail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal migration validation workflow configuration for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->