### PR TITLE
fix(sitemap): un-revert PR #535 budget + negative cache (P0 prod recidiva)

### DIFF
--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -10,6 +10,7 @@ Layers de implementacao (/sitemap/cnpjs):
 2. Fallback: paginated table query (loop 1k/page ate esgotar)
 """
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -24,8 +25,16 @@ from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
 
-_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
-_sitemap_cache: dict[str, tuple[dict, float]] = {}
+_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h success
+# Negative cache: when DB query saturates and we time out, cache an empty
+# response for 5 min so the next ISR rebuild / crawler hit returns instantly
+# instead of re-saturating the pool. Same pattern as PR #529 perfil-b2g hotfix.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
+# Hard async budget: must respond within this window or fall through to
+# negative cache. supabase-py is sync, so the actual DB call runs in a
+# worker thread (asyncio.to_thread) — the budget bounds total async wait.
+_BUDGET_S = 25.0
+_sitemap_cache: dict[str, tuple[dict, float, float]] = {}  # key -> (data, stored_at, ttl)
 
 _MAX_CNPJS = 5000
 
@@ -61,35 +70,35 @@ class SitemapFornecedoresCnpjResponse(BaseModel):
 
 _MAX_FORNECEDORES_CNPJS = 5000
 
-_fornecedores_sitemap_cache: dict[str, tuple[dict, float]] = {}
+_fornecedores_sitemap_cache: dict[str, tuple[dict, float, float]] = {}  # key -> (data, stored_at, ttl)
 
 
 def _get_cached(key: str) -> Optional[dict]:
     if key not in _sitemap_cache:
         return None
-    data, ts = _sitemap_cache[key]
-    if time.time() - ts >= _CACHE_TTL_SECONDS:
+    data, ts, ttl = _sitemap_cache[key]
+    if time.time() - ts >= ttl:
         del _sitemap_cache[key]
         return None
     return data
 
 
-def _set_cached(key: str, data: dict) -> None:
-    _sitemap_cache[key] = (data, time.time())
+def _set_cached(key: str, data: dict, ttl: float = _CACHE_TTL_SECONDS) -> None:
+    _sitemap_cache[key] = (data, time.time(), ttl)
 
 
 def _get_fornecedores_cached(key: str) -> Optional[dict]:
     if key not in _fornecedores_sitemap_cache:
         return None
-    data, ts = _fornecedores_sitemap_cache[key]
-    if time.time() - ts >= _CACHE_TTL_SECONDS:
+    data, ts, ttl = _fornecedores_sitemap_cache[key]
+    if time.time() - ts >= ttl:
         del _fornecedores_sitemap_cache[key]
         return None
     return data
 
 
-def _set_fornecedores_cached(key: str, data: dict) -> None:
-    _fornecedores_sitemap_cache[key] = (data, time.time())
+def _set_fornecedores_cached(key: str, data: dict, ttl: float = _CACHE_TTL_SECONDS) -> None:
+    _fornecedores_sitemap_cache[key] = (data, time.time(), ttl)
 
 
 @router.get(
@@ -104,10 +113,34 @@ async def sitemap_cnpjs(response: Response):
         record_sitemap_count("cnpjs", len(cached.get("cnpjs", [])))
         return SitemapCnpjsResponse(**cached)
 
-    data = await _fetch_top_cnpjs()
-    _set_cached("cnpjs", data)
+    try:
+        data = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_top_cnpjs),
+            timeout=_BUDGET_S,
+        )
+        _set_cached("cnpjs", data, ttl=_CACHE_TTL_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "sitemap_cnpjs: budget %.0fs exceeded — returning empty negative cache",
+            _BUDGET_S,
+        )
+        data = _empty_cnpjs_response()
+        _set_cached("cnpjs", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.error("sitemap_cnpjs unexpected error: %s", exc)
+        data = _empty_cnpjs_response()
+        _set_cached("cnpjs", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+
     record_sitemap_count("cnpjs", len(data.get("cnpjs", [])))
     return SitemapCnpjsResponse(**data)
+
+
+def _empty_cnpjs_response() -> dict:
+    return {
+        "cnpjs": [],
+        "total": 0,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 def _merge_with_seed(buyer_cnpjs: list[str]) -> list[str]:
@@ -127,12 +160,13 @@ def _merge_with_seed(buyer_cnpjs: list[str]) -> list[str]:
     return result[:_MAX_CNPJS]
 
 
-async def _fetch_top_cnpjs() -> dict:
+def _fetch_top_cnpjs() -> dict:
     """Query pncp_raw_bids for distinct orgao_cnpj with ≥1 active bid.
 
