### PR TITLE
fix(ci): migration-validate uses psql direct apply (SQLSTATE 42601 fix)

### DIFF
--- a/.github/workflows/migration-validate.yml
+++ b/.github/workflows/migration-validate.yml
@@ -29,27 +29,43 @@ jobs:
         with:
           version: latest
 
-      - name: Start Supabase local
+      - name: Start Supabase local (no migrations yet)
         run: |
           # Supabase CLI's --workdir flag chdirs BEFORE init and fails if the
           # target doesn't exist, so create it explicitly and init in-place.
+          # NOTE: do NOT copy migrations into the init dir. supabase start's
+          # internal applier uses prepared statements and rejects multi-command
+          # SQL (SQLSTATE 42601) present in migrations with multiple functions
+          # like 003_atomic_quota_increment.sql. We apply via psql in a later
+          # step which handles multi-statement files natively.
           mkdir -p /tmp/supabase-test
           cd /tmp/supabase-test
           supabase init --yes
-          cd "$GITHUB_WORKSPACE"
-          cp -r supabase/migrations/. /tmp/supabase-test/supabase/migrations/
-          cd /tmp/supabase-test
           supabase start
 
-      - name: Apply all migrations
+      - name: Apply all migrations via psql
         run: |
           cd /tmp/supabase-test
-          supabase db push --local 2>&1 | tee /tmp/migration-output.txt
-          # Check for errors (non-zero exit)
-          if [ $? -ne 0 ]; then
-            echo "::error::Migration sequence failed. See output above."
+          DB_URL=$(supabase status --output json | jq -r '.DB_URL')
+          if [ -z "$DB_URL" ] || [ "$DB_URL" = "null" ]; then
+            echo "::error::Failed to read DB_URL from supabase status"
             exit 1
           fi
+          echo "Applying migrations from $GITHUB_WORKSPACE/supabase/migrations/"
+          shopt -s nullglob
+          # Apply in ascending timestamp order, skip .down.sql rollback scripts.
+          for f in $(ls -1 "$GITHUB_WORKSPACE"/supabase/migrations/*.sql | sort); do
+            base=$(basename "$f")
+            if [[ "$base" == *.down.sql ]]; then
+              echo "  skip (rollback): $base"
+              continue
+            fi
+            echo "  apply: $base"
+            if ! psql "$DB_URL" -v ON_ERROR_STOP=1 -f "$f" 2>&1 | tee -a /tmp/migration-output.txt; then
+              echo "::error::Migration $base failed. See output above."
+              exit 1
+            fi
+          done
 
       - name: Count applied migrations
         run: |


### PR DESCRIPTION
## Summary

Unblocks Validate Migration Sequence global failure on main by switching
from supabase start's internal migration applier to psql -f direct apply.

- **Root cause:** supabase/setup-cli@v1 "latest" now enforces prepared
  statements, which reject multi-command SQL (SQLSTATE 42601) present in
  migrations like 003_atomic_quota_increment.sql (2 PL/pgSQL functions
  + GRANT + COMMENT in a single file). The migration content is correct
  and already applied in production — only CI validation was broken.
- **Fix:** supabase start comes up without migrations; psql -f applies
  each .sql file (excluding .down.sql) with ON_ERROR_STOP=1. psql handles
  multi-statement files natively while still failing on real SQL errors.
- **Impact:** unblocks PR #470 (api_status migration) and #478 (GSC
  dashboard), which both currently sit BLOCKED on this non-required check.

## Testing Plan

- [x] Workflow YAML change is minimal (25 insertions, 9 deletions in a
      single step).
- [x] psql -v ON_ERROR_STOP=1 still fails on real SQL errors (same
      fail-closed behavior as before).
- [x] `.down.sql` rollback scripts are explicitly skipped (they are not
      meant to run forward).
- [ ] Post-merge: observe Validate Migration Sequence goes green on #470
      and #478 automatically (both already have migrations in their diffs).
- [ ] Post-merge: run weekly cron (workflow_dispatch) to verify sequential
      apply of all current migrations still succeeds.

## Closes

Related to STORY-BTS-011 post-#407 drift cluster sweep. Recovers
Validate Migration Sequence to green-on-main baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration process in CI/CD pipeline with improved error handling and explicit per-file migration execution for more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->