### PR TITLE
fix(tests): update regex to match refactored TaskRegistrationError message

### DIFF
--- a/backend/tests/test_task_registry_story413.py
+++ b/backend/tests/test_task_registry_story413.py
@@ -122,7 +122,7 @@ def test_register_rejects_sync_function_when_is_coroutine_true() -> None:
     def not_async() -> None:
         return None
 
-    with pytest.raises(TaskRegistrationError, match="not an async function"):
+    with pytest.raises(TaskRegistrationError, match="is_coroutine=True"):
         registry.register("sync_as_coro", not_async, is_coroutine=True)  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
## Summary

CI Backend Tests (PR Gate) vem falhando em `main` desde o merge `74a909fd` (2026-04-23T15:22Z) com:

```
FAILED tests/test_task_registry_story413.py::test_register_rejects_sync_function_when_is_coroutine_true
AssertionError: Regex pattern did not match.
  Expected regex: 'not an async function'
  Actual message: "TaskRegistry.register('sync_as_coro'): is_coroutine=True but start_fn is not a coroutine function ..."
```

9004 passed, 1 failed. O único teste bloqueando o gate.

## Root Cause

STORY-413 (commit `1900e6ff` em 2026-04-15) refatorou `task_registry.py` movendo o check de `is_coroutine` para o topo da função `register()` e **renomeou** a mensagem de erro:

- **Antes:** `"start_fn is not an async function"`
- **Depois:** `"start_fn is not a coroutine function"`

O teste `test_register_rejects_sync_function_when_is_coroutine_true` não foi atualizado junto com o refactor (regex `match="not an async function"` continua no branch).

## Fix

Atualizar regex do teste para `"is_coroutine=True"` — invariante semântico do path que o teste valida (rejeita sync function quando `is_coroutine=True`). Robusto a renomeações cosméticas futuras entre "async function" ↔ "coroutine function".

```diff
-    with pytest.raises(TaskRegistrationError, match="not an async function"):
+    with pytest.raises(TaskRegistrationError, match="is_coroutine=True"):
         registry.register("sync_as_coro", not_async, is_coroutine=True)
```

## Test plan

- [x] `pytest tests/test_task_registry_story413.py -xvs` → 9/9 passed local
- [ ] Backend Tests (PR Gate) CI → green
- [ ] Merge train após CI verde (fila: #494, #491, #492, #493, #483, #490)

## Closes

- Blocker CI principal de main há ~6h (run `24843530656`)
- Unblocka merge train de 6 PRs aguardando gate (SAB-014, SAB-015, SEO-479, SEO-480, BTS Wave G, docs session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validation to align error message assertions with current task registration error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->