### PR TITLE
feat(seo): EPIC SEO-RECOVERY-Q2 P0+P1 — index orgao_cnpj + sitemap fixes

### DIFF
--- a/backend/routes/_sitemap_cache_headers.py
+++ b/backend/routes/_sitemap_cache_headers.py
@@ -1,0 +1,34 @@
+"""STORY-SEO-015: Cache-Control headers compartilhados para endpoints /v1/sitemap/*.
+
+Habilita CDN/proxy intermediarios (Cloudflare, browsers, crawlers) a cachear
+respostas por 6h fresh + 12h stale-while-revalidate + 24h stale-if-error.
+
+Reduz carga no backend (WEB_CONCURRENCY=2) durante crawler bursts (Googlebot
+parallelism pode atingir 10+ conexoes simultaneas em endpoint sitemap).
+
+Defer (story SEO-015.1): Redis L2 cache layer + purge pos-ingestion.
+TTL natural 6h ja cobre 90% do problema com zero codigo extra alem de headers.
+
+Uso em handler:
+
+    from fastapi import Response
+    from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
+
+    @router.get("/sitemap/foo", ...)
+    async def sitemap_foo(response: Response):
+        response.headers.update(SITEMAP_CACHE_HEADERS)
+        ...
+"""
+
+# 6h fresh (max-age=21600) + 12h stale-while-revalidate + 24h stale-if-error.
+# Tradeoffs:
+#   - 6h fresh: ingestion daily 2am BRT; sitemap muda <=1x/dia. 6h evita over-stale
+#     entre ingestion (max 1 ciclo perdido).
+#   - stale-while-revalidate=43200 (12h): CDN serve stale + dispara refresh em
+#     background. Crawler nunca ve timeout enquanto backend gera nova versao.
+#   - stale-if-error=86400 (24h): se backend 5xx, CDN serve stale por ate 24h.
+#     Crawler nao detecta erros transientes.
+SITEMAP_CACHE_HEADERS = {
+    "Cache-Control": "public, max-age=21600, stale-while-revalidate=43200, stale-if-error=86400",
+    "Vary": "Accept-Encoding",
+}

--- a/backend/routes/itens_publicos.py
+++ b/backend/routes/itens_publicos.py
@@ -19,7 +19,9 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
+
+from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
@@ -362,7 +364,8 @@ async def item_profile(catmat: str):
     response_model=SitemapItensResponse,
     summary="Lista de codigos CATMAT para sitemap.xml",
 )
-async def sitemap_itens():
+async def sitemap_itens(response: Response):
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_cached(_itens_sitemap_cache, "catmats")
     if cached:
         record_sitemap_count("itens", len(cached.get("catmats", [])))

--- a/backend/routes/municipios_publicos.py
+++ b/backend/routes/municipios_publicos.py
@@ -17,7 +17,9 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
+
+from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
@@ -470,10 +472,11 @@ async def municipio_profile(slug: str):
     response_model=SitemapMunicipiosResponse,
     summary="Lista de slugs de municipios para sitemap.xml",
 )
-async def sitemap_municipios():
+async def sitemap_municipios(response: Response):
     """Retorna slugs dos municipios pre-cadastrados para o sitemap.xml.
     Cache: 24h em memoria.
     """
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_cached(_municipio_sitemap_cache, "slugs")
     if cached:
         record_sitemap_count("municipios", len(cached.get("slugs", [])))

--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -15,10 +15,11 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
+from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
@@ -96,7 +97,8 @@ def _set_fornecedores_cached(key: str, data: dict) -> None:
     response_model=SitemapCnpjsResponse,
     summary="CNPJs com ≥1 licitação no datalake (para sitemap)",
 )
-async def sitemap_cnpjs():
+async def sitemap_cnpjs(response: Response):
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_cached("cnpjs")
     if cached:
         record_sitemap_count("cnpjs", len(cached.get("cnpjs", [])))
@@ -226,13 +228,14 @@ async def _fetch_top_cnpjs() -> dict:
     response_model=SitemapFornecedoresCnpjResponse,
     summary="Top CNPJs de fornecedores com contratos no datalake (para sitemap)",
 )
-async def sitemap_fornecedores_cnpj():
+async def sitemap_fornecedores_cnpj(response: Response):
     """Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.
 
     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
     Limite: 5.000 CNPJs por volume de contratos (mais contratos = maior valor SEO).
     Cache: 24h em memoria.
     """
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_fornecedores_cached("fornecedores_cnpj")
     if cached:
         record_sitemap_count("fornecedores-cnpj", len(cached.get("cnpjs", [])))

--- a/backend/routes/sitemap_licitacoes.py
+++ b/backend/routes/sitemap_licitacoes.py
@@ -14,11 +14,12 @@ import os
 import time
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel
 
 from admin import require_admin
 from metrics import record_sitemap_count
+from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
@@ -48,8 +49,9 @@ class LicitacoesIndexableResponse(BaseModel):
     response_model=LicitacoesIndexableResponse,
     summary="Combos setor×UF indexáveis (público — sitemap)",
 )
-async def get_licitacoes_indexable():
+async def get_licitacoes_indexable(response: Response):
     """Retorna combos setor×UF com bids OR contracts suficientes."""
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     global _cache
 
     if _cache is not None:

--- a/backend/routes/sitemap_licitacoes_do_dia.py
+++ b/backend/routes/sitemap_licitacoes_do_dia.py
@@ -1,0 +1,154 @@
+"""STORY-SEO-017: Sitemap endpoint p/ datas indexaveis de /blog/licitacoes-do-dia.
+
+Substitui geracao hardcoded `Array.from({length: 30})` em frontend/app/sitemap.ts
+que gerava 42 URLs 404 (datas sem dados em pncp_raw_bids). Retorna apenas datas
+da janela 30d com COUNT(bids) >= MIN_BIDS_PER_DAY (default 5), garantindo que
+URLs no sitemap sempre retornam 200.
+
+Pattern segue sitemap_orgaos.py (RPC primary com fallback paginado + InMemory cache).
+TTL 1h (dia corrente muda durante o dia).
+"""
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from metrics import record_sitemap_count
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["sitemap"])
+
+_CACHE_TTL_SECONDS = 60 * 60  # 1h — dia corrente muda durante o dia
+_cache: dict[str, tuple[dict, float]] = {}
+
+_WINDOW_DAYS = 30
+_MIN_BIDS_PER_DAY = 5  # threshold para considerar dia indexavel
+
+
+class SitemapLicitacoesDoDiaResponse(BaseModel):
+    dates: list[str]  # ISO YYYY-MM-DD, ordenado DESC
+    total: int
+    updated_at: str
+
+
+def _get_cached(key: str) -> Optional[dict]:
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    data, ts = entry
+    if time.time() - ts >= _CACHE_TTL_SECONDS:
+        del _cache[key]
+        return None
+    return data
+
+
+def _set_cached(key: str, data: dict) -> None:
+    _cache[key] = (data, time.time())
+
+
+@router.get(
+    "/sitemap/licitacoes-do-dia-indexable",
+    response_model=SitemapLicitacoesDoDiaResponse,
+    summary="Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)",
+)
+async def sitemap_licitacoes_do_dia_indexable():
+    """Retorna apenas datas com bids suficientes para ter pagina renderizavel.
+
+    Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
+    """
+    cached = _get_cached("dates")
+    if cached:
+        record_sitemap_count("licitacoes-do-dia-indexable", len(cached.get("dates", [])))
+        return SitemapLicitacoesDoDiaResponse(**cached)
+
+    data = await _fetch_indexable_dates()
+    _set_cached("dates", data)
+    record_sitemap_count("licitacoes-do-dia-indexable", len(data.get("dates", [])))
+    return SitemapLicitacoesDoDiaResponse(**data)
+
+
+async def _fetch_indexable_dates() -> dict:
+    """Scan pncp_raw_bids janela 30d, conta por data, filtra HAVING >=5.
+
+    Implementa client-side aggregation: paginated fetch de data_publicacao
+    apenas (1 col) -> Counter -> filter -> sort DESC.
+
+    50K rows tipico em 30d / 1k per page = ~50 round-trips. Tolerante porque
+    cache TTL 1h reduz para 1x/h por worker.
+    """
+    try:
+        from supabase_client import get_supabase
+
+        sb = get_supabase()
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=_WINDOW_DAYS)).date().isoformat()
+
+        date_counts: dict[str, int] = {}
+        page_size = 1000
+        offset = 0
+        page_count = 0
+
+        while True:
+            resp = (
+                sb.table("pncp_raw_bids")
+                .select("data_publicacao")
+                .eq("is_active", True)
+                .gte("data_publicacao", cutoff)
+                .not_.is_("data_publicacao", "null")
+                .range(offset, offset + page_size - 1)
+                .execute()
+            )
+            page_count += 1
+            if not resp.data:
+                break
+
+            for row in resp.data:
+                raw = row.get("data_publicacao")
+                if not raw:
+                    continue
+                # data_publicacao pode ser ISO datetime ou date — extrair YYYY-MM-DD
+                date_str = str(raw)[:10]
+                if len(date_str) == 10 and date_str[4] == "-" and date_str[7] == "-":
+                    date_counts[date_str] = date_counts.get(date_str, 0) + 1
+
+            if len(resp.data) < page_size:
+                break
+            offset += page_size
+
+            # safety: nao iterar alem de 200 paginas (200K rows) — anomalia
+            if page_count >= 200:
+                logger.warning(
+                    "sitemap_licitacoes_do_dia: stopped at 200 pages — investigate"
+                )
+                break
+
+        indexable = sorted(
+            (date for date, count in date_counts.items() if count >= _MIN_BIDS_PER_DAY),
+            reverse=True,
+        )
+
+        logger.info(
+            "sitemap_licitacoes_do_dia (paginated): %d distinct dates, %d indexable (>=%d bids), %d pages",
+            len(date_counts),
+            len(indexable),
+            _MIN_BIDS_PER_DAY,
+            page_count,
+        )
+
+        return {
+            "dates": indexable,
+            "total": len(indexable),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    except Exception as e:
+        logger.error("sitemap_licitacoes_do_dia failed: %s", e)
+        return {
+            "dates": [],
+            "total": 0,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }

--- a/backend/routes/sitemap_licitacoes_do_dia.py
+++ b/backend/routes/sitemap_licitacoes_do_dia.py
@@ -14,10 +14,11 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
+from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
@@ -55,11 +56,12 @@ def _set_cached(key: str, data: dict) -> None:
     response_model=SitemapLicitacoesDoDiaResponse,
     summary="Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)",
 )
-async def sitemap_licitacoes_do_dia_indexable():
+async def sitemap_licitacoes_do_dia_indexable(response: Response):
     """Retorna apenas datas com bids suficientes para ter pagina renderizavel.
 
     Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
     """
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_cached("dates")
     if cached:
         record_sitemap_count("licitacoes-do-dia-indexable", len(cached.get("dates", [])))

--- a/backend/routes/sitemap_orgaos.py
+++ b/backend/routes/sitemap_orgaos.py
@@ -14,10 +14,11 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
+from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
@@ -53,7 +54,8 @@ def _set_cached(key: str, data: dict) -> None:
     response_model=SitemapOrgaosResponse,
     summary="Órgãos compradores com ≥1 licitação no datalake (para sitemap)",
 )
-async def sitemap_orgaos():
+async def sitemap_orgaos(response: Response):
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_cached("orgaos")
     if cached:
         record_sitemap_count("orgaos", len(cached.get("orgaos", [])))
@@ -170,7 +172,7 @@ class SitemapContratosOrgaoResponse(BaseModel):
     response_model=SitemapContratosOrgaoResponse,
     summary="Órgãos compradores com contratos em pncp_supplier_contracts (para sitemap /contratos/orgao/)",
 )
-async def sitemap_contratos_orgao_indexable():
+async def sitemap_contratos_orgao_indexable(response: Response):
     """Retorna CNPJs de órgãos com ≥1 contrato ativo em pncp_supplier_contracts.
 
     Diferente de /sitemap/orgaos (que usa pncp_raw_bids/licitações), este
@@ -179,6 +181,7 @@ async def sitemap_contratos_orgao_indexable():
     que retornam 200, eliminando os 794 404s reportados no GSC.
     Cache: 24h em memória.
     """
+    response.headers.update(SITEMAP_CACHE_HEADERS)
     key = "contratos_orgao_indexable"
     cached_entry = _contratos_orgao_cache.get(key)
     if cached_entry:

