### PR TITLE
feat(trial-conversion): coupon badge + paywall_hit + plan_selected Mixpanel events

### DIFF
--- a/backend/quota/plan_auth.py
+++ b/backend/quota/plan_auth.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
+from analytics_events import track_funnel_event
 from log_sanitizer import mask_user_id
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,15 @@ async def require_active_plan(user: dict) -> dict:
                 "plan_id": quota_info.plan_id,
             },
         )
+        track_funnel_event(
+            "paywall_hit",
+            user_id=user_id,
+            properties={
+                "reason": "dunning_blocked",
+                "plan_id": quota_info.plan_id,
+                "days_since_failure": _days_since_failure,
+            },
+        )
         raise HTTPException(
             status_code=402,
             detail={
@@ -81,6 +91,15 @@ async def require_active_plan(user: dict) -> dict:
                 "dunning_phase": "grace_period",
                 "days_since_failure": _days_since_failure,
                 "plan_id": quota_info.plan_id,
+            },
+        )
+        track_funnel_event(
+            "paywall_hit",
+            user_id=user_id,
+            properties={
+                "reason": "dunning_grace_period",
+                "plan_id": quota_info.plan_id,
+                "days_since_failure": _days_since_failure,
             },
         )
         raise HTTPException(
@@ -111,6 +130,16 @@ async def require_active_plan(user: dict) -> dict:
                 "plan_id": quota_info.plan_id,
                 "expired_at": quota_info.trial_expires_at.isoformat() if quota_info.trial_expires_at else None,
                 "days_overdue": days_overdue,
+            },
+        )
+        track_funnel_event(
+            "paywall_hit",
+            user_id=user_id,
+            properties={
+                "reason": error_type,
+                "plan_id": quota_info.plan_id,
+                "trial_days_past": days_overdue if is_trial else None,
+                "expired_at": quota_info.trial_expires_at.isoformat() if quota_info.trial_expires_at else None,
             },
         )
 

--- a/docs/sessions/2026-04/2026-04-24-smooth-island-handoff.md
+++ b/docs/sessions/2026-04/2026-04-24-smooth-island-handoff.md
@@ -40,12 +40,19 @@ Mental model corrigido durante sessão (advisor feedback): scheduler de email us
 
 Hipótese conversion bump Day 16: hoje user chega em `/planos?coupon=TRIAL_COMEBACK_20`, vê preço cheio sem perceber desconto. Com banner + preço riscado, desconto torna-se acionável visualmente. Mensurável via `plan_selected` rate em cohort com `has_coupon=true`.
 
+## Estado no encerramento (sessão fechada user request)
+
+- PR #501: `OPEN`, `mergeable=MERGEABLE`, `mergeStateStatus=BLOCKED`
+- **Frontend Tests: PASS** (2 jobs — 2m44s + 5m50s)
+- **Backend Tests: pending** (ainda rodando — único check required restante)
+- Branch `feat/trial-conversion-smooth-island` base atualizada com main
+
 ## Pendente (dono + prazo)
 
-- [ ] **Merge PR #501** — @devops — aguardando CI (Backend Tests + Frontend Tests são os únicos required); auto-merge off, merge manual após checks green
-- [ ] **Smoke prod pós-deploy** — @devops — site+api 200 por ≥30min, `/planos?coupon=TRIAL_COMEBACK_20` renderiza badge
+- [ ] **Merge PR #501** — @devops — aguardar Backend Tests green, `gh pr merge 501 --squash` (auto-merge off repo)
+- [ ] **Smoke prod pós-merge** — @devops — `curl -sf https://smartlic.tech` + `https://api.smartlic.tech/health` ≥30min, abrir `/planos?coupon=TRIAL_COMEBACK_20` verifica badge emerald + preços riscados
 - [ ] **24h soak Mixpanel verify** — próxima sessão (2026-04-25+) — queries prontas abaixo
