### PR TITLE
feat(analytics): emit paywall_hit when search results are truncated

### DIFF
--- a/docs/stories/2026-04/EPIC-MON-AI-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-AI-2026-04.md
@@ -1,0 +1,83 @@
+# EPIC-MON-AI-2026-04: Extras IA/ML sobre o Dataset de 2M+ Contratos
+
+**Priority:** P1 — Wave 2 (moat tecnológico)
+**Status:** Draft
+**Owner:** @architect + @dev + @data-engineer
+**Sprint:** Wave 2 (paralelo com EPIC-MON-SUBS)
+**Meta:** Construir moat defensivo via produtos de IA/ML treinados sobre dataset proprietário; add-ons alto ticket + API ML.
+
+---
+
+## Contexto Estratégico
+
+O dataset de 2.1M contratos históricos é ativo **único no mercado B2G brasileiro** — nenhum competidor tem:
+- Dados estruturados com classificação setorial IA + score de viabilidade
+- Possibilidade de RAG/few-shot sobre corpus proprietário vasto
+- Histórico longitudinal para detecção de sazonalidade/padrões
+
+Três produtos aproveitam esse moat:
+
+| Produto | Preço | Moat |
+|---------|-------|------|
+| Semantic Search / Embeddings API | R$ 0,10–1/query | Base vetorial única do PNCP |
+| AI Copilot de Propostas | R$ 197/proposta ou R$ 497/mês | RAG sobre vencedores — impossível replicar sem o dataset |
+| Radar Preditivo de Editais | R$ 297–997/mês | ML sazonal requer 3+ anos de histórico |
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-AI-01 | P0 | L | @data-engineer + @dev | Draft | Semantic Search / Embeddings API (pgvector) |
+| MON-AI-02 | P1 | XL | @dev + @architect | Draft | AI Copilot de Propostas (RAG) |
+| MON-AI-03 | P1 | XL | @data-engineer + @dev | Draft | Radar Preditivo de Editais (ML sazonal) |
+
+---
+
+## Ordem de Execução
+
+1. **MON-AI-01** primeiro (bloqueia MON-AI-02; usa infra criada em MON-API-01/02)
+2. **MON-AI-02** após MON-AI-01 + MON-REP-01 + MON-SUB-01
+3. **MON-AI-03** paralelo com MON-AI-02 (depende de MON-SCH-01 + MON-SCH-02 + MON-SUB-01; não depende de MON-AI-01)
+
+---
+
+## KPIs do Epic
+
+| KPI | Meta 90 dias | Meta 180 dias |
+|-----|--------------|---------------|
+| Coverage embeddings (top 500k por valor) | 100% | 100% (+ 1M extras) |
+| Queries semantic search/mês | 1.000 | 20.000 |
+| Propostas geradas/mês (Copilot) | 50 | 500 |
+| NPS Copilot | >30 | >50 |
+| Precision Radar Preditivo (backtest) | >60% | >75% |
+| Alertas preditivos acionados | 100/mês | 2.000/mês |
+| Receita Extras IA/ML | R$ 3.000/mês | R$ 50.000/mês |
+
+---
+
+## Dependências
+
+- **Bloqueado por:**
+  - MON-API-01/02 → MON-AI-01 (usa infra API key + metered billing)
+  - MON-AI-01 → MON-AI-02 (RAG usa embeddings)
+  - MON-REP-01 → MON-AI-02 (one-shot R$197)
+  - MON-SUB-01 → MON-AI-02 + MON-AI-03 (add-on recorrente)
+  - MON-SCH-01 + MON-SCH-02 → MON-AI-03
+
+---
+
+## Riscos
+
+- **Custo de embeddings** — vetorizar 2.1M linhas com `text-embedding-3-small` @ USD 0.02/1M tokens; estimativa ~USD 200 one-shot. Priorizar top 500k por valor para controle de custo inicial
+- **Qualidade do Copilot** — rascunhos ruins geram churn; requer validação humana em 20+ propostas reais antes de liberar público
+- **Precision Radar** — ML sazonal sobre procurement é nicho; benchmark internos vs dados históricos obrigatórios antes de cobrar
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — estratégia extra IA/ML (não estava nas 4 camadas originais) |

--- a/docs/stories/2026-04/EPIC-MON-API-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-API-2026-04.md
@@ -1,0 +1,80 @@
+# EPIC-MON-API-2026-04: Camada 4 — API de Dados B2B Monetizada
+
+**Priority:** P1 — Wave 1 Fast-Revenue
+**Status:** Draft
+**Owner:** @architect + @dev + @devops + @qa
+**Sprint:** Wave 1 (paralelo com EPIC-MON-REPORTS)
+**Meta:** Receita B2B pay-per-call R$ 0,50–10/consulta via 3 endpoints + distribuição RapidAPI.
+
+---
+
+## Contexto Estratégico
+
+Hoje a única forma de auth no backend é JWT Supabase (não serve bem B2B). Não existe tabela `api_keys`, middleware `X-API-Key`, nem metered billing (`stripe.UsageRecord`). A STORY-434 (Draft, P2) planeja API GRATUITA sobre licitações ativas — **este epic é diferente**: monetização pay-per-call sobre o dataset de 2M contratos históricos.
+
+**Compradores-alvo:** fintechs, plataformas de compliance, ERPs, sistemas de orçamentação, sites de due diligence, integradores que consomem dado bruto.
+
+**Endpoints:**
+
+| Endpoint | Preço | Use Case |
+|----------|-------|----------|
+| `GET /api/v1/supplier/{cnpj}/history` | R$ 0,50–2 / query | Histórico consolidado por CNPJ |
+| `GET /api/v1/benchmark/price` | R$ 1–5 / query | Distribuição estatística CATMAT/CATSER + UF |
+| `GET /api/v1/supplier/{cnpj}/score` *(Q3)* | R$ 2–10 / query | Score modelado capacidade/risco |
+
+**Distribuição:**
+- Endpoint direto (clientes enterprise)
+- RapidAPI marketplace (DA 91) para descoberta + backlinks
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-API-01 | P0 | M | @dev | Draft | API Key Management (tabela + middleware X-API-Key) |
+| MON-API-02 | P0 | L | @dev + @devops | Draft | Metered Billing (Stripe UsageRecord + audit trail) |
+| MON-API-03 | P1 | M | @dev | Draft | `GET /api/v1/supplier/{cnpj}/history` |
+| MON-API-04 | P1 | M | @dev | Draft | `GET /api/v1/benchmark/price` |
+| MON-API-05 | P1 | M | @dev + @devops | Draft | Distribuição RapidAPI + landing `/api` + docs público |
+| MON-API-06 *(FUTURE Q3)* | P2 | L | @data-engineer + @dev | Backlog | `GET /api/v1/supplier/{cnpj}/score` (requer modelo ML) |
+
+---
+
+## Ordem de Execução
+
+1. **MON-API-01** (sprint 1, bloqueia todas)
+2. **MON-API-02** (sprint 2, depende de MON-API-01)
+3. **MON-API-03** paralelo com **MON-API-04** (MON-API-04 depende também de MON-SCH-02 CATMAT)
+4. **MON-API-05** por último (precisa dos endpoints para docs/demo)
+5. MON-API-06 em backlog Q3
+
+---
+
+## KPIs do Epic
+
+| KPI | Meta 30 dias | Meta 90 dias |
+|-----|-------------|--------------|
+| Clientes B2B ativos | 2 | 15 |
+| Queries/mês | 5.000 | 50.000 |
+| Receita API/mês | R$ 300 | R$ 5.000 |
+| p95 latência | <500ms | <300ms |
+| Uptime | 99.5% | 99.9% |
+| Listagem RapidAPI | Pending | Live + 100 subscribers |
+
+---
+
+## Dependências
+
+- **Bloqueia:** STORY-434 (API pública gratuita) deve reutilizar middleware `X-API-Key` criado em MON-API-01
+- **Bloqueado por:**
+  - MON-SCH-02 (CATMAT) → MON-API-04
+- **Integra com:** MON-AI-01 (Semantic Search usa mesma infra de API key + metered billing)
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — Camada 4 da estratégia de monetização; complementa (não sobrepõe) STORY-434 |

--- a/docs/stories/2026-04/EPIC-MON-DIST-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-DIST-2026-04.md
@@ -1,0 +1,68 @@
+# EPIC-MON-DIST-2026-04: Extras de Distribuição e Empacotamento de Dados
+
+**Priority:** P2 — Wave 3
+**Status:** Draft
+**Owner:** @pm + @architect + @dev + @devops
+**Sprint:** Wave 3 (paralelo com EPIC-MON-SEO)
+**Meta:** Amplificar alcance via 2 canais não convencionais — data licensing one-shot e white-label para consultorias.
+
+---
+
+## Contexto Estratégico
+
+O SmartLic hoje vende majoritariamente direto para o **end-user** (empresa B2G). Dois canais sub-explorados:
+
+### Data Licensing / Bulk Export (one-shot enterprise)
+- Compradores: consultorias McKinsey/BCG, universidades, think tanks, M&A advisors, agências de rating
+- Demanda: dataset temático em CSV/JSON/Parquet para análise offline
+- Ticket: R$ 2.997–49.997 one-shot (sem ciclo de venda longo)
+- Ex: "Construção Civil SP 2020-2025" (500k contratos, R$ 9.997)
+
+### White-label para Consultorias de Licitação
+- Canal: ~15% das empresas B2G usam consultoria especializada — mercado paralelo massivo
+- Modelo: consultoria revende relatórios/monitores com marca própria + Stripe Connect revshare
+- Vantagem: consultoria tem carteira de clientes; nós ganhamos distribuição + receita recorrente escalável
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-DIST-01 | P2 | L | @dev + @devops | Draft | Data Licensing / Bulk Export (pacotes one-shot) |
+| MON-DIST-02 | P2 | XL | @dev + @architect | Draft | White-label para Consultorias (Stripe Connect + branding) |
+
+---
+
+## Ordem de Execução
+
+1. **MON-DIST-01** primeiro (menor esforço, reutiliza MON-REP-01 para checkout)
+2. **MON-DIST-02** depois (requer MON-SUB-01 para revshare em add-ons recorrentes; integração Stripe Connect é complexa)
+
+---
+
+## KPIs do Epic
+
+| KPI | Meta 90 dias | Meta 180 dias |
+|-----|--------------|---------------|
+| Pacotes de dados vendidos | 3 | 30 |
+| Receita data licensing | R$ 15.000 | R$ 250.000 |
+| Parceiros consultoria onboarded | 3 | 15 |
+| GMV via white-label | R$ 5.000 | R$ 60.000 |
+| Revshare a parceiros | R$ 2.500 | R$ 30.000 |
+
+---
+
+## Dependências
+
+- **Bloqueado por:**
+  - MON-REP-01 → MON-DIST-01 (checkout one-shot)
+  - MON-REP-01 + MON-SUB-01 → MON-DIST-02 (checkout + add-ons)
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — extras de distribuição (não estavam nas 4 camadas originais) |

--- a/docs/stories/2026-04/EPIC-MON-REPORTS-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-REPORTS-2026-04.md
@@ -1,0 +1,77 @@
+# EPIC-MON-REPORTS-2026-04: Camada 2 — Relatórios Avulsos Monetizados
+
+**Priority:** P1 — Wave 1 Fast-Revenue
+**Status:** Draft
+**Owner:** @pm (Morgan) + @architect + @dev + @qa + @devops
+**Sprint:** Wave 1 (paralelo com EPIC-MON-API)
+**Meta:** Gerar receita one-shot R$ 47–697/transação via 4 tipos de relatório auto-gerados por Stripe + LLM + email.
+
+---
+
+## Contexto Estratégico
+
+Hoje o SmartLic possui infraestrutura de PDF apenas para 1 tipo de relatório (diagnóstico via `backend/pdf_report.py` com reportlab) e Stripe configurado exclusivamente para assinaturas recorrentes (`mode=subscription`). Faltam:
+
+- Fluxo de **pagamento único** (`mode=payment`) com tabela `purchases` e webhook `charge.succeeded`
+- Pipeline de **geração assíncrona + entrega por email** (tabela `generated_reports`, storage, template `report_ready`)
+- 4 **tipos de relatório** de alto valor percebido:
+
+| Produto | Ticket | Personas |
+|---------|--------|----------|
+| Fornecedor por CNPJ | R$ 47–197 | Advogados, bancos, construtoras pesquisando concorrente |
+| Preço de Referência | R$ 97–297 | Fiscais de contrato, orçamentistas, pregoeiros |
+| Mapeamento de Concorrência | R$ 197–497 | Construtoras, consultorias, M&A advisors |
+| Due Diligence Express (lite v1) | R$ 297–697 | Bancos, fintechs de crédito PME |
+
+Todas as 4 são geradas **automaticamente** (sem ciclo de venda humana) — compra → geração em <5 min → entrega por email com link.
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-REP-01 | P0 | M | @dev | Draft | Stripe one-time + tabela `purchases` + webhook |
+| MON-REP-02 | P0 | M | @dev | Draft | Infra `generated_reports` + email delivery + storage |
+| MON-REP-03 | P1 | L | @dev + @ux | Draft | Relatório Fornecedor por CNPJ (R$ 47–197) |
+| MON-REP-04 | P1 | L | @dev | Draft | Relatório Preço de Referência (R$ 97–297) |
+| MON-REP-05 | P1 | L | @dev | Draft | Relatório Mapeamento de Concorrência (R$ 197–497) |
+| MON-REP-06 | P1 | L | @dev | Draft | Due Diligence Express lite (R$ 297–697) |
+
+---
+
+## Ordem de Execução
+
+1. **MON-REP-01 + MON-REP-02** em paralelo (foundation, bloqueiam todas as outras)
+2. Após MON-REP-02: **MON-REP-03 + MON-REP-05** em paralelo (não dependem de MON-SCH-*)
+3. Após MON-SCH-02: **MON-REP-04**
+4. Após MON-SCH-01 + MON-SCH-02: **MON-REP-06**
+
+---
+
+## KPIs do Epic
+
+| KPI | Meta 30 dias | Meta 90 dias |
+|-----|-------------|--------------|
+| Volume de compras one-shot/mês | 10 | 100 |
+| Receita one-shot/mês | R$ 1.500 | R$ 20.000 |
+| Tempo compra→entrega (p95) | <5 min | <3 min |
+| Taxa de refund | <5% | <2% |
+| NPS do relatório | N/A | >40 |
+
+---
+
+## Dependências
+
+- **Bloqueia:** MON-DIST-01 (Data Licensing reutiliza MON-REP-01 para checkout)
+- **Bloqueado por:**
+  - MON-SCH-02 (CATMAT) → MON-REP-04
+  - MON-SCH-01 (aditivos) + MON-SCH-02 → MON-REP-06
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — Camada 2 da estratégia de monetização dataset 2M+ contratos |

--- a/docs/stories/2026-04/EPIC-MON-SCHEMA-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-SCHEMA-2026-04.md
@@ -1,0 +1,69 @@
+# EPIC-MON-SCHEMA-2026-04: Enriquecimento do Dataset de 2M+ Contratos (Prerequisito)
+
+**Priority:** P0 — Prerequisito para todas as outras camadas de monetização
+**Status:** Draft
+**Owner:** @data-engineer (Dara) + @dev + @architect
+**Sprint:** Wave 1 (paralelo às stories MON-API + MON-REP)
+**Meta:** Enriquecer `pncp_supplier_contracts` com aditivos + CATMAT/CATSER + data_fim/status para desbloquear scoring, benchmarks e monitores.
+
+---
+
+## Contexto Estratégico
+
+O SmartLic possui ~2.1M contratos históricos em `pncp_supplier_contracts` (migração `20260409100000_pncp_supplier_contracts.sql`) com colunas limitadas: `ni_fornecedor`, `nome_fornecedor`, `orgao_cnpj`, `orgao_nome`, `uf`, `municipio`, `esfera`, `valor_global`, `data_assinatura`, `objeto_contrato`, `numero_controle_pncp`.
+
+Faltam dados críticos para os produtos monetizáveis:
+
+- **Aditivos contratuais** — desbloqueia score de risco (Due Diligence, Radar) e alertas (Monitor Órgão)
+- **CATMAT/CATSER** — códigos padronizados de classificação de material/serviço; desbloqueia benchmark estatístico de preço com precisão (versus busca textual sobre `objeto_contrato`)
+- **data_fim + status detalhado** — permite filtros de vigência ("contratos ativos hoje") usados em relatórios e páginas SEO
+
+Sem esses enriquecimentos, produtos pagos das camadas 2-4 ficam degradados (Due Diligence sem sinais de risco; Benchmark API sem precisão; relatórios sem filtro temporal correto).
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-SCH-01 | P0 | M | @data-engineer + @dev | Draft | Crawler + schema de aditivos contratuais |
+| MON-SCH-02 | P0 | M | @data-engineer + @dev | Draft | CATMAT/CATSER parsing + indexação + catálogo |
+| MON-SCH-03 | P0 | S | @data-engineer | Draft | data_fim + vigência + status detalhado |
+
+---
+
+## Ordem de Execução
+
+MON-SCH-01, MON-SCH-02 e MON-SCH-03 são **independentes entre si** — podem executar em paralelo. Recomendado: MON-SCH-02 e MON-SCH-03 começam primeiro (fontes de dado já no PNCP, apenas parsing); MON-SCH-01 (crawler novo + backfill) em paralelo com owner separado.
+
+---
+
+## KPIs do Epic
+
+| KPI | Baseline | Meta 30 dias | Meta 90 dias |
+|-----|----------|-------------|--------------|
+| Coverage CATMAT/CATSER | 0% | 50% dos 2.1M | 80% |
+| Coverage aditivos (últimos 2 anos) | 0% | 30% | 70% |
+| Coverage data_fim | 0% | 90% (onde PNCP expõe) | 95% |
+| Queries benchmark p95 | N/A | <500ms | <300ms |
+
+---
+
+## Dependências Downstream (o que este epic desbloqueia)
+
+- `MON-REP-04` (Relatório Preço Referência) — depende MON-SCH-02
+- `MON-REP-06` (Due Diligence) — depende MON-SCH-01 + MON-SCH-02
+- `MON-API-04` (Benchmark endpoint) — depende MON-SCH-02
+- `MON-SUB-03` (Monitor Órgão alerts aditivos) — depende MON-SCH-01
+- `MON-SUB-04` (Radar Risco) — depende MON-SCH-01
+- `MON-SEO-01` (Score na página pública) — depende MON-SCH-01
+- `MON-SEO-02` (Páginas /categoria) — depende MON-SCH-02
+- `MON-AI-03` (Radar Preditivo) — depende MON-SCH-01 + MON-SCH-02
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — prerequisito do lote de stories de monetização do dataset de 2M+ contratos |

--- a/docs/stories/2026-04/EPIC-MON-SEO-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-SEO-2026-04.md
@@ -1,0 +1,76 @@
+# EPIC-MON-SEO-2026-04: Camada 1 — SEO de Entidade (Funil Orgânico)
+
+**Priority:** P2 — Wave 3 (MOAT orgânico; leva 6-12 meses para maturar)
+**Status:** Draft
+**Owner:** @ux-design-expert + @dev + @devops + squad aiox-seo
+**Sprint:** Wave 3 (após Waves 1+2 em produção)
+**Meta:** Funil orgânico gratuito de alta intenção; CTAs convertendo para camadas pagas 2-4.
+
+---
+
+## Contexto Estratégico
+
+O SmartLic já tem páginas dinâmicas **básicas**:
+- `/fornecedores/[cnpj]` (ISR 24h)
+- `/cnpj/[cnpj]` (variante)
+- `/orgaos/[slug]`
+
+Falta:
+- **Enriquecimento** dessas páginas com dados novos (score de risco MON-SCH-01, aditivos, benchmark MON-SCH-02) e CTAs para camadas pagas
+- **Páginas `/categoria/[slug]`** — programáticas sobre "quanto o governo paga por X" (milhares de slugs via CATMAT/CATSER)
+- **Sitemaps escaláveis** — hoje `sitemap/4.xml` está vazio em produção (bug `BACKEND_URL` no build Railway)
+- **Schema.org JSON-LD completo** para rich results
+
+**Conversão esperada:** páginas de alta intenção → CTA para relatório pago (R$47+) ou monitor (R$147+) ou API (pay-per-call).
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-SEO-01 | P1 | M | @dev + @ux | Draft | Enriquecer `/fornecedores/[cnpj]` (score + aditivos + CTAs) |
+| MON-SEO-02 | P1 | L | @dev | Draft | Criar `/categoria/[slug]` programático (5k+ páginas) |
+| MON-SEO-03 | P1 | M | @dev | Draft | Enriquecer `/orgaos/[slug]` (perfil compras + CTAs) |
+| MON-SEO-04 | P0 | M | @dev + @devops | Draft | Sitemaps dinâmicos escaláveis + fix bug sitemap/4.xml |
+| MON-SEO-05 | P2 | S | @dev | Draft | Schema.org JSON-LD completo |
+
+---
+
+## Ordem de Execução
+
+1. **MON-SEO-04** primeiro (bug fix crítico de infra, desbloqueia todo indexamento)
+2. **MON-SEO-01 + MON-SEO-03** paralelo (depende de MON-SCH-01 aditivos)
+3. **MON-SEO-02** (depende de MON-SCH-02 CATMAT + MON-REP-04 para CTA)
+4. **MON-SEO-05** último (cobre todas as páginas criadas antes)
+
+---
+
+## KPIs do Epic
+
+| KPI | Baseline (2026-04) | Meta 90 dias | Meta 180 dias |
+|-----|-------------------|--------------|---------------|
+| Páginas indexadas Google | ~30% das entidades | 60% | 85% |
+| Cliques orgânicos/mês nas páginas de entidade | <5 | 500 | 5.000 |
+| CTR orgânico | ~0,8% | 2% | 4% |
+| Conversão SEO → purchase (relatório) | 0% | 0,5% | 1,5% |
+| Backlinks referenciando páginas de entidade | 0 | 5 | 30 |
+
+---
+
+## Dependências
+
+- **Bloqueado por:**
+  - MON-SCH-01 (aditivos) → MON-SEO-01, MON-SEO-03
+  - MON-SCH-02 (CATMAT) → MON-SEO-02
+  - MON-REP-03/04 (relatórios) → CTAs nas páginas
+  - MON-SUB-03/04 (monitores) → CTAs nas páginas
+- **Complementa:** EPIC-SEO-ORGANIC-2026-04 (stories já existentes para Observatório)
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — Camada 1 da estratégia de monetização; MOAT orgânico de longo prazo |

--- a/docs/stories/2026-04/EPIC-MON-SUBS-2026-04.md
+++ b/docs/stories/2026-04/EPIC-MON-SUBS-2026-04.md
@@ -1,0 +1,70 @@
+# EPIC-MON-SUBS-2026-04: Camada 3 — Assinaturas de Inteligência (MRR)
+
+**Priority:** P1 — Wave 2
+**Status:** Draft
+**Owner:** @pm + @architect + @dev + @qa
+**Sprint:** Wave 2 (após Wave 1 foundation estabilizada)
+**Meta:** MRR R$ 147–997/mês via 3 add-ons sobre a infra de subscription existente.
+
+---
+
+## Contexto Estratégico
+
+Hoje o SmartLic tem único plano recorrente (SmartLic Pro R$ 397–997/mês via `plan_billing_periods`). Não há noção de **add-ons vendáveis separados do plano base**. A tabela `alerts` suporta monitoramento por filtros genéricos (STORY-301, STORY-315) mas não há produtos empacotados + precificados.
+
+**Produtos planejados:**
+
+| Produto | Preço | Cadência | Uso |
+|---------|-------|----------|-----|
+| Monitor de Segmento por UF | R$ 197–497/mês | Semanal ou Mensal | Empresa operando em 1-3 segmentos |
+| Monitor de Órgão Contratante | R$ 147–397/mês | Mensal | Quem vende recorrente para 1 órgão |
+| Radar de Risco de Fornecedor | R$ 297–997/mês/carteira | Diário (alerta em tempo real) | Bancos/fintechs com exposição PME B2G |
+
+Modelo **add-on standalone ou over-plan** — usuário pode assinar sem ter Smartlic Pro base (melhor DAU fintech), ou como add-on sobre Pro (melhor upsell).
+
+---
+
+## Stories do Epic
+
+| Story | Priority | Effort | Squad | Status | Objetivo |
+|-------|:--------:|:------:|-------|:------:|----------|
+| MON-SUB-01 | P0 | M | @dev | Draft | Add-ons Stripe + schema `monitored_subscriptions` + watchlists |
+| MON-SUB-02 | P1 | L | @dev | Draft | Monitor de Segmento por UF (R$ 197–497/mês) |
+| MON-SUB-03 | P1 | M | @dev | Draft | Monitor de Órgão Contratante (R$ 147–397/mês) |
+| MON-SUB-04 | P1 | L | @dev | Draft | Radar de Risco de Fornecedor (R$ 297–997/mês/carteira) |
+
+---
+
+## Ordem de Execução
+
+1. **MON-SUB-01** (foundation, bloqueia as 3 subsequentes)
+2. **MON-SUB-02** (não depende de MON-SCH-*)
+3. **MON-SUB-03** (depende de MON-SCH-01 aditivos)
+4. **MON-SUB-04** (depende de MON-SCH-01, maior esforço)
+
+---
+
+## KPIs do Epic
+
+| KPI | Meta 60 dias | Meta 180 dias |
+|-----|--------------|---------------|
+| Assinaturas ativas add-ons | 20 | 200 |
+| MRR add-ons | R$ 5.000 | R$ 80.000 |
+| Churn mensal add-ons | <10% | <5% |
+| ARPU add-on | R$ 250 | R$ 400 |
+| % clientes multi-add-on | 10% | 30% |
+
+---
+
+## Dependências
+
+- **Bloqueia:** MON-AI-02 (Copilot add-on), MON-AI-03 (Radar Preditivo add-on), MON-DIST-02 (White-label)
+- **Bloqueado por:** MON-SCH-01 (aditivos) → MON-SUB-03 e MON-SUB-04
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Epic criado — Camada 3 da estratégia de monetização; MRR target R$ 80k/mês em 6 meses |

