### PR TITLE
fix(seo): sitemap fetcher fallback para NEXT_PUBLIC_BACKEND_URL em build-time

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -19,7 +19,7 @@ async function fetchSitemapJson<T>(
   extract: (data: unknown) => T,
   label: string,
 ): Promise<T | null> {
-  const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
+  const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
   const url = `${backendUrl}${endpoint}`;
   try {
     const resp = await fetch(url, {


### PR DESCRIPTION
## Summary

Fix 1-linha em `frontend/app/sitemap.ts`: adiciona `process.env.NEXT_PUBLIC_BACKEND_URL` como fallback do `process.env.BACKEND_URL`. Resolve `sitemap/4.xml=0 URLs` que persistia mesmo após merge do PR #507.

## Context

PR #507 consertou o antipattern SEN-FE-001 (`cache:'no-store'` + `revalidate=N`) mas `sitemap/4.xml` continuou retornando 0 URLs pós-deploy. Investigação revelou **root cause distinto e complementar**: `BACKEND_URL` NÃO é declarado como `ARG`/`ENV` no `frontend/Dockerfile`. Durante Railway CI build:

- `NEXT_PUBLIC_BACKEND_URL` → setado (linha 46-73 do Dockerfile)
- `BACKEND_URL` → **undefined** → `process.env.BACKEND_URL` cai no fallback `http://localhost:8000`
- Todos os 6 fetches em `fetchSitemapJson` batem em `localhost:8000` → connection refused
- Next.js 16 pre-renderiza o sitemap no build com arrays vazios
- Cache persistido via ISR (`revalidate = 3600`) serve sempre `<urlset></urlset>`

## Fix

```typescript
- const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
+ const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
```

Runtime (Railway container): `BACKEND_URL` setado → usado.
Build-time (Railway CI): `BACKEND_URL` undefined → cai em `NEXT_PUBLIC_BACKEND_URL` (inlined).

## Alternativa considerada (rejeitada)

Adicionar `ARG BACKEND_URL` + `ENV BACKEND_URL=$BACKEND_URL` no Dockerfile. Requer também declarar no `deploy.yml` GitHub Action + potencial impacto em outras build steps. Fix de 1 linha em código aplicativo é menos invasivo e estabelece chain de fallback robusto.

## Testing Plan

- [ ] Deploy para prod (Railway auto-deploy após merge)
- [ ] `curl https://smartlic.tech/sitemap/4.xml | grep -c "<url>"` > 100
- [ ] Resubmit `https://smartlic.tech/sitemap.xml` no GSC
- [ ] 48-72h: GSC "Páginas descobertas" shard 4 cresce

## Closes

- Follow-up de PR #507 (SEN-FE-001 sitemap fix)
- Resolve root cause build-time descoberto pós-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend URL resolution for sitemap fetching to support enhanced environment variable configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->