### PR TITLE
feat(analytics): emit trial_started funnel event in subscription.created webhook

### DIFF
--- a/backend/tests/test_trial_started_event.py
+++ b/backend/tests/test_trial_started_event.py
@@ -1,0 +1,156 @@
+"""
+Wave B (generic-sparrow plan) — `trial_started` event emit in subscription.created webhook.
+
+Closes funnel: signup_completed → trial_started → paywall_hit → checkout_completed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_subscription_data(status="trialing", sub_id="sub_test_123",
+                             customer_id="cus_test_456",
+                             plan_metadata="plan_pro_monthly",
+                             trial_end=1735689600,
+                             interval="month", interval_count=1):
+    """Build a Stripe-like subscription object as a dict (uses .get())."""
+    data = {
+        "id": sub_id,
+        "status": status,
+        "customer": customer_id,
+        "trial_end": trial_end,
+        "metadata": {"plan_id": plan_metadata},
+        "plan": {"interval": interval, "interval_count": interval_count},
+        "items": {"data": [{"plan": {"interval": interval, "interval_count": interval_count}}]},
+    }
+
+    class _SubObj:
+        def __init__(self, d):
+            self._d = d
+            self.id = d["id"]
+
+        def get(self, key, default=None):
+            return self._d.get(key, default)
+
+    return _SubObj(data)
+
+
+def _make_event(sub_obj, event_type="customer.subscription.created"):
+    event = MagicMock()
+    event.type = event_type
+    event.data.object = sub_obj
+    return event
+
+
+def _make_supabase_with_user(user_id="user-uuid-1", plan_id="plan_pro_monthly"):
+    """Build a mock Supabase client that returns a matching user_subscriptions row."""
+    sb = MagicMock()
+    result = MagicMock()
+    result.data = [{"user_id": user_id, "plan_id": plan_id}]
+    sb.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = result
+    return sb
+
+
+def _make_supabase_no_match():
+    sb = MagicMock()
+    result = MagicMock()
+    result.data = []
+    sb.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value = result
+    return sb
+
+
+@patch("analytics_events.track_funnel_event")
+def test_trial_started_emitted_when_status_trialing(mock_track):
+    from webhooks.handlers.subscription import _emit_trial_started_event
+
+    sub = _make_subscription_data(status="trialing")
+    sb = _make_supabase_with_user(user_id="u-1", plan_id="plan_pro")
+
+    _emit_trial_started_event(sb, sub)
+
+    mock_track.assert_called_once()
+    args, kwargs = mock_track.call_args
+    assert args[0] == "trial_started"
+    assert args[1] == "u-1"
+    payload = args[2]
+    assert payload["plan_id"] == "plan_pro"
+    assert payload["stripe_subscription_id"] == "sub_test_123"
+    assert payload["billing_period"] == "monthly"
+    assert payload["trial_end_unix"] == 1735689600
+
+
+@patch("analytics_events.track_funnel_event")
+def test_trial_started_billing_period_annual(mock_track):
+    from webhooks.handlers.subscription import _emit_trial_started_event
+
+    sub = _make_subscription_data(interval="year", interval_count=1)
+    sb = _make_supabase_with_user()
+
+    _emit_trial_started_event(sb, sub)
+
+    payload = mock_track.call_args.args[2]
+    assert payload["billing_period"] == "annual"
+
+
+@patch("analytics_events.track_funnel_event")
+def test_trial_started_billing_period_semiannual(mock_track):
+    from webhooks.handlers.subscription import _emit_trial_started_event
+
+    sub = _make_subscription_data(interval="month", interval_count=6)
+    sb = _make_supabase_with_user()
+
+    _emit_trial_started_event(sb, sub)
+
+    payload = mock_track.call_args.args[2]
+    assert payload["billing_period"] == "semiannual"
+
+
+@patch("analytics_events.track_funnel_event")
+def test_trial_started_no_emit_when_user_unresolved(mock_track):
+    from webhooks.handlers.subscription import _emit_trial_started_event
+
+    sub = _make_subscription_data()
+    sb = _make_supabase_no_match()
+
+    _emit_trial_started_event(sb, sub)
+
+    mock_track.assert_not_called()
+
+
+@patch("analytics_events.track_funnel_event")
+async def test_handle_subscription_created_emits_trial_started(mock_track):
+    from webhooks.handlers.subscription import handle_subscription_created
+
+    sub = _make_subscription_data(status="trialing")
+    event = _make_event(sub)
+    sb = _make_supabase_with_user(user_id="u-2", plan_id="plan_pro")
+
+    await handle_subscription_created(sb, event)
+
+    mock_track.assert_called_once()
+    assert mock_track.call_args.args[0] == "trial_started"
+    assert mock_track.call_args.args[1] == "u-2"
+
+
+@patch("analytics_events.track_funnel_event")
+async def test_handle_subscription_created_skips_when_status_not_trialing(mock_track):
+    from webhooks.handlers.subscription import handle_subscription_created
+
+    sub = _make_subscription_data(status="active")
+    event = _make_event(sub)
+    sb = _make_supabase_with_user()
+
+    await handle_subscription_created(sb, event)
+
+    mock_track.assert_not_called()
+
+
+@patch("analytics_events.track_funnel_event", side_effect=RuntimeError("mixpanel down"))
+async def test_handle_subscription_created_swallows_emit_errors(mock_track):
+    """Webhook never breaks if Mixpanel emit fails."""
+    from webhooks.handlers.subscription import handle_subscription_created
+
+    sub = _make_subscription_data(status="trialing")
+    event = _make_event(sub)
+    sb = _make_supabase_with_user()
+
+    await handle_subscription_created(sb, event)

--- a/backend/webhooks/handlers/subscription.py
+++ b/backend/webhooks/handlers/subscription.py
@@ -91,12 +91,23 @@ async def handle_subscription_created(sb, event: stripe.Event) -> None:
     """
     Handle customer.subscription.created event.
 