--- a/docs/stories/2026-04/MON-AI-01-semantic-search-embeddings.md
+++ b/docs/stories/2026-04/MON-AI-01-semantic-search-embeddings.md
@@ -1,0 +1,175 @@
+# MON-AI-01: Semantic Search / Embeddings API (pgvector + HNSW)
+
+**Priority:** P0 (pré-requisito para MON-AI-02)
+**Effort:** L (6-8 dias)
+**Squad:** @data-engineer + @dev + @architect
+**Status:** Draft
+**Epic:** [EPIC-MON-AI-2026-04](EPIC-MON-AI-2026-04.md)
+**Sprint:** Wave 2
+
+---
+
+## Contexto
+
+Para monetizar o dataset de 2.1M contratos como **moat de IA**, precisamos vetorização semântica. Isso habilita:
+- Endpoint público "contratos similares a X" (R$ 0,10-1/query, distribuível via RapidAPI)
+- Base para AI Copilot de Propostas (MON-AI-02) — RAG sobre vencedores similares
+- Potencial futuro: Radar Preditivo (MON-AI-03) pode usar similaridade semântica como feature
+
+**Tech stack:**
+- Extensão Supabase `pgvector` (já disponível)
+- Modelo: `text-embedding-3-small` da OpenAI (1536 dim, USD 0.02/1M tokens)
+- Index: HNSW para busca aproximada sub-linear
+- Cost: ~USD 200 para 2.1M rows (avg 250 tokens/objeto_contrato). Priorizar top 500k por valor primeiro
+
+---
+
+## Acceptance Criteria
+
+### AC1: Schema + extensão pgvector
+
+- [ ] Migração instala extensão:
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+ALTER TABLE public.pncp_supplier_contracts
+  ADD COLUMN embedding vector(1536) NULL,
+  ADD COLUMN embedding_model varchar(50) NULL,
+  ADD COLUMN embedding_updated_at timestamptz NULL;
+
+CREATE INDEX idx_supplier_contracts_embedding_hnsw
+  ON public.pncp_supplier_contracts
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+```
+- [ ] Migração paired down (drop column + extension se não usada em outro lugar)
+
+### AC2: Batch embedding job
+
+- [ ] `backend/ingestion/embed_contracts.py`:
+  - Processa contratos sem embedding, priorizando por `valor_global DESC`
+  - Chunks de 100 rows por call à OpenAI Embeddings API
+  - Rate limit: 3k req/min (OpenAI limit) — respeitar com semaphore
+  - Retry exponencial em 429/503
+  - Update `embedding, embedding_model='text-embedding-3-small', embedding_updated_at=now()`
+- [ ] ARQ cron diário `embed_contracts_batch` processa até 10k rows/dia (~R$ 2-3/dia custo OpenAI)
+- [ ] Script `scripts/backfill_embeddings.py` para priorizar top 500k por valor (manual trigger)
+
+### AC3: RPC `match_contracts`
+
+- [ ] Função SQL:
+```sql
+CREATE OR REPLACE FUNCTION public.match_contracts(
+  query_embedding vector(1536),
+  match_threshold float DEFAULT 0.7,
+  match_count int DEFAULT 20,
+  filter_uf text DEFAULT NULL,
+  filter_setor text DEFAULT NULL
+) RETURNS TABLE (
+  numero_controle_pncp text, ni_fornecedor text, nome_fornecedor text,
+  orgao_nome text, uf text, valor_global numeric, data_assinatura date,
+  objeto_contrato text, similarity float
+)
+LANGUAGE sql STABLE PARALLEL SAFE AS $$
+  SELECT ..., 1 - (embedding <=> query_embedding) as similarity
+  FROM pncp_supplier_contracts
+  WHERE embedding IS NOT NULL
+    AND 1 - (embedding <=> query_embedding) > match_threshold
+    AND (filter_uf IS NULL OR uf = filter_uf)
+    AND (filter_setor IS NULL OR setor_classificado = filter_setor)
+  ORDER BY embedding <=> query_embedding
+  LIMIT match_count;
+$$;
+```
+- [ ] Performance target: p95 < 300ms com 2M embeddings + HNSW
+
+### AC4: Endpoint API público `GET /api/v1/contracts/similar`
+
+- [ ] Query param: `text` (texto a buscar similaridade) OU `contract_id` (usa embedding daquele)
+- [ ] Params opcionais: `limit` (1-50, default 20), `uf`, `setor`, `threshold` (0.0-1.0, default 0.7)
+- [ ] Response: array de contratos similares com score de similarity
+- [ ] Autenticação: X-API-Key (MON-API-01)
+- [ ] Cost: 50 cents (R$ 0,50) por query via MON-API-02
+- [ ] Rate limit: 60 req/min por key
+
+### AC5: Observability
+
+- [ ] Prometheus: `smartlic_embeddings_coverage_pct`, `smartlic_semantic_search_queries_total{hit}`, `smartlic_embeddings_generation_cost_cents_total`
+- [ ] Sentry: alert se `embeddings_coverage_pct < 10%` (falha no backfill)
+
+### AC6: Testes
+
+- [ ] Unit: mock OpenAI response, valida insertion correto
+- [ ] Integration: seed 1k contratos com embeddings + query semantic → ordenação por similaridade correta
+- [ ] Performance: 100 concurrent queries p95 < 300ms
+
+---
+
+## Scope
+
+**IN:**
+- Migração + extension
+- Batch embedding job + cron
+- RPC match_contracts
+- Endpoint público
+- Testes
+
+**OUT:**
+- Embedding de outros campos (razão social, setor label) — v2
+- Multi-vector per contract (hybrid search) — v2
+- Fine-tuning de modelo próprio — fora de escopo
+
+---
+
+## Dependências
+
+- Supabase com pgvector habilitado (verificar: alguns projetos Supabase têm por default)
+- OpenAI API key (existente)
+- MON-API-01 + MON-API-02 (para endpoint monetizado)
+
+---
+
+## Riscos
+
+- **pgvector não habilitado em produção:** validar `CREATE EXTENSION vector;` em staging primeiro
+- **Custo OpenAI runaway:** backfill priorizado + cron diário com budget cap USD 10/dia
+- **HNSW index tempo de construção:** ~2h para 2M rows; aceitar downtime programado ou criar CONCURRENTLY
+- **Dimensão 1536 → row size grande:** ~6KB por row; 2M × 6KB = 12GB tabela. Verificar storage Supabase
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../add_pgvector_embeddings.sql` + `.down.sql`
+- `backend/ingestion/embed_contracts.py` (novo)
+- `backend/jobs/cron/embed_batch.py` (novo)
+- `scripts/backfill_embeddings.py` (novo)
+- `supabase/migrations/.../create_match_contracts_rpc.sql` + `.down.sql`
+- `backend/routes/public_api/similar_contracts.py` (novo)
+- `backend/tests/ingestion/test_embed_contracts.py` (novo)
+- `backend/tests/routes/public_api/test_similar_contracts.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Extensão pgvector ativada em prod
+- [ ] Top 100k contratos por valor com embedding
+- [ ] Cron diário processando incrementalmente
+- [ ] Endpoint público live com p95 < 300ms
+- [ ] Testes passando
+- [ ] Desbloqueia MON-AI-02
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — foundation de moat IA; pré-requisito AI Copilot |

--- a/docs/stories/2026-04/MON-AI-02-ai-copilot-propostas.md
+++ b/docs/stories/2026-04/MON-AI-02-ai-copilot-propostas.md
@@ -1,0 +1,178 @@
+# MON-AI-02: AI Copilot de Propostas (RAG sobre Contratos Vencedores)
+
+**Priority:** P1
+**Effort:** XL (8-10 dias)
+**Squad:** @dev + @architect + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-AI-2026-04](EPIC-MON-AI-2026-04.md)
+**Sprint:** Wave 2 (depende MON-AI-01 + MON-REP-01 + MON-SUB-01)
+
+---
+
+## Contexto
+
+**Produto mais alto ticket do epic IA** e **forte moat**. Usuário sobe o PDF do edital → IA extrai requisitos → busca semântica em contratos vencedores similares (MON-AI-01 RAG) → gera rascunho de proposta estruturada com justificativa técnica.
+
+**Diferencial único:** 2M+ contratos vencedores como corpus de referência — nenhum competidor tem isso.
+
+**Modelo comercial:**
+- **R$ 197/proposta one-shot** (via MON-REP-01) — para uso esporádico
+- **Add-on R$ 497/mês** (via MON-SUB-01) — 20 propostas/mês, sobra acumula
+
+---
+
+## Acceptance Criteria
+
+### AC1: Upload e extração de edital
+
+- [ ] Endpoint `POST /v1/copilot/proposta/draft`:
+  - Body multipart: `edital_pdf` (file) + `tier` (one-shot | subscription) + `contexto_empresa` (str, opcional — ex: razão social, CNAE)
+  - Upload file para Supabase Storage (bucket `copilot-uploads`, 7 days TTL)
+  - Enfileira ARQ job `generate_proposal_draft(upload_id)`
+  - Retorna `{job_id, eta_seconds: 120}`
+
+- [ ] ARQ job `generate_proposal_draft`:
+  1. **Extração** — GPT-4.1-nano com structured output extrai do edital: objeto, requisitos técnicos, critérios de julgamento, valor estimado, prazo, modalidade
+  2. **Retrieval (RAG)** — usa MON-AI-01 para encontrar 10 contratos similares (filtrar por mesma modalidade + similaridade >0.75)
+  3. **Análise** — LLM analisa: "dado esses 10 vencedores, quais elementos comuns nas propostas venceu?"
+  4. **Geração** — LLM produz rascunho em seções:
+     - Apresentação da empresa (usa `contexto_empresa`)
+     - Compreensão do objeto
+     - Metodologia (baseada em padrões detectados)
+     - Cronograma sugerido
+     - Valor proposto (range com justificativa: mediana + 10%)
+     - Elementos diferenciais
+     - Fontes: citar contract_ids vencedores usados como referência
+  5. Gera PDF + Word (.docx) + Markdown
+  6. Cria `generated_reports` row + envia email (reusa MON-REP-02)
+
+### AC2: Schema Pydantic para extração
+
+- [ ] `backend/schemas/copilot/edital_extracted.py`:
+```python
+class EditalExtracted(BaseModel):
+    objeto: str
+    objeto_resumo: str
+    requisitos_tecnicos: list[str]
+    criterios_julgamento: list[str]
+    valor_estimado_cents: int | None
+    prazo_dias: int | None
+    modalidade: int
+    uf_execucao: str | None
+    catmat_catser_sugerido: str | None
+```
+
+### AC3: Prompts multi-stage
+
+- [ ] `backend/llm/prompts/copilot_extraction.py` (stage 1)
+- [ ] `backend/llm/prompts/copilot_analysis.py` (stage 3) — input: 10 contratos similares + edital extraído
+- [ ] `backend/llm/prompts/copilot_generation.py` (stage 4) — structured output com todas as seções
+- [ ] **Ground-truth enforcement:** output DEVE citar `numero_controle_pncp` de contratos vencedores usados; sem citação → falha geração com fallback
+
+### AC4: Geração PDF + Word
+
+- [ ] `backend/reports/copilot_proposal_report.py`:
+  - PDF via reportlab (como outros relatórios)
+  - Word via `python-docx`
+  - Markdown versão raw para copy-paste
+- [ ] Todos os 3 formatos entregues no email (ZIP) + download endpoints separados
+
+### AC5: Frontend `/copilot`
+
+- [ ] `frontend/app/copilot/page.tsx`:
+  - Upload dropzone para PDF de edital (max 20 MB)
+  - Campo "Contexto da empresa" (opcional)
+  - Seletor "One-shot R$ 197" ou "Assinar R$ 497/mês" (se não assinou)
+  - Checkout via MON-REP-01 ou MON-SUB-01
+  - Após compra: página de "processando" (polling a cada 10s)
+  - Resultado: preview HTML + buttons download (PDF/Word/MD)
+
+### AC6: Limites de uso do add-on
+
+- [ ] Tier add-on R$ 497/mês = 20 propostas/mês
+- [ ] Tracking em `monitored_subscriptions.config.proposals_used_current_month`
+- [ ] Se excedido: 402 com CTA "Comprar 5 propostas extras por R$ 99" (one-shot bundle)
+- [ ] Reset no início do ciclo de billing
+
+### AC7: Testes
+
+- [ ] Unit: mock LLM → extração estruturada correta
+- [ ] Integration: E2E com PDF de edital real (bundle 3 editais de teste em `backend/tests/fixtures/`)
+- [ ] Quality gate: manual review de 10 propostas geradas antes do release — nenhuma com dados inventados (ground truth)
+- [ ] E2E Playwright: upload → checkout → processing → download
+
+---
+
+## Scope
+
+**IN:**
+- Upload + extraction
+- RAG pipeline
+- Prompt multi-stage + ground truth
+- 3 formatos de output (PDF, Word, MD)
+- Frontend wizard
+- Limite de uso tier add-on
+- Testes + quality gate humano
+
+**OUT:**
+- Refinamento interativo ("melhore a seção X") — v2
+- Tradução para outros idiomas — fora de escopo
+- Assinatura digital do PDF — fora de escopo
+- Integração com sistemas de gestão de propostas — v2
+
+---
+
+## Dependências
+
+- MON-AI-01 (embeddings para RAG)
+- MON-REP-01 (checkout one-shot)
+- MON-REP-02 (delivery)
+- MON-SUB-01 (add-on recorrente)
+- OpenAI API (já em uso)
+
+---
+
+## Riscos
+
+- **LLM alucinação em proposta paga:** ground-truth + citação obrigatória + quality gate humano antes release
+- **Custo LLM por proposta:** 10 contratos RAG × chunks + prompt grande ≈ 30k tokens × USD 0.002 / 1K = USD 0.06/proposta. Margem ok para R$ 197
+- **Edital pdf com imagens (tabelas):** OCR fallback via Tesseract ou GPT-4 Vision; v1 documentar "apenas PDFs textuais"
+- **Proposta gerada rejeita pelo órgão:** disclaimer "rascunho para revisão humana, não é proposta final aprovada por órgão"
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/copilot/proposta_generator.py` (novo — orquestração)
+- `backend/llm/prompts/copilot_*.py` (3 files)
+- `backend/schemas/copilot/*.py` (novo)
+- `backend/reports/copilot_proposal_report.py` (novo)
+- `backend/jobs/copilot_jobs.py` (novo)
+- `backend/routes/copilot.py` (novo)
+- `frontend/app/copilot/page.tsx` (novo)
+- `backend/tests/copilot/test_proposal_generator.py` (novo)
+- `backend/tests/fixtures/editais/*.pdf` (seed 3 editais reais)
+
+---
+
+## Definition of Done
+
+- [ ] 10 propostas geradas em staging, validadas em review humano (0 dados inventados, 0 citações fake)
+- [ ] E2E: upload → checkout → geração em <3 min → download funciona
+- [ ] Add-on subscription com 20 usos/mês rastreado corretamente
+- [ ] Custo médio por proposta <USD 0.10 (observado via Prometheus)
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — produto de moat IA, high ticket |

--- a/docs/stories/2026-04/MON-AI-03-radar-preditivo-editais.md
+++ b/docs/stories/2026-04/MON-AI-03-radar-preditivo-editais.md
@@ -1,0 +1,192 @@
+# MON-AI-03: Radar Preditivo de Editais (ML Sazonal)
+
+**Priority:** P1
+**Effort:** XL (8-10 dias)
+**Squad:** @data-engineer + @dev + @architect
+**Status:** Draft
+**Epic:** [EPIC-MON-AI-2026-04](EPIC-MON-AI-2026-04.md)
+**Sprint:** Wave 2 (depende MON-SCH-01/02 + MON-SUB-01)
+
+---
+
+## Contexto
+
+Dataset de 2.1M contratos com 3+ anos de histórico permite **detecção de padrões sazonais**: órgão X licita serviço Y recorrentemente em mês Z. Ex: "Município São Paulo sempre licita limpeza urbana em setembro (contrato vencendo em dezembro)".
+
+**Produto:** add-on "Radar Preditivo" que prevê editais dos próximos 30-60 dias para (órgão + CATMAT/CATSER). Fornecedor se antecipa — prepara proposta, entra em contato com órgão, ganha vantagem competitiva.
+
+**Modelo comercial:**
+- Add-on R$ 297-997/mês (via MON-SUB-01)
+- Tiers: 5 previsões (R$ 297), 20 (R$ 597), ilimitado (R$ 997)
+
+**Diferencial:** competidores reactive (mostram editais publicados); SmartLic proactive (antes da publicação).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Detecção de sazonalidade
+
+- [ ] `backend/ml/seasonal_detection.py`:
+  - Para cada tupla (orgao_cnpj, catmat_catser) com ≥ 3 contratos histórico ≥ 2 anos:
+    - Calcula coeficiente de sazonalidade via `statsmodels.tsa.seasonal_decompose` ou `prophet`
+    - Se coef >= 0.6 (limiar de confiança): marca como "padrão sazonal confirmado"
+    - Extrai mês(es) do ano com maior probabilidade de novo contrato
+    - Calcula intervalo médio entre contratos (dias)
+- [ ] Pipeline offline rodando semanalmente (ARQ cron)
+- [ ] Persistir em `seasonal_patterns`:
+```sql
+CREATE TABLE public.seasonal_patterns (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  orgao_cnpj varchar(14) NOT NULL,
+  catmat_catser varchar(10) NOT NULL,
+  setor_classificado text NULL,
+  uf varchar(2) NULL,
+  coef_sazonalidade numeric(4,3) NOT NULL,
+  months_high_prob int[] NOT NULL,  -- [9, 10] = setembro, outubro
+  interval_days_mean int NOT NULL,
+  interval_days_stddev int NOT NULL,
+  last_contract_date date NOT NULL,
+  historical_n_contracts int NOT NULL,
+  confidence_tier text NOT NULL CHECK (confidence_tier IN ('high','medium','low')),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(orgao_cnpj, catmat_catser)
+);
+CREATE INDEX ON seasonal_patterns (months_high_prob, coef_sazonalidade);
+```
+
+### AC2: Previsão de próximos editais
+
+- [ ] `backend/ml/prediction_engine.py`:
+  - Para cada `seasonal_patterns` row + `last_contract_date`:
+    - Calcula `expected_next_date = last_contract_date + interval_days_mean`
+    - Se `expected_next_date` está nos próximos 30-60 dias E `current_month+1 IN months_high_prob`:
+      - Gera predição em `predicted_bids`:
+```sql
+CREATE TABLE public.predicted_bids (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  orgao_cnpj varchar(14) NOT NULL,
+  catmat_catser varchar(10) NOT NULL,
+  expected_publish_date date NOT NULL,
+  expected_publish_window_start date NOT NULL,
+  expected_publish_window_end date NOT NULL,
+  confidence_score numeric(3,2) NOT NULL,
+  estimated_value_cents int NULL,
+  historical_evidence jsonb NOT NULL,  -- últimos 3-5 contratos como prova
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','fulfilled','missed','cancelled')),
+  fulfilled_bid_id text NULL REFERENCES pncp_raw_bids(id)
+);
+```
+  - ARQ cron semanal atualiza predictions
+
+### AC3: Validação de predições (feedback loop)
+
+- [ ] Cron diário `validate_predictions_job`:
+  - Para cada `predicted_bids` com `status='pending'`:
+    - Busca em `pncp_raw_bids` por editais novos match (orgao_cnpj + catmat_catser + data dentro de janela)
+    - Se encontra: marca `status='fulfilled'`, `fulfilled_bid_id`
+    - Se janela expirou sem match: `status='missed'`
+- [ ] Backtest mensal: compara predictions vs pncp_raw_bids reais dos últimos 6 meses → computa precision/recall
+- [ ] Se precision < 50% por 2 meses: fine-tune thresholds (adjust via config YAML)
+
+### AC4: Endpoint `/v1/radar-preditivo` (add-on restrito)
+
+- [ ] `GET /v1/radar-preditivo` (auth JWT + check `monitored_subscriptions.addon_type='radar_preditivo' AND active=true`)
+- [ ] Query params: `setor` (obrigatório), `uf` (opcional), `min_confidence` (default 0.7)
+- [ ] Retorna array de `predicted_bids` do user (limit por tier)
+- [ ] Rate limit: 30 req/min
+
+### AC5: Dashboard `/radar-preditivo`
+
+- [ ] `frontend/app/radar-preditivo/page.tsx`:
+  - Seletor setor + UF
+  - Lista de predições: órgão, CATMAT, expected_date, confidence, valor estimado, botão "Ver evidência histórica"
+  - Mapa do Brasil com densidade de predições (heatmap)
+  - Timeline próximos 60 dias
+- [ ] Onboarding: tutorial de 3 slides "Como usar o radar"
+
+### AC6: Notificações de alerta (tier Premium)
+
+- [ ] Trigger diário: se nova predição entra dentro de 15 dias de expected_publish_date + CATMAT match watchlist do user → email alerta
+- [ ] Template `radar_preditivo_alert.py`
+
+### AC7: Testes
+
+- [ ] Unit: `test_seasonal_detection.py` — série temporal sintética com padrão conhecido → detecta corretamente
+- [ ] Integration: pipeline completo para 1 órgão real → gera predições plausíveis
+- [ ] Backtest: precision >= 55% em 6 meses histórico (gate para release)
+
+---
+
+## Scope
+
+**IN:**
+- Detecção sazonal offline
+- Engine de predição
+- Validação feedback loop
+- Endpoint + dashboard + alertas
+- Backtest precision gate
+- Testes
+
+**OUT:**
+- ML sofisticado (LSTM, Transformers) — v2 se Prophet/seasonal_decompose não atingir target
+- Predição de vencedor (quem ganhará o edital) — é outro produto (futuro Q3)
+- Recomendação de preço para proposta — é outro produto (combina com MON-AI-02)
+
+---
+
+## Dependências
+
+- **MON-SCH-01 (aditivos)** — dá sinal de contrato "ativo" para filtragem
+- **MON-SCH-02 (CATMAT)** — bloqueador absoluto (sem CATMAT, sazonalidade vira ruído)
+- MON-SUB-01 (add-on recorrente)
+- Python ML libs: `statsmodels` ou `prophet`
+
+---
+
+## Riscos
+
+- **Precision baixa em categorias não-sazonais:** filtrar apenas pairs com `coef_sazonalidade >= 0.6`; se amostra fica muito pequena, documentar como "v1 cobertura restrita, expandindo"
+- **Backtest mostra precision <50%:** release bloqueado; ajuste de thresholds ou adiamento para Q3
+- **Dataset ruidoso (mudança de código CATMAT ao longo do tempo):** limitar janela a 3 anos recentes
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_seasonal_patterns.sql` + `.down.sql`
+- `supabase/migrations/.../create_predicted_bids.sql` + `.down.sql`
+- `backend/ml/seasonal_detection.py` (novo)
+- `backend/ml/prediction_engine.py` (novo)
+- `backend/jobs/cron/seasonal_detection_job.py` (novo)
+- `backend/jobs/cron/validate_predictions_job.py` (novo)
+- `backend/routes/radar_preditivo.py` (novo)
+- `backend/templates/emails/radar_preditivo_alert.py` (novo)
+- `frontend/app/radar-preditivo/page.tsx` (novo)
+- `scripts/backtest_predictions.py` (novo)
+- `backend/tests/ml/test_seasonal_detection.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Pipeline semanal rodando + persistindo predictions
+- [ ] Backtest 6 meses: precision >= 55%
+- [ ] 10 predições de exemplo validadas com analista humano
+- [ ] Dashboard funcional
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — moat IA via ML sazonal sobre histórico proprietário |