--- a/backend/routes/trial_emails.py
+++ b/backend/routes/trial_emails.py
@@ -75,16 +75,25 @@ async def unsubscribe_trial_emails(
 
 @router.post("/trial-emails/webhook")
 async def resend_webhook(request: Request):
-    """AC11: Handle Resend webhook events for email tracking."""
+    """Handle Resend webhook events for email tracking.
+
+    Accepts the full delivery lifecycle (sent → delivered → opened → clicked)
+    plus failure paths (bounced, complained, delivery_delayed, failed) so the
+    admin funnel dashboard can distinguish "email never arrived" from "email
+    arrived but wasn't engaged". Service handler
+    (`services.trial_email_sequence.handle_resend_webhook`) populates the
+    columns added in migration 20260424180000_trial_email_delivery_tracking.
+    Always returns 200 so Resend doesn't retry on transient server errors.
+    """
     try:
         body = await request.json()
         event_type = body.get("type", "")
         data = body.get("data", {})
 
-        if event_type not in ("email.opened", "email.clicked", "email.delivered"):
-            return JSONResponse({"status": "ignored"})
+        from services.trial_email_sequence import RESEND_STATUS_MAP, handle_resend_webhook
+        if event_type not in RESEND_STATUS_MAP:
+            return JSONResponse({"status": "ignored", "event_type": event_type})
 
-        from services.trial_email_sequence import handle_resend_webhook
         processed = await handle_resend_webhook(event_type, data)
 
         return JSONResponse({"status": "processed" if processed else "skipped"})

--- a/backend/services/trial_email_sequence.py
+++ b/backend/services/trial_email_sequence.py
@@ -834,15 +834,53 @@ def _render_email(
 # AC11: Resend webhook handler for opens/clicks
 # ============================================================================
 
+RESEND_STATUS_MAP = {
+    "email.sent": "sent",
+    "email.delivered": "delivered",
+    "email.opened": "opened",
+    "email.clicked": "clicked",
+    "email.bounced": "bounced",
+    "email.complained": "complained",
+    "email.delivery_delayed": "delivery_delayed",
+    "email.failed": "failed",
+}
+
+# Status precedence: higher value wins when multiple events land for the
+# same email. e.g. opened (3) must not downgrade a row that already
+# reached clicked (4). bounced / complained / failed are terminal.
+_STATUS_PRIORITY = {
+    None: 0,
+    "queued": 1,
+    "sent": 2,
+    "delivered": 3,
+    "opened": 4,
+    "clicked": 5,
+    "delivery_delayed": 2,
+    "bounced": 6,
+    "complained": 6,
+    "failed": 6,
+}
+
+
 async def handle_resend_webhook(event_type: str, data: dict) -> bool:
-    """AC11: Process Resend webhook for email open/click tracking.
+    """Process Resend webhook for email tracking.
+
+    Populates columns added in migration 20260424180000_trial_email_delivery_tracking:
+    delivery_status / delivered_at / bounced_at / complained_at / failed_at /
+    bounce_reason. Also keeps the pre-existing opened_at / clicked_at columns
+    populated for backward compatibility with dashboards built before the
+    migration landed.
+
+    Emits Mixpanel funnel events so conversion dashboards can show the
+    real email funnel (sent → delivered → opened → clicked) instead of
+    the broken "14 sent / 0 opens" view the session started with.
 
     Args:
-        event_type: Resend event type (e.g., "email.opened", "email.clicked")
-        data: Webhook payload data
+        event_type: Resend event type (email.delivered, email.opened, etc.)
+        data: Resend webhook payload ``data`` object. ``email_id`` is required.
 
     Returns:
-        True if processed, False if skipped/error
+        True if the update touched a row, False if skipped / unknown event.
     """
     try:
         from supabase_client import get_supabase, sb_execute
@@ -851,28 +889,80 @@ async def handle_resend_webhook(event_type: str, data: dict) -> bool:
         if not email_id:
             return False
 
+        new_status = RESEND_STATUS_MAP.get(event_type)
+        if new_status is None:
+            return False
+
         sb = get_supabase()
         now = datetime.now(timezone.utc).isoformat()
 
-        if event_type == "email.opened":
-            await sb_execute(
-                sb.table("trial_email_log")
-                .update({"opened_at": now})
-                .eq("resend_email_id", email_id)
-                .is_("opened_at", "null")
-            )
-            return True
+        # 1) Fetch the existing row so we can (a) respect status precedence
+        # and (b) enrich the Mixpanel event with user_id + email_type.
+        existing = await sb_execute(
+            sb.table("trial_email_log")
+            .select("id, user_id, email_type, delivery_status, opened_at, clicked_at")
+            .eq("resend_email_id", email_id)
+            .limit(1)
+        )
+        rows = getattr(existing, "data", None) or []
+        if not rows:
+            return False
+        row = rows[0]
 
+        current_status = row.get("delivery_status")
+        if _STATUS_PRIORITY.get(new_status, 0) < _STATUS_PRIORITY.get(current_status, 0):
+            # Event arrived out of order (e.g. delivered after opened).
+            # Keep the higher-priority status but still record the timestamp
+            # for the specific event so delivered_at / bounced_at etc. are
+            # accurate even when the overall state already moved on.
+            update: dict = {}
+        else:
+            update = {"delivery_status": new_status}
+
+        if event_type == "email.delivered":
+            update["delivered_at"] = now
+        elif event_type == "email.opened":
+            if not row.get("opened_at"):
+                update["opened_at"] = now
         elif event_type == "email.clicked":
+            if not row.get("clicked_at"):
+                update["clicked_at"] = now
+        elif event_type == "email.bounced":
+            update["bounced_at"] = now
+            reason = data.get("bounce", {}).get("type") or data.get("bounce_reason")
+            if reason:
+                update["bounce_reason"] = str(reason)[:200]
+        elif event_type == "email.complained":
+            update["complained_at"] = now
+        elif event_type == "email.failed":
+            update["failed_at"] = now
+            reason = data.get("reason") or data.get("failure_reason")
+            if reason:
+                update["bounce_reason"] = str(reason)[:200]
+
+        if update:
             await sb_execute(
                 sb.table("trial_email_log")
-                .update({"clicked_at": now})
+                .update(update)
                 .eq("resend_email_id", email_id)
-                .is_("clicked_at", "null")
             )
-            return True
 
-        return False
+        # 2) Fire Mixpanel funnel event (fire-and-forget, never blocks webhook).
+        try:
+            from analytics_events import track_funnel_event
+            track_funnel_event(
+                f"trial_email_{new_status}",
+                row.get("user_id") or "",
+                {
+                    "email_type": row.get("email_type"),
+                    "resend_email_id": email_id,
+                    "event_type": event_type,
+                },
+            )
+        except Exception:
+            pass
+
+        return True
 
     except Exception as e:
         logger.error(f"Resend webhook processing error: {e}")

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -67,6 +67,7 @@ from routes.compliance_publicos import router as compliance_publicos_router
 from routes.itens_publicos import router as itens_publicos_router
 from routes.observatorio import router as observatorio_router
 from routes.sitemap_licitacoes import router as sitemap_licitacoes_router
+from routes.sitemap_licitacoes_do_dia import router as sitemap_licitacoes_do_dia_router
 from routes.indice_municipal import router as indice_municipal_router
 from routes.notifications import router as notifications_router
 from routes.export import router as edital_export_router
@@ -107,6 +108,7 @@ _v1_routers = [
     itens_publicos_router,
     observatorio_router,
     sitemap_licitacoes_router,
+    sitemap_licitacoes_do_dia_router,
     indice_municipal_router,
     notifications_router,
     edital_export_router,

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -19194,7 +19194,7 @@
     },
     "/v1/trial-emails/webhook": {
       "post": {
-        "description": "AC11: Handle Resend webhook events for email tracking.",
+        "description": "Handle Resend webhook events for email tracking.\n\nAccepts the full delivery lifecycle (sent \u2192 delivered \u2192 opened \u2192 clicked)\nplus failure paths (bounced, complained, delivery_delayed, failed) so the\nadmin funnel dashboard can distinguish \"email never arrived\" from \"email\narrived but wasn't engaged\". Service handler\n(`services.trial_email_sequence.handle_resend_webhook`) populates the\ncolumns added in migration 20260424180000_trial_email_delivery_tracking.\nAlways returns 200 so Resend doesn't retry on transient server errors.",
         "operationId": "resend_webhook_v1_trial_emails_webhook_post",
         "responses": {
           "200": {

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -9328,6 +9328,32 @@
         "title": "SitemapItensResponse",
         "type": "object"
       },
+      "SitemapLicitacoesDoDiaResponse": {
+        "properties": {
+          "dates": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Dates",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dates",
+          "total",
+          "updated_at"
+        ],
+        "title": "SitemapLicitacoesDoDiaResponse",
+        "type": "object"
+      },
       "SitemapMunicipiosResponse": {
         "properties": {
           "slugs": {
@@ -18894,6 +18920,28 @@
         "summary": "Lista de codigos CATMAT para sitemap.xml",
         "tags": [
           "itens-publicos"
+        ]
+      }
+    },
+    "/v1/sitemap/licitacoes-do-dia-indexable": {
+      "get": {
+        "description": "Retorna apenas datas com bids suficientes para ter pagina renderizavel.\n\nElimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.",
+        "operationId": "sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SitemapLicitacoesDoDiaResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)",
+        "tags": [
+          "sitemap"
         ]
       }
     },

--- a/backend/tests/test_sitemap_cache_headers.py
+++ b/backend/tests/test_sitemap_cache_headers.py
@@ -1,0 +1,100 @@
+"""STORY-SEO-015: Cache-Control headers em endpoints /v1/sitemap/*.
+
+Valida que todos os 8 endpoints sitemap publicos respondem com Cache-Control
+permitindo CDN/proxy/browser cachear por 6h fresh + 12h SWR + 24h stale-if-error.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from startup.app_factory import create_app
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_all_caches():
+    """Clear in-memory caches between tests to ensure handler runs."""
+    try:
+        from routes.sitemap_cnpjs import _sitemap_cache as c1, _fornecedores_sitemap_cache as c2
+        c1.clear(); c2.clear()
+    except Exception:
+        pass
+    try:
+        from routes.sitemap_orgaos import _sitemap_cache as o1, _contratos_orgao_cache as o2
+        o1.clear(); o2.clear()
+    except Exception:
+        pass
+    try:
+        from routes import sitemap_licitacoes
+        sitemap_licitacoes._cache = None
+    except Exception:
+        pass
+    try:
+        from routes.sitemap_licitacoes_do_dia import _cache as l3
+        l3.clear()
+    except Exception:
+        pass
+
+
+EXPECTED_CC = "public, max-age=21600, stale-while-revalidate=43200, stale-if-error=86400"
+
+
+@pytest.mark.parametrize(
+    "endpoint,patch_target,return_value",
+    [
+        ("/v1/sitemap/cnpjs", "supabase_client.get_supabase", MagicMock()),
+        ("/v1/sitemap/orgaos", "supabase_client.get_supabase", MagicMock()),
+        ("/v1/sitemap/contratos-orgao-indexable", "supabase_client.get_supabase", MagicMock()),
+        ("/v1/sitemap/fornecedores-cnpj", "supabase_client.get_supabase", MagicMock()),
+        ("/v1/sitemap/licitacoes-do-dia-indexable", "supabase_client.get_supabase", MagicMock()),
+    ],
+)
+def test_sitemap_endpoint_emits_cache_control(client, endpoint, patch_target, return_value):
+    """STORY-SEO-015 AC2: cada endpoint sitemap emite Cache-Control configurado."""
+    with patch(patch_target, return_value=return_value):
+        resp = client.get(endpoint)
+    assert resp.status_code == 200, f"{endpoint} failed: {resp.text[:200]}"
+    cc = resp.headers.get("cache-control", "")
+    assert cc == EXPECTED_CC, f"{endpoint} cache-control: {cc!r}"
+    assert resp.headers.get("vary", "") == "Accept-Encoding"
+
+
+def test_sitemap_municipios_emits_cache_control(client):
+    """municipios usa cache + lista hardcoded (nao precisa mock supabase)."""
+    resp = client.get("/v1/sitemap/municipios")
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control", "") == EXPECTED_CC
+
+
+def test_sitemap_itens_emits_cache_control(client):
+    """itens usa cache + lista hardcoded (nao precisa mock supabase)."""
+    resp = client.get("/v1/sitemap/itens")
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control", "") == EXPECTED_CC
+
+
+def test_sitemap_licitacoes_indexable_emits_cache_control(client):
+    """licitacoes-indexable e o mais complexo (gather paralelo)."""
+    with patch("routes.sitemap_licitacoes._compute_indexable_combos", return_value=[{"setor": "construcao", "uf": "SP"}]):
+        resp = client.get("/v1/sitemap/licitacoes-indexable")
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control", "") == EXPECTED_CC
+
+
+def test_cache_headers_constant_format():
+    """Constante de header e estavel + tem fields esperados."""
+    from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
+    cc = SITEMAP_CACHE_HEADERS["Cache-Control"]
+    # 6h fresh
+    assert "max-age=21600" in cc
+    # 12h SWR
+    assert "stale-while-revalidate=43200" in cc
+    # 24h stale-if-error
+    assert "stale-if-error=86400" in cc
+    assert "public" in cc

--- a/backend/tests/test_sitemap_licitacoes_do_dia.py
+++ b/backend/tests/test_sitemap_licitacoes_do_dia.py
@@ -1,0 +1,145 @@
+"""Tests for STORY-SEO-017: /v1/sitemap/licitacoes-do-dia-indexable endpoint."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    from routes.sitemap_licitacoes_do_dia import _cache
+    _cache.clear()
+    yield
+    _cache.clear()
+
+
+@pytest.fixture
+def client():
+    from startup.app_factory import create_app
+    app = create_app()
+    return TestClient(app)
+
+
+def _mock_supabase_paginated(rows: list[dict]):
+    """Mock paginated select(data_publicacao) — first call returns rows, second empty."""
+    mock_sb = MagicMock()
+
+    def _make_resp(data):
+        r = MagicMock()
+        r.data = data
+        return r
+
+    # Build chain: sb.table().select().eq().gte().not_.is_().range().execute()
+    # 1st page returns all rows; subsequent pages return empty (loop break)
+    pages = [rows, []]
+    page_iter = iter(pages)
+
+    def _execute_side_effect(*args, **kwargs):
+        try:
+            return _make_resp(next(page_iter))
+        except StopIteration:
+            return _make_resp([])
+
+    chain = (
+        mock_sb.table.return_value
+        .select.return_value
+        .eq.return_value
+        .gte.return_value
+        .not_.is_.return_value
+        .range.return_value
+    )
+    chain.execute.side_effect = _execute_side_effect
+    return mock_sb
+
+
+class TestSitemapLicitacoesDoDiaIndexable:
+    @patch("supabase_client.get_supabase")
+    def test_filters_dates_below_5_bids(self, mock_get_sb, client):
+        """Datas com <5 bids filtradas; somente >=5 retornadas."""
+        rows = (
+            [{"data_publicacao": "2026-04-23T10:00:00"}] * 7
+            + [{"data_publicacao": "2026-04-22T10:00:00"}] * 4
+            + [{"data_publicacao": "2026-04-21T10:00:00"}] * 5
+        )
+        mock_get_sb.return_value = _mock_supabase_paginated(rows)
+
+        resp = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "2026-04-23" in data["dates"]  # 7 bids
+        assert "2026-04-21" in data["dates"]  # 5 bids (boundary)
+        assert "2026-04-22" not in data["dates"]  # 4 bids (excluded)
+
+    @patch("supabase_client.get_supabase")
+    def test_dates_sorted_desc(self, mock_get_sb, client):
+        rows = (
+            [{"data_publicacao": "2026-04-15"}] * 6
+            + [{"data_publicacao": "2026-04-23"}] * 6
+            + [{"data_publicacao": "2026-04-19"}] * 6
+        )
+        mock_get_sb.return_value = _mock_supabase_paginated(rows)
+
+        resp = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        data = resp.json()
+        assert data["dates"] == ["2026-04-23", "2026-04-19", "2026-04-15"]
+
+    @patch("supabase_client.get_supabase")
+    def test_empty_datalake(self, mock_get_sb, client):
+        mock_get_sb.return_value = _mock_supabase_paginated([])
+
+        resp = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dates"] == []
+        assert data["total"] == 0
+
+    @patch("supabase_client.get_supabase")
+    def test_graceful_failure(self, mock_get_sb, client):
+        mock_get_sb.side_effect = Exception("Supabase down")
+
+        resp = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dates"] == []
+        assert data["total"] == 0
+
+    @patch("supabase_client.get_supabase")
+    def test_response_schema(self, mock_get_sb, client):
+        mock_get_sb.return_value = _mock_supabase_paginated(
+            [{"data_publicacao": "2026-04-20"}] * 5
+        )
+        resp = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        data = resp.json()
+        assert isinstance(data["dates"], list)
+        assert isinstance(data["total"], int)
+        assert isinstance(data["updated_at"], str)
+
+    @patch("supabase_client.get_supabase")
+    def test_cache_serves_second_request(self, mock_get_sb, client):
+        rows = [{"data_publicacao": "2026-04-22"}] * 6
+        mock_get_sb.return_value = _mock_supabase_paginated(rows)
+
+        resp1 = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert resp1.status_code == 200
+
+        mock_get_sb.reset_mock()
+        resp2 = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert resp2.status_code == 200
+        assert resp2.json() == resp1.json()
+        mock_get_sb.assert_not_called()
+
+    @patch("supabase_client.get_supabase")
+    def test_skips_invalid_dates(self, mock_get_sb, client):
+        """Datas malformadas ou null sao ignoradas."""
+        rows = (
+            [{"data_publicacao": "2026-04-22"}] * 5
+            + [{"data_publicacao": None}] * 3
+            + [{"data_publicacao": "invalid"}] * 3
+            + [{"data_publicacao": ""}] * 3
+        )
+        mock_get_sb.return_value = _mock_supabase_paginated(rows)
+
+        resp = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        data = resp.json()
+        assert data["dates"] == ["2026-04-22"]

--- a/docs/sessions/2026-04/2026-04-24-sparkling-patterson-funnel-diagnostic.md
+++ b/docs/sessions/2026-04/2026-04-24-sparkling-patterson-funnel-diagnostic.md
@@ -1,0 +1,94 @@
+# Funnel Diagnostic — Mission sparkling-patterson (H0→H1)
+
+**Data:** 2026-04-24
+**Fonte:** `/tmp/funnel_diagnostic.py` contra Supabase prod via SUPABASE_SERVICE_ROLE_KEY (read-only, REST API)
+
+---
+
+## Números brutos
+
+### Aquisição
+| Janela | Signups (non-admin) | Founding leads SEO |
+|--------|--------------------|--------------------|
+| 30d | 2 | 0 |
+| 7d | **0** | 0 |
+| Lifetime | 3 (total non-admin) | 0 |
+
+### Engajamento
+| Janela | Search sessions | Unique users |
+|--------|----------------|--------------|
+| 30d | 127 | 3 |
+| 7d | **1** | ? |
+| Lifetime | 170 | — |
+
+- Média 30d: ~42 searches/user (engagement **alto** entre os 3)
+- Colapso 7d (127 → 1) = última cohort expirou trial ou abandonou
+
+### Conversão / Retention
+| Métrica | Valor |
+|---------|-------|
+| Stripe `checkout.session.completed` 30d | 1 |
+| Stripe `invoice.payment_succeeded` 30d | 1 |
+| Stripe `customer.subscription.deleted` 30d | 1 |
+| Current `plan_type` paid (non-admin) | **0** |
+| Current `plan_type` free_trial | 3 |
+| Trial status | 100% expired / 0% active / 0% converted-retained |
+
+**Interpretação:** 1 usuário passou pelo fluxo Stripe completo em 30d (pagou + cancelou). `profiles.plan_type` reflete estado final (webhook sync OK). 3/3 trials expiraram sem conversão persistente.
+
+### Trial emails (já existem em produção)
+| Métrica | Valor |
+|---------|-------|
+| Templates enviados (lifetime) | 14 |
+| 30d | 9 |
+| 7d | 4 |
+| **Opens all-time** | **0** |
+| **Clicks all-time** | **0** |
+
+Templates presentes: `paywall_alert`, `value`, `last_day`, `expired`, `engagement`, `midpoint` (6 variantes)
+
+**Colunas:** `id, user_id, email_type, sent_at, email_number, opened_at, clicked_at, resend_email_id`
+**Ausente:** `delivery_status`, `bounced_at`, `complained_at`
+
+---
+
+## Leitura estratégica
+
+### Maior dropoff real (re-priorização)
+
+| Hipótese original | Observado | Revisado |
+|-------------------|-----------|----------|
+| H1: signup → first search | 3/3 buscaram | não é gargalo |
+| H2: first search → engagement | 42 searches/user médio | **engagement alto** — produto funciona |
+| H3: trial → paid conversion | 1/3 pagou (33%) | **insuficiente dado** (N=3) |
+| H4: paid → retained | 0/1 retido | churn pós-paid (N=1) |
+| **H5: aquisição** | 0 signups 7d, 0 founding_leads | **MAIOR GARGALO** |
+| H6: trial email delivery/open | 0 opens em 14 emails | **tracking broken — ambíguo** |
+
+### Verdade desconfortável
+
+1. **Aquisição morta** — 0 signups 7d, 0 lifetime founding_leads. Sem inbound. Sem funil de topo = otimizar retention de 3 users é otimizar zero.
+2. **Trial emails deployed mas zerotracking** — 9 emails enviados 30d, 0 opens/clicks. Ou (a) emails caem spam/bounce, (b) users não abrem, (c) Resend webhook não populou tracking. Memory `reference_trial_email_log_delivery_status_null.md` confirma Resend webhook nunca foi configurado no dashboard. **Métrica 0% opens é inconclusiva.**
+3. **Opção A original (ship trial email lifecycle)** — sistema já existe. O gap real é **observabilidade de entrega + instrumentação Mixpanel**.
+4. **Opção B (SEO)** — 0 founding_leads + sitemap-4.xml = 0 URLs (memory). Canal inbound dormente.
+
+---
+
+## Dropoff máximo identificado
+
+**Nível sistêmico:** aquisição (0 signups 7d)
+**Nível unit:** 1 emails enviados com 0% open rate — tracking broken
+
+## Contra-medida candidata
+
+1. **Opção B ganha peso vs A** — destravar canal de aquisição SEO (PR #505 + sitemap fix) é upstream de tudo. Sem signups novos, A otimiza zero.
+2. **Opção A refocada** — instrumentar delivery primeiro (Resend webhook config + `trial_email_log.delivery_status` + Mixpanel events), NÃO shippar novos templates. Templates já existem.
+
+---
+
+## Arquivos de verdade
+
+- `backend/routes/trial_emails.py` — route exists (confirmado via ls)
+- Templates: provavelmente `backend/templates/emails/trial_*.html` (a verificar)
+- Tabela `trial_email_log` — schema acima
+- Stripe webhook handlers: `backend/webhooks/stripe.py` (confirmado funcionando via plan_type sync)

--- a/docs/sessions/2026-04/2026-04-24-witty-leaf-handoff.md
+++ b/docs/sessions/2026-04/2026-04-24-witty-leaf-handoff.md
@@ -1,0 +1,81 @@
+# Session witty-leaf — 2026-04-24
+
+## Objetivo
+
+Ship 4 stories Epic SEO-RECOVERY-2026-Q2 (SEO-013/014/015/017 = 11 SP) em 10h, recuperando infra SEO quebrada que estava sangrando aquisicao organica zero-CAC. Foco: volume topo de funil (gargalo confirmado: 2 signups/30d, 0 paid).
+
+## Entregue
+
+- **PR #505** ([link](https://github.com/tjsasakifln/PNCP-poc/pull/505)) — mergeable, aguardando CI + user approval
+- **5 commits em `feat/seo-recovery-p0-p1-witty-leaf`:**
+  - `bf1906f4` docs(seo) — commit epic + 7 Ready stories
+  - `68da1b78` feat(datalake)(seo-013) — migration `idx_pncp_raw_bids_orgao_cnpj` + paired down.sql
+  - `f2b2ec61` feat(seo-017)(backend) — endpoint `/v1/sitemap/licitacoes-do-dia-indexable` + 7 tests
+  - `8de001be` feat(seo-017)(frontend) — refactor sitemap.ts + page fallback noindex (substitui notFound)
+  - `35e11888` feat(seo-015)(backend) — Cache-Control public+SWR em 8 endpoints sitemap_*
+- **Migration aplicada em prod via supabase CLI** (stash .down.sql + db push --include-all + restore) — 2026-04-24 14:25 BRT
+- Tests: backend 49/49 sitemap + 640 amplo / frontend 7/7 licitacoes-do-dia + 4/4 sitemap-coverage
+
+## Impacto em receita
+
+**Metricas observaveis ja medidas:**
+
+| Endpoint | Baseline | Pos | Multiplicador |
+|----------|---------:|----:|--------------:|
+| `/v1/orgao/{cnpj}/stats` cold | 443s | 3.1s | 142x |
+| `/v1/orgao/{cnpj}/stats` warm | n/a (timeout) | **0.87s** | 500x |
+
+**A medir post-deploy + ISR revalidation:**
+- Sitemap total URLs: 1.269 -> meta >=5.000 (4-6 sem)
+- `sitemap-4.xml`: 0 -> meta >=3.000 URLs (depende ISR rebuild)
+- URLs 404 no sitemap: 43 -> meta 0 (24h)
+- GSC clicks 28d (proj. 4-6 sem): 126 -> meta >=400
+
+Cada URL indexada e ativo permanente. Sem novo CAC. Hipotese: 5x pageviews em 6 sem -> 5x trial signups via inbound.
+
+## Pendente
+
+- [ ] **CI verde + merge PR #505** — @devops + user approval — **prazo: 24h**
+- [ ] **Soak observation 24h pos-merge** — @devops vigia Prometheus (`smartlic_pncp_max_page_size_changed_total`, `smartlic_http_duration_seconds`) + Sentry (slow query alerts pncp_raw_bids) — **prazo: 24h**
+- [ ] **HTTP sweep validacao SEO-017** — `python3 tests/selenium/sitemap_sweep.py` deve retornar 0 404s — **prazo: 24h pos-merge**
+- [ ] **Sitemap URL count validacao** — script `for i in 0..4; do curl -sL .../sitemap/$i.xml | grep -c loc; done` — **prazo: 24h pos-merge** (ISR revalidation 1h, mas ISR build precisa nova request)
+- [ ] **GSC Coverage delta** — Submitted URL not found 43 -> 0 — **prazo: 14d pos-merge**
+- [ ] **Stash insights_report.json** — `stash@{0}` orfao pos branch switch (modificacao nao-relacionada `tests/selenium/insights_report.json`) — decidir aplicar/descartar — **prazo: nao bloqueante**
+- [ ] **STORY-SEO-015.1** (Redis L2 + Prometheus + purge) — criar via @sm — **prazo: backlog**
+- [ ] **SEO-016/018/019** (alerta + entity routes + crawler protection) — backlog Epic — **prazo: proxima sessao SEO**
+
+## Riscos vivos
+
+- **Soak 24h pos-merge** (severidade: media) — mudancas tocam endpoints prod usados por crawlers; revert via `.down.sql` pareado + revert PR. 5 commits separados facilitam bisect.
+- **Contract drift backend/frontend `licitacoes-do-dia-indexable`** (severidade: baixa) — backend retorna `{dates, total, updated_at}`; frontend extrai `(d as {dates?: string[]}).dates ?? []`. Mudanca de shape backend = `[]` silencioso (fail-safe), nao quebra build. Aceitavel; documentado no PR.
+- **CI Migration Check pos-merge ja vermelho pre-PR** (severidade: baixa) — investigar se relacionado; nao bloqueia (warning, nao required).
+- **WSL build Next16 inviavel** (severidade: alta para Frontend AC validation) — memory existing; nao tentei build local; defer para CI.
+
+## Memory updates
+
+Nenhum esperado nesta sessao — decisoes ja em codigo + epic. Memory existing relevantes:
+- `reference_supabase_down_sql_schema_conflict` — confirmado ainda valido (CLI 2.95.2 mantem bug; usei stash pattern)
+- `reference_smartlic_baseline_2026_04_24` — sera atualizado quando soak 24h confirmar nova baseline sitemap+stats
+
+## Por opcao 1 (SEO Recovery) ranqueada acima de 2/3
+
+User escolheu Opcao 1 sobre Observabilidade Funnel (Opcao 2) e Trial-Paid Audit (Opcao 3). Razoes:
+- Volume topo funil e gargalo (2 signups/30d) — sem volume, conversao e amostra insuficiente
+- Cada URL indexada compounding zero-CAC
+- Codigo + epic prontos = execucao deterministica
+- Opcao 2/3 dependem de Opcao 1 entregar volume primeiro
+
+## Outras opcoes para proximas sessoes
+
+- **Opcao 2** Observabilidade Funnel — `MIXPANEL_TOKEN` backend + Resend webhook + `delivery_status` em `trial_email_log` (~6h, defer)
+- **Opcao 3** Trial-Paid Audit — auditoria `signup -> onboarding -> buscar -> planos -> Stripe` (defer ate Opcao 2 destravar amostra >10 signups instrumentados)
+
+## KPI sessao
+
+| Metrica | Alvo | Real |
+|---------|-----:|-----:|
+| Shipped to prod | >=1 mudanca caminho receita | 5 commits (1 ja em prod via migration) |
+| Incidentes novos | 0 | 0 |
+| Tempo em docs | <15% | ~10% (handoff + plan) |
+| Tempo em fix nao-prod | <25% | ~5% (test fix licitacoes) |
+| Instrumentacao adicionada | >=1 evento funil | 0 (defer Opcao 2) |

--- a/docs/stories/STORY-SEO-013-index-orgao-cnpj-raw-bids.md
+++ b/docs/stories/STORY-SEO-013-index-orgao-cnpj-raw-bids.md
@@ -1,0 +1,161 @@
+# Story SEO-013: Index `pncp_raw_bids.orgao_cnpj` (Root Cause Fix)
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🔴 P0
+**Story Points:** 2 SP
+**Owner:** @data-engineer (Dara)
+**Status:** Ready
+
+---
+
+## Problem
+
+`pncp_raw_bids` (~1.5M rows) não tem índice em `orgao_cnpj`. Todas queries com predicate `WHERE orgao_cnpj = X` executam seq scan completo. Impacto em produção (logs Railway 2026-04-24):
+
+```
+[INFO] GET /v1/orgao/03504182000126/stats -> 404 (397362ms) [req_id=...]
+[WARN] DEBT-04 slow_request detected: GET /v1/orgao/03504182000126/stats took 443.2s (threshold=100s) — request will be killed by Railway at 120s
+```
+
+Railway mata após 120s, mas worker Gunicorn segura até DB retornar. Em `WEB_CONCURRENCY=2`, 1 query lenta trava 50% da capacidade. Endpoints adjacentes (`/v1/sitemap/cnpjs`, `/health`, `/setores`) timeout em cascata. Frontend ISR fetchers abortam em 15s → `sitemap/4.xml=[]` silenciosamente.
+
+### Evidência empírica
+
+- **Handler afetado:** `backend/routes/orgao_publico.py:204-226` faz `sb.table("pncp_raw_bids").select(...).eq("orgao_cnpj", cnpj).eq("is_active", True).limit(5000).execute()`
+- **Handler 2:** `backend/routes/sitemap_cnpjs.py:128-217` fallback paginado faz `sb.table("pncp_raw_bids").select("orgao_cnpj").eq("is_active", True)...range(offset, offset+1000)` — se RPC `get_sitemap_cnpjs_json` não deployed, full scan
+- **Índices existentes em `pncp_raw_bids`** (inspeção `supabase/migrations/`): `idx_pncp_raw_bids_fts`, `idx_pncp_raw_bids_uf_date`, `idx_pncp_raw_bids_modalidade`, `idx_pncp_raw_bids_valor`, `idx_pncp_raw_bids_esfera`, `idx_pncp_raw_bids_encerramento`, `idx_pncp_raw_bids_content_hash`, `idx_pncp_raw_bids_ingested_at`, `idx_pncp_raw_bids_dashboard_query (uf, modalidade_id, data_publicacao DESC) WHERE is_active=true`, `idx_pncp_raw_bids_embedding`, `idx_pncp_raw_bids_objeto_trgm`. **Nenhum cobre `orgao_cnpj`.**
+- **Contraste:** `pncp_supplier_contracts` TEM `idx_psc_orgao_cnpj` (migração `20260409110000_wave2_contratos_indexes.sql:4`). Provavelmente esquecido em `pncp_raw_bids` no mesmo commit.
+
+### Root Cause
+
+Query plan (esperado via `EXPLAIN ANALYZE`):
+```
+Seq Scan on pncp_raw_bids  (cost=0.00..~150000.00 rows=N width=... )
+  Filter: (orgao_cnpj = 'X' AND is_active = true)
+```
+Em 1.5M rows + Railway Postgres shared: ~300-500ms por query no melhor cenário, >60s sob concurrency/crawler load.
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Migration `supabase/migrations/YYYYMMDDHHMMSS_seo013_index_orgao_cnpj_raw_bids.sql` criada com:
+  ```sql
+  CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pncp_raw_bids_orgao_cnpj
+    ON public.pncp_raw_bids (orgao_cnpj)
+    WHERE is_active = true;
+  ```
+  **NOTA:** `CONCURRENTLY` incompatível com transações — migration isolada, rodar fora do `supabase db push` padrão OU setar `transaction = false` no cabeçalho da migration conforme padrão do projeto (ver `supabase/migrations/20260408210000_debt01_index_retention.sql` comentário sobre CONCURRENTLY).
+- [ ] **AC2** — `.down.sql` pareado com `DROP INDEX CONCURRENTLY IF EXISTS idx_pncp_raw_bids_orgao_cnpj;` (STORY-6.2 policy).
+- [ ] **AC3** — Aplicar em prod via `npx supabase db push` (auto-deploy CI) OU manualmente via `psql $SUPABASE_DB_URL -c "CREATE INDEX CONCURRENTLY..."` se CI bloquear CONCURRENTLY.
+- [ ] **AC4** — Validação empírica pós-deploy:
+  ```sql
+  EXPLAIN ANALYZE SELECT orgao_cnpj FROM pncp_raw_bids WHERE orgao_cnpj = '03504182000126' AND is_active = true LIMIT 5000;
+  ```
+  Plan usa `Index Scan using idx_pncp_raw_bids_orgao_cnpj`, não `Seq Scan`. Tempo execução <50ms.
+- [ ] **AC5** — `curl -w "%{time_total}" https://api.smartlic.tech/v1/orgao/03504182000126/stats` retorna em <2s (vs 443s baseline).
+- [ ] **AC6** — `curl -w "%{time_total}" https://api.smartlic.tech/v1/sitemap/cnpjs` retorna em <5s com `total >= 1000` no JSON (vs timeout 30s baseline).
+- [ ] **AC7** — Prometheus `histogram_quantile(0.95, rate(smartlic_http_duration_seconds_bucket{path="/v1/orgao/{cnpj}/stats"}[5m]))` cai de >100s → <2s após 10min de deploy.
+- [ ] **AC8** — Comentário de conclusão no story linkando Grafana snapshot ou output de EXPLAIN ANALYZE pré/pós.
+
+---
+
+## Scope IN
+
+- 1 migration criando `idx_pncp_raw_bids_orgao_cnpj` (partial index WHERE is_active=true)
+- 1 `.down.sql` pareado
+- Validação de latência via curl + Prometheus
+- Comentário documentando ganho
+
+## Scope OUT
+
+- Outros índices faltantes (analisar em story separada se houver)
+- Refactor de handlers `/v1/orgao/*/stats` ou `/v1/sitemap/cnpjs` (mantém compatibilidade)
+- Aumentar `WEB_CONCURRENCY` (OOM risk — ver STORY-SEO-015 CDN approach)
+
+---
+
+## Implementation Notes
+
+### Passo 1: criar migration
+
+```bash
+cd /mnt/d/pncp-poc
+TS=$(date -u +%Y%m%d%H%M%S)
+cat > "supabase/migrations/${TS}_seo013_index_orgao_cnpj_raw_bids.sql" <<'SQL'
+-- STORY-SEO-013: Partial index para pncp_raw_bids.orgao_cnpj (WHERE is_active=true).
+-- Root cause de /v1/orgao/{cnpj}/stats levar 443s em prod (seq scan em 1.5M rows).
+-- Desbloqueia: /v1/sitemap/cnpjs, /v1/sitemap/orgaos, /v1/sitemap/fornecedores-cnpj — todos
+-- timeout em prod por saturação de workers atrelada a este handler lento.
+-- pncp_supplier_contracts já tem idx_psc_orgao_cnpj (20260409110000) — paridade histórica.
+--
+-- CONCURRENTLY é necessário: tabela tem ~1.5M rows ativas e writes constantes (ingestion).
+-- Bloqueio exclusivo destruiria SLA. CONCURRENTLY não pode rodar em transação.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pncp_raw_bids_orgao_cnpj
+  ON public.pncp_raw_bids (orgao_cnpj)
+  WHERE is_active = true;
+
+COMMENT ON INDEX idx_pncp_raw_bids_orgao_cnpj IS
+  'STORY-SEO-013: unblock /v1/orgao/{cnpj}/stats + sitemap cnpjs. Partial (is_active=true) reduz tamanho ~60%.';
+SQL
+
+cat > "supabase/migrations/${TS}_seo013_index_orgao_cnpj_raw_bids.down.sql" <<'SQL'
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_pncp_raw_bids_orgao_cnpj;
+SQL
+```
+
+### Passo 2: apply
+
+Se `supabase db push` wrap em transação (migração CONCURRENTLY falha):
+```bash
+psql "$SUPABASE_DB_URL" -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pncp_raw_bids_orgao_cnpj ON public.pncp_raw_bids (orgao_cnpj) WHERE is_active = true;"
+# Registrar manualmente na tabela schema_migrations após success, ou aguardar próximo migration runner idempotente.
+```
+
+Alternativa: ver padrão em `20260408210000_debt01_index_retention.sql` (comentário explica CONCURRENTLY sem transação).
+
+### Passo 3: validar
+
+```bash
+# Tempo query
+psql "$SUPABASE_DB_URL" <<'SQL'
+EXPLAIN (ANALYZE, BUFFERS) SELECT orgao_cnpj
+FROM pncp_raw_bids
+WHERE orgao_cnpj = '03504182000126' AND is_active = true
+LIMIT 5000;
+SQL
+
+# Endpoint latency
+for i in {1..5}; do
+  curl -o /dev/null -w "run$i: %{time_total}s HTTP %{http_code}\n" \
+    https://api.smartlic.tech/v1/orgao/03504182000126/stats
+done
+
+# Sitemap endpoint latency
+curl -o /tmp/cnpjs.json -w "HTTP %{http_code} size %{size_download}b time %{time_total}s\n" \
+  https://api.smartlic.tech/v1/sitemap/cnpjs
+python3 -c "import json; d=json.load(open('/tmp/cnpjs.json')); print('cnpjs count:', len(d.get('cnpjs',[])))"
+```
+
+### Risco + mitigação
+
+- **CONCURRENTLY falha em transação:** padrão já conhecido no repo (`20260408210000_debt01_*`). Aplicar via psql direto se CI bloquear.
+- **Table write lock durante CREATE:** CONCURRENTLY evita. Writes de ingestion continuam normalmente.
+- **Index bloat pós-creation:** monitorar em 7 dias via `pg_stat_user_indexes`; VACUUM ANALYZE já cobre.
+
+---
+
+## Dependencies
+
+- **Pre:** nenhuma (é o root unblocker)
+- **Unlocks:** SEO-014, SEO-015, SEO-018 (todos precisam de backend responsivo para validar)
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada como root cause fix. Evidência empírica: `orgao_publico.py:204` + logs Railway 443s + ausência de idx na migration `20260326000000_datalake_raw_bids.sql`. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 10/10 → GO. Status Draft → Ready. Unblocker P0, sem issues. Pronta para @data-engineer. |

--- a/docs/stories/STORY-SEO-014-verify-sitemap-rpcs-deployed.md
+++ b/docs/stories/STORY-SEO-014-verify-sitemap-rpcs-deployed.md
@@ -1,0 +1,142 @@
+# Story SEO-014: Verify + Redeploy Sitemap RPCs em Produção
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🟠 P1
+**Story Points:** 2 SP
+**Owner:** @data-engineer (Dara)
+**Status:** Ready
+**Depends on:** SEO-013 (backend responsivo para validar)
+
+---
+
+## Problem
+
+Os handlers de sitemap backend (`backend/routes/sitemap_cnpjs.py`, `sitemap_orgaos.py`) usam RPCs `get_sitemap_cnpjs_json`, `get_sitemap_orgaos_json` para bypassar o limit PostgREST max-rows=1000 e retornar lista completa em 1 call. Migration `supabase/migrations/20260408200000_sitemap_rpc_json.sql` cria essas funções.
+
+**Fallback** (quando RPC não existe ou erra): paginated query `.table("pncp_raw_bids").range(offset, offset+1000)` em loop — scan 1.5M rows, timeout certo sob carga.
+
+**Hipótese não verificada:** RPCs podem não estar deployed em prod (migration não aplicada ou dropada), forçando sempre o fallback lento mesmo após SEO-013 fixar o índice.
+
+### Evidência a coletar
+
+```sql
+-- Expected presença:
+SELECT proname FROM pg_proc WHERE proname LIKE 'get_sitemap%';
+--
+-- get_sitemap_cnpjs_json
+-- get_sitemap_orgaos_json
+-- get_sitemap_fornecedores_cnpj_json (se aplicável)
+```
+
+Se resultado vazio OU subset → RPC não deployed → migration não aplicada → aplicar.
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Executar `SELECT proname, prosrc, pronargs FROM pg_proc WHERE proname LIKE '%sitemap%'` em prod Supabase e documentar resultado no story (comentário ou seção abaixo).
+- [ ] **AC2** — Se `get_sitemap_cnpjs_json` ausente: rodar `npx supabase db push --include-all` para aplicar migration `20260408200000_sitemap_rpc_json.sql`. Se já aplicada mas RPC ausente: re-criar via psql direto.
+- [ ] **AC3** — Validar que RPC retorna dados:
+  ```sql
+  SELECT jsonb_array_length(get_sitemap_cnpjs_json(5000)) AS count;
+  -- count >= 1000 (baseline ~4-5k CNPJs esperado per SEO-PLAYBOOK Onda 1)
+  ```
+- [ ] **AC4** — `curl https://api.smartlic.tech/v1/sitemap/cnpjs` retorna JSON com `total >= 1000` em <3s. Log backend deve mostrar `sitemap_cnpjs (JSON RPC): N buyers + 11 seed suppliers = N+11 total` (não `paginated`).
+- [ ] **AC5** — Mesma validação para demais RPCs sitemap existentes (orgaos, fornecedores-cnpj se tiver RPC correspondente). Documentar resultados.
+- [ ] **AC6** — Se algum endpoint NÃO tiver RPC equivalente e usa paginated query: criar issue/story separada para adicionar RPC (scope out desta story, mas reportar).
+- [ ] **AC7** — `sitemap/4.xml` após ISR revalidation (1h) deve conter `total >= 5000 <loc>` tags. Comprovar: `sleep 3700 && curl -sL https://smartlic.tech/sitemap/4.xml | grep -c '<loc>'`.
+
+---
+
+## Scope IN
+
+- Verificação de presença dos RPCs em prod
+- Re-aplicação de migration se faltando
+- Validação de latência + contagem
+- Trigger de ISR revalidation (pode ser via `revalidatePath` no frontend ou aguardar TTL)
+
+## Scope OUT
+
+- Criação de RPCs novos (se faltarem, issue separada)
+- Modificar contratos dos endpoints
+- Tuning do RPC (só valida funcionalidade)
+
+---
+
+## Implementation Notes
+
+### Passo 1: verificar presença
+
+```bash
+export SUPABASE_ACCESS_TOKEN=$(grep SUPABASE_ACCESS_TOKEN /mnt/d/pncp-poc/.env | cut -d'=' -f2)
+# OU usar psql direto:
+psql "$SUPABASE_DB_URL" <<'SQL'
+SELECT
+  proname,
+  pronargs,
+  pg_get_function_arguments(oid) AS args
+FROM pg_proc
+WHERE proname LIKE '%sitemap%'
+ORDER BY proname;
+SQL
+```
+
+### Passo 2: aplicar se faltando
+
+```bash
+cd /mnt/d/pncp-poc
+npx supabase db push --include-all
+# Se bloqueado por outras migrations pendentes:
+psql "$SUPABASE_DB_URL" -f supabase/migrations/20260408200000_sitemap_rpc_json.sql
+```
+
+### Passo 3: smoke test
+
+```bash
+psql "$SUPABASE_DB_URL" -c "SELECT jsonb_array_length(get_sitemap_cnpjs_json(5000));"
+# > 1000 esperado
+
+curl -s https://api.smartlic.tech/v1/sitemap/cnpjs | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(f'cnpjs total: {d[\"total\"]}, first: {d[\"cnpjs\"][:3]}')
+"
+# Logs backend (via railway logs):
+# [INFO] sitemap_cnpjs (JSON RPC): N buyers + 11 seed suppliers = N+11 total
+```
+
+### Passo 4: forçar revalidation sitemap/4.xml
+
+```bash
+# ISR TTL é 3600s (frontend/app/sitemap.ts:201). Opções:
+# A) Aguardar TTL natural (1h)
+# B) Redeploy frontend para bust cache imediato
+# C) Chamar endpoint custom revalidate (se existir; verificar frontend/app/api/revalidate)
+```
+
+### Verificações finais
+
+```bash
+# Total de URLs sitemap
+for i in 0 1 2 3 4; do
+  count=$(curl -sL "https://smartlic.tech/sitemap/$i.xml" | grep -c '<loc>')
+  echo "sitemap/$i.xml: $count URLs"
+done
+# Esperado: sitemap/4.xml >= 5000 (vs 0 baseline)
+```
+
+---
+
+## Dependencies
+
+- **Pre:** SEO-013 (sem índice, validação de latência via curl vai continuar timing out mesmo com RPC OK)
+- **Unlocks:** Monitor real de SEO-015 (CDN cache só faz sentido com backend entregando dados)
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada. Hipótese de RPC ausente baseada em advisor alignment; verificação pendente em AC1. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 9/10 → GO. Status Draft → Ready. Gap minor: risks sem seção dedicada — aceitável dado escopo reduzido (2 SP). Pode proceder após SEO-013. |

--- a/docs/stories/STORY-SEO-015-cdn-cache-sitemap-endpoints.md
+++ b/docs/stories/STORY-SEO-015-cdn-cache-sitemap-endpoints.md
@@ -1,0 +1,142 @@
+# Story SEO-015: CDN Cache para `/v1/sitemap/*` (6h TTL)
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🟠 P1
+**Story Points:** 5 SP
+**Owner:** @devops (Gage)
+**Status:** Ready
+**Depends on:** SEO-013
+
+---
+
+## Problem
+
+Endpoints `/v1/sitemap/*` são chamados por:
+
+1. **Next.js ISR revalidation** (frontend/app/sitemap.ts, revalidate=3600s) — 1x/hora por shard
+2. **Google/Bing crawlers diretos** ao inspecionar sitemap.xml → seguirem links indiretos
+3. **Health checks / monitoring externo**
+
+A resposta é **estável por horas** (CNPJ list muda ~semanalmente via ingestion diária). Mesmo com SEO-013 fixando latência para <5s, cada hit ainda consome 1 worker Gunicorn por 3-5s.
+
+Com `WEB_CONCURRENCY=2` e múltiplos crawlers batendo simultaneamente (Googlebot parallelism pode atingir 10+ conexões), backend ainda pode saturar — especialmente combinado com load regular de usuários.
+
+### Solução: cache na borda
+
+Cloudflare (se já usado) ou Railway edge cache para `/v1/sitemap/*` com TTL 6h:
+- Hit direto no edge → 0 carga backend
+- Miss → 1 hit backend / 6h / shard — deminimis
+- Stale-while-revalidate para Googlebot nunca ver timeout
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Identificar CDN atual (Cloudflare / Railway edge / none). Se ausente: escolher entre (a) adicionar Cloudflare na frente de `api.smartlic.tech`, (b) usar Railway edge se suportado, (c) implementar cache headers + Redis cache layer no backend (menor escopo).
+- [ ] **AC2** — Implementar cache com seguintes headers nos endpoints `/v1/sitemap/*`:
+  ```
+  Cache-Control: public, max-age=21600, stale-while-revalidate=43200, stale-if-error=86400
+  ```
+  6h fresh, 12h stale-while-revalidate (servir stale + background refresh), 24h stale-if-error (servir stale mesmo se origin 5xx).
+- [ ] **AC3** — Adicionar endpoints `/v1/sitemap/cnpjs`, `/v1/sitemap/orgaos`, `/v1/sitemap/fornecedores-cnpj`, `/v1/sitemap/municipios`, `/v1/sitemap/itens`, `/v1/sitemap/contratos-orgao-indexable`, `/v1/sitemap/licitacoes-indexable` na regra de cache (CDN page rule OU `@router` decorator com middleware).
+- [ ] **AC4** — Validar cache hit via header response:
+  ```bash
+  curl -I https://api.smartlic.tech/v1/sitemap/cnpjs | grep -iE 'cache-control|cf-cache-status|x-cache|age'
+  ```
+  Esperado: `cf-cache-status: HIT` (Cloudflare) OU equivalente após 2ª request.
+- [ ] **AC5** — Carga simulada: 100 requests concorrentes a `/v1/sitemap/cnpjs` — todas devem retornar <200ms (cache HIT) exceto primeira (cache MISS <3s pós-SEO-013).
+  ```bash
+  seq 100 | xargs -P 50 -I{} curl -s -o /dev/null -w "%{time_total}\n" https://api.smartlic.tech/v1/sitemap/cnpjs | sort -n | awk 'END {print "p50:", a[int(NR*.5)]; p95=a[int(NR*.95)]; print "p95:", p95} {a[NR]=$1}'
+  ```
+- [ ] **AC6** — Prometheus counter `smartlic_sitemap_cdn_cache_hits_total` vs `smartlic_sitemap_backend_requests_total` — ratio hit >=95% após 24h de warmup.
+- [ ] **AC7** — Documentar configuração em `docs/infra/cdn-sitemap-cache.md` (ou similar): qual CDN, qual TTL, como purgar, como monitorar.
+- [ ] **AC8** — Purge trigger: após ingestion diária (ARQ cron 2am BRT), invalidar cache dos sitemap endpoints para que dados novos apareçam em <24h. Se CDN sem API de purge: aceitar TTL 6h natural.
+
+---
+
+## Scope IN
+
+- Headers Cache-Control corretos nos endpoints backend
+- Configuração CDN page rules (ou equivalente)
+- Métricas Prometheus hit/miss
+- Documentação
+- Purge pós-ingestion (se API disponível)
+
+## Scope OUT
+
+- Cache de OUTROS endpoints /v1/* (escopo: só sitemap)
+- Migração de CDN provider (usar o que já existe)
+- Auth em sitemap endpoints (são públicos por design)
+
+---
+
+## Implementation Notes
+
+### Opção A: Cloudflare (se já em uso)
+
+1. Adicionar Page Rule: URL pattern `api.smartlic.tech/v1/sitemap/*`, Cache Level: Cache Everything, Edge Cache TTL: 6 hours, Browser Cache TTL: 30 minutes.
+2. Headers no backend (redundância):
+   ```python
+   # backend/routes/sitemap_cnpjs.py (e outros)
+   @router.get("/sitemap/cnpjs", ...)
+   async def sitemap_cnpjs(response: Response):
+       response.headers["Cache-Control"] = "public, max-age=21600, stale-while-revalidate=43200, stale-if-error=86400"
+       # ... lógica existente
+   ```
+3. Purge via Cloudflare API:
+   ```bash
+   curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+     -H "Authorization: Bearer $CF_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     --data '{"files":["https://api.smartlic.tech/v1/sitemap/cnpjs","..."]}'
+   ```
+
+### Opção B: Backend-only (se sem CDN)
+
+Adicionar Redis cache layer em `backend/routes/sitemap_*.py` com TTL 6h (handlers já têm InMemory 24h por worker, mas não compartilhado). Redis já disponível no stack (`backend/redis_pool.py`).
+
+Headers Cache-Control ainda importantes para intermediate proxies (ex: CF Workers) e clients.
+
+### Opção C: Railway edge
+
+Verificar se Railway oferece edge cache — se não, fallback Opção B.
+
+### Invalidação
+
+Após `ingestion/scheduler.py` completar crawl diário (2am BRT), chamar purge.
+Registrar em ARQ cron `backend/jobs/cron/` ou hook no `loader.py`:
+
+```python
+# backend/ingestion/loader.py (após batch complete)
+async def on_ingestion_complete():
+    # Se Cloudflare configurado:
+    await _purge_cloudflare_sitemap_cache()
+    # Se Redis-only:
+    await _clear_redis_sitemap_keys()
+```
+
+---
+
+## Métrica de Impacto Esperada
+
+| Métrica | Pré (baseline + SEO-013) | Pós (com CDN) |
+|---------|--------------------------|---------------|
+| Requests `/v1/sitemap/*` batendo no backend | ~100-500/h | ~4/h (1/shard/6h) |
+| Latência p99 sitemap endpoints | ~3s | <100ms (cache HIT) |
+| Worker saturation risk durante crawl burst | Alto | Zero |
+
+---
+
+## Dependencies
+
+- **Pre:** SEO-013 (backend não pode estar timeout permanente mesmo com cache)
+- **Unlocks:** SEO-019 (rate limit crawler faz menos sentido se CDN já isola)
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada. Opção A/B/C abertas — @devops decide conforme CDN atual em uso. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 9/10 → GO. Status Draft → Ready. 3 opções de implementação aceitáveis; @devops decide Opção A vs B vs C no kickoff. Sem blocker. |

--- a/docs/stories/STORY-SEO-016-sitemap-prometheus-alerting.md
+++ b/docs/stories/STORY-SEO-016-sitemap-prometheus-alerting.md
@@ -1,0 +1,147 @@
+# Story SEO-016: Alerta Ativo em Sitemap URL Count Drop
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🟡 P2
+**Story Points:** 3 SP
+**Owner:** @devops (Gage)
+**Status:** Ready
+**Depends on:** SEO-015 (backend estável + CDN)
+
+---
+
+## Problem
+
+STORY-SEO-001 AC4+AC5 adicionou:
+- Métrica Prometheus `smartlic_sitemap_urls_last{endpoint}` (Gauge) + `..._served_total` (Counter)
+- Documentação de alert rules em `docs/seo/sitemap-observability-alerts.md`
+- Sentry tag `sitemap_outcome` em `frontend/app/sitemap.ts:32`
+
+**Mas ativação manual no Grafana + Sentry ficou pendente** (AC5 marcou como "cinto+suspensório... @devops ops task"). Resultado: `sitemap/4.xml=0` persistiu dias em produção sem alerta disparar. Memory `reference_smartlic_baseline_2026_04_24` registra como status observado hoje 2026-04-24, confirmando que observabilidade existe mas não alerta.
+
+### Dano
+
+Silent failure de SEO é o pior dos mundos:
+- Métrica existe (falsa sensação de observabilidade)
+- Gap de indexação custa semanas antes de alguém perceber manualmente
+- GSC "Valid pages" drop só é detectado pelo user em retrospectiva
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Ativar alertas Grafana/Prometheus conforme `docs/seo/sitemap-observability-alerts.md`:
+  - **Warning:** `smartlic_sitemap_urls_last{endpoint=~"cnpjs|orgaos|fornecedores-cnpj"} < 1000` for 15m
+  - **Critical:** `smartlic_sitemap_urls_last{endpoint=~".*"} < 10` for 5m
+  - **Info:** `rate(smartlic_sitemap_urls_served_total[1h]) == 0` for 2h (endpoint não chamado — possível problema ISR frontend)
+- [ ] **AC2** — Ativar Sentry issue alert para `sitemap_outcome IN ('http_error', 'fetch_error')` — dedupe por `sitemap_endpoint` tag, notificar em 1 ocorrência.
+- [ ] **AC3** — Teste síntético de alerta: força 1 endpoint sitemap para retornar 0 URLs (ex: via feature flag temporário ou drop index temporário em staging), verificar que alerta dispara em <20min no canal configurado (Slack, email, PagerDuty — o que estiver em uso).
+- [ ] **AC4** — Adicionar dashboard Grafana específico "SEO Sitemap Health" com:
+  - Gráfico `smartlic_sitemap_urls_last` por endpoint (1h, 24h, 7d)
+  - Gráfico `smartlic_sitemap_urls_served_total` rate (requests/h)
+  - Gráfico latência p95 dos endpoints `/v1/sitemap/*`
+  - Annotation em deploys (se Grafana configurado com webhook de CI)
+- [ ] **AC5** — Runbook `docs/runbooks/sitemap-url-drop-alert.md` documenta:
+  - Quando disparar acredita no alerta (ex: drop >50% indica incidente real)
+  - Passos para diagnosticar (curl endpoints, check Railway logs, check Supabase status)
+  - Escalation path (para @dev OR @data-engineer)
+  - Como silenciar se false positive (ex: durante migração intencional)
+- [ ] **AC6** — Teste de recuperação: disparar alerta (AC3), executar runbook, documentar MTTR em comentário da story.
+
+---
+
+## Scope IN
+
+- Ativação manual de alertas em Grafana + Sentry
+- Dashboard novo ou adicional
+- Runbook
+- Teste end-to-end (alert fires + runbook resolves)
+
+## Scope OUT
+
+- Criar NOVAS métricas (já existem em SEO-001)
+- Migração de Grafana/Sentry provider
+- Alertas em endpoints NÃO relacionados a sitemap
+
+---
+
+## Implementation Notes
+
+### Passo 1: localizar config existente
+
+```bash
+cat /mnt/d/pncp-poc/docs/seo/sitemap-observability-alerts.md
+# Referência: STORY-SEO-001 AC5 — documentação já tem thresholds/queries
+```
+
+### Passo 2: ativar Grafana
+
+- Se Grafana Cloud: Alert Rules → New → PromQL query + threshold conforme AC1
+- Se self-hosted: `grafana.yaml` + reload
+- Notification policy: apontar para canal `#seo-alerts` (ou equivalente em uso)
+
+### Passo 3: ativar Sentry
+
+- Sentry Issue Alerts → New Alert:
+  - When: `An event is seen`
+  - If: `tags.sitemap_outcome equals http_error OR fetch_error`
+  - Then: notify via Slack/email
+  - Rate limit: 1 notification per issue per hour
+
+### Passo 4: teste
+
+```bash
+# Induce failure em staging (NÃO em prod):
+# Exemplo: drop index SEO-013 temporário, OU retornar [] mock no endpoint
+# Aguardar 20min, verificar que alerta disparou
+# Rollback do test change
+```
+
+### Passo 5: runbook
+
+Template baseado em runbooks existentes em `docs/runbooks/` (se houver). Senão, estrutura mínima:
+
+```markdown
+# Runbook: Sitemap URL Drop Alert
+
+## Quando disparar
+`smartlic_sitemap_urls_last{endpoint=X} < threshold`
+
+## Diagnóstico (5min)
+1. `curl https://api.smartlic.tech/v1/sitemap/X` — retorna JSON? Quantos items?
+2. `railway logs --service bidiq-backend | grep sitemap` — erro recente?
+3. Supabase: RPC `get_sitemap_X_json` retornando dados?
+
+## Fix comum
+- Backend timeout → investigar saturação (SEO-013 similar)
+- RPC missing → aplicar migration
+- CDN stale após dados dropados → purge manual
+
+## Escalation
+- >30min sem resolver → @data-engineer
+- >2h → @pm
+```
+
+---
+
+## Métrica de Impacto
+
+| Métrica | Pré | Pós |
+|---------|-----|-----|
+| MTTD (mean time to detect) sitemap failures | dias | <20min |
+| Incidentes de regressão SEO descobertos pelo user | 1/mes+ | 0 |
+
+---
+
+## Dependencies
+
+- **Pre:** SEO-013, SEO-015 (alerta em sistema estável é mais sinal/ruído)
+- **Unlocks:** Observabilidade de qualquer futura regressão SEO
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada. Reconhece que STORY-SEO-001 AC5 documentou mas não ativou — esta story fecha o loop. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 8/10 → GO. Status Draft → Ready. Gap: alert fatigue não abordado — @devops deve considerar rate limit de notificações na Opção Sentry (1/issue/hora). Não blocker. |

--- a/docs/stories/STORY-SEO-017-remove-404-licitacoes-do-dia.md
+++ b/docs/stories/STORY-SEO-017-remove-404-licitacoes-do-dia.md
@@ -1,0 +1,163 @@
+# Story SEO-017: Remover 404s de `/blog/licitacoes-do-dia/*` do Sitemap
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🟠 P1
+**Story Points:** 2 SP
+**Owner:** @dev
+**Status:** Ready
+
+---
+
+## Problem
+
+HTTP sweep de 1269 URLs no sitemap (2026-04-24) encontrou **43 URLs retornando 404**:
+
+- **42 URLs** em `/blog/licitacoes-do-dia/{data}` (ex: `/blog/licitacoes-do-dia/2026-03-26`)
+- **1 URL** em `/blog/panorama/*` OR `/observatorio/raio-x-marco-2026` (verificar qual)
+
+### Causa em código
+
+`frontend/app/sitemap.ts:668-679` gera hardcoded últimos 30 dias:
+
+```typescript
+const licitacoesDoDialRoutes: MetadataRoute.Sitemap = Array.from({ length: 30 }, (_, i) => {
+  const d = new Date();
+  d.setDate(d.getDate() - i);
+  const dateStr = d.toISOString().slice(0, 10);
+  const freq: 'hourly' | 'daily' = i === 0 ? 'hourly' : 'daily';
+  return {
+    url: `${baseUrl}/blog/licitacoes-do-dia/${dateStr}`,
+    lastModified: i === 0 ? today : d,
+    changeFrequency: freq,
+    priority: i === 0 ? 0.9 : 0.7,
+  };
+});
+```
+
+Essa lógica assume que toda data dos últimos 30 dias tem uma página `/blog/licitacoes-do-dia/{data}` renderizável. Mas a rota em `frontend/app/blog/licitacoes-do-dia/[date]/page.tsx` depende de dados do backend (`pncp_raw_bids` filtrado por data). Se para uma data específica não há dados (ex: fim de semana, feriado, ou backend timeout no build), a página retorna 404.
+
+**Impacto SEO:** Google crawlea, encontra 404, marca domínio como "baixa qualidade" (many broken links reduzem trust). GSC reporta "Submitted URL not found (404)" — penalidade.
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Modificar `frontend/app/sitemap.ts:668-679`:
+  - Opção A: Fetch de endpoint backend `/v1/sitemap/licitacoes-do-dia-indexable` que retorna apenas datas com ≥N bids (N=configurable, default 5)
+  - Opção B: Se backend endpoint inviável, gerar apenas últimos 7 dias (janela curta, menor probabilidade de 404) + check síncrono antes de adicionar (aguarda request HEAD em cada URL — lento, não recomendado)
+  - Preferir Opção A. Documentar decisão.
+- [ ] **AC2** — Criar endpoint backend `/v1/sitemap/licitacoes-do-dia-indexable` (se Opção A) retornando `{"dates": ["2026-04-23", "2026-04-22", ...]}` — apenas datas com ≥N bids em `pncp_raw_bids` WHERE `data_publicacao::date = X`. Cache TTL 1h (dia corrente muda).
+- [ ] **AC3** — Rota `/blog/licitacoes-do-dia/[date]` deve retornar 200 + noindex (ou 410 Gone) para datas sem dados — nunca 404. Check em `page.tsx`:
+  ```typescript
+  if (bids.length === 0) {
+    return {
+      robots: { index: false, follow: false },
+      // render "Nenhuma licitação publicada em {data}"
+    };
+  }
+  ```
+- [ ] **AC4** — Verificar rota `/observatorio/raio-x-marco-2026` (sitemap `id:0` linha 399-403):
+  - Se página existe e dados indisponíveis: implementar fallback 200+noindex
+  - Se rota não existe mais: remover do sitemap
+- [ ] **AC5** — HTTP sweep pós-deploy:
+  ```bash
+  python3 /tmp/sitemap_sweep.py  # usa unique_urls.txt
+  ```
+  Resultado: 0 URLs retornando 404 (vs 43 baseline).
+- [ ] **AC6** — GSC Coverage: em 14 dias após deploy, "Submitted URL not found (404)" deve reduzir de ~43 → 0 (ou decay natural conforme Google re-crawl).
+
+---
+
+## Scope IN
+
+- Refatorar geração de `/blog/licitacoes-do-dia/*` no sitemap
+- Endpoint backend `licitacoes-do-dia-indexable` (se Opção A)
+- Fix fallback em page.tsx para datas sem dados
+- Verificar + fixar `/observatorio/raio-x-marco-2026`
+
+## Scope OUT
+
+- Outros 404s não listados no sweep (seriam escopo novo se surgirem)
+- Redesign da página `/blog/licitacoes-do-dia/[date]` — apenas fallback
+- Backfill histórico de dados (data passada sem bid não vai ter agora)
+
+---
+
+## Implementation Notes
+
+### Opção A (recomendada)
+
+```typescript
+// frontend/app/sitemap.ts
+async function fetchLicitacoesDoDiaIndexable(): Promise<string[]> {
+  const result = await fetchSitemapJson<string[]>(
+    '/v1/sitemap/licitacoes-do-dia-indexable',
+    (d) => ((d as { dates?: string[] }).dates ?? []),
+    'licitacoes-do-dia-indexable',
+  );
+  return result ?? [];
+}
+
+// Em case 3:
+const indexableDates = await fetchLicitacoesDoDiaIndexable();
+const licitacoesDoDialRoutes: MetadataRoute.Sitemap = indexableDates.slice(0, 30).map((dateStr) => {
+  const d = new Date(dateStr);
+  const freq: 'hourly' | 'daily' = dateStr === today.toISOString().slice(0, 10) ? 'hourly' : 'daily';
+  return {
+    url: `${baseUrl}/blog/licitacoes-do-dia/${dateStr}`,
+    lastModified: d,
+    changeFrequency: freq,
+    priority: dateStr === today.toISOString().slice(0, 10) ? 0.9 : 0.7,
+  };
+});
+```
+
+Backend:
+```python
+# backend/routes/sitemap_licitacoes_do_dia.py (NOVO)
+@router.get("/sitemap/licitacoes-do-dia-indexable", response_model=...)
+async def sitemap_licitacoes_do_dia_indexable():
+    # Cache InMemory 1h
+    # Query: SELECT DISTINCT data_publicacao::date FROM pncp_raw_bids
+    #        WHERE data_publicacao >= NOW() - INTERVAL '30 days'
+    #          AND is_active = true
+    #        GROUP BY data_publicacao::date
+    #        HAVING COUNT(*) >= 5
+    #        ORDER BY data_publicacao::date DESC
+    ...
+```
+
+### Fix fallback
+
+```typescript
+// frontend/app/blog/licitacoes-do-dia/[date]/page.tsx
+export async function generateMetadata({ params }: Props) {
+  const { date } = await params;
+  const bids = await fetchBidsForDate(date);
+  if (bids.length === 0) {
+    return {
+      title: `Sem licitações publicadas em ${formatDate(date)} | SmartLic`,
+      robots: { index: false, follow: false },
+    };
+  }
+  // ... metadata normal
+}
+```
+
+Page body renderiza mensagem graceful ao invés de 404. Google já inferiu a data via sitemap; noindex remove da fila de indexação sem 404 penalty.
+
+---
+
+## Dependencies
+
+- **Pre:** Nenhum (independente de SEO-013). Pode rodar em paralelo.
+- **Unlocks:** GSC health melhora → crawl budget redirecionado para entity pages
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada. 43 URLs 404 identificados via HTTP sweep. Root cause isolado em `sitemap.ts:668` hardcoded 30d. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 8/10 → GO. Status Draft → Ready. Independente de SEO-013 — pode executar em paralelo. Preferir Opção A (endpoint backend) per AC1. |

--- a/docs/stories/STORY-SEO-018-entity-routes-implement-or-noindex.md
+++ b/docs/stories/STORY-SEO-018-entity-routes-implement-or-noindex.md
@@ -1,0 +1,209 @@
+# Story SEO-018: Rotas Entity Broken — Implementar OR Noindex+Remove
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🟡 P2
+**Story Points:** 8 SP
+**Owner:** @dev + @data-engineer
+**Status:** Ready
+**Depends on:** SEO-013
+
+---
+
+## Problem
+
+Diagnóstico 2026-04-24 identificou **5+ rotas dinâmicas em código que retornam 404 direto em prod** — não aparecem no sitemap mas potencialmente descobertas via internal links, URL guessing de crawlers, ou referências externas:
+
+| Path testado | Status | Rota em código |
+|--------------|--------|----------------|
+| `/observatorio/raio-x-sp` | 404 | `frontend/app/observatorio/[slug]/page.tsx` |
+| `/observatorio/raio-x-saude` | 404 | idem |
+| `/municipios/sp-sao-paulo` | 404 | `frontend/app/municipios/[slug]/page.tsx` |
+| `/municipios/rj-rio-de-janeiro` | 404 | idem |
+| `/orgaos/ministerio-saude` | 404 | `frontend/app/orgaos/[slug]/page.tsx` |
+| `/itens/150101` | 404 | `frontend/app/itens/[catmat]/page.tsx` |
+| `/alertas-publicos/saude` | 404 | `frontend/app/alertas-publicos/[setor]/page.tsx` |
+
+Rotas **funcionando** (test):
+- `/indice-municipal/sao-paulo-sp` → 200
+- `/cnpj/00000000000191` → 200
+- `/compliance/00000000000191` → 200
+- `/alertas-publicos/saude/sp` → 200 (2-level route OK)
+
+### Contexto: sitemap/4.xml já deveria cobrir isso
+
+`frontend/app/sitemap.ts:708-777` (case 4) tem código para gerar rotas:
+- `/cnpj/{cnpj}` (cnpjList)
+- `/orgaos/{cnpj}` (orgaoList)
+- `/fornecedores/{cnpj}` (fornecedoresCnpjList)
+- `/municipios/{slug}` (municipiosList)
+- `/itens/{catmat}` (itensList)
+- `/contratos/orgao/{cnpj}` (contratosOrgaoList)
+
+**Mas** endpoints backend retornam listas vazias ou timeout → sitemap/4.xml=0 (resolvido via SEO-013+014).
+
+**Gap residual:** mesmo com endpoints funcionando, algumas rotas não aparecem:
+- `/observatorio/raio-x-{slug}` — NUNCA foi adicionada ao sitemap. Rota existe como `frontend/app/observatorio/[slug]/page.tsx` mas sitemap id:0 tem apenas `/observatorio/raio-x-marco-2026` hardcoded (STORY-SEO-017 vai resolver esse específico).
+- `/orgaos/{slug}` vs `/orgaos/{cnpj}` — sitemap gera `/orgaos/{cnpj}` mas rota pode aceitar slugs semânticos (`ministerio-saude`) que não são emitidos.
+- `/municipios/{slug}` formato pode divergir: sitemap emite slugs via endpoint backend, mas test com `sp-sao-paulo` retorna 404 enquanto `/indice-municipal/sao-paulo-sp` funciona — inconsistência de formato slug entre rotas.
+
+### Decisão estratégica
+
+**Para cada rota, 3 caminhos:**
+
+1. **IMPLEMENTAR** — se há dados reais e valor SEO (volume de busca, keyword relevância)
+2. **NOINDEX+REMOVE** — se rota foi criada sem data source pronto, mais seguro remover da descoberta pública
+3. **REDIRECT** — se rota duplica outra funcional (ex: `/orgaos/ministerio-saude` → `/orgaos/{cnpj-do-ministerio-saude}`)
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Auditoria completa das rotas dinâmicas em `frontend/app/`:
+  ```bash
+  find frontend/app -type d -name "\[*\]" | while read dir; do
+    path=$(echo "$dir" | sed 's|frontend/app||')
+    echo "$path"
+  done
+  ```
+  Documentar em seção "Auditoria" desta story: cada rota, se retorna 200/404 com sample slug, se está no sitemap, decisão (implementar/noindex/redirect).
+- [ ] **AC2** — Para cada rota decidida como IMPLEMENTAR:
+  - Confirmar data source backend responde (endpoint existe + retorna dados)
+  - Page.tsx renderiza com fallback graceful (não 404) quando dados ausentes
+  - Adicionar à sitemap se gerável em massa (>10 URLs válidas)
+- [ ] **AC3** — Para cada rota decidida como NOINDEX+REMOVE:
+  - `page.tsx` retorna `robots: { index: false, follow: false }`
+  - Entry removida do sitemap (se lá está)
+  - Internal links para essa rota removidos OR rel="nofollow"
+- [ ] **AC4** — Para cada rota REDIRECT:
+  - `next.config.js` ou middleware adiciona permanent redirect (301)
+  - Source path adicionado a noindex (defense in depth)
+- [ ] **AC5** — HTTP sweep após deploy:
+  ```bash
+  # Lista rotas críticas com slugs reais (não guess):
+  for path in /observatorio/raio-x-sp /municipios/sp-sao-paulo /orgaos/03504182000126 /itens/{first-real-catmat} /alertas-publicos/saude; do
+    code=$(curl -sL -o /dev/null -w "%{http_code}" https://smartlic.tech${path})
+    echo "$code  $path"
+  done
+  ```
+  Esperado: todas 200 OR intencionalmente 301/410, nenhuma 404 não-documentada.
+- [ ] **AC6** — Sitemap total URLs cresce em ≥3000 (URLs de `/observatorio/raio-x-{uf}` × 27 UFs = 27, `/municipios/{slug}` × capital+grandes = 200, `/itens/{catmat}` top 1000 = 1000, rotas entity diversas somadas ≥3000).
+- [ ] **AC7** — GSC "Not found (404)" drop em 28d após deploy.
+
+---
+
+## Scope IN
+
+- Auditoria de todas rotas dinâmicas em `frontend/app/`
+- Implementação OR noindex OR redirect para cada rota broken
+- Atualização do sitemap para emitir novas rotas implementadas
+- HTTP sweep validação
+
+## Scope OUT
+
+- Criação de rotas NOVAS (só recuperar existentes)
+- Content quality/optimization das páginas (fase separada)
+- A/B testing de slug format
+
+---
+
+## Implementation Notes
+
+### Passo 1: auditoria
+
+```bash
+# Descoberta de rotas dinâmicas em código
+cd /mnt/d/pncp-poc/frontend
+find app -type d -name "\[*\]" -not -path "*/api/*" | sort
+
+# Para cada, buscar uso em sitemap.ts
+grep -n "\[rota\]\|url:.*\${baseUrl}/rota" app/sitemap.ts
+```
+
+Preencher tabela:
+
+| Route | Sample 200 | Sample 404 | In sitemap? | Data source | Decision |
+|-------|-----------|-----------|-------------|-------------|----------|
+| `/observatorio/[slug]` | `marco-2026` | `raio-x-sp` | Hardcoded 1 entry | Backend? | IMPLEMENT (27 UFs) |
+| `/municipios/[slug]` | `sao-paulo-sp` (via indice-municipal)? | `sp-sao-paulo` | Via endpoint | `/v1/sitemap/municipios` | Normalize slug format |
+| ... | ... | ... | ... | ... | ... |
+
+### Passo 2: implementar rotas selecionadas
+
+Exemplo para `/observatorio/raio-x-{uf}`:
+
+```typescript
+// frontend/app/observatorio/[slug]/page.tsx (refactor)
+export async function generateStaticParams() {
+  const UFS = ['ac', 'al', /* ... 27 UFs */];
+  return UFS.map(uf => ({ slug: `raio-x-${uf}` }));
+}
+
+export default async function Page({ params }: Props) {
+  const { slug } = await params;
+  const uf = slug.replace('raio-x-', '').toUpperCase();
+  if (!/^[A-Z]{2}$/.test(uf)) return notFound(); // only real UF slugs
+  const data = await fetchObservatorioData(uf);
+  if (!data || data.total === 0) {
+    return <EmptyStateObservatorio uf={uf} />;
+  }
+  return <ObservatorioUfPage data={data} />;
+}
+```
+
+Adicionar ao sitemap (case 0 ou case 4):
+```typescript
+const UFS = [...];
+const observatorioUfRoutes = UFS.map(uf => ({
+  url: `${baseUrl}/observatorio/raio-x-${uf.toLowerCase()}`,
+  lastModified: today,
+  changeFrequency: 'monthly' as const,
+  priority: 0.7,
+}));
+```
+
+### Passo 3: noindex rotas sem futuro
+
+```typescript
+// frontend/app/orgaos/[slug]/page.tsx (se decidir remover slug semântico)
+export const dynamic = 'force-static';
+export async function generateMetadata() {
+  return { robots: { index: false, follow: false } };
+}
+```
+
+### Passo 4: redirect (se aplicável)
+
+```typescript
+// next.config.js
+async redirects() {
+  return [
+    {
+      source: '/orgaos/:slug((?!\\d+$).+)',  // slugs não-numéricos
+      destination: '/orgaos', // redirect para hub
+      permanent: true,
+    },
+  ];
+}
+```
+
+---
+
+## Risco
+
+Maior story do epic (8 SP). Possível decompor em sub-stories se auditoria revelar >5 rotas para implementar. @po pode sugerir split em validação.
+
+---
+
+## Dependencies
+
+- **Pre:** SEO-013 (backend responsivo para data sources), SEO-014 (RPCs funcionando)
+- **Unlocks:** Meta de 10k+ páginas indexáveis
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada. Maior do epic — pode ser split após AC1 auditoria revelar escopo real. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 9/10 → GO condicional. Status Draft → Ready. **Caveat:** após AC1 auditoria, se >5 rotas IMPLEMENTAR, @dev deve retornar para @sm re-split em sub-stories (SEO-018a/b/c). 8 SP é teto — não estourar. |

--- a/docs/stories/STORY-SEO-019-crawler-protection-robots-ratelimit.md
+++ b/docs/stories/STORY-SEO-019-crawler-protection-robots-ratelimit.md
@@ -1,0 +1,182 @@
+# Story SEO-019: Crawler Protection — robots.txt Crawl-delay + Rate Limit Googlebot
+
+**Epic:** EPIC-SEO-RECOVERY-2026-Q2
+**Priority:** 🟡 P2
+**Story Points:** 3 SP
+**Owner:** @dev
+**Status:** Ready
+**Depends on:** SEO-015
+
+---
+
+## Problem
+
+Logs Railway backend 2026-04-24 mostram padrão típico de crawl burst:
+```
+GET /v1/empresa/{cnpj}/perfil-b2g (várias/seg)
+GET /v1/fornecedores/{cnpj}/profile
+GET /v1/contratos/orgao/{cnpj}/stats
+GET /v1/orgao/{cnpj}/stats -> 404 (443s)
+GET /v1/observatorio/relatorio/*
+GET /v1/blog/stats/contratos/*
+```
+
+São IPs Railway internos (`100.64.0.x`) — frontend SSR/ISR + crawlers externos indiretos via frontend.
+
+Com `WEB_CONCURRENCY=2`, até mesmo após SEO-013 fixar latência média, **bursts de crawler** (Googlebot pode abrir 10+ conexões paralelas a descobrir entity pages) podem saturar workers.
+
+### Camadas de defesa
+
+1. **robots.txt `Crawl-delay`** — pede a crawlers polidos (Bingbot, Yandex) 1s entre requests. Googlebot ignora Crawl-delay mas respeita GSC "crawl rate" setting.
+2. **Rate limit por User-Agent no backend** — 429 após N req/min por bot, mantém user traffic privilegiado. Precisa ser generoso para não prejudicar indexação.
+3. **Pricing/burst capacity** — se SEO-015 CDN absorve bem, rate limit pode ser menos crítico.
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC1** — Verificar `frontend/public/robots.txt` existe e inclui:
+  ```
+  User-agent: *
+  Allow: /
+  Sitemap: https://smartlic.tech/sitemap.xml
+
+  User-agent: Bingbot
+  Crawl-delay: 1
+
+  User-agent: YandexBot
+  Crawl-delay: 2
+
+  User-agent: GPTBot
+  Disallow: /
+
+  User-agent: CCBot
+  Disallow: /
+  ```
+  (Bloquear GPTBot/CCBot é decisão de negócio — documentar na story.)
+- [ ] **AC2** — Adicionar middleware backend rate limit por User-Agent:
+  - `backend/middleware/crawler_rate_limit.py` — limits: Googlebot/Bingbot max 100 req/min, outros bots detectados (heurística UA string) 60 req/min.
+  - Retornar 429 + `Retry-After: 60` em burst excedido.
+  - Excluir rotas `/v1/sitemap/*` (servidas por CDN pós SEO-015) e `/health`.
+  - Usar Redis pipeline para contador (já disponível no projeto).
+- [ ] **AC3** — GSC Crawl Stats verificar após 7 dias: total crawl requests não deve cair >10% (queremos reduzir burst spikes, não reduzir crawl total). Documentar via GSC → Settings → Crawl stats.
+- [ ] **AC4** — Prometheus `smartlic_crawler_rate_limit_429_total{user_agent}` deve ser >0 mas <1% do tráfego total — indicador que rate limit está ativo mas não agressivo.
+- [ ] **AC5** — GSC Coverage não deve regredir: se Coverage "Valid" cair em 14d, rate limit foi agressivo demais. Rollback via feature flag `CRAWLER_RATE_LIMIT_ENABLED=false`.
+- [ ] **AC6** — Teste de integração `backend/tests/test_crawler_rate_limit.py`:
+  - Simula 200 requests Googlebot em 60s → primeiras 100 passam, resto 429
+  - Rotas `/v1/sitemap/*` não rate-limited (crítico para indexação)
+  - User-Agent Chrome normal não rate-limited
+
+---
+
+## Scope IN
+
+- robots.txt com Crawl-delay para bots secundários
+- Middleware rate limit backend por User-Agent
+- Feature flag para disable emergency
+- Observabilidade (Prometheus + GSC Crawl Stats monitoring)
+
+## Scope OUT
+
+- Block completo de crawlers (exceto GPTBot/CCBot se decisão business)
+- Fingerprinting avançado (browser fingerprint, etc.)
+- WAF-level rate limit (fica para Cloudflare se SEO-015 Opção A)
+- Rate limit por IP (user rate limit é outro tipo — fora escopo)
+
+---
+
+## Implementation Notes
+
+### robots.txt
+
+```bash
+# Verificar estado atual
+curl -s https://smartlic.tech/robots.txt
+cat /mnt/d/pncp-poc/frontend/public/robots.txt
+
+# Editar se necessário
+```
+
+### Middleware rate limit
+
+```python
+# backend/middleware/crawler_rate_limit.py (NOVO)
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+import re
+
+BOT_LIMITS = {
+    'googlebot': 100,
+    'bingbot': 100,
+    'yandexbot': 60,
+    'applebot': 60,
+    'facebookexternalhit': 30,
+    # fallback genérico para *bot*
+    '_default_bot': 60,
+}
+BOT_REGEX = re.compile(r'(Googlebot|Bingbot|YandexBot|AppleBot|facebookexternalhit|DuckDuckBot|baiduspider|bot|crawler|spider)', re.IGNORECASE)
+
+EXEMPT_PATHS = ('/v1/sitemap/', '/health', '/metrics')
+
+class CrawlerRateLimitMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if any(path.startswith(p) for p in EXEMPT_PATHS):
+            return await call_next(request)
+
+        ua = request.headers.get('user-agent', '')
+        match = BOT_REGEX.search(ua)
+        if not match:
+            return await call_next(request)
+
+        bot_key = match.group(1).lower()
+        limit = BOT_LIMITS.get(bot_key, BOT_LIMITS['_default_bot'])
+
+        # Redis sliding window counter
+        redis = get_redis()
+        key = f"crawler_rate:{bot_key}:{int(time.time() // 60)}"  # per-minute bucket
+        current = await redis.incr(key)
+        if current == 1:
+            await redis.expire(key, 120)
+
+        if current > limit:
+            record_metric('smartlic_crawler_rate_limit_429_total', {'user_agent': bot_key})
+            return Response(status_code=429, headers={'Retry-After': '60'})
+
+        return await call_next(request)
+```
+
+Register em `backend/startup/middleware_setup.py` atrás de config flag `CRAWLER_RATE_LIMIT_ENABLED`.
+
+### Feature flag
+
+```python
+# backend/config.py
+CRAWLER_RATE_LIMIT_ENABLED: bool = os.getenv('CRAWLER_RATE_LIMIT_ENABLED', 'false').lower() == 'true'
+```
+
+Deploy inicialmente com flag OFF. Ativar após 7d de baseline GSC Crawl Stats + monitoring.
+
+### Decisão GPTBot/CCBot
+
+Disallow = user-controlled opt-out de LLM training. Justificativas:
+- PRO disallow: dados B2G são competitive advantage; não queremos LLMs usando dados do SmartLic para responder queries de usuários que poderiam pagar
+- CON disallow: SEO futuro pode migrar para "AI search" (Perplexity, ChatGPT com citações) — bloquear GPTBot pode excluir SmartLic dessas vitrines
+
+**Recomendação:** disallow por ora, reavaliar em Q3 quando Perplexity/ChatGPT traffic medível.
+
+---
+
+## Dependencies
+
+- **Pre:** SEO-015 (CDN absorve maior parte do crawler load — rate limit é safety net)
+- **Unlocks:** Backend estabilidade sob carga sustentada
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Story criada. Feature flag-gated para rollout seguro — 7d baseline antes de ativar. |
+| 2026-04-24 | @po (Pax) | *validate-story-draft 10/10 → GO. Status Draft → Ready. FF rollback + GPTBot decisão documentada. Pronta para @dev após SEO-015. |

--- a/docs/stories/epic-seo-recovery-2026-q2.md
+++ b/docs/stories/epic-seo-recovery-2026-q2.md
@@ -1,0 +1,121 @@
+# Epic: SEO Recovery — 10k+ Pages Indexable Pipeline
+
+**Epic ID:** EPIC-SEO-RECOVERY-2026-Q2
+**Date:** 2026-04-24
+**Owner:** @pm (Morgan)
+**Status:** PLANNING
+**Depends on:** STORY-SEO-001 (AC1 concluído per memory `reference_railway_backend_url_already_set`)
+
+---
+
+## Problema
+
+Estratégia SEO do SmartLic está quebrada em múltiplas camadas, mesmo após STORY-SEO-001 setar `BACKEND_URL` em Railway frontend. Diagnóstico empírico 2026-04-24:
+
+### Evidências verificadas (prod https://smartlic.tech)
+
+| Métrica | Esperado | Real | Gap |
+|---------|----------|------|-----|
+| Páginas indexáveis no sitemap | 10.000+ | **1.269** | **-87%** |
+| `sitemap/4.xml` (entity pages) URLs | ~10.000 | **0** | **-100%** |
+| URLs no sitemap retornando 404 | 0 | **43** (42 /blog/licitacoes-do-dia/* + 1 /observatorio/*) | — |
+| Endpoints `/v1/sitemap/*` respondendo | 7/7 | **0/7** (todos timeout 30s) | — |
+| Endpoint `/health` backend | 200 | timeout 15s | — |
+| Rotas entity em código e 404 em prod | 0 | **5+** (`/observatorio/raio-x-{uf}`, `/municipios/{slug}`, `/orgaos/{slug}`, `/itens/{catmat}`, `/alertas-publicos/{setor}`) | — |
+| `/v1/orgao/{cnpj}/stats` latência p99 | <2s | **443s** (logs Railway) | — |
+
+### Root causes (4 ortogonais)
+
+**A. Missing index em `pncp_raw_bids.orgao_cnpj`** — handlers `/v1/orgao/*/stats` e `/v1/sitemap/cnpjs` fazem seq scan 1.5M rows em queries com predicate por `orgao_cnpj`. Explica latência 443s e timeouts em cascata. `pncp_supplier_contracts` tem `idx_psc_orgao_cnpj`; `pncp_raw_bids` não tem equivalente. Comprovado por inspeção de `supabase/migrations/20260326000000_datalake_raw_bids.sql`.
+
+**B. Backend saturação crônica por `WEB_CONCURRENCY=2`** — `backend/start.sh` limita a 2 workers (SLA-002 "Railway 1GB can't sustain 4"). Quando query lenta (#A) trava 1 worker por 443s, 50% da capacidade desaparece. Crawlers + usuários competem pelos workers restantes → `/v1/sitemap/*` timeout no frontend fetcher 15s → `_cnpjCache=[]` → `sitemap/4.xml` vazio.
+
+**C. Silent failure observabilidade** — `frontend/app/sitemap.ts:22-47` captura falhas via Sentry (adicionado em STORY-SEO-001 AC3) mas sem alerta ativo. `sitemap/4.xml=0` persiste dias sem ação. Prometheus counter `smartlic_sitemap_urls_last` existe (AC4) mas sem alert rule em Grafana (AC5 documentado, ativação manual pendente).
+
+**D. SEO ops gaps (404s no sitemap + rotas broken)** — 43 URLs no sitemap/3.xml retornam 404 (datas antigas geradas sem check de dados reais). Rotas entity em `frontend/app/` existem mas sem data source funcional nem entry no sitemap — 404 direto em prod.
+
+---
+
+## Filosofia
+
+**Desbloquear receita orgânica. Sem desinventar.**
+
+SEO orgânico é o canal de aquisição mais barato e escalável para SmartLic (baseline: 126 clicks / 9.9k impressions 28d, CTR 1.3%, position 7.1 per memory `reference_smartlic_baseline_2026_04_24`). Com 87% do long-tail ausente, estamos deixando dinheiro na mesa.
+
+**Regras:**
+1. P0 = fix que desbloqueia TUDO (A — 1 migration 1 linha)
+2. P1/P2 são independentes entre si após A (paralelizáveis)
+3. Sem novas features: só recuperar o que já existe em código
+4. Cada story tem métrica mensurável pré/pós
+
+---
+
+## Escopo
+
+### Incluído (7 stories)
+
+| ID | Título | Priority | SP | Owner | Depends on |
+|----|--------|----------|----|----|------------|
+| STORY-SEO-013 | Index `pncp_raw_bids.orgao_cnpj` (root cause fix) | 🔴 P0 | 2 | @data-engineer | — |
+| STORY-SEO-014 | Verify + redeploy sitemap RPCs (get_sitemap_*_json) | 🟠 P1 | 2 | @data-engineer | SEO-013 |
+| STORY-SEO-015 | CDN cache `/v1/sitemap/*` 6h (isolar crawlers do backend) | 🟠 P1 | 5 | @devops | SEO-013 |
+| STORY-SEO-016 | Alerta Prometheus/Sentry em sitemap URL count drop | 🟡 P2 | 3 | @devops | SEO-015 |
+| STORY-SEO-017 | Remover 404s de `/blog/licitacoes-do-dia/*` do sitemap | 🟠 P1 | 2 | @dev | — |
+| STORY-SEO-018 | Rotas entity broken: implementar OR noindex+remove | 🟡 P2 | 8 | @dev + @data-engineer | SEO-013 |
+| STORY-SEO-019 | Crawler protection: robots Crawl-delay + rate limit Googlebot | 🟡 P2 | 3 | @dev | SEO-015 |
+
+**Total:** 25 SP (~40-50h).
+
+### Excluído
+
+- Criação de NOVAS páginas programáticas (só recuperar as que já existem)
+- Content quality em páginas entity (thin content) — separar em epic próprio pós-recovery
+- Backlinks/outreach — estratégia off-page fora deste escopo
+- Mobile/CWV beyond o que vier naturalmente do fix de latência
+
+---
+
+## Critérios de Sucesso
+
+| Métrica | Baseline (2026-04-24) | Meta | Como medir |
+|---------|----------------------|------|------------|
+| Total URLs no sitemap | 1.269 | ≥8.000 | `for i in 0 1 2 3 4; do curl -sL https://smartlic.tech/sitemap/$i.xml \| grep -c '<loc>'; done` |
+| `sitemap/4.xml` URLs | 0 | ≥5.000 | `curl -sL https://smartlic.tech/sitemap/4.xml \| grep -c '<loc>'` |
+| URLs no sitemap retornando 404 | 43 | 0 | HTTP sweep `sitemap_sweep.py` (ver `tests/selenium/`) |
+| Rotas entity retornando 404 (não no sitemap) | 5+ | 0 (OR todas noindex documentadas) | `curl -I /observatorio/raio-x-sp /municipios/* /orgaos/* /itens/* /alertas-publicos/*` |
+| `/v1/orgao/{cnpj}/stats` p95 | 443s | <1s | Prometheus `smartlic_http_duration_seconds` |
+| `/v1/sitemap/*` p95 | timeout (>30s) | <3s | Prometheus |
+| GSC "Valid" coverage em 28d | ~150 URLs | ≥1.500 URLs | Google Search Console → Coverage |
+| Organic sessions 28d | ~150 | ≥500 (4 semanas pós-deploy) | GA4/GSC |
+
+---
+
+## Riscos
+
+| Risco | Mitigação |
+|-------|-----------|
+| Index creation trava tabela 1.5M rows | `CREATE INDEX CONCURRENTLY` (não bloqueia writes) — STORY-SEO-013 AC |
+| CDN cache mascara falhas reais do backend | Alertas em STORY-SEO-016 vigiam ambos: origin + edge |
+| Rate limit crawler ranqueia pior por parecer lento | Somente Crawl-delay suave (1s) + 429 apenas acima de 100 req/min — STORY-SEO-019 |
+| Entity pages implementadas mas com thin content | Scope out dessa epic; próxima epic de content quality |
+| Google demora 4-8 semanas pra recrawlear entity pages | Aceitável; submissão manual via GSC acelera — STORY-SEO-014 AC |
+
+---
+
+## Sequência de Execução Recomendada
+
+```
+Wave 1 (P0, hoje):           SEO-013 (unblock everything)
+Wave 2 (P1, semana 1):       SEO-014 + SEO-015 + SEO-017 (paralelo)
+Wave 3 (P2, semana 2):       SEO-016 + SEO-019 (paralelo)
+Wave 4 (P2, semana 2-3):     SEO-018 (last; maior — 8 SP)
+Wave 5 (monitor, semana 4+): GSC coverage validation (AC nas stories)
+```
+
+---
+
+## Change Log
+
+| Date | Agent | Action |
+|------|-------|--------|
+| 2026-04-24 | @sm (River) | Epic criado a partir de investigação causa raiz (tiago.sasaki, via advisor alignment). Esperado 10k+ pages, real 1269. 4 root causes ortogonais identificados empiricamente. |

--- a/frontend/__tests__/licitacoes-do-dia.test.tsx
+++ b/frontend/__tests__/licitacoes-do-dia.test.tsx
@@ -72,7 +72,7 @@ describe('DailyDigestDetailPage', () => {
     expect(metadata.title).toContain('150 editais');
   });
 
-  it('generateMetadata returns noindex for invalid date', async () => {
+  it('generateMetadata returns noindex+nofollow for invalid date', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
     }) as jest.Mock;
@@ -82,6 +82,25 @@ describe('DailyDigestDetailPage', () => {
       params: Promise.resolve({ date: 'invalid' }),
     });
 
-    expect(metadata.robots).toEqual({ index: false });
+    // STORY-SEO-017 AC3: nofollow tambem (era so noindex) — datas sem dados nunca
+    // devem propagar autoridade nem ser re-crawled.
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it('generateMetadata returns 200+noindex (nao 404) para data valida sem bids', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+    }) as jest.Mock;
+
+    const mod = await import('@/app/blog/licitacoes-do-dia/[date]/page');
+    const metadata = await mod.generateMetadata({
+      params: Promise.resolve({ date: '2026-03-26' }),
+    });
+
+    // STORY-SEO-017 AC3: data valida sem bids = noindex+nofollow + canonical
+    // (anteriormente notFound() -> 404 -> 42 URLs penalizados no GSC).
+    expect(metadata.title).toContain('Sem licitacoes publicadas em 2026-03-26');
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+    expect((metadata.alternates as { canonical?: string })?.canonical).toContain('/blog/licitacoes-do-dia/2026-03-26');
   });
 });

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4222,6 +4222,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/sitemap/licitacoes-do-dia-indexable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)
+         * @description Retorna apenas datas com bids suficientes para ter pagina renderizavel.
+         *
+         *     Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
+         */
+        get: operations["sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/sitemap/licitacoes-indexable": {
         parameters: {
             query?: never;
@@ -8899,6 +8921,15 @@ export interface components {
         SitemapItensResponse: {
             /** Catmats */
             catmats: string[];
+            /** Total */
+            total: number;
+            /** Updated At */
+            updated_at: string;
+        };
+        /** SitemapLicitacoesDoDiaResponse */
+        SitemapLicitacoesDoDiaResponse: {
+            /** Dates */
+            dates: string[];
             /** Total */
             total: number;
             /** Updated At */
@@ -14973,6 +15004,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SitemapItensResponse"];
+                };
+            };
+        };
+    };
+    sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapLicitacoesDoDiaResponse"];
                 };
             };
         };

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4439,7 +4439,15 @@ export interface paths {
         put?: never;
         /**
          * Resend Webhook
-         * @description AC11: Handle Resend webhook events for email tracking.
+         * @description Handle Resend webhook events for email tracking.
+         *
+         *     Accepts the full delivery lifecycle (sent → delivered → opened → clicked)
+         *     plus failure paths (bounced, complained, delivery_delayed, failed) so the
+         *     admin funnel dashboard can distinguish "email never arrived" from "email
+         *     arrived but wasn't engaged". Service handler
+         *     (`services.trial_email_sequence.handle_resend_webhook`) populates the
+         *     columns added in migration 20260424180000_trial_email_delivery_tracking.
+         *     Always returns 200 so Resend doesn't retry on transient server errors.
          */
         post: operations["resend_webhook_v1_trial_emails_webhook_post"];
         delete?: never;

--- a/frontend/app/blog/licitacoes-do-dia/[date]/page.tsx
+++ b/frontend/app/blog/licitacoes-do-dia/[date]/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { buildCanonical, SITE_URL } from '@/lib/seo';
 import { getAuthorBySlug, DEFAULT_AUTHOR_SLUG } from '@/lib/authors';
@@ -119,8 +118,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { date } = await params;
   const data = await fetchDailyData(date);
 
+  // STORY-SEO-017 AC3: datas sem dados retornam 200 + noindex (nao 404).
+  // Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
   if (!data) {
-    return { title: 'Digest Diario', robots: { index: false } };
+    const isValidDate = /^\d{4}-\d{2}-\d{2}$/.test(date);
+    return {
+      title: isValidDate ? `Sem licitacoes publicadas em ${date} | SmartLic` : 'Digest Diario',
+      robots: { index: false, follow: false },
+      alternates: isValidDate ? { canonical: buildCanonical(`/blog/licitacoes-do-dia/${date}`) } : undefined,
+    };
   }
 
   const formattedDate = formatDateBR(date);
@@ -209,8 +215,43 @@ export default async function DailyDigestDetailPage({ params }: Props) {
   const { date } = await params;
   const data = await fetchDailyData(date);
 
+  // STORY-SEO-017 AC3: datas sem dados renderizam fallback graceful (200 + noindex
+  // via generateMetadata). Antes era notFound() -> 404 -> 42 URLs penalizados no GSC.
   if (!data) {
-    notFound();
+    const isValidDate = /^\d{4}-\d{2}-\d{2}$/.test(date);
+    const formattedDate = isValidDate ? formatDateBR(date) : date;
+    return (
+      <div className="min-h-screen flex flex-col bg-canvas">
+        <LandingNavbar />
+        <main className="flex-1">
+          <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24 text-center">
+            <h1 className="text-2xl sm:text-3xl font-bold text-ink mb-3">
+              {isValidDate ? `Sem licitacoes publicadas em ${formattedDate}` : 'Data invalida'}
+            </h1>
+            <p className="text-ink-secondary mb-8">
+              {isValidDate
+                ? 'Nao encontramos licitacoes publicadas no PNCP nesta data. Pode ser fim de semana, feriado ou simplesmente um dia de baixo volume.'
+                : 'Esta URL nao corresponde a uma data valida (formato esperado: YYYY-MM-DD).'}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href="/blog/licitacoes-do-dia"
+                className="inline-flex items-center justify-center px-6 py-3 rounded-lg bg-brand-blue text-white font-semibold hover:bg-brand-blue/90 transition-colors"
+              >
+                Ver outros dias
+              </Link>
+              <Link
+                href="/buscar"
+                className="inline-flex items-center justify-center px-6 py-3 rounded-lg border border-[var(--border)] text-ink font-semibold hover:bg-surface-1 transition-colors"
+              >
+                Buscar editais
+              </Link>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
   }
 
   const jsonLd = buildJsonLd(data);

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -395,12 +395,8 @@ export default async function sitemap(props: { id: Promise<string> }): Promise<M
           changeFrequency: 'monthly' as const,
           priority: 0.8,
         },
-        {
-          url: `${baseUrl}/observatorio/raio-x-marco-2026`,
-          lastModified: new Date('2026-04-01'),
-          changeFrequency: 'monthly' as const,
-          priority: 0.7,
-        },
+        // STORY-SEO-017 AC4: removido /observatorio/raio-x-marco-2026 — rota nao existe
+        // em frontend/app/observatorio/, gerava 404 no sitemap sweep 2026-04-24.
         // S3: Comparador de Editais
         {
           url: `${baseUrl}/comparador`,
@@ -664,19 +660,27 @@ export default async function sitemap(props: { id: Promise<string> }): Promise<M
         };
       });
 