-- [ ] **Delete script ad-hoc** `backend/scripts/audit_trial_email_log_smooth_island.py` — próxima sessão (untracked, só existe local)
+- [ ] **Delete script ad-hoc** `backend/scripts/audit_trial_email_log_smooth_island.py` — próxima sessão (untracked)
 
 ## 24h soak queries (para próxima sessão)
 
@@ -88,12 +95,16 @@ Nada não-derivável descoberto — memory permanece inalterada.
 
 | Métrica | Alvo | Realizado |
 |---------|------|-----------|
-| Shipped to prod | ≥1 mudança caminho de receita | PR #501 pronto (aguarda merge + deploy) |
+| Shipped to prod | ≥1 mudança caminho de receita | PARCIAL — PR #501 pronto, não mergeado (user encerrou) |
 | Incidentes novos | 0 | 0 |
-| Tempo em docs | <15% | ~10% (este handoff) |
+| Tempo em docs | <15% | ~10% (handoff + audit script) |
 | Tempo em fix não-prod | <25% | 0% (tudo prod-targeted) |
-| Instrumentação adicionada | ≥1 evento funil | 2 eventos (`paywall_hit` + `plan_selected`) |
+| Instrumentação adicionada | ≥1 evento funil | 2 eventos (`paywall_hit` backend + `plan_selected` frontend) |
+
+## Memory updates
+
+Salvo em memory: `reference_trial_email_log_delivery_status_null.md` — coluna `delivery_status` em `trial_email_log` é NULL em 100% dos registros auditados (9 emails para 2 users). Scheduler registra dispatch mas Resend callback não popula status. Não-derivável — quem auditar delivery no futuro deve ir em Resend dashboard, não em DB.
 
 ## Próxima ação prioritária
 
-**@devops aguarda CI green e mergeia #501. Depois smoke prod. Próxima sessão: verify 24h soak Mixpanel.**
+**@devops aguarda Backend Tests green → `gh pr merge 501 --squash` → smoke prod. Próxima sessão: verify 24h soak Mixpanel (queries acima).**

