### PR TITLE
fix(seo)(seo-020): Dockerfile ARG BACKEND_URL for build-time sitemap

### DIFF
--- a/docs/stories/STORY-SEO-020-dockerfile-backend-url-arg.md
+++ b/docs/stories/STORY-SEO-020-dockerfile-backend-url-arg.md
@@ -1,0 +1,78 @@
+# STORY-SEO-020: Dockerfile build-time `BACKEND_URL` ARG (sitemap fix)
+
+## Status
+
+Approved
+
+## Story
+
+**As a** crawler do Google buscando indexar `https://smartlic.tech/sitemap/4.xml`,
+**I want** que o sitemap seja gerado com URLs reais durante o build do frontend (não fallback localhost),
+**so that** páginas programmatic (cnpj, orgaos, municipios, fornecedores, contratos-orgao) sejam descobertas e indexadas — destravando 3x tráfego.
+
+## Acceptance Criteria
+
+1. `frontend/Dockerfile` declara `ARG BACKEND_URL` na seção de ARGs (logo após `NEXT_PUBLIC_BACKEND_URL`).
+2. `BACKEND_URL` é convertido em `ENV BACKEND_URL=$BACKEND_URL` na seção de ENVs do estágio builder.
+3. Build args do Railway service `bidiq-frontend` incluem `BACKEND_URL=https://api.smartlic.tech` (verificar via `railway variables --service bidiq-frontend --kv | grep BACKEND_URL`).
+4. Build log do próximo deploy mostra fetches contra `https://api.smartlic.tech/v1/sitemap/*` (não `localhost:8000`).
+5. `curl -I https://smartlic.tech/sitemap/4.xml` retorna `200` com `Content-Length` >5kB (vs 0 atualmente).
+6. `curl https://smartlic.tech/sitemap/4.xml | grep -c "<loc>"` retorna ≥1000 URLs após próximo deploy.
+7. Smoke-test em staging confirma comportamento antes do deploy a prod.
+
+## Tasks / Subtasks
+
+- [ ] Task 1 — Editar Dockerfile (AC: 1, 2)
+  - [ ] Adicionar `ARG BACKEND_URL` após linha 68 (entre ARGs `NEXT_PUBLIC_*`)
+  - [ ] Adicionar `ENV BACKEND_URL=$BACKEND_URL` na seção ENV (linha 71+)
+- [ ] Task 2 — Configurar Railway build arg (AC: 3)
+  - [ ] @devops adiciona `BACKEND_URL=https://api.smartlic.tech` nas vars do service `bidiq-frontend`
+  - [ ] Confirmar via `railway variables --service bidiq-frontend --kv | grep BACKEND_URL`
+- [ ] Task 3 — Validação build-time (AC: 4)
+  - [ ] Forçar rebuild (cachebust em Dockerfile ou commit trivial)
+  - [ ] Inspecionar build log no Railway: confirmar fetches a `api.smartlic.tech`
+- [ ] Task 4 — Validação runtime (AC: 5, 6)
+  - [ ] `curl -I` em todos `/sitemap/*.xml`
+  - [ ] Contar `<loc>` em sitemap-4.xml
+- [ ] Task 5 — Smoke staging (AC: 7)
+  - [ ] Validar fluxo completo em staging primeiro
+
+## Dev Notes
+
+**Plano:** Wave 2, story 2 (CRITICAL — bloqueia stories 3-6 de SEO).
+
+**Audit evidence:**
+- `frontend/Dockerfile:44-68` declara `ARG NEXT_PUBLIC_BACKEND_URL` mas **não** `ARG BACKEND_URL`
+- `frontend/app/sitemap.ts:22` faz fallback `process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'`
+- Resultado: build-time fetches em sitemap.ts caem em `localhost:8000` → todas RPC retornam vazio → sitemap-4.xml com 0 URLs em prod
+
+**Memória relevante:** `reference_frontend_dockerfile_backend_url_gap.md` (2026-04-24) já documentou o gap.
+
+**Memória adicional:** `feedback_sen_fe_001_recidiva_sitemap.md` — após fix, fazer grep global por outros call sites com fallback similar (`process.env.BACKEND_URL ||`) para garantir que não há recidiva.
+
+**Files mapeados:**
+- `frontend/Dockerfile` (edit)
+- `frontend/app/sitemap.ts` (validação, sem edit)
+
+### Testing
+
+- Manual: build local com `--build-arg BACKEND_URL=https://api.smartlic.tech` e inspecionar `.next/server/app/sitemap*.js`
+- Smoke prod: `curl -I https://smartlic.tech/sitemap/{0,1,2,3,4,5}.xml` todos 200 com Content-Length >0
+
+## Dependencies
+
+- **Bloqueia:** STORY-SEO-021, STORY-SEO-022, STORY-SEO-023, STORY-SEO-024 (sitemap quebrado mascara fixes SEO)
+- **Bloqueado por:** nenhum
+- **Risco:** alto blast radius (rebuild frontend); coordenar window com @devops
+
+## Owners
+
+- Primary: @devops (Dockerfile + Railway vars)
+- Quality: @qa (smoke prod)
+- Consult: @architect (se múltiplos call sites precisam refator)
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-04-26 | 0.1 | Initial draft via /sm baseado em plano de crescimento | @sm (River) |

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@
 
 # CACHE BUST - forces Railway rebuild (change to invalidate cache)
 # GTM-FIX-002: Add missing NEXT_PUBLIC_* build ARGs for Sentry/Mixpanel/Stripe