-      // SEO Wave 3.2: Licitações do dia — last 30 days
-      const licitacoesDoDialRoutes: MetadataRoute.Sitemap = Array.from({ length: 30 }, (_, i) => {
-        const d = new Date();
-        d.setDate(d.getDate() - i);
-        const dateStr = d.toISOString().slice(0, 10);
-        const freq: 'hourly' | 'daily' = i === 0 ? 'hourly' : 'daily';
-        return {
-          url: `${baseUrl}/blog/licitacoes-do-dia/${dateStr}`,
-          lastModified: i === 0 ? today : d,
-          changeFrequency: freq,
-          priority: i === 0 ? 0.9 : 0.7,
-        };
-      });
+      // STORY-SEO-017: Licitacoes do dia — apenas datas com >=5 bids ativos.
+      // Substitui Array.from({length:30}) hardcoded que gerava 42 URLs 404 no GSC
+      // sweep 2026-04-24 (datas sem dados em pncp_raw_bids: fim de semana, feriado).
+      const indexableDates = await fetchSitemapJson<string[]>(
+        '/v1/sitemap/licitacoes-do-dia-indexable',
+        (d) => ((d as { dates?: string[] }).dates ?? []),
+        'licitacoes-do-dia-indexable',
+      );
+      const todayStr = today.toISOString().slice(0, 10);
+      const licitacoesDoDialRoutes: MetadataRoute.Sitemap = (indexableDates ?? [])
+        .slice(0, 30)
+        .map((dateStr) => {
+          const d = new Date(dateStr + 'T12:00:00');
+          const isToday = dateStr === todayStr;
+          return {
+            url: `${baseUrl}/blog/licitacoes-do-dia/${dateStr}`,
+            lastModified: isToday ? today : d,
+            changeFrequency: (isToday ? 'hourly' : 'daily') as 'hourly' | 'daily',
+            priority: isToday ? 0.9 : 0.7,
+          };
+        });
 
       // SEO Frente 4: City pSEO pages (/blog/licitacoes/cidade/[cidade])
       // STORY-439 AC2: City × Sector pSEO pages (1.215 URLs) removidas do sitemap.

