### PR TITLE
fix(incident): blog_stats wedge Stage 3 — async to_thread + 10s budget + negative cache

### DIFF
--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -13,6 +13,7 @@ Cache: InMemory 6h TTL.
 Safety: No internal IDs or direct links (same as sectors_public.py).
 """
 
+import asyncio
 import logging
 import time
 import unicodedata
@@ -28,9 +29,19 @@ from sectors import SECTORS, SectorConfig
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/blog/stats", tags=["blog-stats"])
 
-# 6h InMemory cache
+# 6h InMemory cache (success path)
 _CACHE_TTL_SECONDS = 6 * 60 * 60
-_blog_cache: dict[str, tuple[dict, float]] = {}
+# 5min negative cache (DB timeout / failure path) — pattern from
+# empresa_publica._NEGATIVE_CACHE_TTL_SECONDS. Stops Googlebot retry-storm
+# from re-saturating Supabase pool while letting the next crawl wave probe
+# again after a short window.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
+# Hard budget for a single contratos query. Sync .execute() runs in a
+# worker thread (asyncio.to_thread) so the event loop stays responsive
+# even when the query saturates; wait_for caps total wall-clock so the
+# Railway proxy 15s healthcheck timeout never trips.
+_CONTRATOS_QUERY_BUDGET_S = 10.0
+_blog_cache: dict[str, tuple[dict, float, float]] = {}  # (data, stored_at, ttl_seconds)
 
 # All 27 Brazilian UFs
 ALL_UFS = [
@@ -302,15 +313,15 @@ class ContratosCidadeSetorStats(BaseModel):
 def _cache_get(key: str) -> Optional[dict]:
     if key not in _blog_cache:
         return None
-    data, ts = _blog_cache[key]
-    if time.time() - ts >= _CACHE_TTL_SECONDS:
+    data, ts, ttl = _blog_cache[key]
+    if time.time() - ts >= ttl:
         del _blog_cache[key]
         return None
     return data
 
 
-def _cache_set(key: str, data: dict) -> None:
-    _blog_cache[key] = (data, time.time())
+def _cache_set(key: str, data: dict, ttl: float = _CACHE_TTL_SECONDS) -> None:
+    _blog_cache[key] = (data, time.time(), ttl)
 
 
 def invalidate_blog_cache() -> None:
@@ -875,72 +886,104 @@ def _safe_float_blog(val) -> float:
         return 0.0
 
 
-def _compute_contratos_stats(
+def _query_contratos_sync(
+    *,
+    uf: Optional[str] = None,
+    municipio_pattern: Optional[str] = None,
+) -> list[dict]:
+    """Sync Supabase query against pncp_supplier_contracts.
+
+    Must run inside ``asyncio.to_thread(...)`` — the supabase-py client uses
+    blocking httpx and will wedge the event loop otherwise. The 2026-04-27
+    Stage 3 outage was caused by this function being called directly from
+    an async handler with no thread-offload; a single 30s ``ilike`` on
+    municipio froze ``/health/live`` for every Railway proxy probe.
+    """
+    from supabase_client import get_supabase
+    sb = get_supabase()
+
+    query = (
+        sb.table("pncp_supplier_contracts")
+        .select(
+            "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
+            "valor_global,data_assinatura,objeto_contrato,uf,municipio"
+        )
+        .eq("is_active", True)
+    )
+    if uf:
+        query = query.eq("uf", uf)
+    if municipio_pattern:
+        # pncp_supplier_contracts.municipio is free-text — case-insensitive
+        # substring match via ilike (handles variations like "São Paulo" vs "SAO PAULO").
+        query = query.ilike("municipio", f"%{municipio_pattern}%")
+
+    resp = (
+        query
+        .order("data_assinatura", desc=True)
+        .limit(5000)
+        .execute()
+    )
+    return resp.data or []
+
+
+def _empty_contratos_stats() -> dict:
+    """Minimal payload returned when the DB query fails or times out.
+
+    Shape matches the success-path dict so Pydantic models validate. Caller
+    decides cache TTL (negative cache: ``_NEGATIVE_CACHE_TTL_SECONDS``).
+    """
+    now = datetime.now(timezone.utc)
+    return {
+        "total_contracts": 0,
+        "total_value": 0.0,
+        "avg_value": 0.0,
+        "top_orgaos": [],
+        "top_fornecedores": [],
+        "monthly_trend": [],
+        "by_uf": [],
+        "last_updated": now.isoformat(),
+        "n_unique_orgaos": 0,
+        "n_unique_fornecedores": 0,
+        "sample_contracts": [],
+    }
+
+
+async def _compute_contratos_stats(
     sector: Optional[SectorConfig] = None,
     *,
     uf: Optional[str] = None,
     municipio_pattern: Optional[str] = None,
-) -> dict:
-    """Query pncp_supplier_contracts with optional UF/municipio filters, aggregate.
+) -> tuple[dict, bool]:
+    """Query pncp_supplier_contracts and aggregate.
 
-    Returns a dict containing the common aggregation fields (total_contracts,
-    total_value, avg_value, top_orgaos, top_fornecedores, monthly_trend, by_uf).
-    Endpoint wrappers add their specific fields (sector_id, cidade, etc).
-
-    Raises HTTPException(502) on DB failure.
+    Returns ``(data, partial)`` where ``partial=True`` means the query failed
+    or exceeded ``_CONTRATOS_QUERY_BUDGET_S`` and ``data`` is an empty
+    fallback shape. Callers should cache the partial response under a
+    shorter TTL (``_NEGATIVE_CACHE_TTL_SECONDS``) so Googlebot retry storms
+    don't keep hitting the slow query path.
     """
     try:
-        from supabase_client import get_supabase
-        sb = get_supabase()
-
-        query = (
-            sb.table("pncp_supplier_contracts")
-            .select(
-                "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
-                "valor_global,data_assinatura,objeto_contrato,uf,municipio"
-            )
-            .eq("is_active", True)
+        rows = await asyncio.wait_for(
+            asyncio.to_thread(
+                _query_contratos_sync,
+                uf=uf,
+                municipio_pattern=municipio_pattern,
+            ),
+            timeout=_CONTRATOS_QUERY_BUDGET_S,
         )
-        if uf:
-            query = query.eq("uf", uf)
-        if municipio_pattern:
-            # pncp_supplier_contracts.municipio is free-text — case-insensitive
-            # substring match via ilike (handles variations like "São Paulo" vs "SAO PAULO").
-            query = query.ilike("municipio", f"%{municipio_pattern}%")
-
-        resp = (
-            query
-            .order("data_assinatura", desc=True)
-            .limit(5000)
-            .execute()
+    except asyncio.TimeoutError:
+        logger.warning(
+            "contratos query exceeded %.0fs budget (sector=%s uf=%s municipio=%s)",
+            _CONTRATOS_QUERY_BUDGET_S,
+            sector.id if sector else None, uf, municipio_pattern,
         )
+        return _empty_contratos_stats(), True
     except Exception as e:
         logger.error(
             "contratos DB query failed (sector=%s uf=%s municipio=%s): %s",
             sector.id if sector else None, uf, municipio_pattern, e,
         )
-        # SmartLic incident 2026-04-27 humble-dolphin: hobby plan + 1 worker
-        # + DB statement_timeout (8s) on (uf, municipio_pattern ilike) was
-        # raising 502 and producing crawler retry storm that wedged the only
-        # uvicorn worker. Returning empty stats keeps endpoint responsive
-        # while DB recovers; the 6h cache layer at endpoint level absorbs
-        # the empty response so subsequent hits don't re-query.
-        now = datetime.now(timezone.utc)
-        return {
-            "total_contracts": 0,
-            "total_value": 0.0,
-            "avg_value": 0.0,
-            "top_orgaos": [],
-            "top_fornecedores": [],
-            "monthly_trend": [],
-            "by_uf": [],
-            "last_updated": now.isoformat(),
-            "n_unique_orgaos": 0,
-            "n_unique_fornecedores": 0,
-            "sample_contracts": [],
-        }
-
-    rows = resp.data or []
+        return _empty_contratos_stats(), True
 
     # Filter by sector keywords (if sector provided)
     if sector is not None:
@@ -1047,7 +1090,7 @@ def _compute_contratos_stats(
         "n_unique_orgaos": len(orgao_agg),
         "n_unique_fornecedores": len(forn_agg),
         "sample_contracts": sample_contracts_raw,
-    }
+    }, False
 
 
 @router.get("/contratos/{setor_id}", response_model=ContratosSetorStats)
@@ -1063,9 +1106,9 @@ async def get_contratos_setor_stats(setor_id: str):
     if cached:
         return ContratosSetorStats(**cached)
 
-    base = _compute_contratos_stats(sector)
+    base, partial = await _compute_contratos_stats(sector)
     data = {"sector_id": sector.id, "sector_name": sector.name, **base}
-    _cache_set(cache_key, data)
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if partial else _CACHE_TTL_SECONDS)
     return ContratosSetorStats(**data)
 
 
