### PR TITLE
fix(analytics): add mixpanel-python to requirements (P0 — events silenced 7d)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -78,6 +78,15 @@ sentry-sdk[fastapi]==2.52.0
 # Prometheus metrics exporter (GTM-RESILIENCE-E03)
 prometheus_client>=0.20.0
 
+# Product analytics (paywall_hit, trial_started, signup_completed, ...).
+# MIXPANEL_TOKEN é required em prod startup (PR #530 MON-FN-005), mas a
+# lib estava ausente do requirements até esta sessão (goofy-llama
+# 2026-04-27): `_get_mixpanel()` em backend/analytics_events.py:36
+# falhava silently em ImportError, devolvendo None, e os events só
+# iam para `logger.debug`. Resultado: 7d sem nenhum event backend no
+# dashboard Mixpanel apesar do token configurado.
+mixpanel>=4.10.0
+
 # Async job queue for background LLM + Excel processing (GTM-RESILIENCE-F01)
 arq>=0.26,<1.0
 


### PR DESCRIPTION
## Summary

PR #530 (MON-FN-005) tornou `MIXPANEL_TOKEN` required em prod startup, mas a biblioteca cliente nunca foi adicionada ao `requirements.txt`. **Confirmado empiricamente nesta sessão (goofy-llama 2026-04-27)** via Mixpanel dashboard:

| Categoria | Volume últimos 7d |
|----------|-------------------|
| Client-side (`page_load`, `page_exit`, `Opt In`) | ~150 events ✅ |
| Backend (`paywall_hit`, `trial_started`, `signup_completed`, `onboarding_completed`, `trial_email_sent`, `trial_risk_assessed`) | **0 events** ⚠️ |

## Root Cause

`backend/analytics_events.py:31-38`:

```python
try:
    from mixpanel import Mixpanel
    _mixpanel_client = Mixpanel(token)
    logger.info("Mixpanel analytics initialized")
    return _mixpanel_client
except ImportError:
    logger.debug("mixpanel-python not installed — analytics events will be logged only")
    return None
```

`ImportError` silencioso → `_get_mixpanel()` retorna None → `track_event` cai em `logger.debug` em vez de chamar `mp.track()`. Token estava setado em Railway (Phase 1 audit confirmou `MIXPANEL_TOKEN` presente), mas sem a lib nenhum event chega ao Mixpanel SaaS.

## Context

Pre-revenue runway-critical, n=2 trials/30d (memory `feedback_n2_below_noise_eng_theater.md`). Sem instrumentação backend ficamos **cegos sobre onde o trial morre** — exatamente o sinal que importa para decidir próxima ação de receita.

Memory `reference_mixpanel_backend_token_gap_2026_04_24.md` registrava gap relacionado (token ausente até piped-cray). Esta PR fecha a outra metade: lib ausente.

## Fix

Adiciona `mixpanel>=4.10.0` em `backend/requirements.txt` na seção de observability (próximo a `prometheus_client`, `sentry-sdk`, `opentelemetry-*`).

## Testing Plan

- [x] Diff localmente confirma 1 linha adicionada
- [ ] CI Backend Tests green (lib agora disponível, mock paths em testes existentes continuam válidos via `_get_mixpanel` retornando None quando token vazio)
- [ ] CI Frontend Tests green (sem mudança frontend)

## Pre-deploy

Nenhum env var novo. `MIXPANEL_TOKEN` já está setado em Railway `bidiq-backend`.

## Post-deploy (verification — soak 30min)

- [ ] Após deploy, executar uma ação de funil em produção (ex: signup novo usuário OR trigger paywall via quota exhausted).
- [ ] Verificar Mixpanel dashboard `/project/3991930/view/4487757/app/events?time_range=Today` para evento backend (`signup_completed` OR `paywall_hit`).
- [ ] Logs Railway: ver `Mixpanel analytics initialized` (info-level) em backend startup.

## Risk Assessment

| Risk | Likelihood | Impact | Mitigation |
|------|-----------|--------|-----------|
| `mixpanel-python` 4.10+ tem breaking change vs 4.9 | Low | Low | Lib é estável; track API não muda há anos |
| Lib adiciona overhead em hot path | Low | Negligible | `track_event` é fire-and-forget com try/except permissivo |
| Volume de events estoura quota Mixpanel free tier | Low | Low | Plan free = 100k/mo, n=2 trials/30d projeta volume baixíssimo |

## Closes

- Memory `reference_mixpanel_backend_token_gap_2026_04_24.md` (token gap fechado em piped-cray + lib gap fechado aqui = pipeline backend funnel completo)
- Implícito em PR #530 (MON-FN-005 estava incompleto sem a lib)

## Companion

- PR #534 (security HMAC + service_role timeout) — defense-in-depth no caminho de pagamento
- PR #535 (sitemap budget+to_thread+negative cache) — recovery do funil de aquisição orgânica

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend dependencies to support analytics tracking infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->