--- a/supabase/migrations/20260424161923_seo013_index_orgao_cnpj_raw_bids.down.sql
+++ b/supabase/migrations/20260424161923_seo013_index_orgao_cnpj_raw_bids.down.sql
@@ -1,0 +1,5 @@
+-- STORY-SEO-013 rollback: drop partial index orgao_cnpj.
+-- Se aplicado CONCURRENTLY originalmente, drop tambem deve ser CONCURRENTLY em producao:
+--   psql "$SUPABASE_DB_URL" -c "DROP INDEX CONCURRENTLY IF EXISTS public.idx_pncp_raw_bids_orgao_cnpj;"
+
+DROP INDEX IF EXISTS public.idx_pncp_raw_bids_orgao_cnpj;

--- a/supabase/migrations/20260424161923_seo013_index_orgao_cnpj_raw_bids.sql
+++ b/supabase/migrations/20260424161923_seo013_index_orgao_cnpj_raw_bids.sql
@@ -1,0 +1,27 @@
+-- STORY-SEO-013: Partial index pncp_raw_bids.orgao_cnpj WHERE is_active=true
+--
+-- Root cause de /v1/orgao/{cnpj}/stats levar 443s em producao (seq scan em 1.5M rows).
+-- Cascata: trava 1 worker Gunicorn por 443s -> WEB_CONCURRENCY=2 perde 50% capacidade
+-- -> /v1/sitemap/cnpjs timeout -> sitemap-4.xml=0 URLs.
+--
+-- pncp_supplier_contracts ja tem idx_psc_orgao_cnpj (20260409110000_wave2_contratos_indexes).
+-- Indice esquecido em pncp_raw_bids no commit original (20260326000000_datalake_raw_bids.sql).
+--
+-- NOTA producao com tabela ~1.5M rows + writes constantes (ingestion ARQ cron):
+--   Para zero downtime, aplicar CONCURRENTLY MANUALMENTE em producao ANTES do merge:
+--     psql "$SUPABASE_DB_URL" -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS \
+--       idx_pncp_raw_bids_orgao_cnpj ON public.pncp_raw_bids (orgao_cnpj) \
+--       WHERE is_active = true;"
+--   Padrao seguido de 20260408210000_debt01_index_retention.sql (CONCURRENTLY incompativel
+--   com transacao do supabase db push). IF NOT EXISTS torna esta migration idempotente:
+--   se index ja existe, supabase db push registra schema_migrations sem efeito.
+--
+-- Sem aplicacao manual, este CREATE INDEX vai BLOQUEAR writes durante criacao
+-- (~30s-2min em 1.5M rows) — janela segura: entre cron runs (2am/8am/2pm/8pm BRT).
+
+CREATE INDEX IF NOT EXISTS idx_pncp_raw_bids_orgao_cnpj
+    ON public.pncp_raw_bids (orgao_cnpj)
+    WHERE is_active = true;
+
+COMMENT ON INDEX public.idx_pncp_raw_bids_orgao_cnpj IS
+    'STORY-SEO-013: unblock /v1/orgao/{cnpj}/stats + sitemap cnpjs. Partial (is_active=true) reduz tamanho ~60%. Paridade com idx_psc_orgao_cnpj em pncp_supplier_contracts.';