-    Uses get_sitemap_cnpjs_json RPC (RETURNS json scalar) which bypasses
-    PostgREST max-rows=1000. Falls back to paginated table query if RPC
-    doesn't exist yet (e.g., migration not yet applied).
+    Sync — supabase-py is sync, so caller wraps this in asyncio.to_thread
+    to keep the event loop free. Uses get_sitemap_cnpjs_json RPC
+    (RETURNS json scalar) which bypasses PostgREST max-rows=1000. Falls
+    back to paginated table query if RPC doesn't exist yet.
     """
     try:
         from supabase_client import get_supabase
@@ -233,7 +267,7 @@ async def sitemap_fornecedores_cnpj(response: Response):
 
     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
     Limite: 5.000 CNPJs por volume de contratos (mais contratos = maior valor SEO).
-    Cache: 24h em memoria.
+    Cache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).
     """
     response.headers.update(SITEMAP_CACHE_HEADERS)
     cached = _get_fornecedores_cached("fornecedores_cnpj")
@@ -241,13 +275,29 @@ async def sitemap_fornecedores_cnpj(response: Response):
         record_sitemap_count("fornecedores-cnpj", len(cached.get("cnpjs", [])))
         return SitemapFornecedoresCnpjResponse(**cached)
 
-    data = await _fetch_top_fornecedores_cnpjs()
-    _set_fornecedores_cached("fornecedores_cnpj", data)
+    try:
+        data = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_top_fornecedores_cnpjs),
+            timeout=_BUDGET_S,
+        )
+        _set_fornecedores_cached("fornecedores_cnpj", data, ttl=_CACHE_TTL_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "sitemap_fornecedores_cnpj: budget %.0fs exceeded — returning empty negative cache",
+            _BUDGET_S,
+        )
+        data = _empty_cnpjs_response()
+        _set_fornecedores_cached("fornecedores_cnpj", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.error("sitemap_fornecedores_cnpj unexpected error: %s", exc)
+        data = _empty_cnpjs_response()
+        _set_fornecedores_cached("fornecedores_cnpj", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+
     record_sitemap_count("fornecedores-cnpj", len(data.get("cnpjs", [])))
     return SitemapFornecedoresCnpjResponse(**data)
 
 
-async def _fetch_top_fornecedores_cnpjs() -> dict:
+def _fetch_top_fornecedores_cnpjs() -> dict:
     """Busca os CNPJs de fornecedores mais ativos em pncp_supplier_contracts.
 
     Estrategia: paginated scan para contar contratos por ni_fornecedor,

--- a/backend/routes/sitemap_licitacoes.py
+++ b/backend/routes/sitemap_licitacoes.py
@@ -24,8 +24,13 @@ from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
 
-_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
-_cache: Optional[tuple[dict, float]] = None
+_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h success
+# Negative cache TTL — same pattern as PR #529 perfil-b2g hotfix.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
+# Outer async budget: covers bids parallel queries + contracts (which has its
+# own 60s wait_for). Hard cap so a wedged datalake cannot block the route.
+_BUDGET_S = 90.0
+_cache: Optional[tuple[dict, float, float]] = None  # (data, stored_at, ttl)
 
 _DEFAULT_BIDS_THRESHOLD = 5
 _DEFAULT_CONTRACTS_THRESHOLD = 1
@@ -55,23 +60,49 @@ async def get_licitacoes_indexable(response: Response):
     global _cache
 
     if _cache is not None:
-        data, ts = _cache
-        if time.time() - ts < _CACHE_TTL_SECONDS:
+        data, ts, ttl = _cache
+        if time.time() - ts < ttl:
             record_sitemap_count("licitacoes-indexable", len(data.get("combos", [])))
             return LicitacoesIndexableResponse(**data)
 
     bids_threshold = int(os.getenv("MIN_ACTIVE_BIDS_FOR_INDEX", str(_DEFAULT_BIDS_THRESHOLD)))
-    combos = await _compute_indexable_combos(bids_threshold)
 
     from datetime import datetime, timezone
-    result = {
-        "combos": combos,
-        "total": len(combos),
-        "threshold": bids_threshold,
-        "updated_at": datetime.now(timezone.utc).isoformat(),
-    }
-    _cache = (result, time.time())
-    record_sitemap_count("licitacoes-indexable", len(combos))
+    try:
+        combos = await asyncio.wait_for(
+            _compute_indexable_combos(bids_threshold),
+            timeout=_BUDGET_S,
+        )
+        result = {
+            "combos": combos,
+            "total": len(combos),
+            "threshold": bids_threshold,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _cache = (result, time.time(), _CACHE_TTL_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "get_licitacoes_indexable: budget %.0fs exceeded — returning empty negative cache",
+            _BUDGET_S,
+        )
+        result = {
+            "combos": [],
+            "total": 0,
+            "threshold": bids_threshold,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _cache = (result, time.time(), _NEGATIVE_CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.error("get_licitacoes_indexable unexpected error: %s", exc)
+        result = {
+            "combos": [],
+            "total": 0,
+            "threshold": bids_threshold,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _cache = (result, time.time(), _NEGATIVE_CACHE_TTL_SECONDS)
+
+    record_sitemap_count("licitacoes-indexable", len(result.get("combos", [])))
     return LicitacoesIndexableResponse(**result)
 
 
@@ -92,7 +123,7 @@ async def refresh_sitemap_cache(_admin=Depends(require_admin)):
         "threshold": bids_threshold,
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }
-    _cache = (result, time.time())
+    _cache = (result, time.time(), _CACHE_TTL_SECONDS)
     logger.info("sitemap_licitacoes: cache refreshed manually — %d combos", len(combos))
     return {"status": "refreshed", "total_combos": len(combos), "threshold": bids_threshold}
 

--- a/backend/routes/sitemap_licitacoes_do_dia.py
+++ b/backend/routes/sitemap_licitacoes_do_dia.py
@@ -9,6 +9,7 @@ Pattern segue sitemap_orgaos.py (RPC primary com fallback paginado + InMemory ca
 TTL 1h (dia corrente muda durante o dia).
 """
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timedelta, timezone
@@ -23,8 +24,11 @@ from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
 
-_CACHE_TTL_SECONDS = 60 * 60  # 1h — dia corrente muda durante o dia
-_cache: dict[str, tuple[dict, float]] = {}
+_CACHE_TTL_SECONDS = 60 * 60  # 1h success — dia corrente muda durante o dia
+# Negative cache TTL — same pattern as PR #529 perfil-b2g hotfix.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
+_BUDGET_S = 25.0
+_cache: dict[str, tuple[dict, float, float]] = {}  # key -> (data, stored_at, ttl)
 
 _WINDOW_DAYS = 30
 _MIN_BIDS_PER_DAY = 5  # threshold para considerar dia indexavel
@@ -40,15 +44,23 @@ def _get_cached(key: str) -> Optional[dict]:
     entry = _cache.get(key)
     if entry is None:
         return None
-    data, ts = entry
-    if time.time() - ts >= _CACHE_TTL_SECONDS:
+    data, ts, ttl = entry
+    if time.time() - ts >= ttl:
         del _cache[key]
         return None
     return data
 
 
-def _set_cached(key: str, data: dict) -> None:
-    _cache[key] = (data, time.time())
+def _set_cached(key: str, data: dict, ttl: float = _CACHE_TTL_SECONDS) -> None:
+    _cache[key] = (data, time.time(), ttl)
+
+
+def _empty_dates_response() -> dict:
+    return {
+        "dates": [],
+        "total": 0,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 @router.get(
@@ -67,13 +79,29 @@ async def sitemap_licitacoes_do_dia_indexable(response: Response):
         record_sitemap_count("licitacoes-do-dia-indexable", len(cached.get("dates", [])))
         return SitemapLicitacoesDoDiaResponse(**cached)
 
-    data = await _fetch_indexable_dates()
-    _set_cached("dates", data)
+    try:
+        data = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_indexable_dates),
+            timeout=_BUDGET_S,
+        )
+        _set_cached("dates", data, ttl=_CACHE_TTL_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "sitemap_licitacoes_do_dia: budget %.0fs exceeded — empty negative cache",
+            _BUDGET_S,
+        )
+        data = _empty_dates_response()
+        _set_cached("dates", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.error("sitemap_licitacoes_do_dia unexpected error: %s", exc)
+        data = _empty_dates_response()
+        _set_cached("dates", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+
     record_sitemap_count("licitacoes-do-dia-indexable", len(data.get("dates", [])))
     return SitemapLicitacoesDoDiaResponse(**data)
 
 
-async def _fetch_indexable_dates() -> dict:
+def _fetch_indexable_dates() -> dict:
     """Scan pncp_raw_bids janela 30d, conta por data, filtra HAVING >=5.
 
     Implementa client-side aggregation: paginated fetch de data_publicacao

--- a/backend/routes/sitemap_orgaos.py
+++ b/backend/routes/sitemap_orgaos.py
@@ -9,6 +9,7 @@ Implementation layers:
 2. Fallback: paginated table query (loop 1k/page until exhausted)
 """
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -23,8 +24,11 @@ from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
 
-_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
-_sitemap_cache: dict[str, tuple[dict, float]] = {}
+_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h success
+# Negative cache TTL — same pattern as PR #529 perfil-b2g hotfix.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
+_BUDGET_S = 25.0
+_sitemap_cache: dict[str, tuple[dict, float, float]] = {}  # key -> (data, stored_at, ttl)
 
 _MAX_ORGAOS = 2000
 
@@ -38,15 +42,23 @@ class SitemapOrgaosResponse(BaseModel):
 def _get_cached(key: str) -> Optional[dict]:
     if key not in _sitemap_cache:
         return None
-    data, ts = _sitemap_cache[key]
-    if time.time() - ts >= _CACHE_TTL_SECONDS:
+    data, ts, ttl = _sitemap_cache[key]
+    if time.time() - ts >= ttl:
         del _sitemap_cache[key]
         return None
     return data
 
 
-def _set_cached(key: str, data: dict) -> None:
-    _sitemap_cache[key] = (data, time.time())
+def _set_cached(key: str, data: dict, ttl: float = _CACHE_TTL_SECONDS) -> None:
+    _sitemap_cache[key] = (data, time.time(), ttl)
+
+
+def _empty_orgaos_response() -> dict:
+    return {
+        "orgaos": [],
+        "total": 0,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 @router.get(
@@ -61,13 +73,29 @@ async def sitemap_orgaos(response: Response):
         record_sitemap_count("orgaos", len(cached.get("orgaos", [])))
         return SitemapOrgaosResponse(**cached)
 
-    data = await _fetch_top_orgaos()
-    _set_cached("orgaos", data)
+    try:
+        data = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_top_orgaos),
+            timeout=_BUDGET_S,
+        )
+        _set_cached("orgaos", data, ttl=_CACHE_TTL_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "sitemap_orgaos: budget %.0fs exceeded — returning empty negative cache",
+            _BUDGET_S,
+        )
+        data = _empty_orgaos_response()
+        _set_cached("orgaos", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.error("sitemap_orgaos unexpected error: %s", exc)
+        data = _empty_orgaos_response()
+        _set_cached("orgaos", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+
     record_sitemap_count("orgaos", len(data.get("orgaos", [])))
     return SitemapOrgaosResponse(**data)
 
 
-async def _fetch_top_orgaos() -> dict:
+def _fetch_top_orgaos() -> dict:
     """Query pncp_raw_bids for distinct orgao_cnpj with ≥1 active bid.
 
     Uses get_sitemap_orgaos_json RPC (RETURNS json scalar) which bypasses
@@ -157,7 +185,7 @@ async def _fetch_top_orgaos() -> dict:
 # SEO-460: /sitemap/contratos-orgao-indexable — órgãos com contratos reais
 # ---------------------------------------------------------------------------
 
-_contratos_orgao_cache: dict[str, tuple[dict, float]] = {}
+_contratos_orgao_cache: dict[str, tuple[dict, float, float]] = {}  # key -> (data, stored_at, ttl)
 _MAX_CONTRATOS_ORGAOS = 2000
 
 
@@ -185,19 +213,35 @@ async def sitemap_contratos_orgao_indexable(response: Response):
     key = "contratos_orgao_indexable"
     cached_entry = _contratos_orgao_cache.get(key)
     if cached_entry:
-        data, ts = cached_entry
-        if time.time() - ts < _CACHE_TTL_SECONDS:
+        data, ts, ttl = cached_entry
+        if time.time() - ts < ttl:
             record_sitemap_count("contratos-orgao-indexable", len(data.get("orgaos", [])))
             return SitemapContratosOrgaoResponse(**data)
         del _contratos_orgao_cache[key]
 
-    data = await _fetch_contratos_orgao_indexable()
-    _contratos_orgao_cache[key] = (data, time.time())
+    try:
+        data = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_contratos_orgao_indexable),
+            timeout=_BUDGET_S,
+        )
+        _contratos_orgao_cache[key] = (data, time.time(), _CACHE_TTL_SECONDS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "sitemap_contratos_orgao_indexable: budget %.0fs exceeded — empty negative cache",
+            _BUDGET_S,
+        )
+        data = _empty_orgaos_response()
+        _contratos_orgao_cache[key] = (data, time.time(), _NEGATIVE_CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.error("sitemap_contratos_orgao_indexable unexpected error: %s", exc)
+        data = _empty_orgaos_response()
+        _contratos_orgao_cache[key] = (data, time.time(), _NEGATIVE_CACHE_TTL_SECONDS)
+
     record_sitemap_count("contratos-orgao-indexable", len(data.get("orgaos", [])))
     return SitemapContratosOrgaoResponse(**data)
 
 
-async def _fetch_contratos_orgao_indexable() -> dict:
+def _fetch_contratos_orgao_indexable() -> dict:
     """Scan pncp_supplier_contracts para distinct orgao_cnpj com is_active=True."""
     try:
         from supabase_client import get_supabase

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -18882,7 +18882,7 @@
     },
     "/v1/sitemap/fornecedores-cnpj": {
       "get": {
-        "description": "Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.\n\nUsado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.\nLimite: 5.000 CNPJs por volume de contratos (mais contratos = maior valor SEO).\nCache: 24h em memoria.",
+        "description": "Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.\n\nUsado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.\nLimite: 5.000 CNPJs por volume de contratos (mais contratos = maior valor SEO).\nCache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).",
         "operationId": "sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get",
         "responses": {
           "200": {

--- a/backend/tests/test_oauth_story224.py
+++ b/backend/tests/test_oauth_story224.py
@@ -396,14 +396,21 @@ class TestAC13TokenDecryption:
         assert decrypted == special_token
 
     def test_decrypt_raises_error_on_tampered_ciphertext(self):
-        """Should raise error when ciphertext is tampered with."""
+        """Should raise error when ciphertext is tampered with.
+
+        Memory `feedback_jwt_base64url_flaky_test.md`: single-char flip in
+        base64url has ~6.25% false-pass rate (Fernet is padding-tolerant for
+        some chars). Use multi-byte sentinel replacement to guarantee
+        HMAC-MAC mismatch.
+        """
         from oauth import encrypt_aes256, decrypt_aes256
 
         plaintext = "ya29.test_token"
         encrypted = encrypt_aes256(plaintext)
 
-        # Tamper with ciphertext (flip a character)
-        tampered = encrypted[:-5] + "X" + encrypted[-4:]
+        # Replace 8 bytes near the end with sentinel chars — guarantees
+        # HMAC mismatch in Fernet, no chance of false-pass on retry.
+        tampered = encrypted[:-12] + "!!!!!!!!" + encrypted[-4:]
 
         with pytest.raises(Exception):  # Fernet raises InvalidToken
             decrypt_aes256(tampered)

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4194,7 +4194,7 @@ export interface paths {
          *
          *     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
          *     Limite: 5.000 CNPJs por volume de contratos (mais contratos = maior valor SEO).
-         *     Cache: 24h em memoria.
+         *     Cache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).
          */
         get: operations["sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get"];
         put?: never;


### PR DESCRIPTION
## Summary

Reaplica PR #535 (revertido sem motivo em commit body vazio `e17252c9`).

## Context

Hoje (2026-04-28) prod ficou down ~40min por exhaustão Supabase. Root cause:
1. **Supabase NANO compute** (0.5GB RAM) saturou — não Disk IO real (disco 25% usado)
2. PR #535 revertido removeu fix budget+negative cache de 6 endpoints sitemap DB-bound

**Recovery aplicado nesta sessão:**
- Restart project Supabase via dashboard
- Upgrade NANO→MICRO (gratuito, Pro plan permitia há tempos — anomalia: já pagavam Micro mas rodava Nano)
- Redeploy backend + worker

**Smoke pós-recovery (Micro 1GB):**
| Endpoint | Status | Time |
|----------|--------|------|
| `/v1/sitemap/cnpjs` | 200 | 1.0s ✅ |
| `/v1/sitemap/orgaos` | 200 | 1.0s ✅ |
| `/v1/sitemap/fornecedores-cnpj` | 200 | 17.4s ⚠️ |
| `/v1/sitemap/contratos-orgao-indexable` | **timeout 30s** ❌ |
| `/v1/sitemap/licitacoes-indexable` | **timeout 30s** ❌ |
| `/v1/sitemap/licitacoes-do-dia-indexable` | **timeout 30s** ❌ |

3 endpoints ainda saturam mesmo com 2x RAM. Próximo Googlebot crawl pesado vai re-saturar e recidivar incident. PR #535 budget + asyncio.to_thread + negative_cache é defesa necessária.

## Risk

- CodeRabbit flagou no PR #535 original 3 issues sobre helper-failure swallowing errors (negative-cache bypass). Esses bugs **persistem** nesta reaplicação. Defesa em profundidade > perfeição imediata.
- Follow-up necessário: refactor helpers para propagar exceções → negative cache funcionar como intended.

## Testing Plan

- [x] Backend Tests gate (PR #535 original passou 14m24s)
- [x] Frontend Tests gate (PR #535 original passou 6m6s)
- [ ] Smoke pós-merge: re-rodar tabela acima → 6 endpoints <25s
- [ ] Sitemap-4.xml prod: aguardar ISR revalidate 1h → URLs > 0

## Closes

- Recidiva incident 2026-04-28 (sitemap saturação)
- Memory `feedback_supabase_disk_io_root_cause_pattern` aprendizado: discriminate antes upgrade compute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection to sitemap endpoints (CNPJ, procurement, daily procurement, and organizations) to improve reliability and prevent request hangs.
  * Improved failure handling: failed requests are now briefly cached to prevent repeated expensive operations.

* **Documentation**
  * Updated endpoint descriptions to clarify caching strategies for successful and failed responses.

* **Tests**
  * Improved stability for cryptographic validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->