### PR TITLE
feat(SEO-PROG-008): build-time assertion BACKEND_URL in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -112,6 +112,25 @@ RUN echo "=== Build-time Environment Variables ===" && \
 # Create build timestamp to prevent caching
 RUN echo "BUILD_TIMESTAMP=$(date +%Y%m%d%H%M%S)" > /tmp/build-info.txt && cat /tmp/build-info.txt
 
+# SEO-PROG-008: Build-time assertion — fail fast if BACKEND_URL absent in prod build.
+# Memory `reference_frontend_dockerfile_backend_url_gap_2026_04_24`: build-time SSG
+# fetches (sitemap.ts, /cnpj/[cnpj], /fornecedores/[cnpj], etc.) silently fall back
+# to localhost:8000 if Railway service var is missing → sitemap-4.xml renders with 0
+# entries → GSC indexing collapses. Asserting at build prevents silent regression.
+RUN if [ "$NEXT_PUBLIC_ENVIRONMENT" = "production" ]; then \
+      if [ -z "$BACKEND_URL" ]; then \
+        echo "ERROR: BACKEND_URL is required in production builds. Set Railway service variable bidiq-frontend.BACKEND_URL=https://api.smartlic.tech" >&2; \
+        exit 1; \
+      fi; \
+      if [ -z "$NEXT_PUBLIC_BACKEND_URL" ]; then \
+        echo "ERROR: NEXT_PUBLIC_BACKEND_URL is required in production builds (client-side fetches). Set Railway service variable bidiq-frontend.NEXT_PUBLIC_BACKEND_URL=https://api.smartlic.tech" >&2; \
+        exit 1; \
+      fi; \
+      echo "BACKEND_URL assertion: OK (BACKEND_URL=$BACKEND_URL, NEXT_PUBLIC_BACKEND_URL=$NEXT_PUBLIC_BACKEND_URL)"; \
+    else \
+      echo "BACKEND_URL assertion: SKIPPED (NEXT_PUBLIC_ENVIRONMENT=$NEXT_PUBLIC_ENVIRONMENT, not production)"; \
+    fi
+
 # Build the application
 # This will inline NEXT_PUBLIC_* vars into the JavaScript bundle
 RUN npm run build && echo "Build completed at $(date)"


### PR DESCRIPTION
## Summary

Adds fail-fast assertion in frontend Dockerfile to block production builds when `BACKEND_URL` or `NEXT_PUBLIC_BACKEND_URL` are absent. Prevents silent regression of the 2026-04-24 sitemap-4.xml=0-entries incident.

## Root Cause

Memory `reference_frontend_dockerfile_backend_url_gap_2026_04_24`: build-time SSG fetches (`sitemap.ts`, `/cnpj/[cnpj]`, `/fornecedores/[cnpj]`, etc.) silently fall back to `localhost:8000` if Railway service var is missing → sitemap-4.xml renders with 0 entries → GSC indexing collapses. STORY-SEO-020 (commit ae1dd7ab) added the ARG declaration but no assertion to detect future drift.

19 SSG routes use `process.env.BACKEND_URL || 'http://localhost:8000'` — if Railway `bidiq-frontend.BACKEND_URL` is unset (terraform error, manual rotation, accidental delete), build passes silently with broken fetches.

## Fix

`frontend/Dockerfile` — added `RUN` block between debug echo and `npm run build`:

- If `NEXT_PUBLIC_ENVIRONMENT=production`: assert `BACKEND_URL` and `NEXT_PUBLIC_BACKEND_URL` are non-empty, exit 1 with actionable message if either missing.
- Else (preview, dev, local docker build): SKIP assertion, log skipped state.

## Testing Plan

- [x] Local Dockerfile syntax verified (no docker build — memory `feedback_wsl_next16_build_inviavel` documents WSL build saturation)
- [x] Pre-deploy verified: `railway variables --service bidiq-frontend --kv | grep BACKEND_URL` returns valid values (memory `reference_railway_backend_url_already_set`)
- [ ] CI green before merge
- [ ] Railway frontend deploy succeeds with assertion log: `BACKEND_URL assertion: OK (BACKEND_URL=https://api.smartlic.tech, NEXT_PUBLIC_BACKEND_URL=https://api.smartlic.tech)`
- [ ] sitemap-4.xml continues populating post-deploy

## Closes

Story SEO-PROG-008 AC2 (build-time assertion). AC3 (chain fallback consistency in 19 SSG routes) deferred — separate cleanup PR. Memory `feedback_n2_below_noise_eng_theater`: minimum viable closes the silent-regression risk; mass refactor pre-revenue is theater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build-time validation to catch missing configuration during production deployments, improving deployment reliability and preventing builds with incomplete setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->