### PR TITLE
fix(cron): new_bids_notifier — column rename profile_context → context_data

### DIFF
--- a/backend/jobs/cron/new_bids_notifier.py
+++ b/backend/jobs/cron/new_bids_notifier.py
@@ -1,7 +1,7 @@
 """jobs.cron.new_bids_notifier — Daily detection of new bids for in-app notification.
 
 STORY-445: New Bid Count Badge — runs once daily at 12:00 UTC (09:00 BRT) after
-morning ingestion. For each active user with profile_context, queries pncp_raw_bids
+morning ingestion. For each active user with context_data, queries pncp_raw_bids
 and stores count in Redis key ``new_bids_count:{user_id}`` with 26h TTL.
 """
 
@@ -29,7 +29,7 @@ async def run_new_bids_notifier() -> dict:
     """Compute per-user new-bid counts and cache them in Redis.
 
     For each active profile (free_trial + smartlic_pro) that has a setor_id
-    and UFs configured in profile_context, counts bids ingested in the last
+    and UFs configured in context_data, counts bids ingested in the last
     26 h and writes the count to ``new_bids_count:{user_id}`` in Redis.
     """
     try:
@@ -41,12 +41,12 @@ async def run_new_bids_notifier() -> dict:
         now = datetime.now(timezone.utc)
         since = (now - timedelta(hours=26)).isoformat()
 
-        # Fetch active profiles that have profile_context set
+        # Fetch active profiles that have context_data set
         profiles_resp = await sb_execute(
             sb.table("profiles")
-            .select("id, plan_type, profile_context")
+            .select("id, plan_type, context_data")
             .in_("plan_type", ["free_trial", "smartlic_pro"])
-            .not_.is_("profile_context", "null")
+            .not_.is_("context_data", "null")
         )
         profiles = profiles_resp.data or []
 
@@ -60,7 +60,7 @@ async def run_new_bids_notifier() -> dict:
         for profile in profiles:
             try:
                 user_id = profile["id"]
-                ctx = profile.get("profile_context") or {}
+                ctx = profile.get("context_data") or {}
 
                 # Support multiple field name conventions
                 setor_id = (

--- a/backend/tests/test_new_bids_notifier.py
+++ b/backend/tests/test_new_bids_notifier.py
@@ -14,22 +14,22 @@ def mock_profiles():
         {
             "id": "user-a",
             "plan_type": "free_trial",
-            "profile_context": {"setor_id": "saude", "ufs": ["SP", "RJ"]},
+            "context_data": {"setor_id": "saude", "ufs": ["SP", "RJ"]},
         },
         {
             "id": "user-b",
             "plan_type": "smartlic_pro",
-            "profile_context": {"setor_id": "construcao", "ufs_selecionadas": ["MG"]},
+            "context_data": {"setor_id": "construcao", "ufs_selecionadas": ["MG"]},
         },
         {
             "id": "user-no-setor",
             "plan_type": "free_trial",
-            "profile_context": {"ufs": ["SP"]},  # missing setor_id
+            "context_data": {"ufs": ["SP"]},  # missing setor_id
         },
         {
             "id": "user-no-ufs",
             "plan_type": "free_trial",
-            "profile_context": {"setor_id": "saude"},  # missing ufs
+            "context_data": {"setor_id": "saude"},  # missing ufs
         },
     ]
 


### PR DESCRIPTION
## Summary

Cron `new_bids_notifier` (STORY-445 — New Bid Count Badge, signal diário de ativação) silenciosamente quebrado: query usa coluna `profiles.profile_context` que **não existe** no DB. Coluna correta é `profiles.context_data` (JSONB), introduzida em STORY-247/SYS-023 quando contexto de perfil foi consolidado.

**Sentry 24h:** 10x `column "profile_context" does not exist` — todos os usuários trial+pro veem badge `0 novos editais` desde o rename, eliminando signal diário de retorno ao app. Direct conversion impact: trial users perdem nudge para sessão diária.

**Discovery (session greedy-piglet, 2026-04-28):**

```sql
SELECT column_name FROM information_schema.columns
 WHERE table_name='profiles' AND column_name LIKE '%context%';
-- → context_data (jsonb)   -- NÃO profile_context
```

**Mudanças (3 ocorrências em código + 4 em testes):**

- `backend/jobs/cron/new_bids_notifier.py`:
  - Linha 47: `select("id, plan_type, profile_context")` → `select("id, plan_type, context_data")`
  - Linha 49: `.not_.is_("profile_context", "null")` → `.not_.is_("context_data", "null")`
  - Linha 63: `profile.get("profile_context")` → `profile.get("context_data")`
  - Docstrings atualizadas para nome correto
- `backend/tests/test_new_bids_notifier.py`: fixtures alinhadas (4 entradas)

`backend/services/digest_service.py` foi inspecionado — já usa `context_data` corretamente; comentário desatualizado é cosmetic, não bug.

**Bug companion NÃO neste PR:** `analytics.py` + `trial_email_sequence.py` referenciam colunas `top_result_*` em `search_sessions` que **nunca foram migradas** (STORY-371 orfã — código mergeado sem migration acompanhando). Será tratado em story dedicada @sm — requer decisão design (migration + populator vs strip do código).

## Testing Plan

- [x] `pytest backend/tests/test_new_bids_notifier.py -v --timeout=30` → 5/5 pass
- [ ] Backend Tests CI green
- [ ] Frontend Tests CI green
- [ ] Pós-deploy: Sentry monitora `column "profile_context" does not exist` cair para 0 em 24h
- [ ] Pós-deploy: query Mixpanel `new_bid_badge_view` retoma para >0 (badge funcional)

## Closes

Não há issue formal — bug descoberto via schema discriminator psql nesta sessão. Story companion (top_result_* migration / strip) será criada @sm.

## Context

- Discovery session: greedy-piglet 2026-04-28
- Coluna correta introduzida em STORY-247 (Profile Context wizard) + SYS-023 (user-scoped Supabase client)
- Padrão `context_data` JSONB com keys: `setor_id`, `ufs`, `porte_empresa`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — session greedy-piglet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration handling in the notification system to enhance data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->