--- a/docs/stories/2026-04/MON-API-01-api-key-management.md
+++ b/docs/stories/2026-04/MON-API-01-api-key-management.md
@@ -1,0 +1,173 @@
+# MON-API-01: API Key Management — Tabela, Middleware X-API-Key, Dashboard
+
+**Priority:** P0
+**Effort:** M (3 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-API-2026-04](EPIC-MON-API-2026-04.md)
+**Sprint:** Wave 1 (bloqueador de MON-API-02/03/04/05 + MON-AI-01; STORY-434 também deve reutilizar)
+
+---
+
+## Contexto
+
+Hoje o backend autentica via **JWT Supabase exclusivamente** (`backend/auth.py::get_current_user` com HTTPBearer). Para monetizar a API B2B (Camada 4) e permitir integrações server-to-server (fintechs, ERPs), precisamos suporte a `X-API-Key: sk_...`:
+
+- Fintechs não querem fazer login OAuth — querem key rotacionável em config
+- RapidAPI espera header padronizado
+- Rate limits e billing por key facilita auditoria
+
+Essa infra também será usada por STORY-434 (API pública gratuita) quando for implementada, e por MON-AI-01 (Semantic Search).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Tabela `api_keys`
+
+- [ ] Migração cria:
+```sql
+CREATE TABLE public.api_keys (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name text NOT NULL,  -- label escolhido pelo user (ex: "Production", "Staging")
+  key_prefix text NOT NULL UNIQUE,  -- primeiros 12 chars do sk_... plaintext, para lookup visual
+  key_hash text NOT NULL,  -- SHA-256 do sk_ full
+  scopes jsonb NOT NULL DEFAULT '["read"]'::jsonb,  -- ["read"], ["read","write"], ["admin"]
+  rate_limit_per_minute int NOT NULL DEFAULT 60,
+  monthly_quota_cents int NOT NULL DEFAULT 500_00,  -- R$ 500 default
+  used_cents_current_month int NOT NULL DEFAULT 0,
+  last_used_at timestamptz NULL,
+  last_used_ip inet NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz NULL,
+  expires_at timestamptz NULL,  -- optional expiration
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX ON api_keys (user_id, revoked_at) WHERE revoked_at IS NULL;
+CREATE INDEX ON api_keys (key_prefix);
+```
+- [ ] RLS: user sees only own keys; service-role full access
+- [ ] Migração paired down
+
+### AC2: Middleware `X-API-Key`
+
+- [ ] Novo `backend/auth/api_key.py`:
+```python
+async def get_current_api_key(x_api_key: str = Header(None)) -> ApiKey:
+    # 1. Parse prefix + hash
+    # 2. Cache L1 Redis 60s por prefix (reduz DB hit)
+    # 3. Check revoked_at, expires_at, monthly_quota
+    # 4. Update last_used_at + last_used_ip (fire-and-forget)
+    # 5. Return ApiKey pydantic model
+```
+- [ ] Dependency factory `require_api_key_or_jwt()` aceita ambos: tenta `X-API-Key` primeiro, fallback `Authorization: Bearer`
+- [ ] Hash SHA-256 + timing-safe compare (`hmac.compare_digest`)
+- [ ] Prefix convention: `sk_live_xxxxxxxx` (prod) ou `sk_test_xxxxxxxx` (dev)
+
+### AC3: Endpoints CRUD de API keys
+
+- [ ] `POST /v1/api-keys` (auth JWT):
+  - Body: `{name: str, scopes?: [str], monthly_quota_cents?: int, expires_at?: datetime}`
+  - Gera key `sk_live_{secrets.token_urlsafe(32)}`
+  - Retorna `{id, key_prefix, full_key}` — **full_key retornado SOMENTE NO CREATE** (plaintext), nunca mais
+  - Limite: max 10 keys ativos por user (free); 50 (paid)
+- [ ] `GET /v1/api-keys` — lista keys do user (sem plaintext, só prefix + metadata)
+- [ ] `PATCH /v1/api-keys/{id}` — atualizar name, scopes, monthly_quota_cents
+- [ ] `DELETE /v1/api-keys/{id}` — soft-delete (seta `revoked_at=now()`)
+
+### AC4: Dashboard frontend `/conta/api-keys`
+
+- [ ] `frontend/app/conta/api-keys/page.tsx`:
+  - Botão "Gerar nova API key" → modal: nome + escopos + limite
+  - Modal pós-criação: mostra plaintext key com botão "Copiar", aviso "Esta chave não será exibida novamente"
+  - Tabela: nome, prefixo (ex: `sk_live_abc***`), último uso, status (ativa/revogada/expirada), gasto mês atual
+  - Ação "Revogar" (confirm dialog)
+- [ ] Link para docs `/api` (criada em MON-API-05)
+
+### AC5: Observability
+
+- [ ] Prometheus: `smartlic_api_key_requests_total{prefix, scope, status}`, `smartlic_api_key_active_total`
+- [ ] Sentry: fingerprint `["api_key", prefix, endpoint]` para erros por key
+- [ ] Log sanitization: **NUNCA** logar full key; apenas prefix
+
+### AC6: Testes
+
+- [ ] Unit: `backend/tests/auth/test_api_key.py`
+  - Create key → hash correto, prefix estável
+  - Valid key → autentica
+  - Revoked key → 401
+  - Expired key → 401
+  - Quota exceeded → 402 Payment Required
+  - Rate limit → 429
+  - Timing-safe compare (teste com key quase-correta)
+- [ ] Integration: `test_require_api_key_or_jwt.py` cobre fallback correto
+- [ ] E2E Playwright: user cria key, copia, revoga
+
+---
+
+## Scope
+
+**IN:**
+- Migração + RLS
+- Middleware + dependency
+- CRUD endpoints
+- Dashboard frontend
+- Prometheus + Sentry
+- Testes
+
+**OUT:**
+- Metered billing per-request (MON-API-02)
+- Webhook de uso anômalo (futuro)
+- OAuth2 client credentials flow (fora de escopo; API key cobre 95% dos casos)
+
+---
+
+## Dependências
+
+- Nenhuma (foundation)
+
+---
+
+## Riscos
+
+- **Key leaked em logs:** log sanitizer enforcement obrigatório — add regex `sk_(live|test)_[A-Za-z0-9_-]{20,}` à denylist
+- **Hash SHA-256 não é BCrypt:** velocidade > segurança (chave já tem 32 bytes entropia, não sofre brute-force viável); documentar decisão
+- **Migration em produção:** tabela vazia inicial, sem risco de lock
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_api_keys_table.sql` + `.down.sql`
+- `backend/auth/api_key.py` (novo)
+- `backend/routes/api_keys.py` (novo)
+- `backend/schemas/api_key.py` (novo)
+- `backend/startup/routes.py` (registrar router)
+- `frontend/app/conta/api-keys/page.tsx` (novo)
+- `backend/tests/auth/test_api_key.py` (novo)
+- `backend/log_sanitizer.py` (adicionar regex para keys)
+
+---
+
+## Definition of Done
+
+- [ ] Migração aplicada em prod
+- [ ] User cria key via dashboard + faz request autenticada em endpoint de teste
+- [ ] Revogação bloqueia próximos requests imediatamente
+- [ ] Testes passando
+- [ ] Log sanitization validada (teste de integração submete request com key e verifica logs)
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — foundation B2B API; também será reutilizada por STORY-434 + MON-AI-01 |

--- a/docs/stories/2026-04/MON-API-02-stripe-metered-billing.md
+++ b/docs/stories/2026-04/MON-API-02-stripe-metered-billing.md
@@ -1,0 +1,188 @@
+# MON-API-02: Metered Billing — Stripe Usage Records + Audit Trail
+
+**Priority:** P0
+**Effort:** L (4-5 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-API-2026-04](EPIC-MON-API-2026-04.md)
+**Sprint:** Wave 1 (depende MON-API-01)
+
+---
+
+## Contexto
+
+Hoje Stripe só tem `mode=subscription` com **fixed monthly price**. Para cobrar **por consulta** (R$ 0,50–10/query), precisamos Stripe metered billing:
+- Produtos Stripe com `price_type=metered` + aggregation `sum`
+- Agregador interno que conta usage e envia `UsageRecord` ao Stripe no final do ciclo de billing
+- Tabela `api_usage_events` para audit trail (reconciliação mensal com Stripe)
+- Feature flag `ENABLE_METERED_BILLING` para rollout gradual
+
+---
+
+## Acceptance Criteria
+
+### AC1: Tabela `api_usage_events`
+
+- [ ] Migração cria:
+```sql
+CREATE TABLE public.api_usage_events (
+  id bigserial PRIMARY KEY,
+  api_key_id uuid NOT NULL REFERENCES api_keys(id),
+  user_id uuid NOT NULL REFERENCES auth.users(id),
+  endpoint text NOT NULL,  -- ex: '/v1/supplier/history'
+  method varchar(10) NOT NULL DEFAULT 'GET',
+  cost_cents int NOT NULL CHECK (cost_cents >= 0),
+  response_status int NOT NULL,
+  response_time_ms int NOT NULL,
+  ip_address inet NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  stripe_usage_record_id text NULL,  -- preenchido quando sincronizado
+  billing_period_start date NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX ON api_usage_events (user_id, created_at DESC);
+CREATE INDEX ON api_usage_events (billing_period_start, user_id) WHERE stripe_usage_record_id IS NULL;
+-- Particionamento por mês recomendado quando > 10M rows/mês
+```
+- [ ] RLS: user sees only own; service-role full access
+- [ ] Migração paired down
+
+### AC2: RPC `log_api_usage` atômico
+
+- [ ] Função SQL:
+```sql
+CREATE OR REPLACE FUNCTION public.log_api_usage(
+  p_api_key_id uuid, p_endpoint text, p_cost_cents int,
+  p_response_status int, p_response_time_ms int, p_ip_address inet
+) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  INSERT INTO api_usage_events (...) VALUES (...);
+  UPDATE api_keys
+    SET used_cents_current_month = used_cents_current_month + p_cost_cents,
+        last_used_at = now(),
+        last_used_ip = p_ip_address
+    WHERE id = p_api_key_id;
+END $$ SECURITY DEFINER;
+```
+- [ ] Performance: p99 < 20ms (medição obrigatória)
+- [ ] Reset mensal de `used_cents_current_month` via cron (AC5)
+
+### AC3: Middleware de billing
+
+- [ ] `backend/services/metered_billing.py::charge_api_request(key, endpoint, cost_cents, status, elapsed_ms)`:
+  - Chamado em `after_response` hook (post-response, fire-and-forget)
+  - Invoca RPC `log_api_usage`
+  - Check quota: se `used_cents_current_month + cost_cents > monthly_quota_cents` → futuro request retorna 402
+- [ ] FastAPI dependency inject: cada endpoint monetizado declara `cost_cents`:
+```python
+@router.get("/supplier/{cnpj}/history", dependencies=[Depends(require_api_key), Depends(meter(cost_cents=100))])
+```
+- [ ] Feature flag `ENABLE_METERED_BILLING=false` por padrão; true em prod
+
+### AC4: Stripe Usage Records sync
+
+- [ ] `backend/services/metered_billing.py::sync_usage_to_stripe(user_id, period_start, period_end)`:
+  - Agrega `api_usage_events` sem `stripe_usage_record_id` no período
+  - Calcula total_cents por usuário
+  - Cria `stripe.UsageRecord.create(subscription_item_id, quantity=total_cents, timestamp=period_end, action='set')`
+  - Backfill `stripe_usage_record_id` + `billing_period_start` nos eventos sincronizados
+- [ ] ARQ cron diário 02:00 BRT `metered_usage_sync_job`:
+  - Processa usuários com `user_subscriptions.is_metered=true`
+  - Idempotente (events com `stripe_usage_record_id NOT NULL` não reprocessa)
+
+### AC5: Reset mensal e cronjobs
+
+- [ ] Cron 01:00 dia 1 de cada mês reset `api_keys.used_cents_current_month = 0` via pg_cron (job único, registrado em migração)
+- [ ] Monitoramento via `cron_job_health` (infra STORY-1.1 já existente)
+
+### AC6: Script Stripe setup
+
+- [ ] `scripts/stripe_setup_metered.py` (run-once):
+  - Cria produto Stripe "SmartLic B2B API — Metered"
+  - Cria 3 tiers de volume discount (ex: primeiros 10k queries R$ 1.00; próximos 40k R$ 0.80; acima R$ 0.60)
+  - Imprime `price_id` para config em Railway vars
+- [ ] Idempotente: valida se produto já existe antes de criar
+
+### AC7: Dashboard admin "Uso da API"
+
+- [ ] `/admin/api-usage` mostra top usuários por gasto mensal, queries/minuto atual, conversion stage (usage → subscription)
+- [ ] Export CSV de eventos (para auditoria)
+
+### AC8: Testes
+
+- [ ] Unit: `test_log_api_usage_rpc.py` — performance p99 < 20ms com 10k events
+- [ ] Integration: `test_metered_billing_sync.py` — mock Stripe, valida UsageRecord.create com quantity correto + backfill
+- [ ] Integration: quota exceeded → 402 na próxima request
+- [ ] Unit: idempotência do sync (2x run → 1 UsageRecord apenas)
+
+---
+
+## Scope
+
+**IN:**
+- Tabela `api_usage_events` + RPC
+- Middleware billing
+- Sync diário Stripe
+- Reset mensal
+- Script setup
+- Dashboard admin
+- Testes
+
+**OUT:**
+- Billing real-time (cada request → Stripe) — caro; batch diário suficiente
+- Partitioning automático da tabela (ativar quando > 10M rows/mês)
+- Credits / free tier specific billing (v2 — hoje quota é hard limit)
+
+---
+
+## Dependências
+
+- MON-API-01 (API keys)
+- Stripe account com produtos metered setup
+
+---
+
+## Riscos
+
+- **Drift entre usage interno e Stripe:** reconciliação diária + alerta Sentry se delta >1%
+- **Perda de events em downtime:** RPC atômico + Redis fila buffer se DB down (v2)
+- **Stripe UsageRecord rate limit:** 100 req/sec — sync diário agrupa por usuário, jamais atinge
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_api_usage_events.sql` + `.down.sql`
+- `supabase/migrations/.../create_log_api_usage_rpc.sql` + `.down.sql`
+- `supabase/migrations/.../schedule_monthly_reset.sql` (pg_cron)
+- `backend/services/metered_billing.py` (novo)
+- `backend/jobs/cron/metered_usage_sync.py` (novo)
+- `scripts/stripe_setup_metered.py` (novo)
+- `backend/routes/admin_api_usage.py` (novo)
+- `frontend/app/admin/api-usage/page.tsx` (novo)
+- `backend/tests/services/test_metered_billing.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Setup Stripe script executado, `price_id_metered` em Railway vars
+- [ ] Feature flag `ENABLE_METERED_BILLING=true` em staging
+- [ ] Test purchase: API key com R$ 10 quota → 100 queries × R$ 0,10 → 0,00 restante → 402 na 101ª
+- [ ] Sync diário em staging → UsageRecord visível em Stripe Dashboard
+- [ ] Dashboard admin mostra dados em tempo real
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — enables pay-per-query B2B; foundation para Camada 4 e MON-AI-01 |

--- a/docs/stories/2026-04/MON-API-03-supplier-history-endpoint.md
+++ b/docs/stories/2026-04/MON-API-03-supplier-history-endpoint.md
@@ -1,0 +1,175 @@
+# MON-API-03: `GET /api/v1/supplier/{cnpj}/history` (R$ 0,50–2/consulta)
+
+**Priority:** P1
+**Effort:** M (3 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-API-2026-04](EPIC-MON-API-2026-04.md)
+**Sprint:** Wave 1 (depende MON-API-01 + MON-API-02)
+
+---
+
+## Contexto
+
+Primeiro endpoint monetizado da Camada 4. Retorna histórico consolidado de contratos por CNPJ — útil para fintechs de crédito PME (due diligence), plataformas de compliance (KYB), ERPs (enrichment de fornecedor), sites B2B.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Endpoint REST
+
+- [ ] `GET /api/v1/supplier/{cnpj}/history`
+- [ ] Autenticação: `X-API-Key` obrigatório (MON-API-01)
+- [ ] Query params opcionais:
+  - `periodo_inicio`: date (default: 5 anos atrás)
+  - `periodo_fim`: date (default: hoje)
+  - `uf`: string 2 chars (filtro opcional)
+  - `limit`: int (1-100, default 50)
+  - `offset`: int (default 0)
+  - `include_details`: bool (default true — embeddded contracts; false = só aggregates)
+
+### AC2: Response schema
+
+```json
+{
+  "cnpj": "12345678000100",
+  "nome_fornecedor": "EMPRESA X LTDA",
+  "period": {"inicio": "2021-04-22", "fim": "2026-04-22"},
+  "aggregates": {
+    "total_contratos": 127,
+    "total_valor_cents": 4525000000,
+    "unique_buyers": 14,
+    "avg_valor_cents": 35629921,
+    "min_valor_cents": 500000,
+    "max_valor_cents": 1200000000,
+    "first_contract_date": "2021-07-15",
+    "last_contract_date": "2026-03-28"
+  },
+  "top_buyers": [
+    {"orgao_cnpj": "...", "orgao_nome": "...", "contratos_count": 34, "valor_total_cents": 12500000000, "share_pct": 27.6},
+    ...
+  ],
+  "sector_breakdown": [
+    {"setor": "informatica", "contratos": 45, "valor_total_cents": 18000000000, "share_pct": 39.8},
+    ...
+  ],
+  "uf_breakdown": [...],
+  "modalidade_breakdown": [...],
+  "contracts": [  // if include_details=true
+    {"numero_controle_pncp": "...", "orgao_nome": "...", "uf": "SP", "valor_cents": 500000, "data_assinatura": "...", "objeto_resumo": "..."},
+    ...
+  ],
+  "pagination": {"limit": 50, "offset": 0, "total": 127, "next_offset": 50},
+  "generated_at": "2026-04-22T14:00:00Z",
+  "cache_status": "fresh"
+}
+```
+
+- [ ] Branding header em todas as responses: `X-Data-Source: SmartLic / PNCP`
+- [ ] Cache-Control: `public, max-age=3600` (1h TTL)
+- [ ] Cost header: `X-Cost-Cents: 100` (para transparência)
+
+### AC3: Performance
+
+- [ ] p95 latency < 500ms
+- [ ] Usar índice composto existente `(ni_fornecedor, data_assinatura DESC)`
+- [ ] Aggregates calculados em uma RPC única (`supplier_history_aggregated`)
+- [ ] L1 cache Redis 5 min por `(cnpj, params_hash)`
+
+### AC4: Validações
+
+- [ ] CNPJ: 14 dígitos, passa validação checksum (reusa `backend/utils/cnpj.py` se existir)
+- [ ] periodo_fim >= periodo_inicio
+- [ ] CNPJ não encontrado → 404 com body `{error: "supplier_not_found", cnpj: "..."}`
+- [ ] 0 contratos no período → 200 com aggregates zerados + array vazio
+
+### AC5: Metered billing integration
+
+- [ ] Cost fixo: 100 cents (R$ 1,00) por request
+- [ ] Variação por volume (Stripe tier discount já configurado em MON-API-02)
+- [ ] Após response: fire-and-forget `log_api_usage` via MON-API-02
+
+### AC6: Documentação OpenAPI
+
+- [ ] Schema Pydantic completo para request/response
+- [ ] Description com exemplo de cURL + Python
+- [ ] Visível em `/api/docs-public` (MON-API-05)
+
+### AC7: Testes
+
+- [ ] Unit: `test_supplier_history_endpoint.py`
+  - Happy path: CNPJ com 10 contratos → aggregates corretos
+  - Filtro UF → subset correto
+  - CNPJ inválido (checksum) → 400
+  - CNPJ não existe → 404
+  - Paginação: limit=10 offset=20 → retorna correto
+- [ ] Performance: 100 queries concorrentes p95 < 500ms
+- [ ] Integration: com API key + metered billing → log_api_usage chamado
+
+---
+
+## Scope
+
+**IN:**
+- Endpoint + schema Pydantic
+- RPC agregador
+- L1 cache Redis
+- Metered billing integration
+- OpenAPI docs
+- Testes
+
+**OUT:**
+- Full-text search em `objeto_contrato` — v2
+- Webhook "novo contrato para CNPJ X" — v2
+- GraphQL alternative — fora de escopo
+- Export Excel/CSV pelo endpoint — usuário monta com os dados retornados
+
+---
+
+## Dependências
+
+- MON-API-01 + MON-API-02 (bloqueadores)
+- Dados de `pncp_supplier_contracts` (já existem)
+
+---
+
+## Riscos
+
+- **CNPJ com 10k+ contratos (governo federal como fornecedor???):** limite implícito via `limit=100` + paginação; se > 1M contratos, response pode timeout → adicionar hard limit 5000 contracts
+- **Privacy concerns:** dados são públicos (lei transparência) mas CNPJs podem pedir remoção por LGPD — add endpoint futuro `/supplier/{cnpj}/opt-out`
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/routes/public_api/supplier_history.py` (novo)
+- `backend/schemas/public_api/supplier_history.py` (novo)
+- `supabase/migrations/.../create_supplier_history_rpc.sql` + `.down.sql`
+- `backend/utils/cnpj.py` (criar se não existe)
+- `backend/tests/routes/public_api/test_supplier_history.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Endpoint live em prod com feature flag `ENABLE_PUBLIC_API=true`
+- [ ] 3 test API keys fazendo requests bem-sucedidos
+- [ ] Métricas Prometheus: `smartlic_api_supplier_history_requests_total`, `smartlic_api_supplier_history_latency_seconds`
+- [ ] p95 < 500ms medido com 100 req/s
+- [ ] OpenAPI visível e válido
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — primeiro endpoint monetizado da Camada 4 |

--- a/docs/stories/2026-04/MON-API-04-benchmark-price-endpoint.md
+++ b/docs/stories/2026-04/MON-API-04-benchmark-price-endpoint.md
@@ -1,0 +1,160 @@
+# MON-API-04: `GET /api/v1/benchmark/price` (R$ 1–5/consulta)
+
+**Priority:** P1
+**Effort:** M (3 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-API-2026-04](EPIC-MON-API-2026-04.md)
+**Sprint:** Wave 1 (depende MON-API-01 + MON-API-02 + MON-SCH-02)
+
+---
+
+## Contexto
+
+Segundo endpoint monetizado. Retorna distribuição estatística de preço para CATMAT/CATSER + UF + período. Persona: ERPs de compras públicas, sistemas de orçamentação, fintechs com engine de credit scoring que considera preço-alvo.
+
+**Preço mais alto que MON-API-03** (R$ 1–5 vs R$ 0,50–2) porque agregação é computationally expensive + valor percebido maior (é insight, não dado bruto).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Endpoint REST
+
+- [ ] `GET /api/v1/benchmark/price`
+- [ ] Query params:
+  - `catmat_catser`: string (obrigatório)
+  - `uf`: string 2 chars (opcional; default "all")
+  - `periodo_meses`: int 3|6|12|24|36 (default 12)
+  - `modalidade`: int (opcional; filtra por modalidade PNCP)
+  - `esfera`: char F|E|M|D (opcional; Federal/Estadual/Municipal/Distrital)
+
+### AC2: Response schema
+
+```json
+{
+  "catmat_catser": "150015",
+  "catmat_catser_label": "Papel sulfite A4 75g",
+  "catmat_catser_tipo": "M",
+  "filters": {"uf": "SP", "periodo_meses": 12, "modalidade": null, "esfera": null},
+  "period": {"inicio": "2025-04-22", "fim": "2026-04-22"},
+  "sample_size": 1247,
+  "statistics": {
+    "media_cents": 2500,
+    "mediana_cents": 2200,
+    "p10_cents": 1500,
+    "p25_cents": 1900,
+    "p50_cents": 2200,
+    "p75_cents": 2800,
+    "p90_cents": 3500,
+    "stddev_cents": 650,
+    "coef_variacao": 0.26
+  },
+  "per_uf": [
+    {"uf": "SP", "n": 340, "mediana_cents": 2100, "media_cents": 2450},
+    ...
+  ],
+  "per_modalidade": [
+    {"modalidade": 6, "modalidade_label": "Pregão Eletrônico", "n": 892, "mediana_cents": 2150},
+    ...
+  ],
+  "outliers": {
+    "above_p95": [{"numero_controle_pncp": "...", "valor_cents": 8500, "desvio_pct": 285.0}, ...],  // top 5
+    "below_p05": [...]
+  },
+  "generated_at": "2026-04-22T14:00:00Z",
+  "data_coverage_pct": 87.3  // % dos contratos com CATMAT populado
+}
+```
+
+### AC3: Uso do RPC MON-SCH-02
+
+- [ ] Consumir `benchmark_by_catmat(catmat, uf, periodo_dias)` criado em MON-SCH-02
+- [ ] Cache L1 Redis 1h por `(catmat, uf, periodo, modalidade, esfera)`
+- [ ] Se `sample_size < 20` → 404 com mensagem "Amostra insuficiente — tente período maior ou sem filtro UF"
+
+### AC4: Rate limiting mais restritivo
+
+- [ ] Cost: 200 cents (R$ 2,00) por request (mais caro que history)
+- [ ] Rate limit: 30 req/min por API key (vs 60 do history) — aggregation é mais pesada
+
+### AC5: Validações
+
+- [ ] `catmat_catser` deve existir em `catmat_catser_catalog` senão 404
+- [ ] UF válida (27 + "all")
+- [ ] periodo_meses ∈ {3,6,12,24,36}
+- [ ] modalidade ∈ {4,5,6,7,8,12}
+
+### AC6: Observability
+
+- [ ] Prometheus: `smartlic_api_benchmark_requests_total{catmat_prefix}`, `smartlic_api_benchmark_coverage_pct`
+- [ ] Sentry alert se `data_coverage_pct < 70%` por 3 dias consecutivos para CATMAT popular (sinal de degradação MON-SCH-02)
+
+### AC7: Testes
+
+- [ ] Unit: teste de stats matemática (dados conhecidos → percentis corretos)
+- [ ] Integration: mock RPC benchmark + assert response correto
+- [ ] Performance: p95 < 300ms (menos dados que history, pode ser mais rápido)
+- [ ] Edge: CATMAT com < 20 contratos → 404
+
+---
+
+## Scope
+
+**IN:**
+- Endpoint + schema
+- Consumo RPC MON-SCH-02
+- Cache L1
+- Prometheus metrics
+- Testes
+
+**OUT:**
+- Previsão de preço futuro — v2 (usa MON-AI-03 Radar Preditivo)
+- Alerta quando meu preço-alvo está fora do range — add-on separado
+- Outliers extremos com explicação LLM — v2
+
+---
+
+## Dependências
+
+- MON-API-01 + MON-API-02
+- **MON-SCH-02 (CATMAT/CATSER)** — bloqueador absoluto
+
+---
+
+## Riscos
+
+- **Low coverage em CATMATs raros:** ok para niche query; response vem com `data_coverage_pct` transparente
+- **Gaming: usuário tenta monitorar preço via polling frequente:** rate limit 30/min mitiga; considerar subscription-based alerts como upsell (MON-SUB-*)
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/routes/public_api/benchmark_price.py` (novo)
+- `backend/schemas/public_api/benchmark_price.py` (novo)
+- `backend/tests/routes/public_api/test_benchmark_price.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Endpoint live + 100+ requests bem-sucedidos em staging
+- [ ] Cache hit rate > 60% após warmup
+- [ ] p95 < 300ms
+- [ ] Coverage average > 80% para CATMATs populares
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — segundo endpoint monetizado Camada 4; depende MON-SCH-02 |

--- a/docs/stories/2026-04/MON-API-05-rapidapi-landing-public-docs.md
+++ b/docs/stories/2026-04/MON-API-05-rapidapi-landing-public-docs.md
@@ -1,0 +1,145 @@
+# MON-API-05: Distribuição RapidAPI + Landing `/api` + Docs Públicos Separados
+
+**Priority:** P1
+**Effort:** M (3 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-API-2026-04](EPIC-MON-API-2026-04.md)
+**Sprint:** Wave 1
+
+---
+
+## Contexto
+
+Os endpoints MON-API-03/04 existem mas precisam de **descoberta + docs comerciais + marketplace**:
+- Landing `/api` vende pricing tiers
+- Swagger público `/api/docs-public` separado do `/docs` interno (que lista endpoints privados)
+- Listagem no RapidAPI (DA 91) para SEO + marketplace discovery
+
+---
+
+## Acceptance Criteria
+
+### AC1: Landing page `/api`
+
+- [ ] `frontend/app/api/page.tsx`:
+  - Hero: "API de Dados Públicos de Licitações e Contratos — 2M+ registros via REST"
+  - Pricing tiers (cards):
+    - **Free**: 100 queries/mês grátis, fair-use, sem SLA
+    - **Growth R$ 297/mês**: 10.000 queries, p95 SLA 500ms, email support
+    - **Scale R$ 997/mês**: 50.000 queries, p95 SLA 300ms, chat support, custom overage R$ 0,50/query
+    - **Enterprise (custom)**: volume unlimited, dedicated support, SLA 99.9%
+  - Seção "Endpoints disponíveis" com cards resumindo cada endpoint + "Ver docs"
+  - Seção "Casos de uso": fintechs, ERPs, compliance platforms, pesquisa acadêmica
+  - Código embedding (tabs): cURL, Python, Node.js, Ruby
+  - Logos "quem usa" (inicialmente vazio, preencher quando 3+ clientes)
+  - CTA "Criar API key grátis" → `/conta/api-keys`
+
+### AC2: Swagger público separado
+
+- [ ] `backend/startup/public_docs.py` configura app FastAPI secundário (ou filtro) que expõe em `/api/docs-public`:
+  - Apenas endpoints com decorator/tag `@public_api`
+  - OAuth2/JWT removido do spec (mostra só X-API-Key)
+  - Custom branding: logo SmartLic, cor, description com contexto
+- [ ] `/docs` original permanece com todos endpoints (admin)
+- [ ] `openapi.json` público em `/api/openapi.json`
+
+### AC3: Branding headers em todos endpoints
+
+- [ ] Middleware global para rotas `/api/v1/*` adiciona:
+  - `X-Data-Source: SmartLic / PNCP (pncp.gov.br)`
+  - `X-Rate-Limit-Remaining: N` (usage atual do minuto)
+  - `X-Documentation: https://smartlic.tech/api`
+  - `Access-Control-Allow-Origin: *` (CORS aberto para dados públicos)
+
+### AC4: RapidAPI submission
+
+- [ ] Criar listagem em https://rapidapi.com:
+  - Nome: "Brazilian Public Procurement Data"
+  - Categorias: "Government Data", "Business Intelligence", "Finance"
+  - 3 endpoints inicialmente: `/supplier/{cnpj}/history`, `/benchmark/price`, `/supplier/{cnpj}/score` (future)
+  - Tiers matching pricing SmartLic (RapidAPI cobra 25% commission)
+  - Exemplos de request/response
+  - SLA declarado 99.5%
+- [ ] `docs/api/rapidapi-submission.md` com checklist + prints da submissão
+- [ ] Integração técnica: header `X-RapidAPI-Proxy-Secret` valida requests vindo do RapidAPI
+
+### AC5: SEO da landing
+
+- [ ] Title: `"API de Dados de Licitações Públicas — 2M+ Contratos | SmartLic"` (61 chars)
+- [ ] Description: `"API REST para acesso a dados de licitações e contratos públicos do Brasil (PNCP). Histórico por CNPJ, benchmark de preços, score de risco. Free tier 100 queries/mês."` (172 chars)
+- [ ] JSON-LD `Service` + `Offer` schemas
+- [ ] Sitemap: adicionar `/api` com priority=0.9
+
+### AC6: Testes
+
+- [ ] Frontend: landing renderiza sem errors, todos os CTAs funcionam
+- [ ] Integration: `X-RapidAPI-Proxy-Secret` rejeita requests sem header válido (quando vindos via RapidAPI)
+- [ ] Swagger `/api/docs-public` lista APENAS endpoints públicos (grep contra lista whitelist)
+- [ ] CORS funciona: request de origin externa chega com `Access-Control-Allow-Origin: *`
+
+---
+
+## Scope
+
+**IN:**
+- Landing `/api` (frontend)
+- Swagger público separado
+- Middleware branding
+- RapidAPI submission + integração
+- SEO
+
+**OUT:**
+- SDK em linguagens (Python/JS) — v2
+- Webhook events (push novos contratos) — v2
+- GraphQL — fora de escopo
+
+---
+
+## Dependências
+
+- MON-API-01 + MON-API-02 + MON-API-03 + MON-API-04 (endpoints precisam existir para RapidAPI validar)
+
+---
+
+## Riscos
+
+- **RapidAPI approval delay:** 1-2 semanas; submeter cedo no sprint, não bloqueia release
+- **25% commission RapidAPI reduz margem:** aceitável para fase inicial (descoberta > margem); clientes enterprise diretos mantêm 100% margem
+- **`/docs` expondo endpoints internos indesejados:** audit manual antes do release; whitelist explícita de endpoints públicos
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `frontend/app/api/page.tsx` (novo)
+- `frontend/app/api/layout.tsx` (novo — se diferente do root)
+- `backend/startup/public_docs.py` (novo)
+- `backend/main.py` (registrar public_docs app)
+- `backend/middleware/api_branding.py` (novo)
+- `docs/api/rapidapi-submission.md` (novo)
+- `frontend/app/sitemap.ts` (estender)
+
+---
+
+## Definition of Done
+
+- [ ] Landing `/api` live em prod, Lighthouse >= 90
+- [ ] `/api/docs-public` live + validado: só endpoints públicos aparecem
+- [ ] Branding headers em 100% das responses `/api/v1/*`
+- [ ] RapidAPI listagem submetida (status: em review OK)
+- [ ] CORS validado cross-origin
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — camada comercial e de descoberta sobre endpoints MON-API-03/04 |

--- a/docs/stories/2026-04/MON-API-06-supplier-score-endpoint.future.md
+++ b/docs/stories/2026-04/MON-API-06-supplier-score-endpoint.future.md
@@ -1,0 +1,87 @@
+# MON-API-06 (FUTURE — Q3): `GET /api/v1/supplier/{cnpj}/score` (R$ 2–10/consulta)
+
+**Priority:** P2 — Backlog Q3
+**Effort:** L (6-8 dias)
+**Squad:** @data-engineer + @dev + @architect
+**Status:** Future (não incluído em Wave 1)
+**Epic:** [EPIC-MON-API-2026-04](EPIC-MON-API-2026-04.md)
+**Sprint:** Q3 (após Waves 1-3 consolidadas)
+
+---
+
+## Contexto
+
+Terceiro endpoint da Camada 4, **mais alto ticket** (R$ 2–10/consulta) porque entrega **score modelado via ML**, não agregação simples. Composição do score:
+
+- Capacidade (30%): volume de contratos executados, diversidade de órgãos, crescimento YoY
+- Adimplência (30%): índice de aditivos, rescisões, % valor aditado
+- Concentração (20%): Herfindahl-Hirschman (órgão + setor), volatilidade
+- Estabilidade (20%): anos atuante, gap entre contratos, sazonalidade
+
+Requer modelo ML treinado em dataset histórico com labels (default rate, churn, sanção CEIS/CNEP no futuro).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Modelo ML offline
+
+- [ ] Pipeline de feature engineering em `backend/ml/supplier_score/features.py`
+- [ ] Modelo: Gradient Boosting (XGBoost ou LightGBM) treinado em labels proxy (ex: fornecedor teve aditivo >50% → label risky)
+- [ ] Cross-validation: AUC > 0.75 mínimo
+- [ ] Model versioning: mlflow ou arquivo versionado em S3 com hash
+
+### AC2: Endpoint
+
+- [ ] `GET /api/v1/supplier/{cnpj}/score`
+- [ ] Response: `{cnpj, score_geral: 0-100, breakdown: {capacidade, adimplencia, concentracao, estabilidade}, percentil_setor, flags[], confidence: 0-1, model_version, computed_at}`
+- [ ] Cache 24h em Redis (score não muda diariamente)
+
+### AC3: Disclaimer e governança
+
+- [ ] Response inclui disclaimer: "score derivado de dados públicos; não constitui análise de crédito formal"
+- [ ] Opt-out endpoint: `POST /api/v1/supplier/{cnpj}/opt-out` (requer prova de titularidade — email do domínio do CNPJ)
+- [ ] Audit log de cada consulta (quem consultou quem, para compliance LGPD)
+
+### AC4: Testes e validação
+
+- [ ] Backtest: score alto para peers históricos estáveis, score baixo para peers com default conhecido
+- [ ] Monitoramento de drift: retrain mensal se AUC cair abaixo 0.7
+
+---
+
+## Dependências
+
+- MON-SCH-01 (aditivos)
+- MON-SCH-02 (CATMAT) — para padrão de preço por categoria
+- MON-AI-01 (embeddings) — opcional, para feature "similaridade com defaulters"
+- CEIS/CNEP integration (MON-REP-06b Q3) — labels para treinamento
+- Infraestrutura ML: GPU opcional para training, CPU suficiente para inference
+
+---
+
+## Scope
+
+**IN (Q3 quando ativado):**
+- Pipeline ML offline
+- Endpoint REST
+- Cache + disclaimer + opt-out
+- Testes + backtest
+
+**OUT (mesmo em Q3):**
+- Score preditivo de "ganhará próximo edital?" — produto separado (pertence a MON-AI-03)
+- Score de correlação entre fornecedores (cartel detection) — story dedicada se virar demanda
+
+---
+
+## Status: BACKLOG Q3
+
+Esta story **não** será implementada em Wave 1. Fica como placeholder para rastreamento do roadmap. Pré-requisitos (MON-SCH-01, MON-SCH-02) sobrepõem com Wave 1.
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story FUTURE criada — roadmap Q3 pós Waves 1-3 |

--- a/docs/stories/2026-04/MON-DIST-01-data-licensing-bulk-export.md
+++ b/docs/stories/2026-04/MON-DIST-01-data-licensing-bulk-export.md
@@ -1,0 +1,167 @@
+# MON-DIST-01: Data Licensing / Bulk Export (Pacotes Temáticos One-Shot)
+
+**Priority:** P2
+**Effort:** L (5-6 dias)
+**Squad:** @dev + @devops + @pm
+**Status:** Draft
+**Epic:** [EPIC-MON-DIST-2026-04](EPIC-MON-DIST-2026-04.md)
+**Sprint:** Wave 3 (depende MON-REP-01)
+
+---
+
+## Contexto
+
+Compradores **enterprise** (consultorias estratégicas, universidades, think tanks, M&A advisors) precisam do dataset **temático em bulk** para análise offline (Python/R/Excel) — não querem API nem relatórios PDF. Querem CSV/JSON/Parquet.
+
+**Modelo:** catálogo de pacotes pré-montados + pacotes on-demand customizados. Checkout reutiliza MON-REP-01.
+
+**Exemplos de pacotes iniciais:**
+- "Construção Civil SP 2020-2025" (~500k contratos, R$ 9.997)
+- "TI Federal 2023-2025" (~150k contratos, R$ 4.997)
+- "Limpeza Municipal Nordeste 2021-2025" (~300k contratos, R$ 6.997)
+- "Top 100 Fornecedores por Setor" (R$ 2.997 por setor)
+
+**Upsell:** assinatura "Data Feed Mensal" (delta de novos contratos no recorte, R$ 997/mês) — considerar em v2.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Tabela `data_packages` + admin UI
+
+- [ ] Migração:
+```sql
+CREATE TABLE public.data_packages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text UNIQUE NOT NULL,
+  description text NOT NULL,
+  filters jsonb NOT NULL,  -- {setor, ufs, periodo_inicio, periodo_fim, modalidades, ...}
+  price_cents int NOT NULL,
+  row_count_est int NOT NULL,
+  formats text[] NOT NULL DEFAULT ARRAY['csv','json','parquet'],
+  schema_doc_url text NULL,  -- link para docs.smartlic.tech/data-packages/{slug}
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+```
+- [ ] Admin UI `/admin/data-packages` para CRUD de pacotes
+- [ ] Seed inicial com 10 pacotes em `scripts/seed_data_packages.py`
+
+### AC2: Gerador async de bulk export
+
+- [ ] `backend/services/bulk_export.py`:
+  - Input: `package_id` ou `custom_filters`, `formato`
+  - Streaming export: `COPY TO STDOUT` do PostgreSQL para arquivo temporário
+  - Formato Parquet via `pyarrow` (mais leve que CSV para dados numéricos)
+  - Upload ao Supabase Storage (bucket `data-exports`, TTL 7 dias)
+  - Geração pode levar 2-15 min dependendo do tamanho
+
+### AC3: Checkout + entrega
+
+- [ ] Reutiliza MON-REP-01: `POST /v1/purchases/checkout` com `product_type='data_package'`, `product_params: {package_id, formato}`
+- [ ] Após payment: ARQ job `generate_data_package` invoca bulk_export, persiste em `generated_reports` (reutiliza infra MON-REP-02)
+- [ ] Email específico `data_package_ready.py` com link signed URL 7 dias
+
+### AC4: Landing `/dados-empresariais`
+
+- [ ] `frontend/app/dados-empresariais/page.tsx`:
+  - Hero: "Licença Enterprise de Dados de Contratações Públicas"
+  - Grid de 10+ pacotes (filtrar por setor)
+  - Cada card: nome, descrição, row count, preço, formatos, "Ver schema"
+  - Botão "Solicitar pacote custom" → form que gera lead (email p/ equipe + opcional checkout direto)
+  - Seção "FAQ": formato, licença (CC-BY 4.0 + termos SmartLic), uso permitido (comercial OK, redistribuição não), atualização
+
+### AC5: Termos de uso
+
+- [ ] `docs/legal/data-license-terms.md`:
+  - Uso comercial e acadêmico permitido
+  - Redistribuição não permitida (client-specific license)
+  - Fonte original: PNCP (obrigatório citar)
+  - Rights reserved SmartLic para dados derivados (score, classificação IA)
+- [ ] Checkbox obrigatório no checkout: "Li e aceito os termos"
+
+### AC6: Analytics
+
+- [ ] Prometheus: `smartlic_data_packages_sold_total{package_slug}`, `smartlic_data_packages_revenue_cents_total`
+- [ ] Top N pacotes mais vendidos → destaque na landing
+
+### AC7: Testes
+
+- [ ] Unit: `test_bulk_export.py` — export de 1k rows para 3 formatos, validar schemas
+- [ ] Integration: purchase → job → file generated → download funciona
+- [ ] Performance: pacote 500k rows gera em <15 min
+
+---
+
+## Scope
+
+**IN:**
+- Tabela + admin UI
+- Gerador bulk export (3 formatos)
+- Checkout + delivery (reutiliza MON-REP-01/02)
+- Landing + FAQ + termos
+- Seed 10 pacotes iniciais
+- Testes
+
+**OUT:**
+- Pacotes recorrentes / data feed mensal — v2
+- API B2B de data license — cobre MON-API-05 (RapidAPI) com tier enterprise custom
+- White-label do dataset — fora de escopo (overlap com MON-DIST-02)
+
+---
+
+## Dependências
+
+- MON-REP-01 (checkout one-shot)
+- MON-REP-02 (delivery infra)
+- Dados `pncp_supplier_contracts` populados (já existem)
+
+---
+
+## Riscos
+
+- **Cliente reivindica redistribuição:** termos claros + audit log por signed URL download
+- **Export muito grande trava worker:** limit 1M rows por pacote; se > solicitar Enterprise custom
+- **Compliance LGPD para datasets com CNPJs:** dados públicos (lei transparência); incluir campo de opt-out para CNPJs que solicitarem (raríssimo)
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_data_packages.sql` + `.down.sql`
+- `backend/services/bulk_export.py` (novo)
+- `backend/jobs/data_package_generation.py` (novo)
+- `backend/templates/emails/data_package_ready.py` (novo)
+- `scripts/seed_data_packages.py` (novo)
+- `backend/routes/data_packages.py` (novo — admin + public)
+- `backend/routes/admin_data_packages.py` (novo)
+- `frontend/app/dados-empresariais/page.tsx` (novo)
+- `frontend/app/admin/data-packages/page.tsx` (novo)
+- `docs/legal/data-license-terms.md` (novo)
+- `backend/tests/services/test_bulk_export.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 10 pacotes seeded em prod
+- [ ] Landing live com pacotes visíveis
+- [ ] Test purchase: compra Parquet → download funciona → arquivo válido em pandas
+- [ ] Termos de uso publicados + aceite obrigatório
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — canal enterprise one-shot; extras de distribuição |

--- a/docs/stories/2026-04/MON-DIST-02-white-label-consultorias.md
+++ b/docs/stories/2026-04/MON-DIST-02-white-label-consultorias.md
@@ -1,0 +1,192 @@
+# MON-DIST-02: White-label para Consultorias (Stripe Connect + Branding Customizado)
+
+**Priority:** P2
+**Effort:** XL (8-10 dias)
+**Squad:** @dev + @architect + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-DIST-2026-04](EPIC-MON-DIST-2026-04.md)
+**Sprint:** Wave 3 (depende MON-REP-01 + MON-SUB-01)
+
+---
+
+## Contexto
+
+~15% das empresas B2G usam **consultorias especializadas** em licitação — canal paralelo massivo. Modelo: consultoria A revende relatórios/monitores/Copilot com sua marca + Stripe Connect revshare.
+
+**Benefícios:**
+- Consultoria traz carteira existente de clientes (distribuição)
+- SmartLic cobra revshare (20-50% flat sobre GMV)
+- Consultoria oferece serviço "premium branded" sem precisar construir backend
+
+**Mecânica Stripe Connect Express:** consultoria faz onboarding → SmartLic processa pagamento (customer do consultor) → Stripe transfere automaticamente % para conta conectada.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Schema partners
+
+- [ ] Migração:
+```sql
+CREATE TABLE public.partner_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_name text NOT NULL,
+  slug text UNIQUE NOT NULL,  -- usado em URL /parceiros/{slug}
+  cnpj varchar(14) NOT NULL,
+  contact_email text NOT NULL,
+  logo_url text NULL,
+  primary_color text NULL DEFAULT '#000000',
+  revshare_pct numeric(4,2) NOT NULL CHECK (revshare_pct BETWEEN 10 AND 80),
+  stripe_connect_account_id text UNIQUE NULL,
+  stripe_connect_onboarded boolean NOT NULL DEFAULT false,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE public.partner_clients (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_id uuid NOT NULL REFERENCES partner_accounts(id),
+  end_user_id uuid NOT NULL REFERENCES auth.users(id),
+  acquired_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(partner_id, end_user_id)
+);
+
+CREATE TABLE public.partner_revshare_events (
+  id bigserial PRIMARY KEY,
+  partner_id uuid NOT NULL REFERENCES partner_accounts(id),
+  purchase_id uuid NULL REFERENCES purchases(id),
+  subscription_id uuid NULL REFERENCES monitored_subscriptions(id),
+  gmv_cents int NOT NULL,
+  revshare_cents int NOT NULL,
+  stripe_transfer_id text NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+### AC2: Stripe Connect Express onboarding
+
+- [ ] Endpoint `POST /v1/partners/onboard` (admin-trigger ou partner-self-serve):
+  - Cria Stripe Connect account `type=express`
+  - Retorna `onboarding_url` (Stripe-hosted)
+  - Webhook `account.updated` sincroniza `stripe_connect_onboarded=true` quando KYC completo
+
+### AC3: Branding customizado em relatórios
+
+- [ ] `backend/reports/_branding.py`:
+  - Função `get_branding_for_purchase(purchase) -> Branding`
+  - Se `partner_clients` tem end_user_id = purchase.user_id: usa branding do partner
+  - Substitui header/footer do PDF com logo + cor do partner
+  - Footer disclaimer: "Serviço oferecido por {partner_name} em parceria com SmartLic"
+
+### AC4: Revshare automático em pagamentos
+
+- [ ] Em MON-REP-01 webhook `checkout.session.completed`:
+  - Se purchase vinculada a partner: calcular `revshare_cents = amount_cents × revshare_pct`
+  - Criar `stripe.Transfer.create(amount, destination=stripe_connect_account_id, ...)`
+  - Insert em `partner_revshare_events` com `stripe_transfer_id`
+- [ ] Para subscriptions (MON-SUB-01): transferência recorrente configurada via Stripe Connect (`application_fee_percent` no subscription item)
+
+### AC5: Dashboard do partner
+
+- [ ] `frontend/app/parceiros/dashboard/page.tsx` (auth via partner portal, não end-user):
+  - Métricas: GMV do mês, revshare acumulado, clientes ativos, taxa conversão
+  - Gráfico evolução GMV 12 meses
+  - Tabela últimas transações
+  - Botão "Dashboard Stripe Connect" (link para Stripe Express)
+  - Códigos de referral (partner slug) para tracking
+
+### AC6: Landing do programa de parceiros
+
+- [ ] `frontend/app/parceiros/page.tsx`:
+  - Proposta de valor
+  - Modelos (20% revshare / 50% / flat fee custom)
+  - FAQ
+  - Formulário "Torne-se parceiro" → lead
+
+### AC7: Attribution de end users a partners
+
+- [ ] Quando usuário chega via URL `?ref={partner_slug}` ou `/parceiros/{partner_slug}`:
+  - Cookie `partner_attribution` (90 dias)
+  - Quando fizer signup: insere em `partner_clients`
+  - Todas purchases futuras desse user têm `partner_id` no metadata
+
+### AC8: Testes
+
+- [ ] Unit: `test_partner_revshare.py` — cálculo correto + criação de transfer
+- [ ] Integration: purchase via partner → transfer efetivado no Stripe
+- [ ] E2E: partner onboarding → envio de link ref → end user compra → revshare calculado
+
+---
+
+## Scope
+
+**IN:**
+- Schema partners (3 tabelas)
+- Stripe Connect Express onboarding
+- Branding custom em relatórios PDF
+- Revshare automático (one-shot + recorrente)
+- Dashboards partner + landing
+- Attribution via ref
+- Testes
+
+**OUT:**
+- Marketplace público de parceiros — v2
+- Badges/selos customizáveis no dashboard do end user — v2
+- Multi-tier branding (sub-parceiros) — fora de escopo
+
+---
+
+## Dependências
+
+- MON-REP-01 + MON-SUB-01 (infra de checkout e subscription)
+- Stripe Connect habilitado (requer KYC da SmartLic como plataforma)
+
+---
+
+## Riscos
+
+- **Stripe Connect KYC para SmartLic:** processo de dias; iniciar cedo no sprint
+- **Revshare 50% pode ser inviável com custo OpenAI alto (Copilot):** ajustar revshare por produto (AI Copilot talvez 30% vs relatórios 50%)
+- **Fraude do partner:** rate limit em onboarding novos usuários via ref (max 50/mês até validar padrão)
+- **End user confundido com branding:** disclaimer discreto + claridade nos ToS
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_partners_tables.sql` + `.down.sql`
+- `backend/services/partner_revshare.py` (novo)
+- `backend/services/partner_onboarding.py` (novo)
+- `backend/reports/_branding.py` (novo + integrar em todos os geradores)
+- `backend/webhooks/handlers/partner_account.py` (novo)
+- `backend/routes/partners.py` (novo)
+- `backend/middleware/partner_attribution.py` (novo — cookie)
+- `frontend/app/parceiros/page.tsx` (novo)
+- `frontend/app/parceiros/dashboard/page.tsx` (novo)
+- `frontend/app/parceiros/[slug]/page.tsx` (novo — landing customizada por partner)
+- `backend/tests/services/test_partner_revshare.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 2 partners em onboarding + 1 completo (KYC done)
+- [ ] Test purchase via ref URL → transfer real efetivado no Stripe test mode
+- [ ] Partner dashboard mostra GMV + revshare em tempo real
+- [ ] Branding custom funciona em PDF gerado
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — canal white-label de alto leverage; complexidade XL justifica a prioridade P2 |

--- a/docs/stories/2026-04/MON-INDEX-monetizacao-dataset.md
+++ b/docs/stories/2026-04/MON-INDEX-monetizacao-dataset.md
@@ -1,0 +1,194 @@
+# MON-INDEX — Monetização do Dataset de 2M+ Contratos (Índice Consolidado)
+
+**Created:** 2026-04-22
+**Owner:** @sm (River)
+**Status:** Draft
+**Epic Super:** estratégia integrada de 7 epics / 27 stories + 1 future
+
+---
+
+## Visão Geral
+
+Plano para transformar o dataset `pncp_supplier_contracts` (~2.1M contratos históricos) em 4 camadas de monetização + 2 blocos de estratégias extras validadas com o usuário em 2026-04-22.
+
+**Priorização fast-revenue:** Wave 1 (Camadas 2+4) → Wave 2 (Camada 3 + IA/ML) → Wave 3 (Camada 1 + Distribuição).
+
+---
+
+## Epics + Stories
+
+### Prereq — EPIC-MON-SCHEMA (3 stories)
+Enriquecimento do schema `pncp_supplier_contracts` (aditivos, CATMAT/CATSER, data_fim).
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-SCH-01](MON-SCH-01-aditivos-crawler-schema.md) | P0 | M | Draft |
+| [MON-SCH-02](MON-SCH-02-catmat-catser-parsing.md) | P0 | M | Draft |
+| [MON-SCH-03](MON-SCH-03-data-fim-vigencia-status.md) | P0 | S | Draft |
+
+### Wave 1a — EPIC-MON-REPORTS (6 stories) — Camada 2
+Relatórios avulsos, R$ 47–697 por venda via Stripe one-time + LLM + email.
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-REP-01](MON-REP-01-stripe-one-time-purchases-webhook.md) | P0 | M | Draft |
+| [MON-REP-02](MON-REP-02-generated-reports-delivery.md) | P0 | M | Draft |
+| [MON-REP-03](MON-REP-03-relatorio-fornecedor-cnpj.md) | P1 | L | Draft |
+| [MON-REP-04](MON-REP-04-relatorio-preco-referencia.md) | P1 | L | Draft |
+| [MON-REP-05](MON-REP-05-relatorio-mapeamento-concorrencia.md) | P1 | L | Draft |
+| [MON-REP-06](MON-REP-06-due-diligence-express-lite.md) | P1 | L | Draft |
+
+### Wave 1b — EPIC-MON-API (5 stories + 1 future) — Camada 4
+API B2B pay-per-call, R$ 0,50–10/consulta, distribuição RapidAPI.
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-API-01](MON-API-01-api-key-management.md) | P0 | M | Draft |
+| [MON-API-02](MON-API-02-stripe-metered-billing.md) | P0 | L | Draft |
+| [MON-API-03](MON-API-03-supplier-history-endpoint.md) | P1 | M | Draft |
+| [MON-API-04](MON-API-04-benchmark-price-endpoint.md) | P1 | M | Draft |
+| [MON-API-05](MON-API-05-rapidapi-landing-public-docs.md) | P1 | M | Draft |
+| [MON-API-06](MON-API-06-supplier-score-endpoint.future.md) | P2 | L | Future (Q3) |
+
+### Wave 2a — EPIC-MON-SUBS (4 stories) — Camada 3
+Assinaturas de inteligência recorrentes R$ 147–997/mês.
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-SUB-01](MON-SUB-01-addons-stripe-monitored-subscriptions.md) | P0 | M | Draft |
+| [MON-SUB-02](MON-SUB-02-monitor-segmento-uf.md) | P1 | L | Draft |
+| [MON-SUB-03](MON-SUB-03-monitor-orgao-contratante.md) | P1 | M | Draft |
+| [MON-SUB-04](MON-SUB-04-radar-risco-fornecedor.md) | P1 | L | Draft |
+
+### Wave 2b — EPIC-MON-AI (3 stories) — Extras IA/ML
+Moat tecnológico via produtos de IA treinados sobre dataset proprietário.
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-AI-01](MON-AI-01-semantic-search-embeddings.md) | P0 | L | Draft |
+| [MON-AI-02](MON-AI-02-ai-copilot-propostas.md) | P1 | XL | Draft |
+| [MON-AI-03](MON-AI-03-radar-preditivo-editais.md) | P1 | XL | Draft |
+
+### Wave 3a — EPIC-MON-SEO (5 stories) — Camada 1
+SEO de entidade: funil orgânico gratuito para compradores das camadas pagas.
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-SEO-01](MON-SEO-01-fornecedor-enriquecer-cta.md) | P1 | M | Draft |
+| [MON-SEO-02](MON-SEO-02-categoria-programatica.md) | P1 | L | Draft |
+| [MON-SEO-03](MON-SEO-03-orgao-enriquecer-cta.md) | P2 | M | Draft |
+| [MON-SEO-04](MON-SEO-04-sitemaps-dinamicos-shards.md) | P0 | M | Draft |
+| [MON-SEO-05](MON-SEO-05-schema-org-jsonld-entity-pages.md) | P2 | S | Draft |
+
+### Wave 3b — EPIC-MON-DIST (2 stories) — Extras Distribuição
+Canais enterprise e white-label.
+
+| Story | Priority | Effort | Status |
+|-------|:--------:|:------:|:------:|
+| [MON-DIST-01](MON-DIST-01-data-licensing-bulk-export.md) | P2 | L | Draft |
+| [MON-DIST-02](MON-DIST-02-white-label-consultorias.md) | P2 | XL | Draft |
+
+---
+
+## Dependências Cross-Epic
+
+```
+MON-SCH-01 (aditivos) ──┬──> MON-REP-06 (Due Diligence)
+                         ├──> MON-SUB-03 (Monitor Órgão)
+                         ├──> MON-SUB-04 (Radar Risco)
+                         └──> MON-SEO-01 (score na pública)
+
+MON-SCH-02 (CATMAT) ─────┬──> MON-REP-04 (Preço Referência)
+                          ├──> MON-API-04 (benchmark endpoint)
+                          ├──> MON-SEO-02 (páginas /categoria)
+                          └──> MON-AI-03 (Radar Preditivo)
+
+MON-REP-01 (one-time) ──┬──> MON-REP-02 → MON-REP-03/04/05/06
+                         ├──> MON-AI-02 (Copilot one-shot)
+                         └──> MON-DIST-01 (Data Licensing)
+
+MON-API-01 (keys) ──> MON-API-02 → MON-API-03/04/05
+                                 └──> MON-AI-01 (Semantic Search)
+
+MON-SUB-01 (add-ons) ──┬──> MON-SUB-02/03/04
+                        ├──> MON-AI-02 (Copilot add-on)
+                        ├──> MON-AI-03 (Radar Preditivo add-on)
+                        └──> MON-DIST-02 (White-label)
+
+MON-AI-01 ──> MON-AI-02 (RAG depende de embeddings)
+```
+
+---
+
+## Projeção de Receita
+
+| Produto | Ticket | Volume Q3 | Volume Q4 | MRR/Rev Q4 |
+|---------|--------|-----------|-----------|------------|
+| Relatório Fornecedor | R$ 97 avg | 60/mês | 300/mês | R$ 29k/mês |
+| Relatório Preço | R$ 197 avg | 20 | 100 | R$ 19.7k |
+| Relatório Concorrência | R$ 347 avg | 10 | 50 | R$ 17.3k |
+| Due Diligence | R$ 497 avg | 10 | 50 | R$ 25k |
+| Monitor Segmento | R$ 297/mês | 10 ass. | 50 ass. | R$ 14.8k MRR |
+| Monitor Órgão | R$ 247/mês | 10 | 40 | R$ 9.9k MRR |
+| Radar Risco | R$ 597/mês | 5 | 20 | R$ 11.9k MRR |
+| API B2B | R$ ~1/query | 10k/mês | 100k/mês | R$ 10k/mês |
+| AI Copilot | R$ 497/mês | 10 | 50 | R$ 24.8k MRR |
+| Radar Preditivo | R$ 497/mês | 5 | 30 | R$ 14.9k MRR |
+| Data Licensing | R$ 6.997 avg | 3 | 15 | R$ 105k one-shot |
+| White-label (revshare 40%) | - | 2 partners | 10 partners | R$ 30k MRR |
+| **TOTAL Q4 (run-rate)** | | | | **~R$ 180k/mês + R$ 105k one-shot** |
+
+Target conservador: MRR R$ 100k no mês 6; Receita anual Run-rate >= R$ 2M.
+
+---
+
+## Ordem Sugerida de Execução
+
+### Sprint 1 (semanas 1-2)
+- MON-SCH-01, MON-SCH-02, MON-SCH-03 (paralelo, squads separados)
+- MON-API-01 + MON-REP-01 (paralelo)
+
+### Sprint 2 (semanas 3-4)
+- MON-API-02 + MON-REP-02 (depend 1-1)
+- MON-REP-03 (inicia, produto com maior volume)
+
+### Sprint 3 (semanas 5-6)
+- MON-REP-04 (depende MON-SCH-02 concluído)
+- MON-REP-05
+- MON-API-03 + MON-API-04
+
+### Sprint 4 (semanas 7-8)
+- MON-REP-06 (depende MON-SCH-01 + MON-SCH-02)
+- MON-API-05 (distribuição)
+- **Wave 1 FIM — receita inicial esperada ~R$ 5k-10k/mês**
+
+### Sprint 5-8 (semanas 9-16): Wave 2
+- MON-SUB-01 + MON-AI-01 (paralelo)
+- MON-SUB-02/03/04 + MON-AI-02/03
+
+### Sprint 9-12 (semanas 17-24): Wave 3
+- MON-SEO-04 primeiro (fix bug)
+- MON-SEO-01/02/03 em paralelo
+- MON-SEO-05 (polimento)
+- MON-DIST-01 + MON-DIST-02 em paralelo (squads dedicados)
+
+---
+
+## Verificação End-to-End (pós Wave 3)
+
+1. Receita validada em staging — cada produto com test purchase em Stripe test mode
+2. Pipeline de dados — coverage CATMAT >= 80%, aditivos >= 50% últimos 2 anos
+3. SEO — 5k+ URLs categoria indexadas, sitemap shards funcionando
+4. API B2B — 3 endpoints p95 <500ms, metered billing reportando a Stripe
+5. Assinaturas — 3 monitors + 2 add-ons IA entregando
+6. IA — Copilot precision >70% em review humano; Radar Preditivo precision >60% backtest
+7. Testes — pytest full suite + frontend + E2E golden paths
+8. Observability — Grafana dashboards de conversão, MRR, ARPU, API usage
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Índice consolidado criado — 27 stories + 1 future ativos; plano validado com o usuário |

--- a/docs/stories/2026-04/MON-REP-01-stripe-one-time-purchases-webhook.md
+++ b/docs/stories/2026-04/MON-REP-01-stripe-one-time-purchases-webhook.md
@@ -1,0 +1,175 @@
+# MON-REP-01: Stripe One-Time Purchase + Tabela `purchases` + Webhook
+
+**Priority:** P0
+**Effort:** M (3 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-REPORTS-2026-04](EPIC-MON-REPORTS-2026-04.md)
+**Sprint:** Wave 1 (bloqueador de MON-REP-02/03/04/05/06 + MON-AI-02 + MON-DIST-01)
+
+---
+
+## Contexto
+
+Hoje o Stripe está configurado **apenas para assinaturas recorrentes** (`mode=subscription` em `backend/routes/billing.py`). A tabela `user_subscriptions` rastreia assinaturas, mas não há tabela para compras únicas. O webhook `webhooks/stripe.py` trata `checkout.session.completed` e `customer.subscription.*` mas não `charge.succeeded` nem `payment_intent.succeeded`.
+
+Para lançar relatórios avulsos (Camada 2), pacotes de dados (MON-DIST-01) e compras one-shot de AI Copilot (MON-AI-02), precisamos da infra de **pagamento único** + rastreamento + trigger de entrega automática.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Tabela `purchases`
+
+- [ ] Migração cria:
+```sql
+CREATE TABLE public.purchases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  product_type text NOT NULL CHECK (product_type IN (
+    'report_supplier', 'report_price_reference', 'report_competition',
+    'report_due_diligence', 'data_package', 'ai_proposal', 'custom'
+  )),
+  product_params jsonb NOT NULL DEFAULT '{}'::jsonb,
+  amount_cents int NOT NULL CHECK (amount_cents > 0),
+  currency char(3) NOT NULL DEFAULT 'BRL',
+  stripe_checkout_session_id text UNIQUE,
+  stripe_payment_intent_id text UNIQUE,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN (
+    'pending', 'paid', 'delivered', 'refunded', 'failed', 'expired'
+  )),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  paid_at timestamptz NULL,
+  delivered_at timestamptz NULL,
+  refunded_at timestamptz NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX ON purchases (user_id, created_at DESC);
+CREATE INDEX ON purchases (status, created_at) WHERE status IN ('pending','paid');
+```
+- [ ] RLS: `SELECT`/`UPDATE` restringe ao próprio `user_id`; `INSERT`/`DELETE` apenas service role
+- [ ] Migração paired down
+
+### AC2: Endpoint de checkout one-time
+
+- [ ] `POST /v1/purchases/checkout` recebe `{product_type, product_params, success_url, cancel_url}`
+- [ ] Validação de `product_type` + preço via lookup `PRODUCT_CATALOG` (hardcoded inicial em `backend/services/product_catalog.py`, depois migra para tabela)
+- [ ] Cria Stripe session `mode='payment'` com `line_items` dinâmico + metadata `purchase_id`
+- [ ] Insere row em `purchases` com `status='pending'` + `stripe_checkout_session_id`
+- [ ] Retorna `{purchase_id, checkout_url}`
+- [ ] Rate limit: 10 checkouts/minuto por usuário (reusa infra `quota/`)
+
+### AC3: Webhook handler para pagamento
+
+- [ ] Adicionar em `backend/webhooks/handlers/payment.py`:
+  - `checkout.session.completed` com `mode='payment'` → atualiza `status='paid'`, `paid_at=now()`, `stripe_payment_intent_id`, enfileira ARQ job `generate_report_job(purchase_id)` (criado em MON-REP-02)
+  - `charge.refunded` → atualiza `status='refunded'`, `refunded_at=now()`, envia email de confirmação de reembolso
+  - `payment_intent.payment_failed` → `status='failed'` + email para usuário
+- [ ] Idempotência via `stripe_payment_intent_id` (UNIQUE constraint) — webhook replay não duplica registro
+- [ ] Signature verification já existente em `stripe.py` — reutilizar
+
+### AC4: Lista de produtos catalogados
+
+- [ ] `backend/services/product_catalog.py` expõe dict:
+```python
+PRODUCT_CATALOG = {
+    'report_supplier': {'tiers': [(47_00, 'basic'), (97_00, 'standard'), (197_00, 'premium')]},
+    'report_price_reference': {'tiers': [(97_00, 'basic'), (197_00, 'standard'), (297_00, 'premium')]},
+    'report_competition': {'tiers': [(197_00, 'basic'), (347_00, 'standard'), (497_00, 'premium')]},
+    'report_due_diligence': {'tiers': [(297_00, 'basic'), (497_00, 'standard'), (697_00, 'premium')]},
+    'ai_proposal': {'tiers': [(197_00, 'one_shot')]},
+    'data_package': {'dynamic': True},  # validado contra tabela data_packages (MON-DIST-01)
+}
+```
+- [ ] Teste unitário valida que `amount_cents` do request bate com tier declarado
+
+### AC5: Endpoint admin de listagem
+
+- [ ] `GET /v1/admin/purchases` (paginado, admin only): últimas compras com filtros `status`, `product_type`, `user_email`
+- [ ] Frontend `/admin/purchases` simples (reusar componentes de `/admin/cache`)
+
+### AC6: Testes
+
+- [ ] Unit: `backend/tests/routes/test_purchases_checkout.py`
+  - Happy path: valid product_type + tier → Stripe session criada + row pending
+  - Invalid product_type → 400
+  - Tier não existe → 400
+  - Rate limit 10/min → 429
+- [ ] Integration: `backend/tests/webhooks/test_payment_handler.py`
+  - `checkout.session.completed` happy path → status='paid' + job enfileirado (mock ARQ)
+  - Replay idempotência: mesma session event 2x → 1 insert apenas
+  - `charge.refunded` → status='refunded' + email
+- [ ] E2E: Playwright test em `frontend/e2e-tests/checkout-one-time.spec.ts` (mock Stripe)
+
+---
+
+## Scope
+
+**IN:**
+- Migração `purchases` + RLS
+- `backend/routes/purchases.py` (novo)
+- `backend/webhooks/handlers/payment.py` (novo)
+- `backend/services/product_catalog.py` (novo)
+- Endpoint admin + frontend dashboard
+- Testes
+
+**OUT:**
+- Geração de relatórios (MON-REP-02)
+- Entrega por email (MON-REP-02)
+- Storage de PDFs (MON-REP-02)
+- Produtos específicos — cada relatório tem sua story (MON-REP-03 em diante)
+
+---
+
+## Dependências
+
+- Stripe account configurado em dev e prod (já existe)
+- Rate limiter (já existe em `quota/`)
+- ARQ worker (já em produção)
+
+---
+
+## Riscos
+
+- **Coexistência `mode=payment` vs `mode=subscription`:** webhook handler precisa distinguir via `session.mode`; teste de regressão garante que subscription flow não quebra
+- **Webhooks fora de ordem:** `charge.succeeded` pode chegar antes de `checkout.session.completed` → lógica idempotente por `stripe_payment_intent_id` resolve
+- **Reembolso parcial:** v1 só suporta reembolso total (tudo-ou-nada); reembolso parcial fica para Q3
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_purchases_table.sql` + `.down.sql`
+- `backend/routes/purchases.py` (novo)
+- `backend/services/product_catalog.py` (novo)
+- `backend/webhooks/handlers/payment.py` (novo)
+- `backend/webhooks/stripe.py` (dispatcher — adicionar handler)
+- `backend/routes/admin_purchases.py` (novo)
+- `frontend/app/admin/purchases/page.tsx` (novo)
+- `backend/tests/routes/test_purchases_checkout.py` (novo)
+- `backend/tests/webhooks/test_payment_handler.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Migração aplicada em produção
+- [ ] Test purchase em Stripe test mode bem-sucedido (status: pending → paid)
+- [ ] Webhook replay bem-sucedido (idempotência validada)
+- [ ] `pytest backend/tests/routes/test_purchases_checkout.py` + `test_payment_handler.py` passando
+- [ ] E2E Playwright cobrindo checkout flow
+- [ ] Dashboard admin mostra compras em tempo real
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — bloqueador Wave 1 para todos os relatórios pagos + pacotes de dados + AI Copilot one-shot |

--- a/docs/stories/2026-04/MON-REP-02-generated-reports-delivery.md
+++ b/docs/stories/2026-04/MON-REP-02-generated-reports-delivery.md
@@ -1,0 +1,189 @@
+# MON-REP-02: Infra `generated_reports` + Delivery por Email + Storage
+
+**Priority:** P0
+**Effort:** M (3 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-REPORTS-2026-04](EPIC-MON-REPORTS-2026-04.md)
+**Sprint:** Wave 1 (bloqueador de MON-REP-03/04/05/06 + MON-AI-02)
+
+---
+
+## Contexto
+
+MON-REP-01 cria `purchases` + checkout. Quando uma compra vira `status='paid'`, um job ARQ precisa:
+1. Despachar para o gerador correto (strategy pattern por `product_type`)
+2. Gerar PDF assincronamente (pode levar 1-5 min para relatórios complexos)
+3. Armazenar em Supabase Storage
+4. Gerar link assinado (signed URL) com expiração de 48h
+5. Enviar email via Resend com link de download + confirmação
+
+Hoje existe apenas 1 tipo de PDF (`backend/pdf_report.py` para diagnóstico), síncrono e sem persistência. Precisamos da camada de orquestração.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Tabela `generated_reports`
+
+- [ ] Migração cria:
+```sql
+CREATE TABLE public.generated_reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  purchase_id uuid UNIQUE NOT NULL REFERENCES purchases(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id),
+  report_type text NOT NULL,
+  status text NOT NULL DEFAULT 'queued' CHECK (status IN (
+    'queued', 'generating', 'completed', 'failed', 'expired'
+  )),
+  storage_bucket text NOT NULL DEFAULT 'generated-reports',
+  storage_path text NULL,  -- reports/{user_id}/{report_id}.pdf
+  file_size_bytes int NULL,
+  download_count int NOT NULL DEFAULT 0,
+  last_downloaded_at timestamptz NULL,
+  generated_at timestamptz NULL,
+  expires_at timestamptz NULL,  -- 48h after generated_at
+  error_message text NULL,
+  attempt_count int NOT NULL DEFAULT 0,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX ON generated_reports (user_id, created_at DESC);
+CREATE INDEX ON generated_reports (status, attempt_count) WHERE status IN ('queued','failed');
+```
+- [ ] RLS: user sees only own; service-role full access
+- [ ] Migração paired down
+
+### AC2: Supabase Storage bucket
+
+- [ ] Migração cria bucket `generated-reports` (privado) via SQL: `INSERT INTO storage.buckets (id, name, public) VALUES ('generated-reports', 'generated-reports', false)`
+- [ ] RLS policy em `storage.objects`: SELECT permitido apenas se `bucket_id='generated-reports' AND auth.uid()::text = (storage.foldername(name))[1]`
+- [ ] Upload via backend service-role apenas (não exposto ao frontend diretamente)
+
+### AC3: ARQ job `generate_report`
+
+- [ ] `backend/jobs/report_generation.py` implementa:
+```python
+async def generate_report_job(ctx, purchase_id: UUID) -> dict:
+    # 1. fetch purchase + create generated_reports row (status=generating)
+    # 2. dispatch por purchase.product_type → gerador específico (strategy)
+    # 3. upload PDF to Supabase Storage at reports/{user_id}/{report_id}.pdf
+    # 4. update generated_reports: status=completed, storage_path, generated_at, expires_at=now+48h
+    # 5. enqueue send_report_ready_email(purchase_id)
+    # 6. on exception: status=failed, error_message, attempt_count++; retry max 3x
+```
+- [ ] Strategy pattern em `backend/reports/` com registry:
+```python
+REPORT_GENERATORS = {
+    'report_supplier': SupplierReportGenerator,
+    'report_price_reference': PriceReferenceReportGenerator,
+    # ... etc
+}
+```
+- [ ] Timeout: 5 min por geração; exceeded → fail + retry
+- [ ] Métricas Prometheus: `smartlic_report_generation_duration_seconds{product_type}`, `smartlic_report_generation_failures_total{product_type,reason}`
+
+### AC4: Template email `report_ready.py`
+
+- [ ] Novo `backend/templates/emails/report_ready.py`:
+  - Assunto: `"📄 Seu relatório {product_name} está pronto"`
+  - Body: nome do produto, parâmetros resumidos (ex: "CNPJ: XX.XXX.XXX/0001-XX"), botão CTA "Baixar relatório" (link assinado 48h), link secundário "Acessar histórico", rodapé legal
+  - Versões HTML + text/plain
+  - Emoji substituído por asset CDN (se branding requer)
+- [ ] Invocação: `email_service.send_email_async(user_email, subject, html, text)` com retry
+
+### AC5: Endpoint de download com signed URL
+
+- [ ] `GET /v1/reports/{report_id}/download` — autenticado JWT (não API key)
+- [ ] Valida:
+  - `user_id == auth.uid()`
+  - `status == 'completed'`
+  - `expires_at > now()`
+- [ ] Gera signed URL do Supabase Storage com TTL 5 minutos (`supabase.storage.from_('generated-reports').create_signed_url(path, 300)`)
+- [ ] Retorna `{download_url, expires_at, file_size_bytes}` — frontend faz fetch direto
+- [ ] Incrementa `download_count` e atualiza `last_downloaded_at`
+- [ ] Rate limit 20/min por user
+
+### AC6: Cron de limpeza
+
+- [ ] ARQ cron diário 03:00 BRT: marca `status='expired'` em reports com `expires_at < now()` + remove PDF do storage
+- [ ] Métricas: `smartlic_reports_expired_total`, `smartlic_reports_storage_cleaned_bytes_total`
+
+### AC7: Testes
+
+- [ ] Unit: `backend/tests/jobs/test_report_generation_dispatcher.py` — mock generator, valida strategy dispatch + status transitions
+- [ ] Integration: E2E flow — purchase paid → job executes → file in storage → email sent (mock Resend)
+- [ ] Unit: `backend/tests/routes/test_report_download.py` — ownership check, expiração, rate limit
+- [ ] Unit: template email renderiza sem quebras (ambos HTML e text)
+
+---
+
+## Scope
+
+**IN:**
+- Migração + bucket + RLS
+- ARQ job + strategy pattern
+- Template email
+- Download endpoint
+- Cron de cleanup
+- Testes
+
+**OUT:**
+- Geradores específicos (MON-REP-03 em diante)
+- Notificação webhook para integradores (fora do escopo; podem polling GET `/reports/{id}`)
+
+---
+
+## Dependências
+
+- MON-REP-01 (purchases table + webhook) — obrigatória
+- Supabase Storage habilitado (já em uso para outros ativos)
+- Resend configurado (já em uso — STORY-301 e outras)
+- ARQ worker (já em prod)
+
+---
+
+## Riscos
+
+- **Geração PDF pesada bloqueia worker:** timeout 5 min previne; considerar worker dedicado `PROCESS_TYPE=report_worker` se volume crescer
+- **Storage cost runaway:** 48h TTL + cleanup cron limita; monitorar Supabase Storage usage semanalmente
+- **Email não entregue:** Resend tem retry automático; fallback manual via admin UI para reenvio (`POST /v1/admin/reports/{id}/resend-email`)
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_generated_reports_table.sql` + `.down.sql`
+- `supabase/migrations/.../create_generated_reports_bucket.sql`
+- `backend/jobs/report_generation.py` (novo)
+- `backend/reports/__init__.py` + `_registry.py` (novo)
+- `backend/templates/emails/report_ready.py` (novo)
+- `backend/routes/reports.py` (estender — adicionar `/v1/reports/{id}/download`)
+- `backend/jobs/cron/report_cleanup.py` (novo)
+- `backend/tests/jobs/test_report_generation_dispatcher.py` (novo)
+- `backend/tests/routes/test_report_download.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Migração + bucket aplicados em produção
+- [ ] Mock generator (`debug_report`) end-to-end: purchase → job → storage → email → download funciona
+- [ ] p95 geração (mock) < 30s
+- [ ] Cron cleanup rodando + métricas Prometheus visíveis
+- [ ] Testes backend passando
+- [ ] E2E Playwright cobrindo fluxo completo (mock Stripe + Resend)
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — pipeline de geração + entrega, bloqueador de todos os 4 tipos de relatório |

--- a/docs/stories/2026-04/MON-REP-03-relatorio-fornecedor-cnpj.md
+++ b/docs/stories/2026-04/MON-REP-03-relatorio-fornecedor-cnpj.md
@@ -1,0 +1,152 @@
+# MON-REP-03: Relatório Fornecedor por CNPJ (R$ 47–197)
+
+**Priority:** P1
+**Effort:** L (4-5 dias)
+**Squad:** @dev + @ux-design-expert + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-REPORTS-2026-04](EPIC-MON-REPORTS-2026-04.md)
+**Sprint:** Wave 1
+
+---
+
+## Contexto
+
+Primeiro produto monetizável da Camada 2. **Maior volume esperado** — qualquer pessoa pesquisando um CNPJ é lead potencial (advogado, banco, M&A, construtora verificando concorrente).
+
+**3 tiers de preço:**
+- **Basic R$ 47:** histórico resumido, top 5 órgãos, valor total por ano
+- **Standard R$ 97:** + comparativo vs mediana setor/UF, distribuição modalidade, gráfico evolução
+- **Premium R$ 197:** + sinais de risco (score, índice de aditivos*), histórico completo até 5 anos, apêndice com top 20 contratos
+
+*Se MON-SCH-01 ainda não completado na data de lançamento, tier Premium lança sem "índice de aditivos" (documentar em landing).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Gerador PDF do relatório
+
+- [ ] `backend/reports/supplier_report.py` implementa `SupplierReportGenerator`:
+  - Input: `purchase.product_params = {cnpj: str, tier: 'basic'|'standard'|'premium', periodo_anos: int}`
+  - Output: PDF em bytes
+  - Seções Basic: Capa → Sumário executivo LLM → Top órgãos (tabela) → Valor por ano (gráfico) → Rodapé legal
+  - Seções Standard (+): Distribuição modalidade (pizza) → Comparativo vs mediana (bar chart) → Timeline de contratos
+  - Seções Premium (+): Sinais de risco (score, % contratos aditados, concentração top 3 órgãos) → Apêndice top 20 contratos (tabela detalhada)
+
+### AC2: Prompt LLM customizado
+
+- [ ] `backend/llm/prompts/supplier_summary.py` com prompt estruturado:
+  - Input: dados agregados do CNPJ (top órgãos, valores, tendências)
+  - Output: `SupplierSummarySchema` (Pydantic) com `resumo_executivo`, `destaques[]`, `sinais_atencao[]`
+- [ ] Ground-truth correction: valida que `resumo_executivo` não inventa dados ausentes (ex: não diz "90% em SP" se no dataset é 60%)
+- [ ] Fallback determinístico se LLM falhar (template estático com placeholders)
+
+### AC3: Landing + preview + checkout
+
+- [ ] `frontend/app/relatorios/fornecedor/[cnpj]/page.tsx`:
+  - SSR: buscar dados básicos do CNPJ (via `empresa_publica.py`)
+  - Header: "Relatório Fornecedor — {nome}"
+  - **Preview gratuito** (3 bullets gerados por LLM: "Empresa X atende principalmente Y", "Top órgão: Z", "Valor total R$ W")
+  - 3 cards de tier (Basic / Standard / Premium) com comparativo de features
+  - Botão "Comprar por R$ X" chama `POST /v1/purchases/checkout` com `{product_type: 'report_supplier', product_params: {cnpj, tier}}`
+  - Redirect para Stripe Checkout (sucesso → `/conta/compras?purchase_id=X`)
+  - SEO: title + description otimizados para busca CNPJ
+
+### AC4: Página de conta "Meus Relatórios"
+
+- [ ] `frontend/app/conta/compras/page.tsx` (nova ou estende `/conta/assinatura`):
+  - Lista todos `purchases` do user
+  - Cada linha: produto, data compra, status (pending/gerando/pronto/expirado), botão Download
+  - Download chama `GET /v1/reports/{report_id}/download` e abre em nova aba
+  - Exibe "Relatório expira em Xh" se `expires_at` próximo
+
+### AC5: Testes
+
+- [ ] Unit: `backend/tests/reports/test_supplier_report.py`
+  - Gera PDF Basic válido (>0 bytes, páginas esperadas)
+  - Gera PDF Premium com todas as seções
+  - LLM falha → fallback determinístico funciona
+  - CNPJ sem contratos → PDF com mensagem "Nenhum contrato encontrado" (não quebra)
+- [ ] Integration: `backend/tests/integration/test_supplier_report_e2e.py`
+  - purchase paid → job → PDF gerado → storage → email
+- [ ] Frontend: `frontend/__tests__/relatorios-fornecedor.test.tsx`
+  - Preview renderiza sem crash
+  - Click em tier → chama checkout
+- [ ] E2E Playwright: user compra Basic, recebe email mockado, download link funciona
+
+### AC6: Observability
+
+- [ ] Prometheus: `smartlic_supplier_reports_generated_total{tier}`, `smartlic_supplier_reports_revenue_cents_total{tier}`
+- [ ] Sentry breadcrumbs em cada etapa da geração
+
+---
+
+## Scope
+
+**IN:**
+- Gerador PDF (reportlab — já em uso)
+- Prompt LLM + ground-truth correction
+- Landing SSR + checkout UI
+- Página "Meus Relatórios"
+- Testes unit + integration + E2E
+
+**OUT:**
+- Relatório customizado (user escolhe seções) — fora de v1
+- Relatório em formato Word ou Excel — v1 só PDF
+- Comparativo de 2 CNPJs — fora de v1
+
+---
+
+## Dependências
+
+- MON-REP-01 (checkout + purchases)
+- MON-REP-02 (generator dispatch + delivery)
+- Dados de `pncp_supplier_contracts` (já existem)
+- BrasilAPI ou `empresa_publica.py` para razão social/endereço (já em uso)
+
+---
+
+## Riscos
+
+- **LLM hallucination em sinais de risco Premium:** ground-truth correction obrigatória; testes cobrem casos edge
+- **CNPJ com milhares de contratos (empresas grandes) geram PDF pesado:** limite `MAX_CONTRACTS_IN_DETAIL=500` no Premium; incluir tabela paginada ou apêndice "top 500 por valor"
+- **CNPJ sem contratos:** PDF com mensagem explicativa; considerar oferecer refund se coverage=0
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/reports/supplier_report.py` (novo)
+- `backend/reports/_base.py` (novo — abstract ReportGenerator)
+- `backend/reports/_registry.py` (estender)
+- `backend/llm/prompts/supplier_summary.py` (novo)
+- `backend/schemas/supplier_summary.py` (novo — Pydantic schema)
+- `frontend/app/relatorios/fornecedor/[cnpj]/page.tsx` (novo)
+- `frontend/app/conta/compras/page.tsx` (novo ou estende)
+- `backend/tests/reports/test_supplier_report.py` (novo)
+- `frontend/__tests__/relatorios-fornecedor.test.tsx` (novo)
+- `frontend/e2e-tests/buy-supplier-report.spec.ts` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 3 test purchases end-to-end (1 por tier) bem-sucedidas em staging
+- [ ] PDFs validados por review humano: nenhum dado inventado, layout legível, branding consistente
+- [ ] Prometheus métricas visíveis
+- [ ] Testes backend + frontend + E2E passando
+- [ ] Landing page SSR com Lighthouse >= 85
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — primeiro produto monetizável da Camada 2, maior volume esperado |

--- a/docs/stories/2026-04/MON-REP-04-relatorio-preco-referencia.md
+++ b/docs/stories/2026-04/MON-REP-04-relatorio-preco-referencia.md
@@ -1,0 +1,131 @@
+# MON-REP-04: Relatório Preço de Referência por Categoria (R$ 97–297)
+
+**Priority:** P1
+**Effort:** L (4-5 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-REPORTS-2026-04](EPIC-MON-REPORTS-2026-04.md)
+**Sprint:** Wave 1 (depende MON-SCH-02)
+
+---
+
+## Contexto
+
+Personas-alvo: **fiscais de contrato, orçamentistas, pregoeiros** que precisam justificar preço estimado em contratação pública. Hoje usam "Painel de Preços" do governo (UX horrível) + planilhas manuais. Relatório SmartLic entrega distribuição estatística automática em PDF profissional.
+
+Pergunta-mãe: *"Quanto o governo pagou por [CATMAT/CATSER X] em [UF Y] nos últimos [N meses]?"*
+
+**3 tiers:**
+- **Basic R$ 97:** distribuição nacional para 1 CATMAT/CATSER, 12 meses
+- **Standard R$ 197:** distribuição por UF + 24 meses + outliers
+- **Premium R$ 297:** 3 CATMAT/CATSER em um único relatório + análise comparativa
+
+---
+
+## Acceptance Criteria
+
+### AC1: Gerador PDF
+
+- [ ] `backend/reports/price_reference_report.py` implementa `PriceReferenceReportGenerator`:
+  - Input: `{catmats: [str], uf: str|'all', periodo_meses: 12|24|36, tier: ...}`
+  - Usa RPC `benchmark_by_catmat` (MON-SCH-02) como fonte principal
+  - Seções: Capa → Sumário executivo (LLM) → Distribuição estatística (P10/P25/P50/P75/P90, média, mediana, desvio) → Histograma de preços → Tabela outliers (top/bottom 10%)
+  - Standard (+): Mapa de calor por UF
+  - Premium (+): Análise comparativa multi-CATMAT
+
+### AC2: Landing + seletor de categoria
+
+- [ ] `frontend/app/relatorios/preco-referencia/page.tsx`:
+  - Seletor autocompletar de CATMAT/CATSER (query `catmat_catser_catalog`)
+  - Seletor UF (27 + "Nacional")
+  - Seletor período (12/24/36 meses)
+  - Preview gratuito: "123 contratos encontrados, mediana R$ 4.500" (visible sem compra)
+  - 3 cards de tier
+  - SEO: `/relatorios/preco-referencia` (sem parâmetros na URL), compra persiste parâmetros em `product_params`
+
+### AC3: Prompt LLM para sumário
+
+- [ ] `backend/llm/prompts/price_reference_summary.py`:
+  - Input: estatísticas + top outliers
+  - Output: resumo executivo (narrativo) + "contexto comparativo" (ex: "preços em SP são 15% acima da mediana nacional")
+  - Ground-truth correction garante que não invente percentis
+
+### AC4: Validação de escopo estatístico mínimo
+
+- [ ] Se RPC retorna < 20 contratos para a combinação (catmat+uf+periodo):
+  - Basic/Standard: sugere expandir período ou remover filtro UF; bloqueia checkout com mensagem
+  - Premium: permite prosseguir mas com disclaimer "dados limitados"
+- [ ] Nunca gera relatório com < 5 contratos (validar antes do job iniciar)
+
+### AC5: Testes
+
+- [ ] Unit: `backend/tests/reports/test_price_reference_report.py`
+  - Gera PDF Basic válido com dados mockados
+  - Rejeita combinação com < 20 contratos (Basic)
+  - Premium com 3 CATMATs diferentes
+- [ ] Integration: E2E flow completo
+- [ ] Snapshot test: PDF Basic tem páginas/seções esperadas
+
+---
+
+## Scope
+
+**IN:**
+- Gerador PDF + prompt LLM
+- Landing + seletor
+- Validação de escopo estatístico
+- Testes
+
+**OUT:**
+- Sub-categorização (ex: CATMAT pai + filhos) — v2
+- Export Excel/CSV — v2
+- Alerta quando preço-alvo está dentro de faixa — vira add-on MON-SUB-*
+
+---
+
+## Dependências
+
+- MON-REP-01 + MON-REP-02 (checkout + delivery)
+- **MON-SCH-02 (CATMAT/CATSER)** — bloqueador absoluto
+- RPC `benchmark_by_catmat` operacional
+
+---
+
+## Riscos
+
+- **CATMAT coverage < 80%:** produto mostra "dados parciais" no rodapé se coverage <90% para aquela categoria
+- **Outliers extremos distorcendo stats:** aplicar IQR filter opcional (flag) para tier Premium
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/reports/price_reference_report.py` (novo)
+- `backend/llm/prompts/price_reference_summary.py` (novo)
+- `frontend/app/relatorios/preco-referencia/page.tsx` (novo)
+- `frontend/app/components/CatmatAutocomplete.tsx` (novo)
+- `backend/tests/reports/test_price_reference_report.py` (novo)
+- `frontend/e2e-tests/buy-price-reference.spec.ts` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 3 test purchases (1 por tier)
+- [ ] PDFs validados: estatísticas batem com queries diretas ao datalake
+- [ ] Landing Lighthouse >= 85
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — produto para fiscais/pregoeiros; requer MON-SCH-02 CATMAT |

--- a/docs/stories/2026-04/MON-REP-05-relatorio-mapeamento-concorrencia.md
+++ b/docs/stories/2026-04/MON-REP-05-relatorio-mapeamento-concorrencia.md
@@ -1,0 +1,125 @@
+# MON-REP-05: Relatório Mapeamento de Concorrência (R$ 197–497)
+
+**Priority:** P1
+**Effort:** L (5 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-REPORTS-2026-04](EPIC-MON-REPORTS-2026-04.md)
+**Sprint:** Wave 1
+
+---
+
+## Contexto
+
+Personas: **construtoras, consultorias, M&A advisors** que precisam entender players dominantes em um segmento+UF. Pergunta-mãe: *"Quem são os maiores players em [setor] em [UF], quem cresceu, quem perdeu share?"*
+
+Valor percebido alto (R$ 197–497) justifica análise longitudinal rica.
+
+**3 tiers:**
+- **Basic R$ 197:** top 20 players, market share atual, 12 meses
+- **Standard R$ 347:** + growth/decline YTD, novos entrantes, churn, 24 meses
+- **Premium R$ 497:** + análise multi-UF, tendência trimestral, heatmap de concentração
+
+---
+
+## Acceptance Criteria
+
+### AC1: Gerador PDF
+
+- [ ] `backend/reports/competition_mapping_report.py`:
+  - Input: `{setor: str, uf: str, periodo_meses: int, tier: ...}`
+  - Seções Basic: Capa → Resumo LLM → Top 20 players (tabela ordenada por valor) → Tree map market share → Distribuição modalidade
+  - Standard (+): Timeline entrantes/saídas (gráfico lollipop) → Growth/decline YTD por player (bar chart ordenado) → "Concentração HHI" (Herfindahl-Hirschman Index)
+  - Premium (+): Multi-UF comparativa → Tendência trimestral evolutiva → Heatmap player × órgão
+
+### AC2: RPC agregador
+
+- [ ] Migração cria função `competitors_in_segment(p_setor text, p_uf text, p_periodo_meses int)`:
+  - Retorna lista ordenada de players com: `ni_fornecedor, nome, total_valor, contratos_count, market_share_pct, growth_yoy_pct, rank`
+  - Performance p95 < 500ms (índices existentes bastam)
+- [ ] RPC `new_entrants_churn(p_setor, p_uf, p_periodo)` retorna listas de entrantes e saídas (primeira/última aparição em N meses)
+
+### AC3: Landing + seletor
+
+- [ ] `frontend/app/relatorios/concorrencia/page.tsx`:
+  - Seletor setor (do catálogo existente — 15 setores SmartLic)
+  - Seletor UF
+  - Seletor período
+  - Preview: "47 players encontrados no setor X em UF Y. Top player detém 22% de share"
+  - 3 cards de tier
+
+### AC4: Prompt LLM
+
+- [ ] `backend/llm/prompts/competition_analysis.py`:
+  - Input: top 20 players + métricas
+  - Output: análise narrativa de "dinâmica competitiva" (ex: "setor concentrado com HHI 2.800, liderança de X")
+  - Ground-truth correction obrigatória
+
+### AC5: Testes
+
+- [ ] Unit: teste de geração para cada tier com dados sintéticos
+- [ ] Integration: E2E completo
+- [ ] Snapshot: Basic tem exatamente as seções esperadas
+
+---
+
+## Scope
+
+**IN:**
+- Gerador PDF
+- 2 RPCs agregadores
+- Landing + seletor
+- Prompt LLM + ground truth
+- Testes
+
+**OUT:**
+- Exportação Excel — v2
+- Análise geográfica detalhada por município — v2
+- Comparação entre 2+ setores — v2
+
+---
+
+## Dependências
+
+- MON-REP-01 + MON-REP-02
+- Dados de `pncp_supplier_contracts` + classificação setorial IA (existente)
+
+---
+
+## Riscos
+
+- **Setor com <20 players:** bloqueia Basic; Standard permite com disclaimer
+- **HHI calculation em dataset ruidoso:** aplicar dedupe por `ni_fornecedor` (mesmo CNPJ pode aparecer como variante)
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/reports/competition_mapping_report.py` (novo)
+- `backend/llm/prompts/competition_analysis.py` (novo)
+- `supabase/migrations/.../create_competitors_rpcs.sql` + `.down.sql`
+- `frontend/app/relatorios/concorrencia/page.tsx` (novo)
+- `backend/tests/reports/test_competition_mapping.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 3 test purchases por tier
+- [ ] PDFs validados contra query manual
+- [ ] Testes passando
+- [ ] Dogfood: equipe compra 1 relatório do próprio setor SmartLic ("SaaS B2G") e confirma dados
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — produto para construtoras/consultorias/M&A |

--- a/docs/stories/2026-04/MON-REP-06-due-diligence-express-lite.md
+++ b/docs/stories/2026-04/MON-REP-06-due-diligence-express-lite.md
@@ -1,0 +1,141 @@
+# MON-REP-06: Due Diligence Express Lite (R$ 297–697, SEM CEIS/CNEP na v1)
+
+**Priority:** P1
+**Effort:** L (5 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-REPORTS-2026-04](EPIC-MON-REPORTS-2026-04.md)
+**Sprint:** Wave 1 (depende MON-SCH-01 + MON-SCH-02)
+
+---
+
+## Contexto
+
+Personas: **bancos, fintechs de crédito PME, seguradoras** com exposição a fornecedores B2G. Produto mais alto ticket da Camada 2.
+
+**v1 é "lite" — documentado explicitamente:**
+- Inclui: score de adimplência via aditivos, concentração de receita (top 3 órgãos %), padrão de superfaturamento (desvio vs mediana por categoria)
+- **NÃO inclui:** consultas CEIS/CNEP (bases de sanções da CGU), histórico judicial, CND, scraping Receita. Esses ficam para `MON-REP-06b` em Q3.
+
+Disclaimer obrigatório no PDF + landing.
+
+**3 tiers:**
+- **Basic R$ 297:** score geral, top concentrações
+- **Standard R$ 497:** + histórico de aditivos por contrato + análise de superfaturamento
+- **Premium R$ 697:** + comparativo vs peers setor/UF + recomendações de mitigação
+
+---
+
+## Acceptance Criteria
+
+### AC1: Score de risco derivado
+
+- [ ] `backend/services/supplier_risk_score.py` calcula score 0-100 combinando:
+  - **Índice de aditivos (30%):** `aditivos_pct_valor` médio ponderado (quanto maior, pior score)
+  - **Concentração de receita (25%):** % top 3 órgãos no total (concentração > 80% = alto risco)
+  - **Padrão de preço (25%):** desvio médio vs mediana por categoria (contratos muito acima = sinal alerta)
+  - **Volatilidade (20%):** desvio padrão do valor anual (alta volatilidade = instabilidade)
+- [ ] Normalização percentil: score do fornecedor X comparado à distribuição de peers (setor + UF)
+- [ ] Retorna `{score_geral, breakdown, percentil_setor, flags[], explicacao}`
+- [ ] Cacheado em `supplier_risk_summary_mv` (view materializada de MON-SCH-01)
+
+### AC2: Gerador PDF
+
+- [ ] `backend/reports/due_diligence_report.py`:
+  - Input: `{cnpj: str, tier: ...}`
+  - Header com disclaimer "v1 não inclui CEIS/CNEP — consulta complementar recomendada"
+  - Basic: resumo LLM → score 0-100 + bar chart → top 3 órgãos concentração → flags
+  - Standard (+): timeline de aditivos por contrato → análise de superfaturamento com outliers → seção "sinais de atenção"
+  - Premium (+): comparativo percentil vs peers → tabela de recomendações (estruturada em 5-7 items por LLM com RAG sobre casos similares)
+
+### AC3: Landing com disclaimer explícito
+
+- [ ] `frontend/app/relatorios/due-diligence/page.tsx`:
+  - Seletor CNPJ (input ou autocompletar)
+  - **Box destacado:** "v1 não substitui consulta CEIS/CNEP — disponível em Q3"
+  - Preview: score dummy + 2 flags (para dar gostinho)
+  - 3 cards tier
+  - Seção FAQ com "O que está incluído" / "O que NÃO está incluído"
+
+### AC4: Prompt LLM para recomendações (Premium)
+
+- [ ] `backend/llm/prompts/due_diligence_recommendations.py`:
+  - Input: flags detectadas + stats do fornecedor
+  - Output: 5-7 recomendações estruturadas (ex: "Solicitar comprovação de capacidade técnica antes de contratar"; "Avaliar garantia reforçada por concentração de receita >80%")
+  - Ground-truth correction evita recomendações genéricas que não se aplicam
+
+### AC5: Testes
+
+- [ ] Unit: `test_supplier_risk_score.py` — score determinístico para dados conhecidos
+- [ ] Unit: geração PDF por tier
+- [ ] Integration: E2E com CNPJ real
+- [ ] Snapshot: disclaimer aparece no PDF e landing
+
+---
+
+## Scope
+
+**IN:**
+- Risk score calculado (5 dimensões, normalização percentil)
+- Gerador PDF 3 tiers
+- Landing + disclaimer
+- Prompt LLM para recomendações Premium
+- Testes
+
+**OUT:**
+- **CEIS/CNEP integration (fica para MON-REP-06b Q3)**
+- Consulta CNPJ na Receita Federal — fora de escopo
+- Score com ML — futuro (MON-API-06)
+- Monitoramento contínuo — fica para Radar de Risco (MON-SUB-04)
+
+---
+
+## Dependências
+
+- MON-REP-01 + MON-REP-02
+- **MON-SCH-01 (aditivos)** — bloqueador absoluto (score precisa de aditivos)
+- **MON-SCH-02 (CATMAT)** — necessário para desvio de preço por categoria
+- View `supplier_risk_summary_mv` populada
+
+---
+
+## Riscos
+
+- **Expectativa frustrada com "sem CEIS":** disclaimer obrigatório em landing + PDF; email de confirmação de compra reforça
+- **Score inadequado sem aditivos completos:** se `aditivos_last_checked_at IS NULL` para >50% dos contratos, rebaixar confiança do score com flag visual
+- **Falsos positivos em "superfaturamento":** diferença >50% vs mediana pode ser explicada (especificação técnica diferente); disclaimer "sinal para investigação, não conclusão"
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/services/supplier_risk_score.py` (novo)
+- `backend/reports/due_diligence_report.py` (novo)
+- `backend/llm/prompts/due_diligence_recommendations.py` (novo)
+- `frontend/app/relatorios/due-diligence/page.tsx` (novo)
+- `backend/tests/services/test_supplier_risk_score.py` (novo)
+- `backend/tests/reports/test_due_diligence_report.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 3 test purchases por tier
+- [ ] Score validado: fornecedor com muitos aditivos score baixo; fornecedor limpo score alto
+- [ ] PDFs + landing com disclaimer visível e claro
+- [ ] Testes passando
+- [ ] Future story `MON-REP-06b` (integração CEIS/CNEP) documentada em backlog Q3
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — v1 lite sem CEIS/CNEP; persona bancos/fintechs de crédito PME |

--- a/docs/stories/2026-04/MON-SCH-01-aditivos-crawler-schema.md
+++ b/docs/stories/2026-04/MON-SCH-01-aditivos-crawler-schema.md
@@ -1,0 +1,149 @@
+# MON-SCH-01: Crawler e Schema de Aditivos Contratuais
+
+**Priority:** P0
+**Effort:** M (2-3 dias)
+**Squad:** @data-engineer + @dev
+**Status:** Draft
+**Epic:** [EPIC-MON-SCHEMA-2026-04](EPIC-MON-SCHEMA-2026-04.md)
+**Sprint:** Wave 1
+
+---
+
+## Contexto
+
+A tabela `pncp_supplier_contracts` (~2.1M rows, migração `20260409100000_pncp_supplier_contracts.sql`) não armazena informações de **aditivos contratuais** (termos aditivos de prazo/valor). Aditivos são sinal crítico para:
+
+- **Score de risco de fornecedor** (Due Diligence Express — MON-REP-06): % contratos com aditivo >30% valor, % aditamento médio
+- **Alertas de órgão** (Monitor de Órgão — MON-SUB-03): órgão aditou contrato em >20% valor ou >6 meses
+- **Radar de risco** (MON-SUB-04): delta score quando CNPJ monitorado sofre aditivo anômalo
+- **Página pública** (`/fornecedores/[cnpj]` — MON-SEO-01): exibir "índice de aditivos" como sinal de confiabilidade
+
+PNCP expõe endpoint `/api/consulta/v1/contratos/{numeroControlePNCP}/termos-aditivos` que retorna lista de aditivos com `numeroAditivo`, `tipoAditivo` (prazo/valor/ambos), `valorAditado`, `prazoAditado`, `dataAssinatura`.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Schema enriquecimento em `pncp_supplier_contracts`
+
+- [ ] Migração `supabase/migrations/YYYYMMDDHHMMSS_add_aditivos_to_supplier_contracts.sql` adiciona:
+  - `aditivos_count int DEFAULT 0 NOT NULL`
+  - `aditivos_valor_total numeric(18,2) DEFAULT 0 NOT NULL` (soma `valorAditado`)
+  - `aditivos_prazo_total_dias int DEFAULT 0 NOT NULL` (soma `prazoAditado`)
+  - `aditivos_last_checked_at timestamptz NULL`
+  - `aditivos_pct_valor numeric(5,2) GENERATED ALWAYS AS (CASE WHEN valor_global > 0 THEN (aditivos_valor_total / valor_global) * 100 ELSE 0 END) STORED`
+- [ ] Migração paired down `.down.sql` remove colunas (STORY-6.2 compliance)
+- [ ] Índice B-tree em `aditivos_pct_valor` para queries "contratos aditados >X%"
+- [ ] View `supplier_risk_summary_mv` (materialized, refresh diário) com agregados por CNPJ:
+  - `ni_fornecedor`, `total_contratos`, `contratos_com_aditivo`, `pct_aditados`, `aditivo_medio_valor_pct`, `last_aditivo_date`
+
+### AC2: Crawler de aditivos (ARQ cron)
+
+- [ ] `backend/ingestion/aditivos_crawler.py` — função async `fetch_aditivos(numero_controle_pncp)` consulta endpoint PNCP e retorna lista tipada
+- [ ] Respeitar rate limit PNCP: `max 5 concurrent`, 2s delay entre batches
+- [ ] Retry exponencial (3 tentativas, HTTP 422/429 retryable); circuit breaker compartilhado (`pncp_client.py`)
+- [ ] `backend/jobs/cron/aditivos_sync.py` — ARQ cron diário 06:00 BRT:
+  - Processa 10.000 contratos por run (ordenados por `aditivos_last_checked_at ASC NULLS FIRST`)
+  - Filtro: só `is_active=true` + `data_assinatura >= NOW() - INTERVAL '3 years'`
+  - Upsert via RPC `upsert_aditivos_for_contract(numero_controle_pncp, aditivos_jsonb)`
+- [ ] Fallback: se endpoint retornar 404, marca `aditivos_count=0` + `aditivos_last_checked_at=NOW()` (evita retry infinito)
+- [ ] Prometheus: `smartlic_aditivos_crawler_requests_total{status}`, `smartlic_aditivos_coverage_pct`
+
+### AC3: Backfill inicial
+
+- [ ] Script `scripts/backfill_aditivos.py` processa priorização:
+  - Tier 1: top 50k contratos por `valor_global` (últimos 2 anos)
+  - Tier 2: restante dos últimos 2 anos
+  - Tier 3: contratos 2-5 anos
+- [ ] Executável em background via `railway run python scripts/backfill_aditivos.py --tier 1`
+- [ ] Progress logging em `ingestion_runs` table (reusa infra existente)
+
+### AC4: Dashboard admin de coverage
+
+- [ ] Endpoint `GET /v1/admin/aditivos-coverage` (admin only): retorna `{total_contracts, checked, coverage_pct, last_run_at, queue_size}`
+- [ ] Frontend `/admin/cache` adiciona card "Aditivos Coverage" (reutilizar componentes existentes)
+
+### AC5: Testes
+
+- [ ] `pytest backend/tests/ingestion/test_aditivos_crawler.py`:
+  - Mock PNCP response happy path (3 aditivos retornados, agregados corretos)
+  - 404 → marca checked + count=0 (não re-consulta em 7 dias)
+  - HTTP 500 retry 3x → circuit breaker open
+  - Rate limit 429 → respeita Retry-After
+- [ ] `pytest backend/tests/jobs/test_aditivos_sync.py` cobre cron scheduling + batch processing
+- [ ] Coverage thresholds respeitados (70% backend)
+
+---
+
+## Scope
+
+**IN:**
+- Migração SQL (+.down) em `supabase/migrations/`
+- `backend/ingestion/aditivos_crawler.py` (novo)
+- `backend/jobs/cron/aditivos_sync.py` (novo)
+- `scripts/backfill_aditivos.py` (novo)
+- View materializada `supplier_risk_summary_mv`
+- Endpoint admin + card frontend
+- Testes
+
+**OUT:**
+- Integração com CEIS/CNEP (bases de sanções externas) — fica para MON-REP-06b Q3
+- UI pública exibindo aditivos — feito em MON-SEO-01
+- Aditivos de contratos anteriores a 5 anos — fora de escopo
+
+---
+
+## Dependências
+
+- PNCP endpoint `/contratos/{numeroControlePNCP}/termos-aditivos` validado funcional (checar 10 amostras via curl antes do dev)
+- ARQ worker deployed (já em produção — `PROCESS_TYPE=worker`)
+- Redis (circuit breaker compartilhado — já em produção)
+
+---
+
+## Riscos
+
+- **Endpoint PNCP pode não expor aditivos de forma consistente:** validar com sample de 100 contratos; se coverage PNCP for <50%, priorizar Tier 1 por valor e aceitar coverage parcial
+- **Backfill pesado:** 500k–1M chamadas à API PNCP. Mitigar com throttle 5 rps e backfill em 1-2 semanas background
+- **Campos jurídicos diferentes por modalidade:** Lei 8.666 (legacy) vs 14.133 — schemas podem variar; tratar com `try/except` + log estruturado
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev durante implementação)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/YYYYMMDDHHMMSS_add_aditivos_to_supplier_contracts.sql` (novo)
+- `supabase/migrations/YYYYMMDDHHMMSS_add_aditivos_to_supplier_contracts.down.sql` (novo)
+- `supabase/migrations/YYYYMMDDHHMMSS_create_supplier_risk_summary_mv.sql` (novo)
+- `backend/ingestion/aditivos_crawler.py` (novo)
+- `backend/jobs/cron/aditivos_sync.py` (novo)
+- `scripts/backfill_aditivos.py` (novo)
+- `backend/routes/admin_aditivos.py` (novo)
+- `frontend/app/admin/cache/page.tsx` (estender)
+- `backend/tests/ingestion/test_aditivos_crawler.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Migração aplicada em produção (via deploy.yml auto-apply)
+- [ ] Backfill Tier 1 completo (top 50k por valor) — validar via `SELECT count(*) WHERE aditivos_last_checked_at IS NOT NULL`
+- [ ] Cron rodando há 7 dias sem failures em Sentry
+- [ ] View `supplier_risk_summary_mv` populada + refresh diário funcionando
+- [ ] Dashboard admin mostra coverage >= 30% dos contratos ativos últimos 2 anos
+- [ ] `pytest backend/tests/ingestion/test_aditivos_crawler.py` passa
+- [ ] Review de segurança: circuit breaker compartilhado evita flood do PNCP; rate limit respeitado
+- [ ] Métricas Prometheus visíveis no Grafana
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — parte de EPIC-MON-SCHEMA, prereq para Due Diligence, Radar Risco, Monitor Órgão |

--- a/docs/stories/2026-04/MON-SCH-02-catmat-catser-parsing.md
+++ b/docs/stories/2026-04/MON-SCH-02-catmat-catser-parsing.md
@@ -1,0 +1,152 @@
+# MON-SCH-02: CATMAT/CATSER Parsing e Indexação
+
+**Priority:** P0
+**Effort:** M (3-4 dias — inclui re-ingestão dos 2.1M registros)
+**Squad:** @data-engineer + @dev
+**Status:** Draft
+**Epic:** [EPIC-MON-SCHEMA-2026-04](EPIC-MON-SCHEMA-2026-04.md)
+**Sprint:** Wave 1
+
+---
+
+## Contexto
+
+CATMAT (Catálogo de Materiais) e CATSER (Catálogo de Serviços) são códigos padronizados do governo federal para classificar objeto de contratação (ex: CATMAT 150015 = "Papel sulfite A4 75g"). Hoje `pncp_supplier_contracts` não armazena esses códigos — apenas `objeto_contrato` (texto livre). Isso limita:
+
+- **Benchmark estatístico de preço** (MON-REP-04 + MON-API-04): sem código padronizado, "média por categoria" vira busca textual imprecisa
+- **Páginas `/categoria/[slug]`** (MON-SEO-02): slugs precisam de IDs padronizados para ser estáveis
+- **Radar Preditivo** (MON-AI-03): detecção de sazonalidade requer categoria estável
+
+PNCP expõe CATMAT/CATSER no endpoint de itens do contrato (`/contratos/{id}/itens`). Também existe catálogo público de códigos (para tabela de referência com labels).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Schema enriquecimento em `pncp_supplier_contracts`
+
+- [ ] Migração adiciona:
+  - `catmat_catser varchar(10) NULL` (código principal — primeiro item do contrato ou moda dos itens)
+  - `catmat_catser_tipo char(1) NULL CHECK (catmat_catser_tipo IN ('M', 'S'))` (Material ou Serviço)
+  - `catmat_catser_secondary varchar(10)[] NULL` (códigos adicionais de itens secundários)
+- [ ] Migração paired down
+- [ ] Índice B-tree em `catmat_catser` (covering: `(catmat_catser, uf, data_assinatura)` para benchmark queries)
+- [ ] Índice GIN em `catmat_catser_secondary`
+
+### AC2: Tabela catálogo de referência
+
+- [ ] Migração cria `catmat_catser_catalog`:
+  - `codigo varchar(10) PRIMARY KEY`
+  - `tipo char(1) NOT NULL CHECK (tipo IN ('M','S'))`
+  - `label text NOT NULL`
+  - `categoria text NULL` (grupo pai no catálogo PNCP)
+  - `slug text UNIQUE NOT NULL` (kebab-case para URLs: `papel-sulfite-a4-75g`)
+  - `row_count int NOT NULL DEFAULT 0` (contador denormalizado, atualizado via trigger ou cron)
+- [ ] Seed inicial via script `scripts/seed_catmat_catser_catalog.py` (fonte: ComprasGov v3 catálogo público)
+- [ ] RLS: leitura pública (`FOR SELECT USING (TRUE)`), escrita service-role
+
+### AC3: Parsing no transformer + re-ingestão
+
+- [ ] `backend/ingestion/transformer.py` estende parse para extrair CATMAT/CATSER do payload de contrato (campo `itens[].codigoCatmatCatser` ou similar)
+- [ ] Fallback LLM quando ausente: GPT-4.1-nano classifica `objeto_contrato` no catálogo (prompt em `backend/llm/prompts/catmat_classifier.py`) — marcado com flag `catmat_source='llm'`
+- [ ] ARQ job `backfill_catmat_catser` processa em batches de 500 rows/batch; ~42 horas estimadas full backfill com 10k batches
+- [ ] Tracking em `ingestion_runs` com checkpoint por `data_assinatura` (resumable)
+- [ ] Prometheus: `smartlic_catmat_coverage_pct{source}` com labels `source=pncp_direct|llm|none`
+
+### AC4: RPC de benchmark por CATMAT
+
+- [ ] Migração cria função SQL:
+```sql
+CREATE OR REPLACE FUNCTION public.benchmark_by_catmat(
+  p_catmat varchar, p_uf varchar DEFAULT NULL, p_periodo_dias int DEFAULT 365
+) RETURNS TABLE (
+  n_contratos int, valor_medio numeric, valor_mediano numeric,
+  p10 numeric, p25 numeric, p75 numeric, p90 numeric,
+  stddev numeric, periodo_inicio date, periodo_fim date
+) LANGUAGE sql STABLE SECURITY DEFINER ...;
+```
+- [ ] Performance: p95 < 300ms com 80% coverage (via índice composto `(catmat_catser, uf, data_assinatura)`)
+- [ ] Teste de regressão: snapshot de benchmark para CATMAT 150015 (papel sulfite) vs valor oficial
+
+### AC5: Testes
+
+- [ ] Unit: `backend/tests/ingestion/test_transformer_catmat.py`
+  - parse CATMAT direto do PNCP (3 formatos diferentes)
+  - fallback LLM quando ausente (mock GPT-4.1-nano)
+  - código inválido → `catmat_catser=NULL` + log
+- [ ] Integration: `backend/tests/test_benchmark_rpc.py`
+  - Seed 100 contratos CATMAT X em UF SP
+  - `benchmark_by_catmat('X', 'SP')` retorna estatísticas corretas
+- [ ] Snapshot test de performance (Benchmark < 300ms)
+
+---
+
+## Scope
+
+**IN:**
+- Migrações (schema + catálogo + RPC)
+- Transformer parsing + LLM fallback
+- Backfill job
+- Seed do catálogo via ComprasGov v3
+- Prometheus metrics
+- Testes
+
+**OUT:**
+- UI de navegação do catálogo (fica em MON-SEO-02)
+- Benchmark API endpoint (fica em MON-API-04, usa este RPC)
+- Relatório PDF de preço referência (fica em MON-REP-04)
+
+---
+
+## Dependências
+
+- Catálogo CATMAT/CATSER acessível via ComprasGov v3 (já usado em `compras_gov_client.py`)
+- OpenAI API configurado (já existe) — custo estimado LLM fallback: ~R$ 150 para classificar 500k rows restantes (0,0003/row × 500k)
+- ARQ worker deploy (já em produção)
+
+---
+
+## Riscos
+
+- **Coverage direto do PNCP incompleto:** pilot sample mostra ~40% dos contratos têm CATMAT no payload; LLM fallback obrigatório para atingir 80%
+- **LLM fallback custo:** estimativa R$150 razoável; se custo real >R$500, reduzir scope (só contratos últimos 3 anos)
+- **Backfill longo (42h):** rodar em background sem impacto em produção; trigger manual via CLI admin
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev durante implementação)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../add_catmat_catser_columns.sql` + `.down.sql`
+- `supabase/migrations/.../create_catmat_catser_catalog.sql` + `.down.sql`
+- `supabase/migrations/.../create_benchmark_by_catmat_rpc.sql` + `.down.sql`
+- `backend/ingestion/transformer.py` (estender)
+- `backend/llm/prompts/catmat_classifier.py` (novo)
+- `scripts/seed_catmat_catser_catalog.py` (novo)
+- `backend/jobs/cron/backfill_catmat.py` (novo)
+- `backend/tests/ingestion/test_transformer_catmat.py` (novo)
+- `backend/tests/test_benchmark_rpc.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Migrações aplicadas + catálogo seeded (~50k entries)
+- [ ] Backfill Tier 1 (últimos 2 anos, top valor) completo: coverage CATMAT >= 70%
+- [ ] RPC `benchmark_by_catmat` rodando p95 < 300ms
+- [ ] Prometheus mostra `smartlic_catmat_coverage_pct` atualizado
+- [ ] Testes passando (unit + integration + snapshot)
+- [ ] Desbloqueia MON-REP-04 + MON-API-04 + MON-SEO-02
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — prereq para Benchmark API, páginas /categoria, Radar Preditivo |

--- a/docs/stories/2026-04/MON-SCH-03-data-fim-vigencia-status.md
+++ b/docs/stories/2026-04/MON-SCH-03-data-fim-vigencia-status.md
@@ -1,0 +1,117 @@
+# MON-SCH-03: data_fim, Vigência e Status Detalhado
+
+**Priority:** P0
+**Effort:** S (1-2 dias)
+**Squad:** @data-engineer
+**Status:** Draft
+**Epic:** [EPIC-MON-SCHEMA-2026-04](EPIC-MON-SCHEMA-2026-04.md)
+**Sprint:** Wave 1
+
+---
+
+## Contexto
+
+`pncp_supplier_contracts` hoje só tem `data_assinatura`. Sem `data_fim`, não é possível responder perguntas como:
+- "Quais contratos estão ativos hoje?" (filtro temporal em relatórios e páginas)
+- "Qual a vigência média de contratos de limpeza em SP?" (insight para relatórios de preço)
+- "Este fornecedor tem contratos próximos do fim?" (sinal para radar comercial)
+
+PNCP expõe `dataInicioVigencia`, `dataFimVigencia`, `situacaoContratacao` nos detalhes do contrato.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Schema enriquecimento
+
+- [ ] Migração adiciona:
+  - `data_inicio_vigencia date NULL`
+  - `data_fim_vigencia date NULL`
+  - `vigencia_meses int GENERATED ALWAYS AS (
+      CASE WHEN data_fim_vigencia IS NOT NULL AND data_inicio_vigencia IS NOT NULL
+      THEN (EXTRACT(EPOCH FROM (data_fim_vigencia - data_inicio_vigencia)) / 2592000)::int
+      ELSE NULL END
+    ) STORED`
+  - `status_detalhado varchar(20) NULL CHECK (status_detalhado IN ('ativo','encerrado','rescindido','suspenso','anulado','desconhecido'))`
+- [ ] Migração paired down
+- [ ] Índice parcial `WHERE status_detalhado='ativo' AND data_fim_vigencia > NOW()` (para queries de contratos ativos)
+
+### AC2: Parsing no transformer
+
+- [ ] `backend/ingestion/transformer.py` estende parse para extrair os 3 campos
+- [ ] Map de status: PNCP `situacaoContratacao.codigo` → enum interno (documentar em comments do transformer)
+- [ ] Fallback quando ausente: `status_detalhado='desconhecido'`, vigência NULL
+- [ ] Backfill via RPC `backfill_vigencia_batch(limit int)` em batches 500, checkpointing em `ingestion_runs`
+
+### AC3: RPC auxiliar
+
+- [ ] Função `is_contract_active(p_numero_controle_pncp varchar) RETURNS boolean` — true se `status_detalhado='ativo' AND data_fim_vigencia > NOW()`
+- [ ] View `contratos_ativos_hoje` (simples, não materializada) para uso em relatórios
+
+### AC4: Testes
+
+- [ ] `backend/tests/ingestion/test_transformer_vigencia.py`:
+  - parse todas as 6 situações PNCP + fallback desconhecido
+  - vigencia_meses calculada corretamente (ex: 12 meses para contrato de 1 ano)
+  - contratos sem data_fim → vigencia_meses NULL
+- [ ] `backend/tests/test_is_contract_active.py` cobre 4 casos (ativo válido, encerrado, rescindido, sem data_fim)
+
+---
+
+## Scope
+
+**IN:**
+- Migração schema (generated column + índice parcial)
+- Transformer parsing
+- RPC `is_contract_active` + view `contratos_ativos_hoje`
+- Backfill job (mais leve que MON-SCH-02 — reusa crawl diário)
+- Testes
+
+**OUT:**
+- UI de filtro "contratos ativos" (ficará em MON-SEO-01/03, MON-REP-*)
+- Alertas de "contrato vencendo" (fora do escopo deste lote — candidato a Q3)
+
+---
+
+## Dependências
+
+- Nenhuma (pode rodar em paralelo com MON-SCH-01 e MON-SCH-02)
+
+---
+
+## Riscos
+
+- **Coverage PNCP inconsistente para contratos antigos:** status_detalhado='desconhecido' para fallback (não afeta queries)
+- **Generated column impacto em backfill:** `GENERATED ALWAYS AS ... STORED` calcula em insert/update; migração usa `ALTER TABLE ... ADD COLUMN ... GENERATED` que pode travar em 2.1M rows → rodar em modo `NOT VALID` + VACUUM/ANALYZE ou usar trigger
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../add_vigencia_status_to_supplier_contracts.sql` + `.down.sql`
+- `supabase/migrations/.../create_is_contract_active_rpc.sql` + `.down.sql`
+- `backend/ingestion/transformer.py` (estender)
+- `backend/tests/ingestion/test_transformer_vigencia.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Migração aplicada em produção
+- [ ] Backfill >= 70% coverage para contratos últimos 3 anos
+- [ ] RPC `is_contract_active` p95 < 50ms
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — desbloqueia filtros temporais em relatórios e páginas SEO |

--- a/docs/stories/2026-04/MON-SEO-01-fornecedor-enriquecer-cta.md
+++ b/docs/stories/2026-04/MON-SEO-01-fornecedor-enriquecer-cta.md
@@ -1,0 +1,154 @@
+# MON-SEO-01: Enriquecer `/fornecedores/[cnpj]` com Score de Risco + Aditivos + CTAs Pagos
+
+**Priority:** P1
+**Effort:** M (3-4 dias)
+**Squad:** @dev + @ux-design-expert
+**Status:** Draft
+**Epic:** [EPIC-MON-SEO-2026-04](EPIC-MON-SEO-2026-04.md)
+**Sprint:** Wave 3 (depende MON-SCH-01 + MON-REP-03 + MON-SUB-04)
+
+---
+
+## Contexto
+
+Página `/fornecedores/[cnpj]` já existe (ISR 24h). Hoje mostra:
+- Dados básicos (razão social, endereço)
+- Lista de contratos recentes
+- Top compradores (órgãos)
+
+**Falta:** elementos que transformem a página em **funil de conversão**:
+- Score de risco (do `supplier_risk_summary_mv` criado em MON-SCH-01)
+- Índice de aditivos (% contratos aditados)
+- 3 CTAs claros para produtos pagos:
+  1. "Comprar relatório completo" (R$ 47+) → MON-REP-03
+  2. "Monitorar este fornecedor em minha carteira" (R$ 297/mês) → MON-SUB-04
+  3. "Consultar via API" (R$ 0,50/query) → MON-API-03 com link para `/api`
+
+---
+
+## Acceptance Criteria
+
+### AC1: Componente `SupplierRiskScore`
+
+- [ ] `frontend/app/components/SupplierRiskScore.tsx`:
+  - Score numeral 0-100 (grande, destacado)
+  - Gauge ou bar chart visual
+  - Label ("Baixo risco", "Moderado", "Alto risco", "Atenção")
+  - Breakdown: aditivos %, concentração %, volatilidade
+  - Disclaimer pequeno "Score derivado de dados públicos"
+- [ ] Dados vêm do view `supplier_risk_summary_mv` via endpoint `GET /v1/suppliers/{cnpj}/risk-summary`
+
+### AC2: Componente `AdditivesIndex`
+
+- [ ] `frontend/app/components/AdditivesIndex.tsx`:
+  - "X% dos contratos sofreram aditivos" (percentual)
+  - Bar chart por ano: aditivos por vencimento
+  - Link expansível "Ver últimos 5 aditivos"
+
+### AC3: Componente `ConversionCTAs`
+
+- [ ] `frontend/app/components/supplier/ConversionCTAs.tsx`:
+  - 3 cards lado-a-lado (mobile: stack):
+    - **Relatório completo** — R$ 47-197 (3 tiers) → redirect `/relatorios/fornecedor/{cnpj}`
+    - **Monitor de Risco** — R$ 297/mês/carteira → redirect `/conta/monitores/novo?type=radar_risco&watch={cnpj}`
+    - **API de Dados** — R$ 0,50/query → redirect `/api`
+  - A/B test placement (sidebar vs inline vs sticky bottom) via feature flag
+- [ ] Event tracking Mixpanel: `cta_view`, `cta_click` por tipo
+
+### AC4: Enriquecer `page.tsx`
+
+- [ ] `frontend/app/fornecedores/[cnpj]/page.tsx`:
+  - Adicionar seções (order): hero → SupplierRiskScore → AdditivesIndex → ConversionCTAs → contratos → top órgãos
+  - Sticky right sidebar com CTA principal em desktop (visibility >= 50% do scroll)
+  - ISR 24h (atual), refresh trigger on-demand via revalidateTag
+
+### AC5: JSON-LD schemas
+
+- [ ] Schema `Organization` com:
+  - `@type: "Organization"`
+  - `identifier: {@type: "PropertyValue", propertyID: "CNPJ", value: "..."}`
+  - `address`, `foundingDate` (se disponível)
+- [ ] Schema `ProfilePage` wrapping
+- [ ] Schema `AggregateRating` usando métricas: `ratingValue` (inverso do score de risco, ex: 100 - score_risco), `reviewCount` (total_contratos)
+
+### AC6: SEO meta tags
+
+- [ ] Title: `"{nome} — CNPJ {cnpj} | Histórico de Contratos Públicos | SmartLic"` (max 60)
+- [ ] Description: `"Histórico completo de contratos públicos de {nome}. {total_contratos} contratos, R$ {total_valor} em valor. Score de risco, aditivos, órgãos contratantes."` (max 160)
+- [ ] og:image dinâmico: card gerado via `@vercel/og` com score + total contratos
+
+### AC7: Testes
+
+- [ ] Unit: `frontend/__tests__/components/SupplierRiskScore.test.tsx`
+- [ ] Snapshot: page renderiza com dados mockados
+- [ ] E2E Playwright: user navega → vê score → clica CTA → vai para landing de compra
+
+---
+
+## Scope
+
+**IN:**
+- 3 novos componentes
+- Enriquecer page
+- JSON-LD schemas
+- SEO metadata + og:image
+- A/B test infra (feature flag)
+- Testes
+
+**OUT:**
+- Dashboard de fornecedor logado (parte de /conta)
+- Filtros de "contratos ativos hoje" — requer MON-SCH-03 (pode vir depois)
+- Integração com dados Receita Federal — v2
+
+---
+
+## Dependências
+
+- **MON-SCH-01** (aditivos + risk summary view)
+- MON-REP-03 (para CTA funcionar)
+- MON-SUB-04 (para CTA do monitor)
+
+---
+
+## Riscos
+
+- **Score de risco pode ofender fornecedor:** disclaimer robusto; link "Contestar dados"; revisar base legal LGPD
+- **Fornecedor com score alto de risco processando judicial:** mitigação comunicacional — score é sinal, não diagnóstico; cada contrato específico pode ter contexto
+- **Coverage aditivos < 50%:** score com confiança baixa → exibir "baseado em dados parciais" com contador "X/Y contratos analisados"
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `frontend/app/fornecedores/[cnpj]/page.tsx` (estender)
+- `frontend/app/components/SupplierRiskScore.tsx` (novo)
+- `frontend/app/components/AdditivesIndex.tsx` (novo)
+- `frontend/app/components/supplier/ConversionCTAs.tsx` (novo)
+- `backend/routes/suppliers_risk.py` (novo endpoint risk-summary)
+- `frontend/app/api/og/supplier/route.tsx` (og:image dinâmico)
+- `frontend/__tests__/components/SupplierRiskScore.test.tsx` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Página live com 3 componentes funcionais
+- [ ] JSON-LD valida em Google Rich Results Test
+- [ ] A/B test rodando em 3 variantes de CTA placement
+- [ ] Mixpanel tracking confirmado
+- [ ] Lighthouse score >= 85
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — funil de conversão da Camada 1 |

--- a/docs/stories/2026-04/MON-SEO-02-categoria-programatica.md
+++ b/docs/stories/2026-04/MON-SEO-02-categoria-programatica.md
@@ -1,0 +1,158 @@
+# MON-SEO-02: Páginas `/categoria/[slug]` Programáticas (5k+ Páginas)
+
+**Priority:** P1
+**Effort:** L (5-6 dias)
+**Squad:** @dev + @devops + @ux
+**Status:** Draft
+**Epic:** [EPIC-MON-SEO-2026-04](EPIC-MON-SEO-2026-04.md)
+**Sprint:** Wave 3 (depende MON-SCH-02 + MON-REP-04)
+
+---
+
+## Contexto
+
+**Pergunta-mãe do SEO:** "Quanto o governo paga por [produto/serviço]?"
+
+Hoje não existe página dedicada a essa query. Após MON-SCH-02 (CATMAT/CATSER + catálogo), podemos gerar **5.000+ páginas programáticas** automaticamente — uma por código CATMAT/CATSER com ≥ 20 contratos históricos.
+
+Cada página é **alta intenção**: orçamentista, pregoeiro, fornecedor avaliando mercado. CTA para MON-REP-04 (Relatório Preço Referência R$ 97-297).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Rota dinâmica `/categoria/[slug]`
+
+- [ ] `frontend/app/categoria/[slug]/page.tsx`:
+  - `generateStaticParams()` gera slugs para top 5k CATMAT/CATSER por volume
+  - ISR 24h
+  - Fallback: on-demand generation para slugs novos
+  - SSR via RPC `benchmark_by_catmat` (MON-SCH-02) + listagem top 20 contratos + top 10 fornecedores
+
+### AC2: Conteúdo da página
+
+- [ ] Hero: "Quanto o governo paga por {label}?" (H1)
+- [ ] Box destacado: mediana nacional (R$), amostra (N contratos)
+- [ ] Seção "Distribuição de preços" — histograma + percentis
+- [ ] Seção "Variação por UF" — tabela sortable com mediana por UF
+- [ ] Seção "Top fornecedores" — 10 players + share
+- [ ] Seção "Últimos contratos" — tabela paginada top 20 por recência
+- [ ] CTA persistente: "Quer análise completa? Compre o Relatório de Preço Referência (R$ 97)"
+- [ ] Sidebar: "Categorias relacionadas" (linkando outros slugs)
+
+### AC3: JSON-LD `Dataset`
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Preços Públicos — {label}",
+  "description": "...",
+  "creator": {"@type": "Organization", "name": "SmartLic"},
+  "distribution": {"@type": "DataDownload", "contentUrl": "https://smartlic.tech/api/..."},
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "measurementTechnique": "Aggregation from PNCP public data"
+}
+```
+
+### AC4: SEO metadata
+
+- [ ] Title: `"{label} — Preços Pagos pelo Governo | SmartLic"` (max 60)
+- [ ] Description: `"Mediana nacional R$ {mediana} para {label}. {n_contratos} contratos no PNCP. Distribuição por UF, top fornecedores. Dados atualizados."` (max 160)
+- [ ] og:image dinâmico: card com mediana + label
+
+### AC5: Sitemap dedicado
+
+- [ ] `frontend/app/sitemap/categorias-[n].ts` shardado por primeira letra do slug (26 shards máximo)
+- [ ] Cada shard lista URLs `/categoria/{slug}` com `lastmod` do `updated_at` do catálogo
+- [ ] Registrado em `sitemap_index.xml` (MON-SEO-04)
+
+### AC6: Thin content gate
+
+- [ ] Página com `sample_size < 10` contratos → noindex + conteúdo degradado "Dados insuficientes. Considere outra categoria."
+- [ ] Página com `sample_size >= 10 AND < 50` → index mas label "Amostra pequena — use com cautela"
+
+### AC7: CTAs múltiplos
+
+- [ ] Sticky CTA bottom em mobile
+- [ ] Inline CTA após histograma
+- [ ] Sidebar CTA com 3 variantes (Relatório R$ 97 / Monitor R$ 197 / API R$ 1/query)
+
+### AC8: Testes
+
+- [ ] Integration: 10 slugs random rendereizam com sucesso
+- [ ] Lighthouse: 90+ performance em slug top 100
+- [ ] Thin content gate: slug com 5 contratos retorna noindex
+- [ ] JSON-LD valida em Rich Results Test
+
+---
+
+## Scope
+
+**IN:**
+- Rota dinâmica + SSR
+- Conteúdo completo (6 seções)
+- JSON-LD Dataset
+- SEO metadata + og:image
+- Sitemap shardado
+- Thin content gate
+- CTAs múltiplos
+- Testes
+
+**OUT:**
+- Filtros interativos (UF, período) no frontend — usar query params, não persistência
+- Comparador multi-categoria — v2
+- Export CSV direto da página — encaminha para MON-API-04
+
+---
+
+## Dependências
+
+- **MON-SCH-02 (CATMAT/CATSER + catálogo)** — bloqueador absoluto
+- MON-REP-04 (CTA principal)
+- MON-SEO-04 (sitemap index)
+
+---
+
+## Riscos
+
+- **Google thin content penalty (AC6 mitiga):** cada página precisa ter ≥ 10 contratos únicos; gates rígidos
+- **5000 páginas geradas ao mesmo tempo sobrecarregam build:** ISR on-demand para a cauda (usar `dynamicParams = true`)
+- **SEO canibalização com `/relatorios/preco-referencia`:** `/categoria/*` é informacional (SEO), `/relatorios/preco-referencia` é transacional (conversão); estabelecer linking entre elas
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `frontend/app/categoria/[slug]/page.tsx` (novo)
+- `frontend/app/categoria/[slug]/loading.tsx` (novo)
+- `frontend/app/api/og/categoria/route.tsx` (novo — og:image dinâmico)
+- `frontend/app/sitemap/categorias-[n].ts` (novo)
+- `backend/routes/categoria.py` (novo — endpoint data aggregado)
+- `frontend/__tests__/categoria-page.test.tsx` (novo)
+- `frontend/e2e-tests/categoria-seo.spec.ts` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 5.000+ slugs gerados e acessíveis
+- [ ] Sitemap shardado registrado no Search Console
+- [ ] Google Rich Results Test valida JSON-LD em 5 samples
+- [ ] Coverage de CATMAT no catálogo >= 80% (dep MON-SCH-02)
+- [ ] Lighthouse 85+ em top slugs
+- [ ] A/B test CTA placements ativo
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — 5k+ páginas programáticas, resposta à query de alto volume de busca |

--- a/docs/stories/2026-04/MON-SEO-03-orgao-enriquecer-cta.md
+++ b/docs/stories/2026-04/MON-SEO-03-orgao-enriquecer-cta.md
@@ -1,0 +1,109 @@
+# MON-SEO-03: Enriquecer `/orgaos/[slug]` com Perfil de Compras + CTAs
+
+**Priority:** P2
+**Effort:** M (3 dias)
+**Squad:** @dev
+**Status:** Draft
+**Epic:** [EPIC-MON-SEO-2026-04](EPIC-MON-SEO-2026-04.md)
+**Sprint:** Wave 3 (depende MON-SCH-01 + MON-SUB-03)
+
+---
+
+## Contexto
+
+Página `/orgaos/[slug]` já existe (básica). Falta transformar em hub de conversão para persona "fornecedor que quer vender para este órgão":
+
+**Valor novo:**
+- Perfil de compras recente (últimos 90 dias)
+- Top 10 fornecedores que o órgão compra
+- **Aditivos recentes** (alerta para fornecedor atento — se órgão aditou, pode haver renovação em breve)
+- Evolução de gastos por ano/categoria
+- CTA para Monitor de Órgão (MON-SUB-03) + API
+
+---
+
+## Acceptance Criteria
+
+### AC1: Componentes novos
+
+- [ ] `OrgTopSuppliers` — tabela top 10 com valor contratado + share
+- [ ] `OrgAdditivesFeed` — timeline aditivos últimos 90d
+- [ ] `OrgSpendEvolution` — line chart gastos 24 meses por CATMAT principal
+- [ ] `OrgCTAs` — 3 cards (Monitor R$ 147/mês, Relatório Fornecedor dos top 10, API)
+
+### AC2: Enriquecer page.tsx
+
+- [ ] `frontend/app/orgaos/[slug]/page.tsx` estende seções
+- [ ] ISR 24h
+
+### AC3: JSON-LD `GovernmentOrganization`
+
+- [ ] Schema:
+```json
+{"@type": "GovernmentOrganization", "identifier": {...}, "address": {...}}
+```
+
+### AC4: SEO metadata
+
+- [ ] Title: `"{nome_orgao} — Compras Públicas | SmartLic"` (max 60)
+- [ ] Description: `"{nome_orgao} contratou R$ {total} em {periodo} com {n} fornecedores. Análise de compras, aditivos, fornecedores principais."` (max 160)
+
+### AC5: Testes
+
+- [ ] Snapshot da página com órgão real
+- [ ] E2E Playwright: user visita → vê perfil → clica Monitor CTA → chega em wizard de criação
+
+---
+
+## Scope
+
+**IN:** 4 componentes novos, JSON-LD, SEO, testes
+**OUT:** Dashboard interativo completo (isso é o que MON-SUB-03 entrega para quem paga)
+
+---
+
+## Dependências
+
+- **MON-SCH-01 (aditivos)** — bloqueador
+- MON-SUB-03 (para CTA funcionar)
+
+---
+
+## Riscos
+
+- **Órgão com poucos dados:** mostrar "Baixa atividade recente" quando volume <10 contratos/ano
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `frontend/app/orgaos/[slug]/page.tsx` (estender)
+- `frontend/app/components/org/OrgTopSuppliers.tsx` (novo)
+- `frontend/app/components/org/OrgAdditivesFeed.tsx` (novo)
+- `frontend/app/components/org/OrgSpendEvolution.tsx` (novo)
+- `frontend/app/components/org/OrgCTAs.tsx` (novo)
+- `backend/routes/orgao_profile.py` (novo ou estender)
+
+---
+
+## Definition of Done
+
+- [ ] Página enriquecida live
+- [ ] JSON-LD válido
+- [ ] Lighthouse 85+
+- [ ] 2 A/B test variants de CTA
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — página existente vira hub de conversão |

--- a/docs/stories/2026-04/MON-SEO-04-sitemaps-dinamicos-shards.md
+++ b/docs/stories/2026-04/MON-SEO-04-sitemaps-dinamicos-shards.md
@@ -1,0 +1,152 @@
+# MON-SEO-04: Sitemaps Dinâmicos Escaláveis + Fix Bug `sitemap/4.xml`
+
+**Priority:** P0
+**Effort:** M (3 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-SEO-2026-04](EPIC-MON-SEO-2026-04.md)
+**Sprint:** Wave 3 (standalone, fix urgente)
+
+---
+
+## Contexto
+
+**Bug crítico:** `sitemap/4.xml` está retornando vazio em produção. Causa provável (memoria do Explore agent): `BACKEND_URL` env var missing em build Railway frontend → fetch para backend falha silenciosamente → sitemap fallback vazio.
+
+**Além do bug:** precisamos escalar sitemap para **2M+ URLs de fornecedor + 5k de categoria + 15k de órgão**. Google enforce 50k URLs/sitemap. Solução: `sitemap_index.xml` apontando para shards.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Diagnóstico + fix sitemap/4.xml
+
+- [ ] Investigar em `frontend/app/sitemap.ts` linhas 43-56 (fetch do backend)
+- [ ] Validar `BACKEND_URL` no build Railway: via `railway variables --service bidiq-frontend | grep BACKEND_URL`
+- [ ] Se missing: adicionar no Railway service
+- [ ] Fallback defensivo: se fetch falha, log Sentry error + não retornar vazio (emitir sitemap parcial com alertas)
+
+### AC2: Sitemap index com shards
+
+- [ ] `frontend/app/sitemap_index.xml/route.ts` gera índice:
+```xml
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://smartlic.tech/sitemap-static.xml</loc></sitemap>
+  <sitemap><loc>https://smartlic.tech/sitemap-blog.xml</loc></sitemap>
+  <sitemap><loc>https://smartlic.tech/sitemap-fornecedores-0.xml</loc></sitemap>
+  ...
+  <sitemap><loc>https://smartlic.tech/sitemap-fornecedores-99.xml</loc></sitemap>
+  <sitemap><loc>https://smartlic.tech/sitemap-categorias-a.xml</loc></sitemap>
+  ...
+  <sitemap><loc>https://smartlic.tech/sitemap-orgaos.xml</loc></sitemap>
+</sitemapindex>
+```
+
+### AC3: Shards de fornecedores
+
+- [ ] `frontend/app/sitemap-fornecedores-[shard]/route.ts`:
+  - Shard por 2 primeiros dígitos de CNPJ (00-99, máximo 100 shards)
+  - Cada shard consulta backend para CNPJs únicos + `lastmod` do último contrato
+  - Priority: 0.8 se `total_valor > R$ 1M`, 0.5 default
+  - Caching: Cache-Control `public, max-age=3600` (1h)
+
+### AC4: Shards de categorias
+
+- [ ] `frontend/app/sitemap-categorias-[letter]/route.ts`:
+  - Shard por primeira letra do slug (26 shards máximo)
+  - Apenas slugs com `sample_size >= 10` (thin content gate)
+
+### AC5: Single sitemap órgãos
+
+- [ ] `frontend/app/sitemap-orgaos/route.ts` — único (15k URLs cabem em 1 sitemap)
+
+### AC6: Atualização robots.txt
+
+- [ ] `frontend/app/robots.ts` referencia `sitemap_index.xml`
+- [ ] Disallow endpoints privados (`/conta`, `/admin`)
+
+### AC7: Monitoring
+
+- [ ] Cron diário `audit_sitemap_health_job`: verifica todos os shards retornam >0 URLs, log Sentry se qualquer falha
+- [ ] Prometheus: `smartlic_sitemap_urls_total{shard}`
+
+### AC8: Google Search Console re-submit
+
+- [ ] Após deploy: resubmit `sitemap_index.xml` no GSC
+- [ ] Monitorar indexação semanalmente por 4 semanas
+
+### AC9: Testes
+
+- [ ] Integration: todos os shards retornam XML válido (schema W3C)
+- [ ] Performance: shard fornecedores com 20k URLs gera em <5s (SSR)
+
+---
+
+## Scope
+
+**IN:**
+- Fix bug sitemap/4.xml
+- Sitemap index + shards
+- Monitoring cron
+- Robots.txt update
+- Testes
+
+**OUT:**
+- hreflang (v2 se lançar internacional)
+- Image/Video sitemaps (não aplicável)
+
+---
+
+## Dependências
+
+- Backend endpoints expostos (pncp_supplier_contracts, catmat_catser_catalog, orgaos)
+- Railway env vars acessíveis
+
+---
+
+## Riscos
+
+- **Googlebot crawl budget runaway:** 2M URLs alta carga; priorizar top via `<priority>` + monitorar no GSC
+- **Shard overflow:** se 1 shard exceder 50k URLs, Google ignora; validar com query `SELECT count(DISTINCT ni_fornecedor) WHERE LEFT(ni_fornecedor, 2) = '00' ...` — se >50k, sub-shardar
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `frontend/app/sitemap_index.xml/route.ts` (novo)
+- `frontend/app/sitemap-fornecedores-[shard]/route.ts` (novo)
+- `frontend/app/sitemap-categorias-[letter]/route.ts` (novo)
+- `frontend/app/sitemap-orgaos/route.ts` (novo)
+- `frontend/app/sitemap-static.xml/route.ts` (novo — URLs estáticas)
+- `frontend/app/sitemap-blog.xml/route.ts` (estender se existe)
+- `frontend/app/sitemap.ts` (remover/substituir pelo index)
+- `frontend/app/robots.ts` (estender)
+- `backend/routes/sitemap_fornecedores.py` (novo — data fetcher)
+- `backend/routes/sitemap_categorias.py` (novo)
+- `backend/jobs/cron/sitemap_health.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] sitemap_index.xml retorna 200 com todos shards listados
+- [ ] Sitemap/4.xml original bug resolvido
+- [ ] 100+ shards de fornecedores renderizam
+- [ ] 26 shards de categorias renderizam
+- [ ] GSC re-submit feito
+- [ ] Cron de monitoring ativo
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — fix de bug crítico + infra escalável de sitemap |

--- a/docs/stories/2026-04/MON-SEO-05-schema-org-jsonld-entity-pages.md
+++ b/docs/stories/2026-04/MON-SEO-05-schema-org-jsonld-entity-pages.md
@@ -1,0 +1,122 @@
+# MON-SEO-05: Schema.org JSON-LD Completo em Todas Páginas de Entidade
+
+**Priority:** P2
+**Effort:** S (2 dias)
+**Squad:** @dev
+**Status:** Draft
+**Epic:** [EPIC-MON-SEO-2026-04](EPIC-MON-SEO-2026-04.md)
+**Sprint:** Wave 3 (polimento final, depende MON-SEO-01/02/03)
+
+---
+
+## Contexto
+
+Componente `SchemaMarkup.tsx` já existe (criado em MKT-002) mas não cobre todos os tipos necessários para rich results em:
+- `/fornecedores/[cnpj]` → `Organization`, `ProfilePage`, `AggregateRating` (MON-SEO-01)
+- `/categoria/[slug]` → `Dataset`, `FAQPage`, `BreadcrumbList` (MON-SEO-02)
+- `/orgaos/[slug]` → `GovernmentOrganization`, `BreadcrumbList` (MON-SEO-03)
+
+Esta story amarra todos em um componente robusto + CI validation.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Extensão `SchemaMarkup.tsx`
+
+- [ ] `frontend/app/components/SchemaMarkup.tsx` aceita types adicionais:
+  - `Organization`, `GovernmentOrganization`, `ProfilePage`
+  - `Dataset`, `DataDownload`
+  - `AggregateRating`, `Review` (futuro — sem reviews de usuário em v1)
+  - `FAQPage` + `Question/Answer`
+  - `BreadcrumbList`
+- [ ] Props tipadas em TypeScript
+
+### AC2: Integração em cada página
+
+- [ ] `/fornecedores/[cnpj]`: Organization + ProfilePage + AggregateRating + BreadcrumbList
+- [ ] `/categoria/[slug]`: Dataset + FAQPage (com 3-5 perguntas frequentes) + BreadcrumbList
+- [ ] `/orgaos/[slug]`: GovernmentOrganization + BreadcrumbList
+
+### AC3: CI validation
+
+- [ ] Novo workflow `.github/workflows/schema-validation.yml`:
+  - Roda em cada PR que toca páginas de entidade
+  - Build + scrapea HTML + extrai JSON-LD
+  - Valida contra schemas oficiais (https://validator.schema.org/ via API)
+  - Falha PR se schema inválido ou campos obrigatórios ausentes
+
+### AC4: Snapshot tests frontend
+
+- [ ] `frontend/__tests__/schema-markup.test.tsx`:
+  - Snapshot de cada page type com JSON-LD esperado
+  - Valida que campos mínimos estão presentes
+
+### AC5: Documentação
+
+- [ ] `docs/seo/schema-org-guidelines.md` com:
+  - Tipos cobertos
+  - Como adicionar novo tipo
+  - Checklist de rich results (Knowledge Panel, FAQ snippet, Dataset panel)
+
+---
+
+## Scope
+
+**IN:**
+- Extensão componente
+- Integração nas 3 páginas
+- CI validation workflow
+- Snapshot tests
+- Documentação
+
+**OUT:**
+- Rich Results para `Article`, `Recipe`, `Event` — não aplicável ao produto
+- hreflang — v2
+
+---
+
+## Dependências
+
+- MON-SEO-01, MON-SEO-02, MON-SEO-03 (páginas existem primeiro)
+
+---
+
+## Riscos
+
+- **Schema validator.schema.org rate limit:** CI cache de respostas + skip em PRs sem mudanças em pages
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `frontend/app/components/SchemaMarkup.tsx` (estender)
+- `frontend/app/fornecedores/[cnpj]/page.tsx` (usar componente)
+- `frontend/app/categoria/[slug]/page.tsx` (usar componente)
+- `frontend/app/orgaos/[slug]/page.tsx` (usar componente)
+- `.github/workflows/schema-validation.yml` (novo)
+- `frontend/__tests__/schema-markup.test.tsx` (estender)
+- `docs/seo/schema-org-guidelines.md` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Todas as 3 páginas de entidade têm JSON-LD completo
+- [ ] Google Rich Results Test valida 10 samples (passa 100%)
+- [ ] CI workflow ativo
+- [ ] Documentação publicada
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — polimento schema.org para rich results |

--- a/docs/stories/2026-04/MON-SUB-01-addons-stripe-monitored-subscriptions.md
+++ b/docs/stories/2026-04/MON-SUB-01-addons-stripe-monitored-subscriptions.md
@@ -1,0 +1,182 @@
+# MON-SUB-01: Add-ons Recorrentes Stripe + Schema `monitored_subscriptions` + Watchlists
+
+**Priority:** P0
+**Effort:** M (3 dias)
+**Squad:** @dev + @devops
+**Status:** Draft
+**Epic:** [EPIC-MON-SUBS-2026-04](EPIC-MON-SUBS-2026-04.md)
+**Sprint:** Wave 2 (bloqueador de MON-SUB-02/03/04 + MON-AI-02 + MON-AI-03 + MON-DIST-02)
+
+---
+
+## Contexto
+
+Hoje existe 1 plano recorrente (Smartlic Pro) via `plan_billing_periods`. Não há conceito de **add-ons vendáveis separadamente**. Para lançar 3 monitores (Camada 3) + Copilot add-on (MON-AI-02) + Radar Preditivo (MON-AI-03), precisamos:
+
+- Modelo Stripe com múltiplos `subscription_items` por customer (plano base + add-ons)
+- Schema interno `monitored_subscriptions` rastreando cada add-on independentemente
+- `watchlist_items` para entidades monitoradas (setor, UF, órgão, CNPJ)
+- Add-ons devem funcionar **standalone** (sem plano base) ou **over-plan**
+
+---
+
+## Acceptance Criteria
+
+### AC1: Tabela `monitored_subscriptions`
+
+- [ ] Migração:
+```sql
+CREATE TABLE public.monitored_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  addon_type text NOT NULL CHECK (addon_type IN (
+    'monitor_segmento_uf', 'monitor_orgao', 'radar_risco',
+    'ai_copilot', 'radar_preditivo'
+  )),
+  tier text NOT NULL,  -- 'basic'|'standard'|'premium'
+  stripe_subscription_id text NOT NULL,
+  stripe_subscription_item_id text NOT NULL UNIQUE,
+  stripe_price_id text NOT NULL,
+  config jsonb NOT NULL DEFAULT '{}'::jsonb,  -- parametros específicos do addon
+  cadence text NOT NULL DEFAULT 'monthly' CHECK (cadence IN ('daily', 'weekly', 'monthly')),
+  price_cents int NOT NULL,
+  active boolean NOT NULL DEFAULT true,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  current_period_end timestamptz NULL,
+  cancelled_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX ON monitored_subscriptions (user_id, active, addon_type);
+```
+- [ ] RLS: user sees only own
+- [ ] Migração paired down
+
+### AC2: Tabela `watchlist_items`
+
+- [ ] Migração:
+```sql
+CREATE TABLE public.watchlist_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscription_id uuid NOT NULL REFERENCES monitored_subscriptions(id) ON DELETE CASCADE,
+  entity_type text NOT NULL CHECK (entity_type IN ('setor', 'uf', 'orgao_cnpj', 'fornecedor_cnpj')),
+  entity_id text NOT NULL,  -- setor slug, UF code, CNPJ 14 digits
+  entity_metadata jsonb NULL,  -- label, config customizada
+  added_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(subscription_id, entity_type, entity_id)
+);
+CREATE INDEX ON watchlist_items (entity_type, entity_id);
+```
+- [ ] Constraint de tier: basic=10 items max, standard=50, premium=500 (check em application layer)
+
+### AC3: Endpoints CRUD
+
+- [ ] `POST /v1/monitors` — cria nova assinatura add-on:
+  - Body: `{addon_type, tier, config, watchlist_items: [...]}`
+  - Cria Stripe subscription_item (em sub existente ou cria sub nova)
+  - Insere `monitored_subscriptions` + `watchlist_items`
+  - Retorna `{id, stripe_subscription_id, next_charge_date, total_cents}`
+- [ ] `GET /v1/monitors` — lista assinaturas ativas do user
+- [ ] `PATCH /v1/monitors/{id}` — atualizar config, tier, watchlist
+- [ ] `DELETE /v1/monitors/{id}` — cancela no Stripe (end of period) + marca `cancelled_at`
+- [ ] `POST /v1/monitors/{id}/watchlist` — adiciona item
+- [ ] `DELETE /v1/monitors/{id}/watchlist/{item_id}` — remove item
+
+### AC4: Webhook handlers extendidos
+
+- [ ] `backend/webhooks/handlers/subscription_item.py`:
+  - `customer.subscription.updated` → sincroniza `stripe_subscription_item_id`, `current_period_end`
+  - `invoice.paid` → confirma pagamento, pode disparar geração primeiro relatório
+  - `customer.subscription.deleted` → marca add-on inativo
+
+### AC5: Dashboard frontend `/conta/monitores`
+
+- [ ] `frontend/app/conta/monitores/page.tsx`:
+  - Lista add-ons ativos (cards por add-on)
+  - Para cada: tier, próxima cobrança, watchlist, botões Editar/Cancelar
+  - "Criar novo monitor" → wizard: tipo → tier → watchlist → checkout
+  - Integração com Stripe Billing Portal para atualização de payment method
+
+### AC6: Catálogo de add-ons em Stripe
+
+- [ ] Script `scripts/stripe_setup_addons.py` (run-once):
+  - Cria Products Stripe para cada addon_type × tier (3×3 + 2×1 = 11 prices)
+  - Printa mapeamento para Railway env vars (`STRIPE_PRICE_MONITOR_SEG_UF_BASIC`, etc)
+- [ ] Lookup table em `backend/services/addon_catalog.py`
+
+### AC7: Testes
+
+- [ ] Unit: `test_monitors_crud.py`
+  - Create monitor happy path → Stripe called + DB row
+  - Watchlist limit por tier (basic=10, standard=50)
+  - Cancel → Stripe called + DB updated
+- [ ] Integration: webhook flow E2E (mock Stripe)
+- [ ] E2E Playwright: user cria Monitor de Segmento UF, adiciona watchlist, cancela
+
+---
+
+## Scope
+
+**IN:**
+- Migrações + RLS
+- CRUD endpoints + webhook handlers
+- Dashboard frontend
+- Stripe setup script
+- Testes
+
+**OUT:**
+- Geração dos relatórios (MON-SUB-02/03/04)
+- Add-ons de AI (MON-AI-02/03) — usam este foundation
+- Upgrade/downgrade tier (v2; v1 = cancelar + criar novo)
+
+---
+
+## Dependências
+
+- Stripe account + Billing Portal configurado
+- Nenhuma story anterior (é foundation da Wave 2)
+
+---
+
+## Riscos
+
+- **Complexidade de multi-add-on billing:** testar com combinações (plan base + 2 add-ons simultâneos)
+- **Downgrade sem proration:** Stripe auto-proration cobre; documentar expectativa usuário
+- **Webhook race conditions:** events podem chegar fora de ordem; lógica idempotente por `stripe_subscription_item_id`
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_monitored_subscriptions.sql` + `.down.sql`
+- `supabase/migrations/.../create_watchlist_items.sql` + `.down.sql`
+- `backend/routes/monitors.py` (novo)
+- `backend/services/addon_catalog.py` (novo)
+- `backend/webhooks/handlers/subscription_item.py` (novo)
+- `scripts/stripe_setup_addons.py` (novo)
+- `frontend/app/conta/monitores/page.tsx` (novo)
+- `backend/tests/routes/test_monitors_crud.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Stripe setup script executado em test + prod
+- [ ] Migração aplicada
+- [ ] User cria add-on via dashboard → Stripe sub_item criado + DB consistente
+- [ ] Cancel → Stripe cancels + ativo=false no período atual
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — foundation Wave 2; habilita 5 add-ons recorrentes |

--- a/docs/stories/2026-04/MON-SUB-02-monitor-segmento-uf.md
+++ b/docs/stories/2026-04/MON-SUB-02-monitor-segmento-uf.md
@@ -1,0 +1,139 @@
+# MON-SUB-02: Monitor de Segmento por UF (R$ 197–497/mês)
+
+**Priority:** P1
+**Effort:** L (4-5 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-SUBS-2026-04](EPIC-MON-SUBS-2026-04.md)
+**Sprint:** Wave 2 (depende MON-SUB-01)
+
+---
+
+## Contexto
+
+Primeiro produto da Camada 3. Relatório automático semanal ou mensal sobre o mercado de um setor+UF específico — entregue por email + dashboard web interativo.
+
+**Conteúdo do relatório:**
+- Novos entrantes (fornecedores que ganharam primeiro contrato no período)
+- Players que saíram (último contrato há > 6 meses)
+- Variação de preços (CATMAT/CATSER mais comuns do setor, delta vs período anterior)
+- Órgãos mais ativos no setor+UF (top 5 por valor contratado)
+- Alertas de aditivos significativos
+
+**2 tiers:**
+- **R$ 197/mês** (weekly): relatório semanal segunda 06:00 BRT
+- **R$ 497/mês** (weekly + alertas real-time): + alertas por email quando novo edital >R$ 500k no setor+UF
+
+---
+
+## Acceptance Criteria
+
+### AC1: Gerador de relatório
+
+- [ ] `backend/monitors/segment_uf_monitor.py`:
+  - Input: `subscription_id, watchlist_items (setor, uf)`
+  - Usa dados de `pncp_supplier_contracts` + `pncp_raw_bids`
+  - Gera PDF (via pipeline MON-REP-02) + dashboard HTML (iframe embedável)
+
+### AC2: ARQ crons
+
+- [ ] `weekly_segment_monitor_job` — segunda 06:00 BRT:
+  - Enfileira todos `monitored_subscriptions` com `addon_type='monitor_segmento_uf'` e `cadence='weekly'`
+  - Por cada: gera relatório + envia email + armazena em `generated_reports`
+- [ ] `monthly_segment_monitor_job` — dia 1 do mês 07:00 BRT (tier anual)
+- [ ] Idempotência: não reenviar se `generated_reports` já tem entry para (subscription_id, period)
+
+### AC3: Dashboard interativo `/monitores/{id}`
+
+- [ ] `frontend/app/monitores/[id]/page.tsx` (protegido por ownership check):
+  - Sidebar: histórico de relatórios do monitor (últimas 12 edições)
+  - Main: visualização do relatório atual (embedable charts Recharts)
+  - Seções: novos entrantes (tabela), saídas (tabela), variação de preços (gráfico), top órgãos (bar chart), alertas
+  - Botão "Baixar PDF" (usa link assinado MON-REP-02)
+  - Botão "Configurar alertas real-time" (tier Premium)
+
+### AC4: Alertas real-time (tier Premium)
+
+- [ ] Integra com pipeline de `new_bids_notifier` (STORY-315) extendido:
+  - Ao detectar novo edital no `pncp_raw_bids` com setor+uf match + valor_estimado > threshold → email push em 15 min
+- [ ] Unsubscribe link por alerta
+
+### AC5: Email template
+
+- [ ] `backend/templates/emails/segment_monitor.py`:
+  - Assunto: `"📊 Monitor {setor} × {uf} — edição semanal"`
+  - Body: resumo executivo (LLM) + 3 highlights + link para dashboard + link PDF
+  - Versão text/plain
+
+### AC6: Testes
+
+- [ ] Unit: gerador com dados mockados
+- [ ] Integration: cron dispara → relatório gerado → email enviado
+- [ ] E2E: user assina → 7 dias depois (mock time) recebe primeiro relatório
+
+---
+
+## Scope
+
+**IN:**
+- Gerador PDF + dashboard HTML
+- 2 crons (weekly + monthly)
+- Alertas real-time (tier Premium)
+- Email template
+- Testes
+
+**OUT:**
+- Customização de seções (user escolhe o que aparece) — v2
+- Notificações WhatsApp/Slack — v2 (considerar add-on separado)
+- Multi-setor em um monitor — requer tier Enterprise v2
+
+---
+
+## Dependências
+
+- MON-SUB-01 (bloqueador absoluto)
+- MON-REP-02 (pipeline de geração + entrega)
+- Classificação setorial IA existente
+- `pncp_raw_bids` + `pncp_supplier_contracts`
+
+---
+
+## Riscos
+
+- **Relatório vazio em setor pouco ativo + UF pequena:** aplicar "expand" (alargar UF para região) se amostra < 10 contratos no período; mensagem "dados limitados, considerar monitor regional"
+- **Flood de alertas em setor quente:** rate limit 5 alertas/dia por monitor; consolidar em digest diário se > 5
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/monitors/segment_uf_monitor.py` (novo)
+- `backend/jobs/cron/monitors.py` (novo)
+- `backend/templates/emails/segment_monitor.py` (novo)
+- `frontend/app/monitores/[id]/page.tsx` (novo)
+- `frontend/app/components/monitor/**` (componentes de dashboard)
+- `backend/tests/monitors/test_segment_uf_monitor.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Cron weekly rodando há 2 semanas sem Sentry errors
+- [ ] 3 test subscribers recebendo relatórios corretos
+- [ ] Dashboard funcional + PDF download funciona
+- [ ] Tier Premium alertas real-time disparam em < 15 min
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — primeiro monitor da Camada 3 |

--- a/docs/stories/2026-04/MON-SUB-03-monitor-orgao-contratante.md
+++ b/docs/stories/2026-04/MON-SUB-03-monitor-orgao-contratante.md
@@ -1,0 +1,118 @@
+# MON-SUB-03: Monitor de Órgão Contratante (R$ 147–397/mês)
+
+**Priority:** P1
+**Effort:** M (3-4 dias)
+**Squad:** @dev
+**Status:** Draft
+**Epic:** [EPIC-MON-SUBS-2026-04](EPIC-MON-SUBS-2026-04.md)
+**Sprint:** Wave 2 (depende MON-SUB-01 + MON-SCH-01)
+
+---
+
+## Contexto
+
+Monitor focado em **1 órgão específico** (CNPJ de órgão público). Personas: fornecedores que vendem recorrente para 1 órgão e querem entender padrão de compras + sinais de renovação.
+
+**Conteúdo:**
+- O que o órgão comprou no período (por CATMAT/CATSER)
+- De quem comprou (top fornecedores)
+- Variação de preços pagos
+- **Alertas de aditivos** (órgão aditou contrato >20% valor ou >6 meses) — inédito no mercado
+- Próximas renovações esperadas (contratos com data_fim dentro de 90 dias)
+
+**2 tiers:**
+- **R$ 147/mês**: monthly report
+- **R$ 397/mês**: monthly report + alertas real-time de novos editais publicados pelo órgão
+
+---
+
+## Acceptance Criteria
+
+### AC1: Gerador de relatório
+
+- [ ] `backend/monitors/orgao_monitor.py`:
+  - Input: `subscription_id, watchlist_items (orgao_cnpj)`
+  - Seções: perfil de compras (último mês), top fornecedores, variação preço vs mediana nacional, **seção alertas aditivos** (usa MON-SCH-01), próximas renovações (usa MON-SCH-03)
+
+### AC2: ARQ cron
+
+- [ ] `monthly_orgao_monitor_job` — dia 5 de cada mês 08:00 BRT
+- [ ] Tier Premium: cron adicional `daily_orgao_edital_alerts` checa novos editais
+
+### AC3: Dashboard interativo
+
+- [ ] `/monitores/{id}` mesma infra de MON-SUB-02 — adaptar seções para visualização de órgão
+
+### AC4: Email template
+
+- [ ] `backend/templates/emails/orgao_monitor.py`
+- [ ] Assunto: `"📋 {orgao_nome} — relatório mensal de compras"`
+
+### AC5: Testes
+
+- [ ] Unit: gerador com órgão simulado
+- [ ] Integration: cron mensal → email
+- [ ] Snapshot: seção de alertas de aditivos mostra corretamente
+
+---
+
+## Scope
+
+**IN:**
+- Gerador + cron
+- Alertas aditivos (usa supplier_risk_summary_mv de MON-SCH-01)
+- Próximas renovações (usa data_fim de MON-SCH-03)
+- Email template
+- Testes
+
+**OUT:**
+- Monitor de múltiplos órgãos em 1 assinatura — vira tier Enterprise v2
+- Comparativo entre órgãos similares — v2
+
+---
+
+## Dependências
+
+- MON-SUB-01 (bloqueador)
+- **MON-SCH-01 (aditivos)** — obrigatório para alertas
+- MON-SCH-03 (data_fim) — obrigatório para "próximas renovações"
+
+---
+
+## Riscos
+
+- **Órgão com baixo volume:** amostra < 5 compras no mês → digest degradado com aviso
+- **Falsos positivos em "renovação esperada":** apenas contratos com data_fim definida no schema; fallback para silêncio se dado ausente
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `backend/monitors/orgao_monitor.py` (novo)
+- `backend/templates/emails/orgao_monitor.py` (novo)
+- `backend/jobs/cron/monitors.py` (estender — já criado em MON-SUB-02)
+- `backend/tests/monitors/test_orgao_monitor.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] Cron monthly rodando
+- [ ] 3 test subscribers recebendo relatório com dados corretos
+- [ ] Alertas de aditivos validados: se órgão teve aditivo >20% no mês, aparece
+- [ ] Próximas renovações mostram contratos com data_fim nos próximos 90d
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — monitor de órgão público; aditivos como diferencial |

--- a/docs/stories/2026-04/MON-SUB-04-radar-risco-fornecedor.md
+++ b/docs/stories/2026-04/MON-SUB-04-radar-risco-fornecedor.md
@@ -1,0 +1,184 @@
+# MON-SUB-04: Radar de Risco de Fornecedor (R$ 297–997/mês/carteira)
+
+**Priority:** P1
+**Effort:** L (5-6 dias)
+**Squad:** @dev + @qa
+**Status:** Draft
+**Epic:** [EPIC-MON-SUBS-2026-04](EPIC-MON-SUBS-2026-04.md)
+**Sprint:** Wave 2 (depende MON-SUB-01 + MON-SCH-01)
+
+---
+
+## Contexto
+
+**Produto de maior ticket da Camada 3.** Persona: bancos e fintechs com exposição a fornecedores PME do setor público — precisam monitorar sinais de risco em **carteiras de CNPJs** (centenas a milhares).
+
+**Valor percebido alto:** detecção antecipada de default → economiza perdas de crédito que podem superar R$ 100k/cliente.
+
+**Triggers monitorados (sinais de risco):**
+- Aditivo anômalo (>30% valor original ou >6 meses prazo)
+- Novo contrato muito acima da mediana de mercado (superfaturamento)
+- Queda abrupta de receita YoY (>40% vs período anterior)
+- Perda de órgão-âncora (órgão que representava >50% da receita)
+- Novos contratos com órgãos problemáticos (flag futuro: CEIS/CNEP quando Q3)
+
+**3 tiers:**
+- **R$ 297/mês** — 50 CNPJs monitorados, alertas diários por email
+- **R$ 597/mês** — 200 CNPJs, alertas real-time (< 2h), webhook outbound
+- **R$ 997/mês** — 500 CNPJs, + dashboard dedicado + API pull
+
+---
+
+## Acceptance Criteria
+
+### AC1: Service de detecção de triggers
+
+- [ ] `backend/monitors/risk_triggers.py` implementa:
+```python
+@dataclass
+class RiskTrigger:
+    cnpj: str
+    trigger_type: str  # 'aditivo_anomalo', 'superfaturamento', 'queda_receita', 'perda_ancora'
+    severity: int  # 1-10
+    detected_at: datetime
+    evidence: dict  # dados específicos do trigger
+    score_delta: float  # mudança no score do fornecedor
+
+def detect_triggers_for_cnpj(cnpj: str, since: datetime) -> list[RiskTrigger]: ...
+```
+- [ ] Cada tipo de trigger tem regra determinística documentada + testada
+- [ ] Score delta calculado usando `supplier_risk_score` (MON-REP-06)
+
+### AC2: ARQ cron `risk_radar_scan`
+
+- [ ] `backend/jobs/cron/risk_scan.py` — diário 06:00 BRT:
+  - Para cada `monitored_subscriptions` com `addon_type='radar_risco'`:
+    - Itera watchlist (até 500 CNPJs)
+    - Para cada CNPJ: detecta triggers desde última varredura
+    - Persiste em `risk_triggers_log` (nova tabela)
+    - Enfileira notificações (email + webhook)
+- [ ] Shard por `subscription_id` para evitar noisy neighbor: max 1 subscription processada por vez por worker
+- [ ] Rate limit interno: max 100 CNPJs checkeds por min por worker
+
+### AC3: Tabela `risk_triggers_log`
+
+- [ ] Migração:
+```sql
+CREATE TABLE public.risk_triggers_log (
+  id bigserial PRIMARY KEY,
+  subscription_id uuid NOT NULL REFERENCES monitored_subscriptions(id),
+  cnpj varchar(14) NOT NULL,
+  trigger_type text NOT NULL,
+  severity int NOT NULL CHECK (severity BETWEEN 1 AND 10),
+  evidence jsonb NOT NULL,
+  score_delta numeric(5,2) NULL,
+  detected_at timestamptz NOT NULL DEFAULT now(),
+  notified_at timestamptz NULL,
+  acknowledged_at timestamptz NULL,
+  acknowledged_by_user_id uuid NULL
+);
+CREATE INDEX ON risk_triggers_log (subscription_id, detected_at DESC);
+CREATE INDEX ON risk_triggers_log (cnpj, detected_at DESC);
+```
+
+### AC4: Notificações email + webhook
+
+- [ ] Template email `risk_alert.py`:
+  - Subject: `"🚨 {cnpj} — {trigger_type} (severidade {severity}/10)"`
+  - Body: CNPJ, nome, trigger, evidência, link para dashboard, CTA "Ignorar este alerta"
+- [ ] Webhook outbound (tier Premium+):
+  - POST para URL configurada pelo cliente com payload JSON + HMAC signature
+  - Retry 3x com backoff exponencial
+  - DLQ em Redis se falhar
+
+### AC5: Dashboard `/monitores/{id}` para radar
+
+- [ ] Adapta dashboard MON-SUB-02:
+  - Seção "Alertas ativos" com triggers dos últimos 30 dias
+  - Botão "Reconhecer" por trigger (marca `acknowledged_at`)
+  - Gráfico de triggers por severidade ao longo do tempo
+  - Tabela "CNPJs na carteira" com score atual + número de triggers ativos
+
+### AC6: Webhook outbound config
+
+- [ ] Endpoint `POST /v1/monitors/{id}/webhook-config`:
+  - Body: `{url, secret, events: [trigger_types]}`
+  - Valida URL (HTTPS obrigatório + teste ping)
+- [ ] Documentação: `docs/api/webhooks-risk-radar.md`
+
+### AC7: Testes
+
+- [ ] Unit: `test_risk_triggers.py` — cada tipo de trigger com dados conhecidos → detecta ou não
+- [ ] Integration: cron full flow E2E
+- [ ] Unit: webhook HMAC signature válida; retry on failure
+- [ ] Performance: scan de 500 CNPJs < 5 min
+
+---
+
+## Scope
+
+**IN:**
+- Service de triggers (4 tipos iniciais)
+- Cron + tabela log
+- Notificações email + webhook
+- Dashboard
+- Testes
+
+**OUT:**
+- CEIS/CNEP triggers (Q3)
+- ML anomaly detection (Q3, complementar a regras determinísticas)
+- Integração Slack/Teams (v2)
+- Alertas SMS (v2)
+
+---
+
+## Dependências
+
+- MON-SUB-01 (bloqueador)
+- **MON-SCH-01 (aditivos)** — obrigatório para trigger de aditivo anômalo
+- `supplier_risk_summary_mv` populada
+
+---
+
+## Riscos
+
+- **False positives causam churn:** cada trigger precisa threshold calibrado em dataset histórico (80% precision target) — gate antes do release
+- **Carteira grande (500 CNPJs) sobrecarrega worker:** shard por subscription, throttle 100 CNPJs/min
+- **Webhook destination down:** DLQ com alerta para cliente; se falha >24h, desativa webhook + email admin
+
+---
+
+## Dev Notes
+
+_(a preencher pelo @dev)_
+
+---
+
+## Arquivos Impactados
+
+- `supabase/migrations/.../create_risk_triggers_log.sql` + `.down.sql`
+- `backend/monitors/risk_triggers.py` (novo)
+- `backend/jobs/cron/risk_scan.py` (novo)
+- `backend/templates/emails/risk_alert.py` (novo)
+- `backend/webhooks/outbound.py` (novo)
+- `backend/routes/monitors_webhook.py` (novo)
+- `frontend/app/monitores/[id]/page.tsx` (estender — componente de radar)
+- `backend/tests/monitors/test_risk_triggers.py` (novo)
+
+---
+
+## Definition of Done
+
+- [ ] 4 tipos de trigger com precision >80% em backtest (6 meses históricos)
+- [ ] Cron rodando com carteira simulada (50 CNPJs) sem Sentry errors por 1 semana
+- [ ] Webhook outbound funciona end-to-end para endpoint de teste
+- [ ] Dashboard funcional
+- [ ] Testes passando
+
+---
+
+## Change Log
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-22 | @sm (River) | Story criada — produto high-ticket Camada 3 para fintechs/bancos |

--- a/frontend/app/buscar/components/search-results/ResultsFooter.tsx
+++ b/frontend/app/buscar/components/search-results/ResultsFooter.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import type { BuscaResult } from "../../../types";
 import { TrialUpsellCTA } from "../../../../components/billing/TrialUpsellCTA";
+import { useAnalytics } from "../../../../hooks/useAnalytics";
 
 interface ResultsFooterProps {
   result: BuscaResult;
@@ -41,6 +42,26 @@ export function ResultsFooter({
   onShowUpgradeModal,
 }: ResultsFooterProps) {
   const [showSourceBadges, setShowSourceBadges] = useState(false);
+  const { trackEvent } = useAnalytics();
+
+  // Fire paywall_hit once per search-result timestamp when paywall is active.
+  // Keyed on result.ultima_atualizacao (per-search unique) so paging/sorting
+  // within the same result doesn't re-fire. Server-truncated results get a
+  // single attributable event for conversion analysis.
+  const firedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!paywallApplied || !totalBeforePaywall) return;
+    const key = result.ultima_atualizacao || "";
+    if (firedFor.current === key) return;
+    firedFor.current = key;
+    trackEvent("paywall_hit", {
+      trigger: "search_truncated",
+      plan_id: planInfo?.plan_id,
+      total_before_paywall: totalBeforePaywall,
+      visible_count: result.licitacoes.length,
+      search_mode: searchMode,
+    });
+  }, [paywallApplied, totalBeforePaywall, result.ultima_atualizacao, result.licitacoes.length, planInfo?.plan_id, searchMode, trackEvent]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Completes the Mixpanel activation funnel so conversion from paywall hit to pricing/checkout is measurable
- Fires `paywall_hit` exactly once per search-result when `paywall_applied=true` with non-null `total_before_paywall`
- Keyed on `result.ultima_atualizacao` via `useRef` so paging/sorting doesn't re-fire within the same result

## Context

Existing conversion events already flow to Mixpanel: `signup_completed`, `checkout_initiated`, `checkout_completed`, `upgrade_modal_opened`. The missing link was `paywall_hit` — without it we can't attribute how many users hit the trial export gate before (or without) converting.

Backend already emits `paywall_applied` + `total_before_paywall` in the search response (STORY-320 AC3). This PR plugs the frontend side.

## Implementation

- `frontend/app/buscar/components/search-results/ResultsFooter.tsx` — added `useAnalytics()` hook invocation + `useEffect` gated on `paywallApplied && totalBeforePaywall`, deduped by `result.ultima_atualizacao` via `useRef` so paging within the same result doesn't re-fire
- Payload: `{ trigger: "search_truncated", plan_id, total_before_paywall, visible_count, search_mode }`
- Respects LGPD consent + `NEXT_PUBLIC_MIXPANEL_TOKEN` gate from `useAnalytics` — no new permission/cookie surface

## Testing Plan

- [x] Local: `npm test -- --testPathPattern="ResultsFooter|useAnalytics"` → 44 passed
- [x] Local: `npx tsc --noEmit` → exit 0
- [ ] Production smoke: after merge, hit `/buscar` with a free-trial account + query that truncates results → verify `paywall_hit` appears in Mixpanel Live View with expected properties
- [ ] CI gate: Backend Tests (PR Gate) + Frontend Tests (PR Gate) must pass

## Closes

- Completes Wave 3.1 of plan abundant-reddy (Mixpanel funnel essentials)
- Unblocks revenue A/B analysis (no ticket, SEO/revenue weekly plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive product roadmap documentation for 2026 Q2–Q3 monetization initiatives, including AI/ML features (semantic search, AI copilot, predictive analytics), B2B API monetization, tiered reports, subscription monitors, and SEO improvements.

* **Analytics**
  * Enhanced tracking for search result paywall interactions to measure user engagement with truncated search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->