### PR TITLE
fix(sen-fe-001): preserve SSG/ISR em /contratos/orgao/[cnpj] (-2238 evt Sentry)

### DIFF
--- a/frontend/app/contratos/orgao/[cnpj]/page.tsx
+++ b/frontend/app/contratos/orgao/[cnpj]/page.tsx
@@ -51,7 +51,7 @@ export function generateStaticParams() {
 async function fetchOrgaoContratosStats(cnpj: string): Promise<OrgaoContratosStats | null> {
   try {
     const resp = await fetch(`${BACKEND_URL}/v1/contratos/orgao/${cnpj}/stats`, {
-      cache: 'no-store', // bypass Next.js Data Cache — sempre fresh no ISR regen
+      next: { revalidate: 14400 }, // ISR-aligned com revalidate da page (4h) — mantém SSG/ISR estático e evita static→dynamic shift
       signal: AbortSignal.timeout(10000),
     });
     if (!resp.ok) return null;

--- a/frontend/e2e-tests/contratos-orgao-ssg.spec.ts
+++ b/frontend/e2e-tests/contratos-orgao-ssg.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+const STATIC_TO_DYNAMIC_PATTERNS = [
+  /Page changed from static to dynamic/i,
+  /markCurrentScopeAsDynamic/i,
+];
+
+// AC5 SEN-FE-001: navegar para /contratos/orgao/[cnpj] nao pode emitir
+// warning Next.js "Page changed from static to dynamic at runtime".
+//
+// Contexto: fetch interno usava `cache: 'no-store'` o que forcava pagina
+// marcada como dynamic at runtime, quebrando SSG/ISR (revalidate 14400 da
+// page). Fix: `next: { revalidate: 14400 }` alinhado com page.
+test.describe('SEN-FE-001 — /contratos/orgao/[cnpj] preserves SSG/ISR', () => {
+  const sampleCnpjs = ['10791831000182', '00394411000209'];
+
+  for (const cnpj of sampleCnpjs) {
+    test(`page /contratos/orgao/${cnpj} does not log static-to-dynamic warning`, async ({ page }) => {
+      const consoleCaptured: string[] = [];
+
+      page.on('console', (msg) => {
+        consoleCaptured.push(`[${msg.type()}] ${msg.text()}`);
+      });
+      page.on('pageerror', (err) => {
+        consoleCaptured.push(`[pageerror] ${err.message}`);
+      });
+
+      const response = await page.goto(`/contratos/orgao/${cnpj}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 20000,
+      });
+
+      const status = response?.status() ?? 0;
+      expect([200, 404]).toContain(status);
+
+      const dynamicWarnings = consoleCaptured.filter((m) =>
+        STATIC_TO_DYNAMIC_PATTERNS.some((pattern) => pattern.test(m)),
+      );
+
+      expect(
+        dynamicWarnings,
+        `Page should not emit Next.js static-to-dynamic warning.\nCaptured:\n${consoleCaptured.join('\n')}`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fix 1-linha que mata 2238 eventos Sentry em 14d (maior volume do projeto) e restaura SSG/ISR da page `/contratos/orgao/[cnpj]`.

- `frontend/app/contratos/orgao/[cnpj]/page.tsx:54` — troca `cache: 'no-store'` por `next: { revalidate: 14400 }` alinhado com ISR da page (`export const revalidate = 14400`).
- `frontend/e2e-tests/contratos-orgao-ssg.spec.ts` — novo Playwright spec cobrindo AC5 (assert NO console warning "Page changed from static to dynamic").

## Context

**Sentry issue [7409705693](https://confenge.sentry.io/issues/7409705693/)**: Next.js 16 emitia runtime error `Page changed from static to dynamic at runtime /contratos/orgao/[cnpj]` — 2238 eventos em 14d (ordem de magnitude acima de qualquer outro issue).

**Raiz:** `cache: 'no-store'` no fetch interno downgradeia a page de ISR para dynamic at runtime. O comentário inline antigo ("bypass Next.js Data Cache — sempre fresh no ISR regen") refletia intenção correta de freshness mas usava a API errada. Next.js 16 interpreta `no-store` como dynamic signal regardless do `revalidate` da page, invalidando o CDN cache.

**Fix:** `next: { revalidate: 14400 }` no fetch alinha o data cache com o page revalidate (4h). Mantém freshness via ISR regen + preserva SSG marking em runtime → CDN volta a servir.

**Impact esperado:**
- Sentry issue 7409705693 → 0 evt/48h post-deploy (AC6 follow-up)
- p95 TTFB `/contratos/orgao/*` cai backend-bound → CDN-served (AC7)
- Reducao de carga em stats endpoints (correlaciona com SEN-BE-006)

## Testing Plan

- [x] 40 tests pass em `contratos|orgao` pattern (jest)
- [x] TypeScript check clean (`npx tsc --noEmit`)
- [x] Playwright spec criado cobrindo AC5 runtime assertion
- [ ] AC4 — `npm run build` marca route como `◐ (ISR)` / `● (SSG)` — **validation em CI** (build local WSL OOM em fetch retries, não-bloqueante)
- [ ] AC6 — Sentry issue 7409705693 zero evt em 48h post-deploy — **follow-up via `/schedule` agent**
- [ ] AC7 — p95 TTFB observability post-deploy

## QA Gate

**Verdict: CONCERNS** (approved with observations)

| Check | Status | Nota |
|-------|--------|------|
| Code review | PASS | 1-line, aligned com sitemap.ts ISR pattern |
| Unit tests | PASS | 40/40 relevant pattern |
| AC | CONCERN | 5/7 done (AC4 defer CI, AC6/AC7 post-deploy inerentes) |
| Regressions | PASS | revalidate alignment exato com page |
| Performance | PASS | Restore CDN-served (improvement) |
| Security | PASS | No auth/env changes |
| Docs | PASS | Story File List + Change Log updated (PR #497) |

## Dependencies

- **Story file** (`docs/stories/SEN-FE-001-contratos-orgao-static-to-dynamic.story.md`) está em PR #497 (session docs snappy-treehouse). Merge order: **#497 primeiro** para story file land em main, depois este PR aplica o fix.

## Closes

Nenhuma issue GitHub. Resolve:
- Sentry issue 7409705693 (2238 eventos) — validate via /schedule agent em +48h
- Restaura SSG/ISR de `/contratos/orgao/[cnpj]` route

## Memory applied

- `project_sitemap_serialize_isr_pattern` — ISR revalidate 3600/14400 convention
- `feedback_advisor_critical_discernment` — discriminador empírico revelou fix real (não remoção cega de no-store)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced caching for the organization contracts page, delivering faster and more consistent page load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->