@@ -1087,7 +1130,7 @@ async def get_contratos_setor_uf_stats(setor_id: str, uf: str):
     if cached:
         return ContratosSetorUfStats(**cached)
 
-    base = _compute_contratos_stats(sector, uf=uf)
+    base, partial = await _compute_contratos_stats(sector, uf=uf)
     # Drop by_uf (always single UF in this scope — keeps payload lean)
     base.pop("by_uf", None)
     data = {
@@ -1096,7 +1139,7 @@ async def get_contratos_setor_uf_stats(setor_id: str, uf: str):
         "uf": uf,
         **base,
     }
-    _cache_set(cache_key, data)
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if partial else _CACHE_TTL_SECONDS)
     return ContratosSetorUfStats(**data)
 
 
@@ -1127,14 +1170,14 @@ async def get_contratos_cidade_stats(cidade: str):
     )
 
     # Filter by UF first (indexed) + ilike on municipio (free-text)
-    base = _compute_contratos_stats(uf=uf, municipio_pattern=municipio_display)
+    base, partial = await _compute_contratos_stats(uf=uf, municipio_pattern=municipio_display)
     base.pop("by_uf", None)
     data = {
         "cidade": municipio_display,
         "uf": uf,
         **base,
     }
-    _cache_set(cache_key, data)
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if partial else _CACHE_TTL_SECONDS)
     return ContratosCidadeStats(**data)
 
 
@@ -1166,7 +1209,7 @@ async def get_contratos_cidade_setor_stats(cidade: str, setor_id: str):
         or cidade.replace("-", " ").title()
     )
 
-    base = _compute_contratos_stats(sector, uf=uf, municipio_pattern=municipio_display)
+    base, partial = await _compute_contratos_stats(sector, uf=uf, municipio_pattern=municipio_display)
     base.pop("by_uf", None)
     data = {
         "cidade": municipio_display,
@@ -1175,5 +1218,5 @@ async def get_contratos_cidade_setor_stats(cidade: str, setor_id: str):
         "sector_name": sector.name,
         **base,
     }
-    _cache_set(cache_key, data)
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if partial else _CACHE_TTL_SECONDS)
     return ContratosCidadeSetorStats(**data)

