### PR TITLE
feat(MON-FN-005): MIXPANEL_TOKEN required in production startup

### DIFF
--- a/backend/config/base.py
+++ b/backend/config/base.py
@@ -93,8 +93,13 @@ def validate_env_vars() -> None:
     AC12: Check required vars: SUPABASE_URL, SERVICE_ROLE_KEY, JWT_SECRET, STRIPE_WEBHOOK_SECRET
     AC13: Warn on recommended vars: OPENAI_API_KEY, STRIPE_SECRET_KEY, SENTRY_DSN
     AC14: Raise RuntimeError if critical vars missing AND ENVIRONMENT=production
+
+    MON-FN-005: MIXPANEL_TOKEN promoted to required in production. Memory
+    `reference_mixpanel_backend_token_gap_2026_04_24` — token was silently
+    absent in prod, suppressing paywall_hit/trial_started events for an
+    unknown period. Funnel analytics is oxygen for monetization decisions.
     """
-    required_vars = ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_JWT_SECRET", "STRIPE_WEBHOOK_SECRET"]
+    required_vars = ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_JWT_SECRET", "STRIPE_WEBHOOK_SECRET", "MIXPANEL_TOKEN"]
     recommended_vars = ["OPENAI_API_KEY", "STRIPE_SECRET_KEY", "SENTRY_DSN"]
 
     env = os.getenv("ENVIRONMENT", os.getenv("ENV", "development")).lower()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,8 +1,13 @@
 """Tests for configuration module, including logging setup."""
 
 import logging
+import os
 import sys
-from config import setup_logging, RetryConfig
+from unittest.mock import patch
+
+import pytest
+
+from config import setup_logging, RetryConfig, validate_env_vars
 
 
 class TestSetupLogging:
@@ -331,3 +336,48 @@ class TestRetryConfig:
         config = RetryConfig(retryable_exceptions=custom_exceptions)
 
         assert config.retryable_exceptions == custom_exceptions
+
+
+class TestValidateEnvVarsMixpanelToken:
+    """MON-FN-005: MIXPANEL_TOKEN must be required in production.
+
+    Memory `reference_mixpanel_backend_token_gap_2026_04_24` — token was
+    silently absent in prod, suppressing paywall_hit/trial_started events
+    for an unknown period. Boot fail closes the gap.
+    """
+
+    @patch.dict(os.environ, {
+        "ENVIRONMENT": "production",
+        "SUPABASE_URL": "https://x.supabase.co",
+        "SUPABASE_SERVICE_ROLE_KEY": "k",
+        "SUPABASE_JWT_SECRET": "s",
+        "STRIPE_WEBHOOK_SECRET": "w",
+        "MIXPANEL_TOKEN": "",
+    }, clear=False)
+    def test_mixpanel_missing_in_production_raises(self):
+        with pytest.raises(RuntimeError, match="MIXPANEL_TOKEN"):
+            validate_env_vars()
+
+    @patch.dict(os.environ, {
+        "ENVIRONMENT": "development",
+        "SUPABASE_URL": "https://x.supabase.co",
+        "SUPABASE_SERVICE_ROLE_KEY": "k",
+        "SUPABASE_JWT_SECRET": "s",
+        "STRIPE_WEBHOOK_SECRET": "w",
+        "MIXPANEL_TOKEN": "",
+    }, clear=False)
+    def test_mixpanel_missing_in_dev_only_warns(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            validate_env_vars()
+        assert any("MIXPANEL_TOKEN" in r.message for r in caplog.records)
+
+    @patch.dict(os.environ, {
+        "ENVIRONMENT": "production",
+        "SUPABASE_URL": "https://x.supabase.co",
+        "SUPABASE_SERVICE_ROLE_KEY": "k",
+        "SUPABASE_JWT_SECRET": "s",
+        "STRIPE_WEBHOOK_SECRET": "w",
+        "MIXPANEL_TOKEN": "bc4162c2267b4c415357a02e2ef39cdc",
+    }, clear=False)
+    def test_mixpanel_present_in_production_passes(self):
+        validate_env_vars()

--- a/backend/tests/test_debt008_backend_stability.py
+++ b/backend/tests/test_debt008_backend_stability.py
@@ -372,7 +372,7 @@ class TestStartupValidation:
         validate_env_vars()  # No exception = pass
 
     def test_all_required_vars_present_no_error(self, monkeypatch):
-        """No error when all required vars including STRIPE_WEBHOOK_SECRET are set."""
+        """No error when all required vars including STRIPE_WEBHOOK_SECRET + MIXPANEL_TOKEN are set."""
         from config import validate_env_vars
 
         monkeypatch.setenv("ENVIRONMENT", "production")
@@ -380,6 +380,7 @@ class TestStartupValidation:
         monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "test_key")
         monkeypatch.setenv("SUPABASE_JWT_SECRET", "test_jwt")
         monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec_test")
+        monkeypatch.setenv("MIXPANEL_TOKEN", "mp_test")  # MON-FN-005
 
         # Should not raise
         validate_env_vars()


### PR DESCRIPTION
## Summary

Promotes `MIXPANEL_TOKEN` from silent-fallback to required env var. Boot fails fast in production if token is absent or empty. Memory `reference_mixpanel_backend_token_gap_2026_04_24` documents the bug: token was silently absent in prod for unknown period, suppressing `paywall_hit`/`trial_started` events.

## Root Cause

`backend/analytics_events.py:26-30` lazy-init Mixpanel client and silently falls back to `logger.debug()` when `MIXPANEL_TOKEN` is empty. Combined with `track_event` being fire-and-forget, the gap was indistinguishable from "no events fired" — only discovered by accident during another investigation.

Pre-revenue n=2 baseline already precarious; analytics blindness is fatal for monetization decisions (pricing, funnel optimization, downsell timing).

## Fix

`backend/config/base.py` — added `MIXPANEL_TOKEN` to `required_vars` list. `validate_env_vars()` already raises `RuntimeError` in production when required vars are missing.

- Production: missing → `RuntimeError`, app fails to boot
- Development: missing → `WARNING` log, app continues (allows local dev without Mixpanel project)

## Testing Plan

- [x] Local pytest 3/3 pass: `tests/test_config.py::TestValidateEnvVarsMixpanelToken`
  - `test_mixpanel_missing_in_production_raises`
  - `test_mixpanel_missing_in_dev_only_warns`
  - `test_mixpanel_present_in_production_passes`
- [x] Pre-deploy verified: `railway variables --service bidiq-backend --kv | grep MIXPANEL_TOKEN` returns valid token
- [ ] CI green before merge
- [ ] Soak post-deploy: `/health` continues 200 OK with valid token

## Closes

Story MON-FN-005 AC1 (boot fail em prod). AC2-7 (healthcheck /ready integration, dedicated assertion module, etc.) deferred — minimum viable to close the gap. Memory `feedback_n2_below_noise_eng_theater`: overengineering pre-n=30 is theater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App now validates that MIXPANEL_TOKEN is set at startup in production and will fail to start with a clear error if it’s missing.
  * In non-production environments, a missing MIXPANEL_TOKEN emits a warning instead of causing startup failure.
  * Prevents silent analytics failures and improves visibility into configuration issues to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->