### PR TITLE
fix(sitemap): module cache distingue fetch-failed de fetched-empty (sitemap-4 stuck-empty)

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -79,7 +79,11 @@ async function fetchLicitacoesIndexable(): Promise<{ setor: string; uf: string }
   // SEO-440: empty fallback — without confirmed backend data, we cannot indicate
   // which combos are indexable. Returning generateLicitacoesParams() (all 405 combos)
   // would place noindex pages in sitemap → GSC "Excluded by noindex" mass error.
-  _licitacoesIndexableCache = result ?? [];
+  // 2026-04-28 elegant-dream: distinguir fetch-failed de fetched-empty.
+  // Antes: result ?? [] colapsava null+[] em "fetched=true,cache=[]" stuck 1h ISR.
+  // Agora: null (timeout/erro) NAO marca fetched → proximo ISR retry o backend.
+  if (result === null) return [];
+  _licitacoesIndexableCache = result;
   _licitacoesIndexableFetched = true;
   return _licitacoesIndexableCache;
 }
@@ -95,7 +99,8 @@ async function fetchContratosOrgaoIndexable(): Promise<string[]> {
     (d) => ((d as { orgaos?: string[] }).orgaos ?? []),
     'contratos-orgao-indexable',
   );
-  _contratosOrgaoCache = result ?? [];
+  if (result === null) return [];
+  _contratosOrgaoCache = result;
   _contratosOrgaoFetched = true;
   return _contratosOrgaoCache;
 }
@@ -111,7 +116,8 @@ async function fetchSitemapCnpjs(): Promise<string[]> {
     (d) => ((d as { cnpjs?: string[] }).cnpjs ?? []),
     'cnpjs',
   );
-  _cnpjCache = result ?? [];
+  if (result === null) return [];
+  _cnpjCache = result;
   _cnpjFetched = true;
   return _cnpjCache;
 }
@@ -131,7 +137,8 @@ async function fetchSitemapFornecedoresCnpj(): Promise<string[]> {
     (d) => ((d as { cnpjs?: string[] }).cnpjs ?? []),
     'fornecedores-cnpj',
   );
-  _fornecedoresCnpjCache = result ?? [];
+  if (result === null) return [];
+  _fornecedoresCnpjCache = result;
   _fornecedoresCnpjFetched = true;
   return _fornecedoresCnpjCache;
 }
@@ -147,7 +154,8 @@ async function fetchSitemapMunicipios(): Promise<string[]> {
     (d) => ((d as { slugs?: string[] }).slugs ?? []),
     'municipios',
   );
-  _municipiosCache = result ?? [];
+  if (result === null) return [];
+  _municipiosCache = result;
   _municipiosFetched = true;
   return _municipiosCache;
 }
@@ -163,7 +171,8 @@ async function fetchSitemapItens(): Promise<string[]> {
     (d) => ((d as { catmats?: string[] }).catmats ?? []),
     'itens',
   );
-  _itensCache = result ?? [];
+  if (result === null) return [];
+  _itensCache = result;
   _itensFetched = true;
   return _itensCache;
 }
@@ -175,7 +184,8 @@ async function fetchSitemapOrgaos(): Promise<string[]> {
     (d) => ((d as { orgaos?: string[] }).orgaos ?? []),
     'orgaos',
   );
-  _orgaoCache = result ?? [];
+  if (result === null) return [];
+  _orgaoCache = result;
   _orgaoFetched = true;
   return _orgaoCache;
 }


### PR DESCRIPTION
## Summary

Frontend module-level cache em `frontend/app/sitemap.ts` colapsava `null` (fetch falhou) e `[]` (fetched empty) em "fetched=true,cache=[]" stuck por 1h ISR. Ship defesa em profundidade contra recidiva sitemap-4=0.

## Context

**Sintoma observado em prod 2026-04-28:** `https://smartlic.tech/sitemap/4.xml` retorna 200/110B/0 URLs (deveria ter ~6k entity pages — CNPJs + órgãos da Onda 1+2 do SEO playbook). Outros sub-sitemaps (0,1,2,3) OK.

**Bootstrap empírico:**
| Endpoint | HTTP | Time |
|----------|------|------|
| `/v1/sitemap/cnpjs` | 200 | 1.6s |
| `/v1/sitemap/orgaos` | 200 | 1.9s |
| `/v1/sitemap/fornecedores-cnpj` | 200 | 1.9s |
| `/v1/sitemap/contratos-orgao-indexable` | 200 | ~26s |
| `/v1/sitemap/licitacoes-indexable` (pré-#539) | timeout >35s | — |
| `/v1/sitemap/licitacoes-do-dia-indexable` (pré-#539) | timeout >35s | — |

Backend já corrigido em `main` via PR #539 (`82bad614` — un-revert PR #535: `asyncio.wait_for` + `asyncio.to_thread` + negative cache curto). Re-test após deploy: ambos endpoints residuais agora 200 em <2s.

**Causa do sitemap-4 vazio observado:** AbortSignal.timeout(15s) ocasional em revalidate hit → `fetchSitemapJson` retorna `null` → `_xxxCache = null ?? []` colapsa em `[]` → `_xxxFetched = true` previne retry. Próximas ISR hits servem `[]` por 1h sem rebuscar backend.

## Fix

7 fetchers no `sitemap.ts` (`fetchLicitacoesIndexable`, `fetchSitemapCnpjs`, `fetchSitemapOrgaos`, `fetchSitemapFornecedoresCnpj`, `fetchSitemapMunicipios`, `fetchSitemapItens`, `fetchContratosOrgaoIndexable`):

- Quando `result === null` (fetch falhou): retornar `[]` para esta request mas **NÃO marcar `_xxxFetched=true`**
- Próxima ISR hit retenta o backend
- Quando `result !== null`: armazena cache + marca fetched (mesmo que array vazio do extract → fetched-empty é estado válido)

Memory updates: `feedback_sen_fe_001_recidiva_sitemap.md` aprendizado sobre cache-stuck-on-error pattern.

## Testing Plan

- [x] Frontend tests: `__tests__/app/sitemap-parallel-fetch.test.ts` (3) + `__tests__/sitemap-coverage.test.ts` (4) → **7/7 passing**
- [ ] Pós-merge T+5min: backend `/v1/sitemap/licitacoes-indexable` + `licitacoes-do-dia-indexable` mantêm 200 <2s (já confirmado pré-merge)
- [ ] Pós-merge T+1h (ISR revalidate): `https://smartlic.tech/sitemap/4.xml` size > 100KB, > 1000 URLs
- [ ] Sentry T+1h: `sitemap_outcome:fetch_error` events drop ~0
- [ ] GSC T+24-48h: sub-sitemap 4 pages indexed > 6000

## Closes

- Recidiva root cause `sitemap/4.xml=0 URLs` (defesa profunda — backend já fix em PR #539)
- PR #538 stale duplicate (já contemplado em #539 mergeado em `82bad614`)

## Risks

- **R1 (médio):** Frontend ISR cache pode requerir force-redeploy adicional pós-merge se cache stuck antes deste fix; mitigação: empty commit ou deploy.yml triggera rebuild
- **R2 (baixo):** Module-level cache em concurrent ISR worker (Next.js multi-worker) — testes Jest cobrem comportamento; multi-worker race testado pelos existentes `sitemap-parallel-fetch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data retrieval error handling to properly distinguish between backend failures and empty datasets. When requests fail, the system now retries on subsequent operations instead of serving cached empty results, improving overall reliability and ensuring data accuracy throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->