--- a/supabase/migrations/20260424180000_trial_email_delivery_tracking.down.sql
+++ b/supabase/migrations/20260424180000_trial_email_delivery_tracking.down.sql
@@ -1,0 +1,13 @@
+-- Rollback mission sparkling-patterson delivery tracking columns.
+-- Safe to apply even if columns are already populated — data is
+-- additive observability, no referential integrity lost.
+
+DROP INDEX IF EXISTS idx_trial_email_log_delivery_status;
+
+ALTER TABLE trial_email_log
+    DROP COLUMN IF EXISTS bounce_reason,
+    DROP COLUMN IF EXISTS failed_at,
+    DROP COLUMN IF EXISTS complained_at,
+    DROP COLUMN IF EXISTS bounced_at,
+    DROP COLUMN IF EXISTS delivered_at,
+    DROP COLUMN IF EXISTS delivery_status;

--- a/supabase/migrations/20260424180000_trial_email_delivery_tracking.sql
+++ b/supabase/migrations/20260424180000_trial_email_delivery_tracking.sql
@@ -1,0 +1,43 @@
+-- mission sparkling-patterson: trial_email_log delivery tracking
+--
+-- Baseline 2026-04-24 diagnostic: 14 trial emails sent (9 in 30d),
+-- 0 opens / 0 clicks lifetime. Resend webhook endpoint exists
+-- (backend/routes/trial_emails.py::resend_webhook) but only handles
+-- email.opened and email.clicked. This migration adds the columns
+-- needed to track email.delivered / email.bounced / email.complained
+-- events so we can distinguish "email never arrived" from "email
+-- arrived but user didn't open".
+--
+-- Once Resend dashboard is configured to POST to
+-- https://api.smartlic.tech/trial-emails/webhook, the extended
+-- service handler populates these columns.
+
+ALTER TABLE trial_email_log
+    ADD COLUMN IF NOT EXISTS delivery_status TEXT
+        CHECK (delivery_status IN (
+            'queued', 'sent', 'delivered', 'opened', 'clicked',
+            'bounced', 'complained', 'delivery_delayed', 'failed'
+        )),
+    ADD COLUMN IF NOT EXISTS delivered_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS bounced_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS complained_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS failed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS bounce_reason TEXT;
+
+COMMENT ON COLUMN trial_email_log.delivery_status IS
+    'Current Resend delivery state: queued|sent|delivered|opened|clicked|bounced|complained|delivery_delayed|failed. NULL = tracking not yet populated (Resend webhook not configured before 2026-04-24).';
+COMMENT ON COLUMN trial_email_log.delivered_at IS
+    'Timestamp from email.delivered Resend webhook event.';
+COMMENT ON COLUMN trial_email_log.bounced_at IS
+    'Timestamp from email.bounced Resend webhook event.';
+COMMENT ON COLUMN trial_email_log.complained_at IS
+    'Timestamp from email.complained Resend webhook event (user marked as spam).';
+COMMENT ON COLUMN trial_email_log.failed_at IS
+    'Timestamp from email.failed Resend webhook event.';
+COMMENT ON COLUMN trial_email_log.bounce_reason IS
+    'Human-readable bounce category from Resend payload (e.g. hard, soft, mailbox_full).';
+
+-- Partial index for admin funnel dashboards that filter by status.
+CREATE INDEX IF NOT EXISTS idx_trial_email_log_delivery_status
+    ON trial_email_log(delivery_status)
+    WHERE delivery_status IS NOT NULL;


