### PR TITLE
docs(session): steady-kurzweil 2026-04-24 — SEN-FE-001 sitemap + entity pages

### DIFF
--- a/docs/sessions/2026-04/2026-04-24-steady-kurzweil-handoff.md
+++ b/docs/sessions/2026-04/2026-04-24-steady-kurzweil-handoff.md
@@ -1,0 +1,64 @@
+# Session steady-kurzweil — 2026-04-24
+
+## Objetivo
+
+Desbloquear funil server-side + restaurar `sitemap/4.xml` + resubmit GSC pra reindex em 48h.
+
+## Entregue
+
+- PR #507 — `fix(seo)(sen-fe-001): align sitemap fetcher cache with page revalidate` — fix 1-linha que resolve `sitemap/4.xml=0 URLs` em prod, desbloqueando 10k+ URLs entity programmatic
+- PR #508 — `fix(seo)(sen-fe-001): align fetchContratosStats cache with page revalidate` — mesmo antipattern em `/contratos/[setor]/[uf]/page.tsx`, descoberto via grep global. Reduz Sentry issue 7409705693 (SEN-FE-001).
+
+## Impacto em receita
+
+**REVENUE-ADJACENT (aquisição orgânica).** Shard 4 do sitemap vinha retornando 0 URLs há semanas, capando crawl budget do Google. Baseline pré-fix: 126 clicks / 9.9k impr 28d (pos 7.1, CTR 1.3%). Esperado pós-deploy + 48-72h GSC reindex: 10k+ URLs discovered, tráfego orgânico entity programmatic ativo.
+
+**Gaps REVENUE-DIRECT eram falsos alarmes (memory desatualizada):**
+- `MIXPANEL_TOKEN` em `bidiq-backend` → **SET** (piped-cray aplicou)
+- `RESEND_WEBHOOK_SECRET` → **SET**; webhook id `758ea803` ativo (sparkling-patterson final)
+- `checkout_completed` Mixpanel event → já emitido como `subscription_activated` (`backend/webhooks/handlers/checkout.py:122,217`)
+- Migration `20260424180000_trial_email_delivery_tracking.sql` → já aplicada em prod
+
+**Descoberta empírica que mudou approach:**
+- Plan inicial: apply SEO-013 index (CREATE INDEX CONCURRENTLY no `pncp_raw_bids.orgao_cnpj`). RPCs medidos pós-probe respondendo <3s p95 (cnpjs=0.7s, orgaos=0.9s, itens=2.5s). Index ortogonal ao bug real.
+- Advisor call encontrou o root cause: antipattern SEN-FE-001 em `sitemap.ts:25-28` (`cache:'no-store'` + `export const revalidate = 3600`). Mesmo bug fixado em `ae1dd7ab` para `/contratos/orgao/[cnpj]` havia passado por sitemap.
+
+## Pendente (dono + prazo)
+
+- [ ] PR #507 merge — @devops — quando BT + FT verdes (FT=SUCCESS, BT=IN_PROGRESS ao commit deste handoff)
+- [ ] PR #508 merge — @devops — após #507 rebase se necessário
+- [ ] Validar `curl sitemap/4.xml | grep -c "<url>"` >5000 — pós-deploy Railway
+- [ ] **User: resubmit `https://smartlic.tech/sitemap.xml` no Google Search Console** — passos abaixo
+- [ ] SEO-013 index — deferred — abrir story se latência RPCs regredir (pré-requisito baseline monitorada)
+- [ ] Resend webhook HMAC verify — gap security vivo em `routes/trial_emails.py::resend_webhook` — defer até volume escalar
+
+## GSC Resubmit — Passos (user)
+
+1. Aguardar Railway deploy completar após merge de #507 (~5-10min pós-merge). Verificar via Railway Activity ou:
+   ```bash
+   curl -s "https://smartlic.tech/sitemap/4.xml" | grep -c "<url>"
+   # Esperado: >5000 (hoje: 0)
+   ```
+2. Ir para Google Search Console → propriedade `smartlic.tech` → menu **Sitemaps**
+3. Se `https://smartlic.tech/sitemap.xml` já estiver listado, clicar 3-pontos → **Remover sitemap** (força re-descoberta). Então re-adicionar no campo "Adicionar um novo sitemap".
+4. Alternativamente: apenas digitar `sitemap.xml` e clicar **Enviar** — GSC redescobre shards.
+5. Status deve aparecer: `Sucesso`, última leitura recente.
+6. Observação 48-72h: GSC → **Páginas** → filtrar `Origem: Sitemap` → shard 4 começa a reportar URLs "Descobertas". Impressões em rotas `/contratos/orgao/{cnpj}`, `/cnpj/{cnpj}`, `/orgaos/{cnpj}`, `/fornecedores/{cnpj}`, `/municipios/{slug}`, `/itens/{catmat}` aumentam nos próximos 7-14 dias.
+
+## Riscos vivos
+
+- **Baixa: fix #507 insuficiente.** Se pós-deploy shard 4 continuar vazio, investigar `contratos-orgao-indexable` (retorna `{"orgaos":[], "total":0}` — legítimo zero ou bug no RPC?). Próxima sessão: 15min diagnose.
+- **Média: `Validate PR Metadata` failing no PR.** Non-blocking (memory `reference_main_required_checks.md` — só BT+FT required), mas pode indicar body sem `## Summary`/`## Test plan`/`## Closes`. Ok — PR body cobre todos.
+
+## Memory updates
+
+- `feedback_sen_fe_001_recidiva_sitemap.md` — NEW: após fix SEN-FE-001, grep global por outros call sites é mandatório. Recorrência 2026-04-24.
+- `MEMORY.md` — trial_email_log entry atualizada (não é mais "webhook unconfigured"); adicionada entry SEN-FE-001 recidiva.
+
+## Objetivo cumprido?
+
+**Parcial.** Fix shipado em PR #507, aguardando merge. GSC resubmit bloqueado até deploy confirmar shard 4 populado. Instrumentação funil (blocks 1.1-1.3 do plan original) descobertas como já resolvidas em sessões anteriores — no-ops.
+
+## Próxima ação prioritária de receita
+
+Aguardar merge PR #507 → validar sitemap/4 >5000 URLs → user resubmit GSC. Única ação de impacto ≥10k URLs indexadas em <72h.


### PR DESCRIPTION
## Summary

Handoff da sessão steady-kurzweil (2026-04-24). Documenta:

- PR #507 (sitemap.ts) + PR #508 (contratos/setor/uf) — fix recidiva SEN-FE-001
- Falsos positivos da memory (MIXPANEL_TOKEN, Resend webhook, checkout event) — já resolvidos em sessões anteriores
- Instruções GSC resubmit para user pós-deploy

## Context

Sessão focou em restaurar `sitemap/4.xml` (vazio em prod há semanas, bloqueando 10k+ URLs entity programmatic do GSC). Descoberta via advisor: root cause era antipattern Next.js 16 (`cache:'no-store'` + `revalidate=N`), o mesmo de `ae1dd7ab` mas em outros call sites.

Plan inicial (SEO-013 index) foi deferred após probe empírico mostrar RPCs backend já <3s p95.

## Testing Plan

- [ ] Handoff legível e acionável
- [ ] Instruções GSC claras para user

## Closes

- Doc durável da sessão steady-kurzweil

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal session handoff documentation recording completed deliverables and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->