### PR TITLE
fix(seo)(sen-fe-001): align sitemap fetcher cache with page revalidate

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -23,7 +23,7 @@ async function fetchSitemapJson<T>(
   const url = `${backendUrl}${endpoint}`;
   try {
     const resp = await fetch(url, {
-      cache: 'no-store',
+      next: { revalidate: 3600 },
       signal: AbortSignal.timeout(15000),
     });
     if (!resp.ok) {


### PR DESCRIPTION
## Summary

Fix 1-linha em `frontend/app/sitemap.ts`: troca `cache:'no-store'` por `next:{revalidate:3600}` no fetcher interno (`fetchSitemapJson`), alinhando com `export const revalidate = 3600` do page-level.

## Context

**Root cause confirmado** de `sitemap/4.xml = 0 URLs em produção**: antipattern Next.js 16 documentado em `feedback_isr_fetch_cache_alignment_next16.md` (SEN-FE-001, 2238 eventos Sentry). O mesmo fix foi aplicado em `ae1dd7ab` para `/contratos/orgao/[cnpj]`, mas passou por `sitemap.ts` sem merge.

Quando page-level declara `revalidate = N` e fetchers internos usam `cache:'no-store'`, o ISR aborta regeneração e serve resultado vazio permanentemente — não há fallback.

## Evidence (pré-fix)

- Shards: `sitemap/0.xml=42`, `/1=60`, `/2=810`, `/3=327`, `/4=0` URLs
- RPCs backend respondendo normalmente (<3s p95)
- Logs frontend: `[sitemap] fetch itens failed Error [TimeoutError]` mesmo com backend healthy
- `contratos-orgao-indexable` retornando `{"orgaos":[], "total":0}` legítimo

## Impact

Desbloqueia 10k+ URLs entity programmatic para reindexação GSC:

- `/cnpj/{cnpj}` (~5k URLs)
- `/orgaos/{cnpj}` (~2k URLs)
- `/fornecedores/{cnpj}` (~5k URLs)
- `/municipios/{slug}` (~200 URLs)
- `/itens/{catmat}` (~1k URLs)
- `/contratos/orgao/{cnpj}` (~2k URLs quando dados existirem)

Baseline GSC 2026-04-24: 126 clicks / 9.9k impr em 28d (pos 7.1). Shard 4 vazio estava capando crawl budget há semanas.

## Testing Plan

- [ ] Deploy para prod (Railway auto-deploy)
- [ ] `curl https://smartlic.tech/sitemap/4.xml | grep -c "<url>"` retorna >5000
- [ ] Resubmit `https://smartlic.tech/sitemap.xml` no Google Search Console
- [ ] Observar 48-72h: GSC "Descoberta" sobe 10k+ URLs em shard 4
- [ ] Sem regressão em shards 0-3 (devem continuar retornando URLs normais)

## Closes

- Fix para memory `feedback_isr_fetch_cache_alignment_next16.md` (SEN-FE-001)
- Baseline para `reference_smartlic_baseline_2026_04_24.md` (sitemap 4=0 observado 2026-04-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced sitemap caching for improved site performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->