### PR TITLE
chore(ci): defer full matrix to post-merge + skip CodeQL on docs-only PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,23 @@
+# mission sparkling-patterson 2026-04-24: skip CodeQL on docs-only PRs
+# (saves ~6min of queue time per docs-only PR). Weekly schedule still
+# scans the full repo against the latest query pack.
 name: "CodeQL Security Scan"
 
 on:
   push:
     branches: [master, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   pull_request:
     branches: [master, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   schedule:
     # Run every Monday at 00:00 UTC
     - cron: '0 0 * * 1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,19 @@
 # Both are needed: this for integration + E2E, backend-tests.yml for quality gates.
 # NOTE: The E2E job here duplicates e2e.yml. e2e.yml is more complete (uploads artifacts,
 # runs smoke tests). tests.yml E2E job serves as a gating step that requires unit tests first.
+#
+# mission sparkling-patterson 2026-04-24: deferred to post-merge. PR gate
+# is backend-tests.yml + frontend-tests.yml (those are what branch
+# protection enforces). Running the Python 3.12 matrix + integration +
+# E2E on every PR was duplicated work that added 8-10 min of queue time
+# per PR. Now runs on push to main/master (catches regressions before
+# deploy) and workflow_dispatch (manual on-demand for risky PRs).
 name: "Tests (Full Matrix + Integration + E2E)"
 
 on:
-  pull_request:
-    branches: [master, main]
   push:
     branches: [master, main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Mission sparkling-patterson 2026-04-24. Memory `project_railway_runners_cost_2026_04.md` (2026-04-23 temporal-rainbow) documented this plan but nothing was shipped. Shipping now.

- **tests.yml** `"Tests (Full Matrix + Integration + E2E)"` — dropped the `pull_request` trigger. Runs only on `push: [master, main]` and `workflow_dispatch`. Branch protection only gates on `Backend Tests (PR Gate)` + `Frontend Tests (PR Gate)`, so the Python 3.12 matrix + integration + E2E jobs that ran on every PR were pure duplication (~8-10 min of queue time per PR).
- **codeql.yml** — `paths-ignore` on `docs/**`, `**/*.md`, and issue/PR templates for both triggers. Docs-only PRs no longer wait ~6 min for a CodeQL scan that has nothing to analyze. Weekly Monday 00:00 UTC cron still scans the full repo.

## Why now

Queue cap is 20 concurrent ubuntu-latest jobs. PR #505 today sat ~15 min in queue waiting for a duplicate full matrix. Fewer redundant jobs = faster time to merge for every PR.

## What is NOT touched

- `backend-tests.yml` (required by branch protection — still runs on every PR)
- `frontend-tests.yml` (required by branch protection — still runs on every PR)
- `chromatic.yml`, `load-test.yml`, `e2e.yml`, `dep-scan.yml`, `editorial-lint.yml` — already had correct `paths:` filters

## Test plan

- [ ] Merge and observe next PR CI run — expect `Tests (Full Matrix + Integration + E2E)` absent from PR checks, present on post-merge push to main
- [ ] Docs-only PR (e.g. a session handoff) — expect CodeQL jobs absent from PR checks
- [ ] Weekly CodeQL scheduled run on Monday still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CodeQL workflow to skip running on documentation-only changes, improving CI/CD efficiency
  * Updated test workflow configuration to run on main branch pushes and manual triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->