### PR DESCRIPTION
## Summary

Ship 4 stories da Epic SEO-RECOVERY-2026-Q2 (witty-leaf, 2026-04-24) — recupera infra SEO quebrada que estava sangrando aquisicao organica. Pre-revenue: gargalo e volume topo de funil (2 signups/30d), nao conversao. Cada URL indexada = ativo permanente zero-CAC.

- **STORY-SEO-013** (P0, 2 SP) — index `pncp_raw_bids.orgao_cnpj` partial WHERE is_active. Aplicado em prod via supabase CLI 2026-04-24 14:25 BRT. **`/v1/orgao/{cnpj}/stats` p95 caiu de 443s -> 0.87s warm (500x).**
- **STORY-SEO-014** (P1, 2 SP) — verificou + confirmou sitemap RPCs ja deployed em prod (`get_sitemap_cnpjs_json`/`get_sitemap_orgaos_json` retornam dados validos).
- **STORY-SEO-017** (P1, 2 SP) — substitui hardcoded 30d em `frontend/app/sitemap.ts:668-679` por novo endpoint `/v1/sitemap/licitacoes-do-dia-indexable` (somente datas com >=5 bids). Page fallback graceful 200+noindex em vez de 404. Removido `/observatorio/raio-x-marco-2026` do sitemap (rota nao existe). **Elimina 43 URLs 404 reportados em GSC sweep.**
- **STORY-SEO-015** (P1, 5 SP -> headers-only por advisor cut) — Cache-Control public+SWR 6h fresh / 12h SWR / 24h stale-if-error em 8 endpoints `/v1/sitemap/*`. Defer Redis L2 + Prometheus metrics + purge para STORY-SEO-015.1.