--- a/backend/tests/test_blog_stats_budget.py
+++ b/backend/tests/test_blog_stats_budget.py
@@ -1,0 +1,160 @@
+"""Hotfix Stage 3 incident 2026-04-27: blog_stats budget + negative cache.
+
+Stage 3 wedge: ``_compute_contratos_stats`` ran sync ``.execute()`` inside an
+async handler. A 30s ``ilike`` on ``municipio`` blocked the only event loop
+worker, ``/health/live`` (pure-async) also stalled, Railway proxy returned
+502 to every probe.
+
+Fix wraps the query in ``asyncio.to_thread`` + ``asyncio.wait_for(10s)`` and
+caches the failure path under ``_NEGATIVE_CACHE_TTL_SECONDS`` (5min) instead
+of the success TTL (6h) so the next Googlebot wave can probe again without a
+day-long stale empty response.
+
+These tests cover the two safety properties:
+  1. Timeout/exception path returns the empty-shape fallback (200 OK, not 502)
+     and caches it under the short TTL.
+  2. Subsequent requests hit the in-memory cache and never re-query the DB.
+"""
+
+import asyncio
+import time
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from main import app
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_blog_cache():
+    from routes.blog_stats import _blog_cache
+    _blog_cache.clear()
+    yield
+    _blog_cache.clear()
+
+
+def _slow_sync_execute(*_args, **_kwargs):
+    """Simulate the wedge: blocking call that exceeds the 10s budget."""
+    time.sleep(15)
+    raise AssertionError("budget should have fired before this returns")
+
+
+class TestContratosBudget:
+    def test_timeout_returns_fallback_and_caches_negative_ttl(self, client):
+        """When the query exceeds _CONTRATOS_QUERY_BUDGET_S, handler must return
+        the empty-shape fallback (200 OK) and store it under the negative TTL."""
+        from routes import blog_stats as bs
+
+        with patch.object(
+            bs,
+            "_query_contratos_sync",
+            side_effect=_slow_sync_execute,
+        ):
+            # Patch budget down to keep test fast — fix still proves the
+            # to_thread + wait_for wrapper short-circuits the slow path.
+            with patch.object(bs, "_CONTRATOS_QUERY_BUDGET_S", 0.1):
+                resp = client.get("/v1/blog/stats/contratos/informatica")
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # Empty-shape fallback, success-path keys present so Pydantic validates
+        assert data["sector_id"] == "informatica"
+        assert data["total_contracts"] == 0
+        assert data["top_orgaos"] == []
+        assert data["top_fornecedores"] == []
+
+        # Cache stored under negative TTL (5min, not 6h)
+        cache_key = "contratos_setor:informatica"
+        assert cache_key in bs._blog_cache
+        _data, _ts, ttl = bs._blog_cache[cache_key]
+        assert ttl == bs._NEGATIVE_CACHE_TTL_SECONDS
+        assert ttl < bs._CACHE_TTL_SECONDS
+
+    def test_cache_hit_skips_db_query(self, client):
+        """Pre-populated cache must be served without invoking the DB query."""
+        from routes import blog_stats as bs
+
+        cache_key = "contratos_setor:informatica"
+        bs._cache_set(
+            cache_key,
+            {
+                "sector_id": "informatica",
+                "sector_name": "Informática",
+                "total_contracts": 42,
+                "total_value": 100000.0,
+                "avg_value": 2380.95,
+                "top_orgaos": [],
+                "top_fornecedores": [],
+                "monthly_trend": [],
+                "by_uf": [],
+                "last_updated": "2026-04-27T00:00:00+00:00",
+                "n_unique_orgaos": 0,
+                "n_unique_fornecedores": 0,
+                "sample_contracts": [],
+            },
+            ttl=bs._CACHE_TTL_SECONDS,
+        )
+
+        with patch.object(bs, "_query_contratos_sync") as mock_query:
+            resp = client.get("/v1/blog/stats/contratos/informatica")
+
+        assert resp.status_code == 200
+        assert resp.json()["total_contracts"] == 42
+        # Critical: DB query MUST NOT have been called — cache served the response
+        mock_query.assert_not_called()
+
+
+class TestComputeContratosStatsAsync:
+    """Direct unit tests on the async helper — independent of FastAPI routing."""
+
+    def test_timeout_returns_partial_true(self):
+        from routes import blog_stats as bs
+
+        with patch.object(bs, "_query_contratos_sync", side_effect=_slow_sync_execute):
+            with patch.object(bs, "_CONTRATOS_QUERY_BUDGET_S", 0.1):
+                data, partial = asyncio.run(bs._compute_contratos_stats())
+
+        assert partial is True
+        assert data["total_contracts"] == 0
+        assert data["sample_contracts"] == []
+
+    def test_db_exception_returns_partial_true(self):
+        from routes import blog_stats as bs
+
+        with patch.object(
+            bs,
+            "_query_contratos_sync",
+            side_effect=RuntimeError("supabase pool exhausted"),
+        ):
+            data, partial = asyncio.run(bs._compute_contratos_stats())
+
+        assert partial is True
+        assert data["total_contracts"] == 0
+
+    def test_success_returns_partial_false(self):
+        from routes import blog_stats as bs
+
+        rows = [
+            {
+                "ni_fornecedor": "11111111000100",
+                "nome_fornecedor": "TechCorp",
+                "orgao_cnpj": "99999999000100",
+                "orgao_nome": "Min Educacao",
+                "valor_global": 100000.0,
+                "data_assinatura": "2026-03-20",
+                "objeto_contrato": "fornecimento de computadores",
+                "uf": "SP",
+            },
+        ]
+        with patch.object(bs, "_query_contratos_sync", return_value=rows):
+            data, partial = asyncio.run(bs._compute_contratos_stats())
+
+        assert partial is False
+        # Aggregation produced something
+        assert "top_orgaos" in data


