### PR TITLE
fix(test): make invalid_signature tamper deterministic (re-sign wrong key)

### DIFF
--- a/backend/tests/test_cancel_trial_token.py
+++ b/backend/tests/test_cancel_trial_token.py
@@ -244,8 +244,15 @@ class TestCancelTrialInfoEndpoint:
         assert resp.json()["detail"]["error"] == "token_expired"
 
     def test_invalid_signature_returns_400(self):
-        token = create_cancel_trial_token(USER_ID)
-        tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+        # Sign the token with a DIFFERENT secret so the endpoint (running
+        # under the autouse fixture secret) always reports invalid_signature.
+        # A single-char flip of the last base64url char leaves ~1/16 of
+        # possibilities where the decoded signature bytes still validate —
+        # that flakiness caused DNS lookup errors in CI whenever the tamper
+        # accidentally kept the signature valid and the handler tried to
+        # call the real Supabase API.
+        with patch.dict(os.environ, {"TRIAL_CANCEL_JWT_SECRET": "wrong-secret-for-tamper-test-deterministic"}):
+            tampered = create_cancel_trial_token(USER_ID)
 
         app = _make_app()
         client = TestClient(app)


### PR DESCRIPTION
## Summary

- `test_invalid_signature_returns_400` was flaky (~1/16 chance of false-pass) because the tamper was a single-char flip on the last base64url char of the JWT signature
- When the flip preserved signature validity, the endpoint proceeded past verification and called Supabase, producing `httpx.ConnectError: Name or service not known` in CI
- Observed failures: PR #468 run 24756529502, PR #469 run 24757408310, main Tests Matrix run 24757680697 — same test, same error, all three

## Context

- Base64url encodes 3 bytes → 4 chars. When signature length isn't divisible by 3, the last char encodes only 2 or 4 bits; flipping that char often yields the same decoded bytes (1/4 or 1/16 aliasing)
- Session memory already documented this pattern under `feedback_jwt_base64url_flaky_test` — "signature tamper via single-char flip tem 6.25% false-pass; use full-replacement ou re-sign"
- Fix uses the re-sign approach: sign with a DIFFERENT secret so the endpoint's verify (using the autouse fixture secret) always rejects

## Testing Plan

- [x] Local: `python3 -m pytest tests/test_cancel_trial_token.py::TestCancelTrialInfoEndpoint::test_invalid_signature_returns_400 -xvs --no-cov` → 1 passed
- [ ] CI Backend Tests (PR Gate) should pass on this PR
- [ ] Once merged to main, re-running #468 and #469 should clear the Backend Tests failures they currently have
- [ ] Tests (Full Matrix + Integration + E2E) on main should turn green

## Closes

- Unblocks PR #468 (parity contract skeleton), PR #469 (countdown timing), and likely other queued PRs
- Part of Wave 1 gate (CI 100% verde) for plan abundant-reddy
- Also clears the last Tests Matrix failure in main (run 24757680697)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of JWT validation test to ensure invalid tokens are reliably rejected during authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->