--- a/docs/sessions/2026-04/2026-04-24-smooth-island-handoff.md
+++ b/docs/sessions/2026-04/2026-04-24-smooth-island-handoff.md
@@ -1,0 +1,99 @@
+# Session smooth-island — 2026-04-24
+
+**Branch:** `feat/trial-conversion-smooth-island` (isolada de main)
+**PR:** [#501](https://github.com/tjsasakifln/PNCP-poc/pull/501)
+**Plan:** `~/.claude/plans/mission-empresa-morrendo-smooth-island.md`
+**Mission:** empresa-morrendo (MRR única métrica)
+**Classe:** REVENUE-DIRECT
+
+## Objetivo
+
+Ship 3 deltas no caminho trial-expiring → paid: coupon badge visual em `/planos` + 2 eventos Mixpanel no funil (`paywall_hit` backend + `plan_selected` frontend). 1 PR isolado.
+
+## Entregue
+
+| PR | Commit | Scope |
+|----|--------|-------|
+| **#501 OPEN** | `812fb39f` | `feat(backend): emit paywall_hit Mixpanel event em require_active_plan` — 3 choke points (dunning_blocked, dunning_grace_period, trial_expired) em `backend/quota/plan_auth.py` |
+| **#501 OPEN** | `ee394342` | `feat(frontend): coupon badge + plan_selected Mixpanel em /planos` — `COUPON_DISCOUNTS` constant, banner emerald, preços riscados em `PlanProCard`+`PlanConsultoriaCard`, `window.mixpanel.track('plan_selected')` antes do POST checkout |
+
+## Audit GATE (Step 1)
+
+Query ad-hoc `backend/scripts/audit_trial_email_log_smooth_island.py` (NÃO commitado) confirmou scheduler funciona:
+
+| User | Created | Trial exp | Emails log |
+|------|---------|-----------|------------|
+| dslicitacoesthe@gmail.com | 2026-04-08 | 2026-04-22 | 5 emails (engagement, paywall_alert, value, last_day, expired) |
+| paulo.souza@adeque-t.com.br | 2026-04-10 | 2026-04-24 | 4 emails (engagement, paywall_alert, value, last_day) — Day 16 expired ainda não caiu |
+
+Observação não-derivável: `delivery_status` coluna está NULL p/ todos os registros — verificar Resend dashboard delivery rate separadamente se métricas forem inconclusivas na próxima sessão.
+
+Mental model corrigido durante sessão (advisor feedback): scheduler de email usa `created_at` + milestones fixos `[0, 3, 7, 10, 13, 16]` — independente do bug velvet-music em `trial_expires_at`. Scheduler estava sempre funcionando mesmo com bug anterior no paywall.
+
+## Impacto em receita
+
+| Mudança | Estado | Como medir (24h soak) |
+|---------|--------|------------------------|
+| Coupon badge 20% visível em `/planos?coupon=TRIAL_COMEBACK_20` | Aguarda merge PR #501 | Smoke manual: abrir URL em browser privado, banner emerald renderiza + preços riscados |
+| `paywall_hit` event Mixpanel (backend) | Aguarda merge PR #501 | Mixpanel: count por `reason={trial_expired, plan_expired, dunning_blocked, dunning_grace_period}` |
+| `plan_selected` event Mixpanel (frontend) | Aguarda merge PR #501 | Mixpanel: count por `plan_id` + `has_coupon`. Funnel rate vs `checkout_initiated` |
+
+Hipótese conversion bump Day 16: hoje user chega em `/planos?coupon=TRIAL_COMEBACK_20`, vê preço cheio sem perceber desconto. Com banner + preço riscado, desconto torna-se acionável visualmente. Mensurável via `plan_selected` rate em cohort com `has_coupon=true`.
+
+## Pendente (dono + prazo)
+
+- [ ] **Merge PR #501** — @devops — aguardando CI (Backend Tests + Frontend Tests são os únicos required); auto-merge off, merge manual após checks green
+- [ ] **Smoke prod pós-deploy** — @devops — site+api 200 por ≥30min, `/planos?coupon=TRIAL_COMEBACK_20` renderiza badge
+- [ ] **24h soak Mixpanel verify** — próxima sessão (2026-04-25+) — queries prontas abaixo
+- [ ] **Delete script ad-hoc** `backend/scripts/audit_trial_email_log_smooth_island.py` — próxima sessão (untracked, só existe local)
+
+## 24h soak queries (para próxima sessão)
+
+Mixpanel:
+- `paywall_hit` count 24h, segmentado por `reason` — esperamos ver dunning minoritário vs trial_expired maioria
+- `plan_selected` count 24h, segmentado por `has_coupon` — cohort com coupon deve ter taxa de conversão para `checkout_initiated` maior que sem coupon
+- Funnel: `paywall_hit` → `plan_selected` → `checkout_initiated` → `payment_succeeded` — identificar onde vaza
+
+Sentry:
+- Sem spike de exceptions em `analytics_events` ou `plan_auth` pós-deploy
+
+DB:
+```sql
+SELECT user_id, email_type, sent_at
+FROM trial_email_log
+WHERE user_id IN (
+  '39b32b6f-15ec-4347-b282-ab7da6ea43af',  -- dsl
+  '285edd6e-6353-424a-9030-b488c01bcf50'   -- pau
+)
+ORDER BY sent_at DESC;
+```
+
+## Riscos vivos
+
+| Risco | Severidade | Prazo virar incidente |
+|-------|-----------|------------------------|
+| Mixpanel token não configurado em prod (eventos silenciam) | LOW | Nenhum — `track_funnel_event` silent-fail, não derruba request. Verify em soak query |
+| `delivery_status` NULL em `trial_email_log` indica que emails talvez não cheguem (apenas logs de dispatch) | MED | Verificar Resend dashboard na próxima sessão — se delivery rate <90%, abrir story |
+| Day 16 expired email não disparou para pau (trial expirou hoje, scheduler corre a cada 2h) | LOW | Cron próxima hora cobre; sem ação necessária |
+
+## Memory updates
+
+| File | Razão |
+|------|-------|
+| Nenhum nesta sessão | Todos findings são derivable do código (scheduler milestones, signature track_funnel_event, pattern window.mixpanel inline) |
+
+Nada não-derivável descoberto — memory permanece inalterada.
+
+## KPIs da sessão
+
+| Métrica | Alvo | Realizado |
+|---------|------|-----------|
+| Shipped to prod | ≥1 mudança caminho de receita | PR #501 pronto (aguarda merge + deploy) |
+| Incidentes novos | 0 | 0 |
+| Tempo em docs | <15% | ~10% (este handoff) |
+| Tempo em fix não-prod | <25% | 0% (tudo prod-targeted) |
+| Instrumentação adicionada | ≥1 evento funil | 2 eventos (`paywall_hit` + `plan_selected`) |
+
+## Próxima ação prioritária
+
+**@devops aguarda CI green e mergeia #501. Depois smoke prod. Próxima sessão: verify 24h soak Mixpanel.**

--- a/frontend/app/planos/components/PlanConsultoriaCard.tsx
+++ b/frontend/app/planos/components/PlanConsultoriaCard.tsx
@@ -21,6 +21,7 @@ interface PlanConsultoriaCardProps {
   isConsultoriaLead: boolean;
   checkoutLoading: boolean;
   onCheckout: () => void;
+  couponDiscountPercent?: number;
 }
 
 export function PlanConsultoriaCard({
@@ -30,8 +31,12 @@ export function PlanConsultoriaCard({
   isConsultoriaLead,
   checkoutLoading,
   onCheckout,
+  couponDiscountPercent,
 }: PlanConsultoriaCardProps) {
   const currentPricing = pricing[billingPeriod];
+  const discountedMonthly = couponDiscountPercent
+    ? currentPricing.monthly * (1 - couponDiscountPercent / 100)
+    : null;
 
   return (
     <div className="mt-16 max-w-lg mx-auto">
@@ -55,12 +60,34 @@ export function PlanConsultoriaCard({
         </div>
         {/* Dynamic Price */}
         <div className="text-center mb-6">
-          <div className="flex items-baseline justify-center gap-1">
-            <span className="text-5xl font-bold text-amber-700 dark:text-amber-400">
-              {formatCurrency(currentPricing.monthly)}
-            </span>
-            <span className="text-lg text-[var(--ink-muted)]">/mês</span>
-          </div>
+          {discountedMonthly !== null ? (
+            <>
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <span className="text-2xl line-through text-[var(--ink-muted)]" data-testid="consultoria-price-original">
+                  {formatCurrency(currentPricing.monthly)}
+                </span>
+                <span
+                  className="inline-block px-2 py-0.5 bg-emerald-100 dark:bg-emerald-900/50 text-emerald-700 dark:text-emerald-400 text-xs font-bold rounded-full"
+                  data-testid="consultoria-coupon-pill"
+                >
+                  -{couponDiscountPercent}%
+                </span>
+              </div>
+              <div className="flex items-baseline justify-center gap-1">
+                <span className="text-5xl font-bold text-emerald-600 dark:text-emerald-400" data-testid="consultoria-price-discounted">
+                  {formatCurrency(discountedMonthly)}
+                </span>
+                <span className="text-lg text-[var(--ink-muted)]">/mês</span>
+              </div>
+            </>
+          ) : (
+            <div className="flex items-baseline justify-center gap-1">
+              <span className="text-5xl font-bold text-amber-700 dark:text-amber-400">
+                {formatCurrency(currentPricing.monthly)}
+              </span>
+              <span className="text-lg text-[var(--ink-muted)]">/mês</span>
+            </div>
+          )}
           {currentPricing.discount && (
             <div className="mt-2">
               <span className="inline-block px-3 py-1 bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-400 text-sm font-semibold rounded-full">

--- a/frontend/app/planos/components/PlanProCard.tsx
+++ b/frontend/app/planos/components/PlanProCard.tsx
@@ -26,6 +26,7 @@ interface PlanProCardProps {
   planLoading?: boolean;
   onCheckout: () => void;
   onManageSubscription: () => void;
+  couponDiscountPercent?: number;
 }
 
 export function PlanProCard({
@@ -39,7 +40,14 @@ export function PlanProCard({
   planLoading,
   onCheckout,
   onManageSubscription,
+  couponDiscountPercent,
 }: PlanProCardProps) {
+  const discountedMonthly = couponDiscountPercent
+    ? currentPricing.monthly * (1 - couponDiscountPercent / 100)
+    : null;
+  const discountedTotal = couponDiscountPercent
+    ? currentPricing.total * (1 - couponDiscountPercent / 100)
+    : null;
   return (
     <div className="max-w-lg mx-auto">
       <div className="backdrop-blur-xl bg-white/50 dark:bg-gray-900/40 border-2 border-[var(--brand-blue)] rounded-card p-8 shadow-gem-amethyst">
@@ -53,12 +61,34 @@ export function PlanProCard({
 
         {/* Dynamic Price */}
         <div className="text-center mb-6">
-          <div className="flex items-baseline justify-center gap-1">
-            <span className="text-5xl font-bold text-[var(--brand-navy)]">
-              {formatCurrency(currentPricing.monthly)}
-            </span>
-            <span className="text-lg text-[var(--ink-muted)]">/mês</span>
-          </div>
+          {discountedMonthly !== null ? (
+            <>
+              <div className="flex items-center justify-center gap-2 mb-1">
+                <span className="text-2xl line-through text-[var(--ink-muted)]" data-testid="price-original">
+                  {formatCurrency(currentPricing.monthly)}
+                </span>
+                <span
+                  className="inline-block px-2 py-0.5 bg-emerald-100 dark:bg-emerald-900/50 text-emerald-700 dark:text-emerald-400 text-xs font-bold rounded-full"
+                  data-testid="coupon-pill"
+                >
+                  -{couponDiscountPercent}%
+                </span>
+              </div>
+              <div className="flex items-baseline justify-center gap-1">
+                <span className="text-5xl font-bold text-emerald-600 dark:text-emerald-400" data-testid="price-discounted">
+                  {formatCurrency(discountedMonthly)}
+                </span>
+                <span className="text-lg text-[var(--ink-muted)]">/mês</span>
+              </div>
+            </>
+          ) : (
+            <div className="flex items-baseline justify-center gap-1">
+              <span className="text-5xl font-bold text-[var(--brand-navy)]">
+                {formatCurrency(currentPricing.monthly)}
+              </span>
+              <span className="text-lg text-[var(--ink-muted)]">/mês</span>
+            </div>
+          )}
 
           {currentPricing.discount && (
             <div className="mt-2">
@@ -67,12 +97,12 @@ export function PlanProCard({
               </span>
               {billingPeriod === "semiannual" && (
                 <p className="text-xs text-[var(--ink-muted)] mt-1">
-                  Cobrado {formatCurrency(currentPricing.total)} a cada 6 meses
+                  Cobrado {formatCurrency(discountedTotal ?? currentPricing.total)} a cada 6 meses
                 </p>
               )}
               {billingPeriod === "annual" && (
                 <p className="text-xs text-[var(--ink-muted)] mt-1">
-                  Cobrado {formatCurrency(currentPricing.total)} por ano
+                  Cobrado {formatCurrency(discountedTotal ?? currentPricing.total)} por ano
                 </p>
               )}
             </div>

--- a/frontend/app/planos/page.tsx
+++ b/frontend/app/planos/page.tsx
@@ -36,6 +36,12 @@ type UserProfile = Partial<components["schemas"]["UserProfileResponse"]>;
 // (consumed here and by ProductSchema.tsx to keep JSON-LD in sync with UI).
 const PRICING_FALLBACK = PRO_PRICING;
 
+// Coupon → discount % mapping. Day 16 trial-expired email sends TRIAL_COMEBACK_20.
+// Keep in sync with Stripe coupon configuration (Stripe is source of truth for actual billing).
+const COUPON_DISCOUNTS: Record<string, number> = {
+  TRIAL_COMEBACK_20: 20,
+};
+
 // GTM-002: Features list
 const FEATURES = [
   { text: "1.000 análises por mês", detail: "Avalie oportunidades em todos os 27 estados" },
@@ -210,6 +216,9 @@ export default function PlanosPage() {
 
   const currentPricing = proPricing[billingPeriod];
   const hasFullAccess = userStatus === "subscriber" || userStatus === "privileged";
+  const couponDiscountPercent = couponCode
+    ? COUPON_DISCOUNTS[couponCode.toUpperCase()]
+    : undefined;
 
   const handleManageSubscription = useCallback(async () => {
     if (!session?.access_token) return;
@@ -231,6 +240,15 @@ export default function PlanosPage() {
     if (!session) { window.location.href = "/login"; return; }
     setCheckoutLoading(true);
     trackEvent("checkout_initiated", { plan_id: "smartlic_pro", billing_period: billingPeriod, source: "planos_page" });
+    if (typeof window !== "undefined" && window.mixpanel) {
+      window.mixpanel.track("plan_selected", {
+        plan_id: "smartlic_pro",
+        billing_period: billingPeriod,
+        has_coupon: !!couponCode,
+        coupon_id: couponCode ?? null,
+        discount_percent: couponDiscountPercent ?? null,
+      });
+    }
     clarityEvent("checkout_initiated");
     claritySet("selected_plan", "smartlic_pro");
     claritySet("billing_period", billingPeriod);
@@ -263,6 +281,15 @@ export default function PlanosPage() {
     if (!session) { window.location.href = "/login"; return; }
     setCheckoutLoading(true);
     trackEvent("checkout_initiated", { plan_id: "consultoria", billing_period: billingPeriod, source: "planos_page" });
+    if (typeof window !== "undefined" && window.mixpanel) {
+      window.mixpanel.track("plan_selected", {
+        plan_id: "consultoria",
+        billing_period: billingPeriod,
+        has_coupon: !!couponCode,
+        coupon_id: couponCode ?? null,
+        discount_percent: couponDiscountPercent ?? null,
+      });
+    }
     clarityEvent("checkout_initiated");
     claritySet("selected_plan", "consultoria");
     claritySet("billing_period", billingPeriod);
@@ -337,6 +364,19 @@ export default function PlanosPage() {
           onManageSubscription={handleManageSubscription}
         />
 
+        {couponDiscountPercent !== undefined && (
+          <div
+            className="mb-6 rounded-card border border-emerald-300 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-900/30 px-4 py-3 text-center text-sm font-medium text-emerald-800 dark:text-emerald-200"
+            role="status"
+            data-testid="coupon-banner"
+          >
+            <span className="font-bold">Desconto de {couponDiscountPercent}% aplicado</span>
+            <span className="ml-2 text-xs text-emerald-700 dark:text-emerald-300">
+              (cupom {couponCode?.toUpperCase()})
+            </span>
+          </div>
+        )}
+
         {/* Billing Period Toggle */}
         <div className="flex justify-center mb-8">
           <PlanToggle value={billingPeriod} onChange={setBillingPeriod} discounts={{ semiannual: proPricing.semiannual.discount, annual: proPricing.annual.discount }} />
@@ -353,6 +393,7 @@ export default function PlanosPage() {
           planLoading={planLoading || authLoading}
           onCheckout={handleCheckout}
           onManageSubscription={handleManageSubscription}
+          couponDiscountPercent={couponDiscountPercent}
         />
 
         {/* ROI Anchor Message */}
@@ -404,6 +445,7 @@ export default function PlanosPage() {
             isConsultoriaLead={isConsultoriaLead}
             checkoutLoading={checkoutLoading}
             onCheckout={() => { if (!session) { window.location.href = "/login"; return; } handleConsultoriaCheckout(); }}
+            couponDiscountPercent={couponDiscountPercent}
           />
         </div>
 


### PR DESCRIPTION
## Summary

Sessão **smooth-island** 2026-04-24. Classe: REVENUE-DIRECT. 3 deltas no caminho trial-expiring → paid.

1. **Coupon badge visual em `/planos`** — banner emerald + preços riscados quando URL contém `?coupon=TRIAL_COMEBACK_20` (enviado no email Day 16 expired). Hoje o coupon era extraído do URL mas não renderizado — user via preço cheio e não percebia desconto ativo. Constante `COUPON_DISCOUNTS` mapeia coupon → % (Stripe segue como source of truth para billing real).
2. **Backend `paywall_hit` Mixpanel event** — emitido nos 3 choke points de `require_active_plan` (dunning_blocked 402, dunning_grace_period 402, trial_expired/plan_expired 403) com propriedades `reason`, `plan_id`, `trial_days_past`, `expired_at`, `days_since_failure`.
3. **Frontend `plan_selected` Mixpanel event** — emitido antes do POST `/v1/checkout` em ambos handlers (Pro + Consultoria). Properties: `plan_id`, `billing_period`, `has_coupon`, `coupon_id`, `discount_percent`.

## Context

Audit GATE (sessão smooth-island) confirmou que o scheduler de trial emails está funcionando: `dsl*@gmail.com` recebeu 5 emails (último `expired` 2026-04-23), `paulo.souza@adeque-t.com.br` recebeu 4 (último `last_day` 2026-04-22). O caminho de email → /planos existe. O gap era visual (coupon invisível) + instrumentação (2 eventos faltando no funil).

Gap #1 (backend → frontend) fechado com `paywall_hit`. Gap #2 (UI → POST checkout) fechado com `plan_selected`. Próxima sessão vai olhar Mixpanel funnel pra decidir onde focar os próximos bumps.

## Testing Plan

- [x] Backend 111/111 pass (`tests/test_quota.py` + `tests/test_analytics_events.py` + `tests/test_routes_analytics.py` + `tests/test_dunning.py` + `tests/test_endpoints_story165.py`)
- [x] Frontend 85/85 pass (`__tests__/planos/*`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Imports OK sem circular (`track_funnel_event` importado em `quota/plan_auth.py`)
- [ ] 24h soak Mixpanel (deferred next session):
  - Query `paywall_hit` events group by `reason` — trial_expired vs dunning split
  - Query `plan_selected` → `checkout_initiated` → `payment_succeeded` funnel rate
  - Query `trial_email_log` user_ids que clicaram CTA Day 16 → `plan_selected` rate

## Closes

Sessão smooth-island 2026-04-24 (ver `docs/sessions/2026-04/2026-04-24-smooth-island-handoff.md`). Não fecha story específica; é instrumentação + UI polish sem feature-flag.

## Rollout

- Sem feature flag — additive events + UI render condicional por query param
- `track_funnel_event` é fire-and-forget silent-fail (não derruba request se Mixpanel offline)
- Coupon badge renderiza condicionalmente em `couponCode` existente — comportamento default inalterado para navegação direta a `/planos` sem query param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coupon codes apply percentage discounts; UI shows original price struck-through, discount pill, discounted price, and a coupon banner.

* **Analytics**
  * Funnel tracking for paywall hits added; plan-selection events now include coupon metadata and discount percent.

* **Documentation**
  * Added handoff notes with rollout, verification steps, measurement plan, and follow-up checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->