### PR TITLE
fix(seo)(sen-fe-001): align fetchContratosStats cache with page revalidate

### DIFF
--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -41,7 +41,7 @@ async function fetchContratosStats(setor: string, uf: string): Promise<Contratos
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
   try {
     const res = await fetch(`${backendUrl}/v1/contratos/${setor}/${uf}/stats`, {
-      cache: 'no-store', // bypass Next.js Data Cache — sempre fresh no ISR regen
+      next: { revalidate: 14400 },
       signal: AbortSignal.timeout(10000),
     });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary

Fix 1-linha em `frontend/app/contratos/[setor]/[uf]/page.tsx`: troca `cache:'no-store'` por `next:{revalidate:14400}` em `fetchContratosStats`, alinhando com `export const revalidate = 14400` do page-level.

## Context

Mesmo antipattern SEN-FE-001 (`feedback_isr_fetch_cache_alignment_next16.md`) fixado em `ae1dd7ab` para `/contratos/orgao/[cnpj]` ainda presente em `/contratos/[setor]/[uf]`. Descoberto via grep global após resolver `sitemap/4.xml=0` no PR #507 (`feedback_sen_fe_001_recidiva_sitemap.md` — lição: fix de padrão não está completo até grep global rodar limpo).

O comentário anterior `"bypass Next.js Data Cache — sempre fresh no ISR regen"` refletia intenção errada. Em Next.js 16, `cache:'no-store'` downgradeia a page para dynamic at runtime, invalidando SSG/ISR marking — exatamente o bug da issue Sentry 7409705693 (2238 eventos em 14d).

## Scope confirmation

Grep `cache:\s*['\"]no-store['\"]` em `frontend/app/` retornou 6 matches:

- ✅ `frontend/app/contratos/[setor]/[uf]/page.tsx` — fetch em runtime (este PR)
- ✅ `frontend/app/sitemap.ts` — fetch em runtime (PR #507)
- 🟡 `frontend/app/fornecedores/[cnpj]/page.tsx` — fetch em `generateStaticParams` (build-time, OK)
- 🟡 `frontend/app/itens/[catmat]/page.tsx` — fetch em `generateStaticParams` (build-time, OK)
- 🟡 `frontend/app/municipios/[slug]/page.tsx` — fetch em `generateStaticParams` (build-time, OK)
- 🟡 `frontend/app/api/*/route.ts` (×2) — API routes, dynamic por natureza (OK)

Apenas call sites em runtime dentro de páginas ISR sofrem do bug.

## Impact

Reduz Sentry issue 7409705693 (SEN-FE-001) em ~X% adicional além do PR #507. Preserva SSG/ISR marking em `/contratos/{setor}/{uf}` (~1600 URLs programmatic setor×UF).

## Testing Plan

- [ ] Deploy para prod (Railway auto-deploy após merge)
- [ ] Sentry issue 7409705693 events/hour decresce em 24h
- [ ] `/contratos/{setor}/{uf}` páginas continuam renderizando corretamente (spot-check 3 URLs)
- [ ] Sem regressão nas shards do sitemap (PR #507 deve continuar funcionando)

## Closes

- Fix complementar para memory `feedback_isr_fetch_cache_alignment_next16.md` (SEN-FE-001)
- Completa grep global iniciado em PR #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized stats data loading performance by enabling response caching, reducing unnecessary requests and improving page load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->