### PR DESCRIPTION
## Summary

Backend SmartLic em wedge total 2026-04-27 ~23:18 UTC: `/health/live` retornando 502 após 15s para todos endpoints, mesmo após PR #529 estabilizar perfil-b2g e fornecedor profile.

**Causa-raiz** (logs Railway + grep código): `routes/blog_stats.py:_compute_contratos_stats` linha 918 era um sync `def` com `.execute()` direto chamado por 4 handlers async SEM `await`. Query `ilike` em municipio sob Googlebot wave saturava Supabase, travava o event loop por 30s+, Railway proxy retornava 502 a cada probe — incluindo healthcheck pure-async. **Stage 3 do mesmo cluster que motivou PR #529** (perfil-b2g, fornecedor).

## Context

- Logs: `[ERROR] contratos DB query failed: The read operation timed out` + `[WARN] Task took 30.061 seconds` (asyncio base_events warning).
- 4 rotas afetadas: `/blog/stats/contratos/{setor}`, `.../uf/{uf}`, `.../cidade/{cidade}`, `.../cidade/{cidade}/setor/{setor}`.
- Pattern `to_thread + wait_for + negative cache` espelha `empresa_publica._set_cached` (PR #529).
- Budget 10s (não 30s do PR #529): advisor recomendou — Googlebot, não user-facing, falha rápida + cache negativo > esperar Railway 502.

## Changes

- `_compute_contratos_stats` virou `async`, retorna `tuple[dict, partial:bool]`.
- Query Supabase isolada em `_query_contratos_sync` rodada via `asyncio.to_thread`.
- `asyncio.wait_for(..., timeout=10s)` cap evita event loop block.
- `_blog_cache` ganha TTL parametrizável; failure path = 5min (`_NEGATIVE_CACHE_TTL_SECONDS`), success = 6h.
- 4 callsites convertidos para `await + tuple unpack + ttl conditional`.

## Testing Plan

- [x] backend/tests/test_blog_stats_budget.py — 5 novos tests (timeout fallback + cache hit + 3 helper unit) — 5/5 PASS local
- [x] Regression suite — 114/114 PASS (test_blog_stats + test_contratos_setor_blog + test_blog_stats_cidade_setor + test_timeout_invariants)
- [x] python3 ast.parse OK
- [ ] CI Backend Tests verde (required check para merge)
- [ ] Pós-merge: deploy Railway SUCCESS (atenção CRIT recidiva rootDirectory bug — memory `reference_railway_rootdir_prod_incident_2026_04_23`)
- [ ] Soak: `/health/live` 10/10 200 OK + curl rota culpada `/v1/blog/stats/contratos/transporte_servicos/uf/MS` 200 OK <2s
- [ ] Sentry: nenhum novo "Task took >5s" 1h pós-deploy

## Closes

- Incident: backend wedge Stage 3 (continuação cluster PR #529)
- Defer: Stage 4 sweep (>20 outras rotas SEO programmatic com mesmo antipattern) → backlog story RES-BE-002 (top-5 routes budget)

---

URGENT: prod 502 ativo. Pull merge ASAP após CI green — auto-deploy Railway substitui pods wedged (drain 120s + overlap 45s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced contracts API endpoints with timeout protection and graceful fallback handling for improved reliability
  * Optimized caching with intelligent time-to-live management for different response types

* **Tests**
  * Added comprehensive test coverage for timeout and caching behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->