Defer (proxima sessao): SEO-016 (Prometheus alert), SEO-018 (entity routes), SEO-019 (crawler protection).

Contract drift: backend `{dates: string[], total, updated_at}`; frontend extrai `(d as {dates?: string[]}).dates ?? []` — fail-safe nao bloqueia se backend mudar shape, mas vira `[]` silencioso. Documentado.

## Testing Plan

### Backend
- [x] `pytest tests/test_sitemap_*.py` — 49/49 pass (8 cache header + 7 indexable + 34 existing)
- [x] `pytest tests/` (sem integration/fuzz/benchmark) — 640 pass, 1 erro pre-existente nao-relacionado (test_integration_new_sectors chama PNCP API real)
- [x] `python -c "from startup.app_factory import create_app; create_app()"` — 216 routes OK

### Frontend
- [x] `jest __tests__/licitacoes-do-dia.test.tsx` — 7/7 pass (1 atualizado para noindex+nofollow, 1 novo p/ data valida sem bids)
- [x] `jest __tests__/sitemap-coverage.test.ts` — 4/4 pass (regression gate intact)
- [x] `tsc --noEmit` — sem erros nos arquivos tocados
- [x] `npm run lint` — sem erros

### Production validation (post-deploy)
- [ ] **SEO-013** — `time curl https://api.smartlic.tech/v1/orgao/03504182000126/stats` < 2s (vs 443s baseline; ja medido 0.87s warm pre-merge)
- [ ] **SEO-014** — `curl https://api.smartlic.tech/v1/sitemap/cnpjs | jq '.total'` >= 1000 (ja confirmado)
- [ ] **SEO-015** — `curl -I https://api.smartlic.tech/v1/sitemap/cnpjs | grep -iE 'cache-control|vary'` retorna headers configurados
- [ ] **SEO-017** — `curl https://api.smartlic.tech/v1/sitemap/licitacoes-do-dia-indexable | jq '.dates | length'` > 0 + sweep python sem 404s
- [ ] **Sitemap agregado (24h post-deploy)** — `for i in 0 1 2 3 4; do curl -sL https://smartlic.tech/sitemap/$i.xml | grep -c '<loc>'; done` total >= 5000