-    SEO-PLAYBOOK Referral: If `metadata.referral_code` is present, mark the
-    matching referral row as converted and credit the referrer with 30 extra
-    days of trial_end on their active subscription (Stripe handles the rest
-    of the prorata automatically on the next invoice).
+    1. Emit `trial_started` Mixpanel funnel event when subscription.status="trialing"
+       — completes signup → trial_started → paywall_hit → checkout_completed funnel.
+    2. SEO-PLAYBOOK Referral: If `metadata.referral_code` is present, mark the
+       matching referral row as converted and credit the referrer with 30 extra
+       days of trial_end on their active subscription (Stripe handles the rest
+       of the prorata automatically on the next invoice).
     """
     subscription_data = event.data.object
+
+    # 1. Emit trial_started analytics event (fire-and-forget, never breaks webhook)
+    try:
+        if subscription_data.get("status") == "trialing":
+            _emit_trial_started_event(sb, subscription_data)
+    except Exception:
+        logger.exception("Failed to emit trial_started analytics event")
+
+    # 2. Referral crediting (existing)
     metadata = subscription_data.get("metadata") or {}
     referral_code = (metadata.get("referral_code") or "").strip().upper()
 
@@ -110,6 +121,78 @@ async def handle_subscription_created(sb, event: stripe.Event) -> None:
     except Exception:
         # Never let referral crediting break the webhook
         logger.exception("Failed to credit referral for code %s", referral_code)
+
+
+def _emit_trial_started_event(sb, subscription_data) -> None:
+    """Emit `trial_started` Mixpanel funnel event for trial subscriptions.
+
+    Resolves user_id via stripe_subscription_id then stripe_customer_id lookup.
+    Fire-and-forget: failures logged, never raised.
+    """
+    from analytics_events import track_funnel_event
+
+    stripe_sub_id = subscription_data.get("id")
+    stripe_customer_id = subscription_data.get("customer")
+
+    user_id = None
+    if stripe_sub_id:
+        sub_result = (
+            sb.table("user_subscriptions")
+            .select("user_id, plan_id")
+            .eq("stripe_subscription_id", stripe_sub_id)
+            .limit(1)
+            .execute()
+        )
+        if sub_result.data:
+            user_id = sub_result.data[0]["user_id"]
+            plan_id = sub_result.data[0].get("plan_id")
+        else:
+            plan_id = None
+    else:
+        plan_id = None
+
+    if not user_id and stripe_customer_id:
+        cust_result = (
+            sb.table("user_subscriptions")
+            .select("user_id, plan_id")
+            .eq("stripe_customer_id", stripe_customer_id)
+            .limit(1)
+            .execute()
+        )
+        if cust_result.data:
+            user_id = cust_result.data[0]["user_id"]
+            plan_id = plan_id or cust_result.data[0].get("plan_id")
+
+    if not user_id:
+        masked = (stripe_sub_id or "")[:8]
+        logger.warning(f"trial_started: cannot resolve user_id for sub {masked}***")
+        return
+
+    plan_id = plan_id or (subscription_data.get("metadata") or {}).get("plan_id")
+    trial_end = subscription_data.get("trial_end")
+
+    stripe_interval = (
+        subscription_data.get("plan", {}).get("interval")
+        or (subscription_data.get("items", {}).get("data") or [{}])[0].get("plan", {}).get("interval")
+    )
+    stripe_interval_count = (
+        subscription_data.get("plan", {}).get("interval_count", 1)
+        or (subscription_data.get("items", {}).get("data") or [{}])[0].get("plan", {}).get("interval_count", 1)
+    )
+    if stripe_interval == "year":
+        billing_period = "annual"
+    elif stripe_interval == "month" and stripe_interval_count == 6:
+        billing_period = "semiannual"
+    else:
+        billing_period = "monthly"
+
+    track_funnel_event("trial_started", user_id, {
+        "plan_id": plan_id,
+        "trial_end_unix": trial_end,
+        "stripe_subscription_id": stripe_sub_id,
+        "billing_period": billing_period,
+    })
+    logger.info(f"trial_started event emitted: user={user_id[:8]}***, plan={plan_id}")
 
 
 def _credit_referral_conversion(sb, referral_code: str, subscription_data) -> None:


### PR DESCRIPTION
## Summary

Adds server-side `trial_started` Mixpanel funnel event in the `customer.subscription.created` Stripe webhook handler when `subscription.status="trialing"`. Completes the revenue funnel:

```
signup_completed → trial_started → paywall_hit → checkout_completed
```

## Context

The frontend already emits `trial_card_captured` on signup but that fires client-side after the card form succeeds — fragile (network failures, ad-blockers, page close before tracker fires can drop the event). The server-side `trial_started` emit confirms Stripe actually created the trialing subscription, giving a reliable denominator for trial→paid CVR analysis.

Wave B of generic-sparrow week plan. Builds on the funnel completion shipped in #474 (paywall_hit).

**Implementation:**
- Modifies `backend/webhooks/handlers/subscription.py::handle_subscription_created`
  - Adds `_emit_trial_started_event()` helper called when `status="trialing"`
  - Resolves `user_id` via `stripe_subscription_id` lookup with `stripe_customer_id` fallback
  - Properties: `user_id`, `plan_id`, `trial_end_unix`, `stripe_subscription_id`, `billing_period`
  - Reuses existing `analytics_events.track_funnel_event` helper (cohort enrichment included)
  - Fire-and-forget: emit failures swallowed, never break webhook
- Adds `backend/tests/test_trial_started_event.py` (7 tests, all passing)

**No new dependencies.** No schema changes. No env vars required (uses existing `MIXPANEL_TOKEN`).

## Testing Plan

- [x] 7 unit tests pass locally (`pytest tests/test_trial_started_event.py -x` → 7/7 in 4.3s)
- [x] Syntax validation (`python3 -c "import ast; ast.parse(...)"`) → OK
- [x] Coverage: trialing-emit, active-skip, billing_period inference (monthly/semiannual/annual), unresolved-user-warn, end-to-end handler dispatch, swallowed-emit-errors
- [ ] Smoke test in prod (post-merge): create trial in Stripe sandbox → verify event appears in Mixpanel Live View with correct distinct_id

## Closes

N/A — Wave B of generic-sparrow week plan. No specific issue, but pairs with #474 (paywall_hit) to close the revenue funnel server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)