-ARG CACHEBUST=20260416-fix-storybook-peer-deps
+ARG CACHEBUST=20260426-seo020-backend-url-arg
 
 # Stage 1: Dependencies
 # Using node:20.11-alpine3.19 instead of node:20-alpine to force layer rebuild
@@ -44,6 +44,10 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_BACKEND_URL
+# STORY-SEO-020: server-only BACKEND_URL needed by sitemap.ts at build time.
+# Without this, frontend/app/sitemap.ts falls back to localhost:8000, producing
+# sitemap-4.xml with 0 <loc> entries in production.
+ARG BACKEND_URL
 ARG NEXT_PUBLIC_CANONICAL_URL
 ARG NEXT_PUBLIC_APP_URL
 ARG NEXT_PUBLIC_APP_NAME=SmartLic
@@ -71,6 +75,7 @@ ARG SENTRY_PROJECT
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL
+ENV BACKEND_URL=$BACKEND_URL
 ENV NEXT_PUBLIC_CANONICAL_URL=$NEXT_PUBLIC_CANONICAL_URL
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_PUBLIC_APP_NAME=$NEXT_PUBLIC_APP_NAME
@@ -93,6 +98,7 @@ ENV SENTRY_PROJECT=$SENTRY_PROJECT
 # Debug: Print build-time environment variables
 RUN echo "=== Build-time Environment Variables ===" && \
     echo "NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL" && \
+    echo "BACKEND_URL=$BACKEND_URL" && \
     echo "NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL" && \
     echo "NEXT_PUBLIC_CANONICAL_URL=$NEXT_PUBLIC_CANONICAL_URL" && \
     echo "NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL" && \


### PR DESCRIPTION
## Summary

Adds missing `ARG BACKEND_URL` to `frontend/Dockerfile` so build-time fetchers (sitemap.ts, entity pages, programmatic pages) reach the production backend instead of falling back to `localhost:8000`.

## Context

`curl https://smartlic.tech/sitemap/4.xml | grep -c "<loc>"` returned **0** in production despite Railway service `bidiq-frontend` already having `BACKEND_URL=https://api.smartlic.tech` set. Root cause: Dockerfile only declared `ARG NEXT_PUBLIC_BACKEND_URL` — server-only `BACKEND_URL` was never propagated to the Next.js build environment.

This blocks **5 SEO stories** (SEO-021/022/023/024 + entity content) and SEO programmatic indexability — the lever for organic inbound trial acquisition.

## Changes

- `frontend/Dockerfile`:
  - `ARG BACKEND_URL` added (paired with existing `ARG NEXT_PUBLIC_BACKEND_URL`)
  - `ENV BACKEND_URL=$BACKEND_URL` exported in builder stage
  - Debug print updated to log `BACKEND_URL`
  - `CACHEBUST` bumped to `20260426-seo020-backend-url-arg`

## Testing Plan

- [ ] Railway rebuild triggered automatically by merge to main
- [ ] Build log shows `BACKEND_URL=https://api.smartlic.tech` (not empty)
- [ ] `curl -I https://smartlic.tech/sitemap/4.xml` → 200 + Content-Length >5kB
- [ ] `curl -s https://smartlic.tech/sitemap/4.xml | grep -c "<loc>"` ≥1000
- [ ] No regression in entity pages (`/cnpj/[cnpj]`, `/orgaos/[slug]`, `/fornecedores/[cnpj]`, `/municipios/[slug]`, `/contratos/orgao/[cnpj]`)

## Closes

- STORY-SEO-020 (`docs/stories/STORY-SEO-020-dockerfile-backend-url-arg.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SEO story documenting backend URL configuration requirements for sitemap generation.

* **Chores**
  * Updated Dockerfile to pass backend URL during build process, ensuring sitemaps use production API URLs instead of localhost fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->