### PR TITLE
hotfix(incident): cache 502 + AbortSignal timeouts (backend wedge recovery)

### DIFF
--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -919,7 +919,26 @@ def _compute_contratos_stats(
             "contratos DB query failed (sector=%s uf=%s municipio=%s): %s",
             sector.id if sector else None, uf, municipio_pattern, e,
         )
-        raise HTTPException(status_code=502, detail="Erro ao consultar o datalake de contratos")
+        # SmartLic incident 2026-04-27 humble-dolphin: hobby plan + 1 worker
+        # + DB statement_timeout (8s) on (uf, municipio_pattern ilike) was
+        # raising 502 and producing crawler retry storm that wedged the only
+        # uvicorn worker. Returning empty stats keeps endpoint responsive
+        # while DB recovers; the 6h cache layer at endpoint level absorbs
+        # the empty response so subsequent hits don't re-query.
+        now = datetime.now(timezone.utc)
+        return {
+            "total_contracts": 0,
+            "total_value": 0.0,
+            "avg_value": 0.0,
+            "top_orgaos": [],
+            "top_fornecedores": [],
+            "monthly_trend": [],
+            "by_uf": [],
+            "last_updated": now.isoformat(),
+            "n_unique_orgaos": 0,
+            "n_unique_fornecedores": 0,
+            "sample_contracts": [],
+        }
 
     rows = resp.data or []
 

--- a/backend/tests/test_blog_stats.py
+++ b/backend/tests/test_blog_stats.py
@@ -806,12 +806,21 @@ class TestContratosSetorUfStats:
             assert data["top_orgaos"] == []
             assert data["top_fornecedores"] == []
 
-    def test_sector_uf_contratos_db_failure_502(self, client):
+    def test_sector_uf_contratos_db_failure_returns_empty(self, client):
+        # Hotfix incident 2026-04-27: DB failure returns 200 + empty stats
+        # (instead of 502) to prevent crawler retry storm that wedged backend.
+        # Endpoint cache absorbs the empty response.
         mock_sb = MagicMock()
         mock_sb.table.side_effect = RuntimeError("connection refused")
         with patch("supabase_client.get_supabase", return_value=mock_sb):
-            res = client.get("/v1/blog/stats/contratos/vestuario/uf/SP")
-            assert res.status_code == 502
+            # Unique slug to bypass cache from preceding tests in the class
+            res = client.get("/v1/blog/stats/contratos/vestuario/uf/AC")
+            assert res.status_code == 200
+            data = res.json()
+            assert data["total_contracts"] == 0
+            assert data["total_value"] == 0.0
+            assert data["top_orgaos"] == []
+            assert data["top_fornecedores"] == []
 
 
 class TestContratosCidadeStats:
@@ -843,12 +852,20 @@ class TestContratosCidadeStats:
             res = client.get("/v1/blog/stats/contratos/cidade/nonexistent-city")
             assert res.status_code == 404
 
-    def test_cidade_contratos_db_failure_502(self, client):
+    def test_cidade_contratos_db_failure_returns_empty(self, client):
+        # Hotfix incident 2026-04-27: DB failure returns 200 + empty stats
+        # (instead of 502) to prevent crawler retry storm that wedged backend.
         mock_sb = MagicMock()
         mock_sb.table.side_effect = RuntimeError("db down")
         with patch("supabase_client.get_supabase", return_value=mock_sb):
-            res = client.get("/v1/blog/stats/contratos/cidade/sao-paulo")
-            assert res.status_code == 502
+            # Unique slug to bypass cache from preceding tests in the class
+            res = client.get("/v1/blog/stats/contratos/cidade/manaus")
+            assert res.status_code == 200
+            data = res.json()
+            assert data["total_contracts"] == 0
+            assert data["total_value"] == 0.0
+            assert data["top_orgaos"] == []
+            assert data["top_fornecedores"] == []
 
 
 class TestContratosCidadeSetorStats:

--- a/frontend/app/api/badge/stats/route.ts
+++ b/frontend/app/api/badge/stats/route.ts
@@ -13,6 +13,7 @@ export async function GET() {
   try {
     const resp = await fetch(`${backendUrl}/v1/stats/public?format=badge`, {
       next: { revalidate: 3600 },
+      signal: AbortSignal.timeout(8000),
     });
 
     if (!resp.ok) {

--- a/frontend/app/estatisticas/page.tsx
+++ b/frontend/app/estatisticas/page.tsx
@@ -127,6 +127,7 @@ async function fetchStats(): Promise<StatsResponse> {
   try {
     const resp = await fetch(`${baseUrl}/v1/stats/public`, {
       next: { revalidate: 21600 },
+      signal: AbortSignal.timeout(8000),
     });
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     return await resp.json();


### PR DESCRIPTION
## Summary

Hotfix for production incident 2026-04-27 ~00:08-00:15 UTC where backend was wedged after PR #513 (SEO-020) merge triggered a frontend rebuild. Build hammered backend with sitemap fetchers + 4146 SSG entity pages; backend on hobby plan with \`WEB_CONCURRENCY=1\` could not absorb the spike; DB \`statement_timeout\` (8s) fires on \`_compute_contratos_stats(uf, municipio_pattern ilike)\` over 2M+ rows in \`pncp_supplier_contracts\`.

\`\`\`
00:08:13 build aborted on /api/badge/stats (60s × 3 retries)
00:09:00+ /health timeout 5-15s — uvicorn worker wedged in DB
00:14:18Z this hotfix branched from main
\`\`\`

## Root Causes (order of effect)

1. **Backend 502 retry storm**: \`_compute_contratos_stats\` raised \`HTTPException(502)\` on DB failure. Endpoint cache only stores on success → crawlers retried failed routes → DDoS the only worker.
2. **Frontend build no abort timeout**: \`/api/badge/stats\` and \`estatisticas/page.tsx\` fetched without \`AbortSignal\` → hung 60s × 3 retries on backend timeout, aborting build.
3. **WEB_CONCURRENCY=1**: over-conservative for hobby plan (48 GB RAM/service); single worker cannot absorb traffic spike. Bumped to 2 out-of-band via Railway vars.

## Changes

- \`backend/routes/blog_stats.py:_compute_contratos_stats\` — return empty stats dict instead of raise 502 on DB failure. 6h endpoint cache absorbs empty response → no retry storm. DB recovers naturally; future success populates cache normally.
- \`frontend/app/api/badge/stats/route.ts\` — \`AbortSignal.timeout(8000)\` so build doesn't hang 60s × 3.
- \`frontend/app/estatisticas/page.tsx\` — same \`AbortSignal.timeout(8000)\`.

## Testing Plan

- [ ] Post-deploy: \`curl https://api.smartlic.tech/health\` returns 200 < 1s.
- [ ] Post-deploy: \`curl https://api.smartlic.tech/blog/stats/contratos/cidade/sao-bernardo-do-campo/setor/engenharia\` returns 200 (empty stats acceptable during DB recovery).
- [ ] Next frontend rebuild does not abort on \`/api/badge/stats\`.
- [ ] Sitemap-4 \`<loc>\` count >0 after rebuild succeeds.

## Follow-up (separate PRs)

- Composite index on \`pncp_supplier_contracts(is_active, uf, lower(municipio))\` to fix the underlying query plan.
- Investigate \`/api/buscar-progress\` \`undici\` module-not-found warning (build log).

## Risk

Empty stats served during DB outage = degraded UX but no broken pages. Acceptable trade-off vs total outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Statistics endpoints now return a consistent empty-stats response when underlying queries fail, avoiding error pages.
  * Backend requests to badge/stats and stats pages now time out after 8s to prevent indefinite loading.

* **Tests**
  * Updated tests to validate the empty-stats behavior and successful responses when query failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->