### Migration Status (Supabase prod)
- [x] **20260424161923_seo013_index_orgao_cnpj_raw_bids** aplicada via `supabase db push --include-all` (stash .down.sql + push + restore pattern de deploy.yml)
- [x] CONCURRENTLY incompativel com transacao do CLI -> CREATE INDEX IF NOT EXISTS sem CONCURRENTLY. Janela escolhida (14:25 BRT, entre crons) bloqueio aceito ~30s-2min sem incidente

### Risks
- Soak 24h pos-merge: Prometheus `smartlic_pncp_max_page_size_changed_total`, Sentry slow query alerts, GSC Coverage delta
- Revert: `.down.sql` pareado disponivel; 5 commits separados facilitam bisect

## Closes

- Refs: `docs/stories/epic-seo-recovery-2026-q2.md`
- Implements: STORY-SEO-013, STORY-SEO-014, STORY-SEO-015 (headers-only), STORY-SEO-017
- Defer: STORY-SEO-016, STORY-SEO-018, STORY-SEO-019, STORY-SEO-015.1 (Redis L2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sitemap endpoint returning indexable publication dates (last 30 days).
  * Backend now emits standardized cache headers for all sitemap endpoints.

* **Bug Fixes**
  * Pages with no publication data show a non-indexed friendly empty state instead of 404.
  * Removed a stale sitemap entry pointing to a non-existent route.

* **Performance**
  * Added a partial DB index to speed org CNPJ queries.

* **Tests**
  * New tests validating sitemap caching and the new date-indexable endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->