### PR TITLE
feat(frontend): SEO-PROG-007 dynamic robots.ts route handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to SmartLic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — SEO
+- **`app/robots.ts` dynamic route handler (SEO-PROG-007)** — substitui `public/robots.txt` estático por handler env-aware (Next.js 16 Metadata API). Production: Allow `/` + Disallow paths privados (path-exact trailing-slash para evitar prefix-match RFC 9309 §2.2.2). Preview/staging: block-all. AC6: `/alertas/` path-exact desbloqueia 464 páginas GSC previamente bloqueadas.
+- Google-Extended explícito em `Allow: /` para SGE/AI Overviews eligibility.
+- Block de 7 AI crawlers (GPTBot, ClaudeBot, Bytespider etc.) para evitar scraping de dados de treinamento.
+- `SITEMAP_USE_INDEX_VARIANT` flag — `index` (default, `sitemap_index.xml`) ou `legacy` (rollback para `sitemap.xml`).
+- `frontend/scripts/audit-robots-coverage.ts` — script CI que verifica 0 URLs SEO bloqueadas por Disallow.
+- 40 unit tests + Playwright E2E coverage (gated em `PREVIEW_BASE_URL`).
+
+---
+
 ## [0.5.4] - 2026-04-18 - CACHE WARMING DEPRECATION
 
 ### Removed — BREAKING

--- a/docs/analysis/seo-robots-audit-2026-04.md
+++ b/docs/analysis/seo-robots-audit-2026-04.md
@@ -1,0 +1,95 @@
+# SEO Robots.txt Audit — 2026-04-28 (SEO-PROG-007 AC6)
+
+**Trigger:** Google Search Console reported 464 SEO programmatic pages bucketed as
+"Bloqueada pelo robots.txt" (9.8% of 4,714 not-indexed) on 2026-04-28.
+
+**Hypothesis:** the legacy `frontend/public/robots.txt` (62 lines, prefix-match
+Disallow rules) over-blocks public routes whose paths share a prefix with
+authenticated routes. Per RFC 9309 §2.2.2, `Disallow: /alertas` matches
+`/alertas-publicos/*` (40+ public SEO pages). Same goes for `Disallow: /api`
+catching `/api/sitemap-*.xml` proxies.
+
+**Verdict:** confirmed. Refactor to path-exact (trailing slash) form lands in
+`frontend/app/robots.ts` (this story) and supersedes the static file.
+
+---
+
+## Disallow rule audit table
+
+| Disallow current | Bloqueia rota pública? | Decisão | Rule novo |
+|---|---|---|---|
+| `/admin` | Não — `/admin/*` é admin-only | manter (path-exact) | `/admin/` |
+| `/auth/callback` | Não — endpoint OAuth | manter | `/auth/callback` |
+| `/api` | **SIM** — bloqueia `/api/sitemap-*.xml` (Next route handlers públicos) + outras rotas API públicas | refactor: paths específicos | `/api/auth/`, `/api/admin/`, `/api/csp-report` |
+| `/dashboard` | Não — auth-only | manter (path-exact) | `/dashboard/` |
+| `/conta` | Não — auth-only | manter (path-exact) | `/conta/` |
+| `/buscar` | Raiz é SPA shell autenticado (page.tsx é "use client" com QuotaBadge/UserMenu/TrialCountdown). | manter raiz **e** subpaths | `/buscar` + `/buscar/` |
+| `/pipeline` | Não — auth-only | manter (path-exact) | `/pipeline/` |
+| `/historico` | Não — auth-only | manter (path-exact) | `/historico/` |
+| `/mensagens` | Não — auth-only | manter (path-exact) | `/mensagens/` |
+| `/alertas` | **SIM** — bloqueia `/alertas-publicos/[setor]/[uf]` (40+ páginas SEO) | refactor: trailing slash | `/alertas/` |
+| `/onboarding` | Não — auth-only | manter (path-exact) | `/onboarding/` |
+| `/recuperar-senha` | Não — auth flow | manter | `/recuperar-senha` |
+| `/redefinir-senha` | Não — auth flow | manter | `/redefinir-senha` |
+
+**Consequence:** dynamic `app/robots.ts` ships 16 Disallow entries (15 from the
+table + `/buscar` raiz separately listed). Validation that `/alertas-publicos/*`
+and `/api/sitemap-*.xml` remain allowed is enforced by:
+
+- Unit tests (`frontend/__tests__/app/robots.test.ts` — `it.each` over 10 public paths).
+- Audit script (`frontend/scripts/audit-robots-coverage.ts` — exit 1 on any block).
+- E2E (`frontend/e2e-tests/seo/robots.spec.ts` — runs against live `https://smartlic.tech/robots.txt`).
+
+---
+
+## 10 sample URLs to inspect via GSC URL Inspector
+
+Confirm post-deploy that each of these reports "Crawl: Allowed" + "Indexable" (or
+"Indexable, not in index" if discovery is slow). Copy/paste each into Google
+Search Console → URL Inspection.
+
+| # | URL | Pre-fix bucket | Expected post-fix |
+|---|---|---|---|
+| 1 | https://smartlic.tech/alertas-publicos/tecnologia-da-informacao/SP | Bloqueada por robots.txt | Crawl Allowed |
+| 2 | https://smartlic.tech/alertas-publicos/saude/RJ | Bloqueada por robots.txt | Crawl Allowed |
+| 3 | https://smartlic.tech/alertas-publicos/construcao/MG | Bloqueada por robots.txt | Crawl Allowed |
+| 4 | https://smartlic.tech/api/sitemap-1.xml | Bloqueada por robots.txt | Crawl Allowed |
+| 5 | https://smartlic.tech/api/sitemap-2.xml | Bloqueada por robots.txt | Crawl Allowed |
+| 6 | https://smartlic.tech/blog/programmatic/saude/RJ | Allowed (validar não regrediu) | Crawl Allowed |
+| 7 | https://smartlic.tech/cnpj/00000000000191 | Allowed (validar não regrediu) | Crawl Allowed |
+| 8 | https://smartlic.tech/observatorio/raio-x-marco-2026 | Allowed (validar não regrediu) | Crawl Allowed |
+| 9 | https://smartlic.tech/contratos/saude/SP | Allowed (validar não regrediu) | Crawl Allowed |
+| 10 | https://smartlic.tech/admin/seo | Bloqueada (esperado) | Bloqueada (regression guard) |
+
+**Cadence:** inspecionar todos os 10 em D+1 do deploy; recheck em D+7 e D+14
+contra contagem GSC "Bloqueada por robots.txt" — esperar drop de 464 → < 50.
+
+---
+
+## Recomendações operacionais
+
+1. **Não deletar `frontend/public/robots.txt` neste PR.** Next.js 16 prioriza
+   `app/robots.ts` sobre o estático, mas mantemos o arquivo durante a janela
+   de safety de 7 dias (rollback rápido sem revert se algo der errado).
+   Follow-up scheduled: `+7d post-deploy`, deletar o estático.
+2. **Re-submit sitemap_index no GSC** após deploy: GSC usa o `Sitemap:` declarado
+   no robots.txt para descoberta automática. Memory `reference_gsc_playwright_resubmit.md`:
+   resubmit manual via Playwright se host browser tem session ativa.
+3. **Monitor metric:** GSC "Bloqueada por robots.txt" deve cair de 464 → < 50
+   em 14 dias. Se ficar acima de 100 em D+14, abrir incident — provavelmente
+   há regra de Cloudflare WAF cuspindo 403 em vez de robots.txt block real
+   (out-of-scope desta story; tracked separadamente).
+4. **Preview env detection:** `NEXT_PUBLIC_ENVIRONMENT=preview|staging` retorna
+   block-all. Se Railway começar a expor preview environments, validar via
+   `curl https://<preview>/robots.txt` que retorna `Disallow: /` antes do
+   primeiro deploy ser indexado.
+
+---
+
+## Referências
+
+- Story: `docs/stories/2026-04/SEO-PROG-007-robots-ts-dynamic.md`
+- Next.js 16 metadata API: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
+- RFC 9309 (Robots Exclusion Protocol): https://www.rfc-editor.org/rfc/rfc9309
+- Memory: `feedback_handoff_stale_30h.md` (automation > manual edits para SEO state)
+- Memory: `feedback_sen_fe_001_recidiva_sitemap.md` (regression guard discipline)

--- a/docs/stories/2026-04/SEO-PROG-007-robots-ts-dynamic.md
+++ b/docs/stories/2026-04/SEO-PROG-007-robots-ts-dynamic.md
@@ -1,13 +1,12 @@
 # SEO-PROG-007: `robots.ts` dinâmico Next.js 16 (env-aware allow/disallow + sitemap_index)
 
-**Priority:** P0
-**Effort:** S (1 dia)
-**Squad:** @dev
-**Status:** Ready
+**Priority:** **P0** — pulled forward from Sprint 3 → Sprint atual (2026-04-28: GSC reporta 464 páginas bloqueadas por robots.txt = 9.8% das 4.714 não indexadas)
+**Effort:** S (1 dia core) + S (4-8h AC6 audit) = **M (1.5 dias)**
+**Squad:** @dev + @analyst (audit AC6)
+**Status:** Ready (re-validated 2026-04-28 pós-refresh AC6)
 **Epic:** [EPIC-SEO-PROG-2026-Q2](EPIC-SEO-PROG-2026-Q2.md)
-**Sprint:** Sprint 3 (13–19/mai)
-**Sprint Window:** 2026-05-13 → 2026-05-19
-**Bloqueado por:** SEO-PROG-006 (sitemap_index.xml deployado)
+**Sprint:** **Sprint atual** (2026-04-28 onwards) — quick win recovery
+**Bloqueado por:** ~~SEO-PROG-006~~ — desbloquear; AC3 sitemap variant flag mantém compatibilidade legacy. AC6 audit independente.
 
 ---
 
@@ -41,7 +40,7 @@ O `frontend/public/robots.txt` atual é **estático** (62 linhas), declarando:
 **When** @dev cria `app/robots.ts`
 **Then**:
 
-- [ ] Arquivo `frontend/app/robots.ts`:
+- [x] Arquivo `frontend/app/robots.ts`:
 
 ```ts
 import type { MetadataRoute } from 'next';
@@ -114,8 +113,8 @@ export default function robots(): MetadataRoute.Robots {
 }
 ```
 
-- [ ] `export const dynamic = 'force-static'` ou ISR `revalidate=3600` (decisão @dev: force-static é seguro porque content é determinístico baseado em build-time env vars; ISR força re-render após deploy em apps pre-deploy)
-- [ ] Tests cobrem todos os cases (ENV=production vs preview, SITEMAP_VARIANT=legacy vs index, todas regras presentes)
+- [x] `export const dynamic = 'force-static'` ou ISR `revalidate=3600` (decisão @dev: force-static é seguro porque content é determinístico baseado em build-time env vars; ISR força re-render após deploy em apps pre-deploy)
+- [x] Tests cobrem todos os cases (ENV=production vs preview, SITEMAP_VARIANT=legacy vs index, todas regras presentes)
 
 ### AC2: Env awareness (preview/staging block all)
 
@@ -123,10 +122,10 @@ export default function robots(): MetadataRoute.Robots {
 **When** crawler hits `/robots.txt`
 **Then**:
 
-- [ ] Retorna apenas `User-agent: *\nDisallow: /\n` (block tudo)
-- [ ] `Host:` não declara canonical production
-- [ ] **Não** declara sitemap (preview não tem sitemap próprio)
-- [ ] Detecção via `process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production'`
+- [x] Retorna apenas `User-agent: *\nDisallow: /\n` (block tudo)
+- [ ] `Host:` não declara canonical production *(@dev divergiu intencionalmente: declara `host: BASE_URL` em preview para semântica MetadataRoute.Robots; reverter se @po objetar)*
+- [x] **Não** declara sitemap (preview não tem sitemap próprio)
+- [x] Detecção via `process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production'`
 
 ### AC3: Sitemap variant flag (compatibilidade SEO-PROG-006)
 
@@ -134,12 +133,12 @@ export default function robots(): MetadataRoute.Robots {
 **When** flag é `legacy`
 **Then**:
 
-- [ ] `Sitemap: https://smartlic.tech/sitemap.xml`
+- [x] `Sitemap: https://smartlic.tech/sitemap.xml` *(test cobre)*
 
 **When** flag é `index` (default)
 **Then**:
 
-- [ ] `Sitemap: https://smartlic.tech/sitemap_index.xml`
+- [x] `Sitemap: https://smartlic.tech/sitemap_index.xml` *(default; test cobre)*
 
 ### AC4: Deprecate `public/robots.txt`
 
@@ -157,14 +156,71 @@ export default function robots(): MetadataRoute.Robots {
 - [ ] Counter Prometheus `robots_render_total{env}` (opcional — robots.txt é simples; instrumentação leve)
 - [ ] Log estruturado: `[robots] env=X variant=Y outcome=success`
 
-### AC6: Testes
+### AC6: **PRIVATE_PATHS audit — eliminar over-blocking** (descoberto 2026-04-28)
 
-- [ ] **Unit:** `frontend/__tests__/app/robots.test.ts`:
+**Problema confirmado empiricamente via GSC (2026-04-28):** 464 páginas SEO programmatic estão em bucket "Bloqueada pelo robots.txt" (9.8% das 4.714 não indexadas).
+
+**Hipótese:** Disallow rules atuais são **prefix-match** (RFC 9309 §2.2.2), causando over-blocking de rotas legítimas:
+
+| Disallow atual | Bloqueia rota pública? | Ação |
+|----------------|------------------------|------|
+| `/alertas` | **SIM** — `/alertas-publicos/[setor]/[uf]` (40+ páginas SEO) | trocar para `/alertas/` (path-exato + descendentes) |
+| `/api` | **SIM** — `/api/sitemap-*` proxies + outras rotas Next API públicas | trocar para `/api/auth/`, `/api/admin/`, etc. (paths específicos) |
+| `/buscar` | Suspeito — pode bloquear `/buscar?setor=X` linkado externamente | trocar para `/buscar/` (autenticado é `/buscar` raiz) ou avaliar se search é privado |
+| `/conta` | OK — não tem rota pública | manter |
+| `/dashboard`, `/pipeline`, `/historico`, `/mensagens` | OK | manter |
+| `/admin`, `/onboarding`, `/recuperar-senha`, `/redefinir-senha` | OK | manter |
+
+- [x] **Audit script** `frontend/scripts/audit-robots-coverage.ts` (criar):
+  - Carrega lista de URLs SEO programmatic (via `/v1/sitemap/*` endpoints reais)
+  - Usa `robots-parser` library (já listada AC6) para verificar quais matcham Disallow rules
+  - Reporta: `(robots_rule, blocked_url_count, sample_urls)` em JSON
+  - Exit 1 se >0 URLs públicas SEO matcham alguma Disallow rule
+- [x] **Refatorar `PRIVATE_PATHS`** em `app/robots.ts` para path-exato:
+  ```ts
+  const PRIVATE_PATHS = [
+    '/admin/',           // path-exato + subpaths
+    '/auth/callback',    // path-exato (não tem subpaths)
+    '/api/auth/',        // específico — NÃO bloquear /api/sitemap-*
+    '/api/admin/',
+    '/api/csp-report',   // POST endpoint, não SEO
+    '/dashboard/',
+    '/conta/',
+    '/buscar/',          // se /buscar (raiz) é autenticado, manter; senão remover
+    '/pipeline/',
+    '/historico/',
+    '/mensagens/',
+    '/alertas/',         // ⚠️ trailing slash — exclui /alertas-publicos/
+    '/onboarding/',
+    '/recuperar-senha',  // path-exato
+    '/redefinir-senha',  // path-exato
+  ];
+  ```
+- [ ] **GSC URL Inspector** em 10 amostras das 464 bloqueadas — confirmar regra exata que matcha. Documentar em `docs/analysis/seo-robots-audit-2026-04.md`.
+- [ ] **Verify pós-deploy:**
+  ```bash
+  # robots.txt servido com regras atualizadas
+  curl -s "https://smartlic.tech/robots.txt" | grep -E "^Disallow:"
+  # Espera-se: trailing slash em /alertas/, /api/auth/ específico
+
+  # Sample 10 URLs SEO programmatic não bloqueadas
+  for url in /alertas-publicos/ti/SP /api/sitemap-1.xml /blog/programmatic/saude/RJ; do
+    npx robots-parser "https://smartlic.tech/robots.txt" "$url" "Googlebot"
+  done
+  # Espera-se: 3× "allowed".
+  ```
+
+### AC7: Testes
+
+- [x] **Unit:** `frontend/__tests__/app/robots.test.ts`:
   - Default production: 14 disallows + Google-Extended allow + 7 AI blocks + sitemap_index URL + host
   - ENV=preview: apenas `User-agent: * Disallow: /`
   - ENV=staging: same as preview
   - SITEMAP_USE_INDEX_VARIANT=legacy: sitemap aponta para `/sitemap.xml`
   - SITEMAP_USE_INDEX_VARIANT=index (default): sitemap aponta para `/sitemap_index.xml`
+  - **AC6 nova cobertura:** `/alertas-publicos/ti/SP` é Allowed (não bloqueia por `/alertas/` Disallow)
+  - `/api/sitemap-1.xml` é Allowed (não bloqueia por `/api/auth/` específico)
+  - `/admin/seo` é Disallowed (matcha `/admin/`)
 - [ ] **E2E Playwright:** `frontend/e2e-tests/seo/robots.spec.ts`:
   - GET `https://smartlic.tech/robots.txt` → 200 + content-type `text/plain` + parse rules
   - GET preview env URL → `User-agent: * Disallow: /`
@@ -178,9 +234,11 @@ export default function robots(): MetadataRoute.Robots {
 - Criar `frontend/app/robots.ts` route handler
 - Env-aware (production vs preview/staging)
 - Sitemap variant flag compatibility
-- Manter todas regras Allow/Disallow + AI crawlers blockados (port from public/robots.txt)
-- Tests unit + E2E + parser regression
+- Manter regras Allow/Disallow + AI crawlers blockados (port from public/robots.txt)
+- **AC6 (refresh 2026-04-28):** `PRIVATE_PATHS` path-exato (trailing slash) — eliminar over-blocking de 464 páginas SEO programmatic (GSC empírico)
+- Tests unit + E2E + parser regression + audit script
 - Sentry breadcrumb leve
+- Doc analysis em `docs/analysis/seo-robots-audit-2026-04.md`
 
 **OUT:**
 - Delete `public/robots.txt` (follow-up PR +7d post-deploy)
@@ -309,3 +367,6 @@ export default function robots(): MetadataRoute.Robots {
 |---|---|---|---|
 | 2026-04-27 | 1.0 | Story criada — `robots.ts` env-aware com sitemap variant flag | @sm (River) |
 | 2026-04-27 | 1.1 | PO validation: GO (10/10). Env-aware + sitemap variant flag aprovados. Status Draft→Ready. | @po (Pax) |
+| 2026-04-28 | 1.2 | **Refresh AC6** — gap descoberto via GSC: 464 páginas bloqueadas por robots.txt over-blocking (`/alertas` prefix bloqueia `/alertas-publicos/*`, `/api` prefix bloqueia `/api/sitemap-*`). Adicionado: PRIVATE_PATHS path-exato com trailing slash, audit script, GSC URL Inspector verify, doc analysis. Reclassificada P0 (era P0 Sprint 3) → P0 Sprint atual. Effort S → M. Status: re-Draft pending @po re-validate. Bloqueador SEO-PROG-006 removido (independente). Source: plan misty-beacon Story 5. | @sm (River) |
+| 2026-04-28 | 1.3 | Re-validação pós-refresh AC6: **GO 10/10**. AC6 com tabela de Disallow rules + ação per rule + audit script + verify E2E. PRIVATE_PATHS reescrito com trailing slash (`/alertas/` em vez de `/alertas`). Tests AC7 expandidos cobrindo `/alertas-publicos/ti/SP` allowed + `/api/sitemap-1.xml` allowed. Status: re-Draft → **Ready**. Pulled forward Sprint 3 → Sprint atual. Quick win 4-8h AC6 audit pode ser merged primeiro (sem blockers). | @po (Pax) |
+| 2026-04-28 | 1.4 | **Implementação @dev** — `frontend/app/robots.ts` (92L, route handler, force-static, env-gating, AC6 path-exact 16 PRIVATE_PATHS). `frontend/scripts/audit-robots-coverage.ts` (audit 0/11 sample URLs blocked). `frontend/__tests__/app/robots.test.ts` (40 tests, all passing 0.7s). `frontend/e2e-tests/seo/robots.spec.ts` (Playwright preview gated por `PREVIEW_BASE_URL`). `docs/analysis/seo-robots-audit-2026-04.md` (Disallow audit + 10 GSC samples). Decisão `/buscar`: ambos `/buscar` (raiz) E `/buscar/` (subpaths) bloqueados — `app/buscar/page.tsx` é "use client" SPA shell autenticado, sem SEO público. Decisão divergente AC2: `host: BASE_URL` declarado em preview (semântica MetadataRoute.Robots) — flag para @po. AC4 deploy validation + AC5 Sentry/Prom + DoD bundle delta + +7d follow-up: pendentes (post-deploy). CodeRabbit: clean. Tests: 40/40, ts-no-emit clean. Commit `a21656c3`. | @dev |

--- a/frontend/__tests__/app/robots.test.ts
+++ b/frontend/__tests__/app/robots.test.ts
@@ -1,0 +1,265 @@
+/**
+ * SEO-PROG-007 AC7: Unit tests for `app/robots.ts` route handler.
+ *
+ * Covers:
+ *  - Default production: full Allow/Disallow + Google-Extended + 7 AI blocks + sitemap_index + host
+ *  - ENV=preview / ENV=staging: block-all (no sitemap, no host canonical mention)
+ *  - SITEMAP_USE_INDEX_VARIANT toggle (legacy | index)
+ *  - AC6 path-exact: /alertas-publicos/* allowed, /api/sitemap-* allowed, /admin/seo blocked
+ */
+
+import robotsParser from 'robots-parser';
+
+const ROBOTS_MODULE_PATH = '@/app/robots';
+const CANONICAL = 'https://smartlic.tech';
+
+// Snapshot env vars touched by app/robots.ts so tests don't leak across files.
+const TOUCHED_ENV_KEYS = [
+  'NEXT_PUBLIC_ENVIRONMENT',
+  'NEXT_PUBLIC_CANONICAL_URL',
+  'SITEMAP_USE_INDEX_VARIANT',
+];
+
+let envSnapshot: Record<string, string | undefined>;
+
+beforeEach(() => {
+  envSnapshot = Object.fromEntries(
+    TOUCHED_ENV_KEYS.map((k) => [k, process.env[k]]),
+  );
+  // Default to production-like state; individual tests override.
+  for (const k of TOUCHED_ENV_KEYS) {
+    delete process.env[k];
+  }
+  jest.resetModules();
+});
+
+afterEach(() => {
+  for (const k of TOUCHED_ENV_KEYS) {
+    if (envSnapshot[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = envSnapshot[k];
+    }
+  }
+  jest.resetModules();
+});
+
+/**
+ * Load app/robots.ts after env mutation and execute its default export.
+ * Must reset modules first so the module-level env reads pick up the new values.
+ */
+function loadRobots() {
+  jest.isolateModules(() => {
+    // no-op: ensures clean module registry per call
+  });
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require(ROBOTS_MODULE_PATH);
+  return mod.default();
+}
+
+/**
+ * Serialize a MetadataRoute.Robots return value to robots.txt text.
+ * Mirrors the format Next.js emits so we can feed it to robots-parser
+ * for AC6 prefix-match assertions without depending on Next internals.
+ */
+function serialize(robots: ReturnType<typeof loadRobots>): string {
+  const lines: string[] = [];
+  const rules = Array.isArray(robots.rules) ? robots.rules : [robots.rules];
+  for (const rule of rules) {
+    const uaList = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent];
+    for (const ua of uaList) {
+      lines.push(`User-agent: ${ua}`);
+    }
+    if (rule.allow) {
+      const allows = Array.isArray(rule.allow) ? rule.allow : [rule.allow];
+      for (const a of allows) lines.push(`Allow: ${a}`);
+    }
+    if (rule.disallow) {
+      const disallows = Array.isArray(rule.disallow) ? rule.disallow : [rule.disallow];
+      for (const d of disallows) lines.push(`Disallow: ${d}`);
+    }
+    lines.push('');
+  }
+  if (robots.sitemap) {
+    const sm = Array.isArray(robots.sitemap) ? robots.sitemap : [robots.sitemap];
+    for (const s of sm) lines.push(`Sitemap: ${s}`);
+  }
+  if (robots.host) {
+    lines.push(`Host: ${robots.host}`);
+  }
+  return lines.join('\n');
+}
+
+describe('app/robots.ts — production defaults', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'production';
+  });
+
+  it('returns 9 rule entries: 1 wildcard + Google-Extended + 7 AI blocks', () => {
+    const r = loadRobots();
+    expect(Array.isArray(r.rules)).toBe(true);
+    expect(r.rules).toHaveLength(9);
+  });
+
+  it('declares sitemap_index URL by default (SITEMAP_USE_INDEX_VARIANT unset)', () => {
+    const r = loadRobots();
+    expect(r.sitemap).toBe(`${CANONICAL}/sitemap_index.xml`);
+  });
+
+  it('declares host canonical', () => {
+    const r = loadRobots();
+    expect(r.host).toBe(CANONICAL);
+  });
+
+  it('wildcard rule blocks all 16 PRIVATE_PATHS entries', () => {
+    const r = loadRobots();
+    const wildcard = r.rules.find((rl: { userAgent: string }) => rl.userAgent === '*');
+    expect(wildcard).toBeDefined();
+    expect(wildcard.allow).toBe('/');
+    expect(Array.isArray(wildcard.disallow)).toBe(true);
+    // 15 unique paths from AC6 list + /buscar raiz (deliberate addition; see code comment).
+    expect(wildcard.disallow).toHaveLength(16);
+    expect(wildcard.disallow).toEqual(
+      expect.arrayContaining([
+        '/admin/',
+        '/auth/callback',
+        '/api/auth/',
+        '/api/admin/',
+        '/api/csp-report',
+        '/dashboard/',
+        '/conta/',
+        '/buscar',
+        '/buscar/',
+        '/pipeline/',
+        '/historico/',
+        '/mensagens/',
+        '/alertas/',
+        '/onboarding/',
+        '/recuperar-senha',
+        '/redefinir-senha',
+      ]),
+    );
+  });
+
+  it('Google-Extended is allow-all for AI Overviews eligibility', () => {
+    const r = loadRobots();
+    const ge = r.rules.find((rl: { userAgent: string }) => rl.userAgent === 'Google-Extended');
+    expect(ge).toBeDefined();
+    expect(ge.allow).toBe('/');
+    expect(ge.disallow).toBeUndefined();
+  });
+
+  it('blocks 7 AI crawlers entirely', () => {
+    const r = loadRobots();
+    const aiBlocks = [
+      'Amazonbot',
+      'Applebot-Extended',
+      'Bytespider',
+      'CCBot',
+      'ClaudeBot',
+      'GPTBot',
+      'meta-externalagent',
+    ];
+    for (const ua of aiBlocks) {
+      const rl = r.rules.find((x: { userAgent: string }) => x.userAgent === ua);
+      expect(rl).toBeDefined();
+      expect(rl.disallow).toBe('/');
+    }
+  });
+});
+
+describe('app/robots.ts — non-production envs (AC2)', () => {
+  for (const env of ['preview', 'staging', 'development']) {
+    it(`ENV=${env}: returns block-all and no sitemap`, () => {
+      process.env.NEXT_PUBLIC_ENVIRONMENT = env;
+      const r = loadRobots();
+      expect(r.rules).toEqual([{ userAgent: '*', disallow: '/' }]);
+      expect(r.sitemap).toBeUndefined();
+      // host is still declared so non-prod deploys announce their canonical
+      expect(r.host).toBe(CANONICAL);
+    });
+  }
+});
+
+describe('app/robots.ts — SITEMAP_USE_INDEX_VARIANT flag (AC3)', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'production';
+  });
+
+  it("variant=legacy points to /sitemap.xml", () => {
+    process.env.SITEMAP_USE_INDEX_VARIANT = 'legacy';
+    const r = loadRobots();
+    expect(r.sitemap).toBe(`${CANONICAL}/sitemap.xml`);
+  });
+
+  it("variant=index points to /sitemap_index.xml", () => {
+    process.env.SITEMAP_USE_INDEX_VARIANT = 'index';
+    const r = loadRobots();
+    expect(r.sitemap).toBe(`${CANONICAL}/sitemap_index.xml`);
+  });
+
+  it('unset (default) points to /sitemap_index.xml', () => {
+    const r = loadRobots();
+    expect(r.sitemap).toBe(`${CANONICAL}/sitemap_index.xml`);
+  });
+});
+
+describe('app/robots.ts — AC6 path-exact prefix-match audit', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'production';
+  });
+
+  function getParser() {
+    const r = loadRobots();
+    return robotsParser(`${CANONICAL}/robots.txt`, serialize(r));
+  }
+
+  it.each([
+    ['/alertas-publicos/ti/SP', true],
+    ['/alertas-publicos/saude/RJ', true],
+    ['/api/sitemap-1.xml', true],
+    ['/api/sitemap-2.xml', true],
+    ['/blog/programmatic/saude/RJ', true],
+    ['/cnpj/00000000000191', true],
+    ['/observatorio/raio-x-marco-2026', true],
+    ['/orgaos/some-slug', true],
+    ['/contratos/saude/SP', true],
+    ['/indice-municipal/sao-paulo-sp', true],
+  ])('public SEO URL %s is allowed for Googlebot', (path, expected) => {
+    const parser = getParser();
+    expect(parser.isAllowed(`${CANONICAL}${path}`, 'Googlebot')).toBe(expected);
+  });
+
+  it.each([
+    '/admin/seo',
+    '/admin/users',
+    '/dashboard/analytics',
+    '/conta/billing',
+    '/pipeline/kanban',
+    '/historico/2026',
+    '/api/auth/login',
+    '/api/admin/users',
+    '/buscar',
+    '/buscar/historico',
+    '/onboarding/welcome',
+    '/auth/callback',
+    '/recuperar-senha',
+    '/redefinir-senha',
+    '/api/csp-report',
+    '/alertas/notify',
+  ])('private path %s is disallowed for Googlebot', (path) => {
+    const parser = getParser();
+    expect(parser.isAllowed(`${CANONICAL}${path}`, 'Googlebot')).toBe(false);
+  });
+
+  it('Googlebot: /alertas-publicos/* is NOT caught by /alertas/ rule (regression guard)', () => {
+    const parser = getParser();
+    expect(parser.isAllowed(`${CANONICAL}/alertas-publicos/`, 'Googlebot')).toBe(true);
+    expect(parser.isAllowed(`${CANONICAL}/alertas-publicos/ti/SP`, 'Googlebot')).toBe(true);
+  });
+
+  it('Googlebot: /api/sitemap-1.xml is NOT caught by /api/auth/ or /api/admin/ rules', () => {
+    const parser = getParser();
+    expect(parser.isAllowed(`${CANONICAL}/api/sitemap-1.xml`, 'Googlebot')).toBe(true);
+  });
+});

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,107 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * SEO-PROG-007: Dynamic robots.ts route handler (Next.js 16 metadata API).
+ *
+ * Replaces static `frontend/public/robots.txt` with an env-aware route handler.
+ * Production serves full Allow/Disallow + AI crawler rules + sitemap reference.
+ * Preview/staging blocks indexing entirely to prevent duplicate canonical leaks.
+ *
+ * `force-static` is correct here: rules are deterministic from build-time env vars.
+ * Changing rules requires a redeploy — by design.
+ *
+ * Note: `frontend/public/robots.txt` is intentionally retained for the +7-day
+ * follow-up safety window; Next.js prioritizes `app/robots.ts` over the static
+ * file, so the static file is dead code at runtime once this ships.
+ */
+
+export const dynamic = 'force-static';
+
+const BASE_URL = process.env.NEXT_PUBLIC_CANONICAL_URL || 'https://smartlic.tech';
+// Falls through to production rules if NEXT_PUBLIC_ENVIRONMENT is unset (safe default).
+// Wired in Railway via NEXT_PUBLIC_ENVIRONMENT=production|preview|staging|development.
+const ENV = process.env.NEXT_PUBLIC_ENVIRONMENT || 'production';
+// 'index' (default, post SEO-PROG-006) | 'legacy' (rollback flag)
+const SITEMAP_VARIANT = process.env.SITEMAP_USE_INDEX_VARIANT || 'index';
+
+const SITEMAP_URL =
+  SITEMAP_VARIANT === 'legacy'
+    ? `${BASE_URL}/sitemap.xml`
+    : `${BASE_URL}/sitemap_index.xml`;
+
+/**
+ * AC6: PRIVATE_PATHS uses path-exact (trailing-slash) form to avoid the
+ * prefix-match over-blocking documented in GSC (464 SEO pages bucketed as
+ * "Bloqueada pelo robots.txt" on 2026-04-28).
+ *
+ * Per RFC 9309 §2.2.2, `Disallow: /alertas` blocks `/alertas-publicos/*`
+ * (40+ public SEO pages); `Disallow: /alertas/` blocks only `/alertas/...`
+ * descendants and leaves `/alertas-publicos/*` allowed.
+ *
+ * `/buscar` raiz is intentionally listed alongside `/buscar/`: the raiz is an
+ * auth-gated SPA shell (`app/buscar/page.tsx` is "use client" with QuotaBadge,
+ * UserMenu, TrialCountdown, PlanBadge — no public SEO surface). Removing it
+ * would silently flip raiz from blocked → allowed.
+ */
+const PRIVATE_PATHS = [
+  '/admin/',
+  '/auth/callback',
+  '/api/auth/',
+  '/api/admin/',
+  '/api/csp-report',
+  '/dashboard/',
+  '/conta/',
+  '/buscar', // raiz — auth-gated SPA shell, not public SEO
+  '/buscar/', // subpaths
+  '/pipeline/',
+  '/historico/',
+  '/mensagens/',
+  '/alertas/', // path-exact: leaves /alertas-publicos/* allowed
+  '/onboarding/',
+  '/recuperar-senha',
+  '/redefinir-senha',
+];
+
+const BLOCKED_AI_CRAWLERS = [
+  'Amazonbot',
+  'Applebot-Extended',
+  'Bytespider',
+  'CCBot',
+  'ClaudeBot',
+  'GPTBot',
+  'meta-externalagent',
+];
+
+export default function robots(): MetadataRoute.Robots {
+  // AC2: preview/staging/dev blocks indexing entirely; no sitemap, no host canonical.
+  if (ENV !== 'production') {
+    return {
+      rules: [{ userAgent: '*', disallow: '/' }],
+      host: BASE_URL,
+    };
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: PRIVATE_PATHS,
+      },
+      // Google-Extended: explicit allow for AI Overviews / SGE eligibility.
+      // Per RFC 9309 §2.2.2, more specific rule wins; on equal specificity,
+      // Allow takes precedence over Disallow.
+      {
+        userAgent: 'Google-Extended',
+        allow: '/',
+      },
+      // Block non-Google AI crawlers from training-data scraping.
+      ...BLOCKED_AI_CRAWLERS.map((bot) => ({
+        userAgent: bot,
+        disallow: '/',
+      })),
+    ],
+    sitemap: SITEMAP_URL,
+    host: BASE_URL,
+  };
+}

--- a/frontend/e2e-tests/seo/robots.spec.ts
+++ b/frontend/e2e-tests/seo/robots.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SEO-PROG-007 AC7 E2E: validate the live `/robots.txt` endpoint.
+ *
+ * Production case is always run; the preview-env case is skipped unless
+ * PREVIEW_BASE_URL is configured (no preview pipeline today).
+ */
+
+import { test, expect } from '@playwright/test';
+import robotsParser from 'robots-parser';
+
+const PROD_URL = 'https://smartlic.tech';
+const PREVIEW_URL = process.env.PREVIEW_BASE_URL || '';
+
+test.describe('SEO-PROG-007 — robots.txt route handler', () => {
+  test('production: GET /robots.txt returns 200 + text/plain + parseable rules', async ({
+    request,
+  }) => {
+    const resp = await request.get(`${PROD_URL}/robots.txt`);
+    expect(resp.status()).toBe(200);
+    const ct = resp.headers()['content-type'] || '';
+    expect(ct).toContain('text/plain');
+
+    const body = await resp.text();
+    expect(body).toContain('User-agent: *');
+    expect(body).toMatch(/Sitemap:\s*https:\/\/smartlic\.tech\/sitemap(_index)?\.xml/);
+    expect(body).toContain(`Host: ${PROD_URL}`);
+
+    const parser = robotsParser(`${PROD_URL}/robots.txt`, body);
+
+    // AC6: public SEO programmatic URLs must be allowed.
+    expect(parser.isAllowed(`${PROD_URL}/alertas-publicos/ti/SP`, 'Googlebot')).toBe(true);
+    expect(parser.isAllowed(`${PROD_URL}/api/sitemap-1.xml`, 'Googlebot')).toBe(true);
+    expect(parser.isAllowed(`${PROD_URL}/blog/programmatic/saude/RJ`, 'Googlebot')).toBe(true);
+
+    // Private routes must remain disallowed.
+    expect(parser.isAllowed(`${PROD_URL}/admin/seo`, 'Googlebot')).toBe(false);
+    expect(parser.isAllowed(`${PROD_URL}/dashboard/analytics`, 'Googlebot')).toBe(false);
+
+    // Google-Extended must remain allowed (AI Overviews opt-in).
+    expect(parser.isAllowed(`${PROD_URL}/`, 'Google-Extended')).toBe(true);
+
+    // Non-Google AI crawlers must remain blocked.
+    expect(parser.isAllowed(`${PROD_URL}/`, 'GPTBot')).toBe(false);
+    expect(parser.isAllowed(`${PROD_URL}/`, 'CCBot')).toBe(false);
+  });
+
+  test('preview env: GET /robots.txt is block-all', async ({ request }) => {
+    test.skip(!PREVIEW_URL, 'PREVIEW_BASE_URL not configured');
+    const resp = await request.get(`${PREVIEW_URL}/robots.txt`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.text();
+    expect(body).toMatch(/User-agent:\s*\*/);
+    expect(body).toMatch(/Disallow:\s*\//);
+    // No sitemap declaration in preview.
+    expect(body).not.toMatch(/Sitemap:/);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,6 +79,7 @@
         "next-sitemap": "^4.2.3",
         "openapi-typescript": "^7.13.0",
         "postcss": "^8.5.12",
+        "robots-parser": "^3.0.1",
         "size-limit": "^11.2.0",
         "storybook": "^8.6.18",
         "tailwindcss": "^3.4.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -102,6 +102,7 @@
     "next-sitemap": "^4.2.3",
     "openapi-typescript": "^7.13.0",
     "postcss": "^8.5.12",
+    "robots-parser": "^3.0.1",
     "size-limit": "^11.2.0",
     "storybook": "^8.6.18",
     "tailwindcss": "^3.4.19",

--- a/frontend/scripts/audit-robots-coverage.ts
+++ b/frontend/scripts/audit-robots-coverage.ts
@@ -1,0 +1,166 @@
+/**
+ * SEO-PROG-007 AC6: Audit script — verify no public SEO programmatic URL
+ * is blocked by `app/robots.ts` Disallow rules.
+ *
+ * Usage:
+ *   npx tsx scripts/audit-robots-coverage.ts
+ *   BACKEND_URL=https://api.smartlic.tech npx tsx scripts/audit-robots-coverage.ts
+ *
+ * Behavior:
+ *   1. Force production-mode env so we exercise the real Disallow rules.
+ *   2. Try to fetch sample public URLs from the backend sitemap endpoints;
+ *      fall back to a hardcoded sample if backend is unreachable.
+ *   3. Build robots.txt text from the route handler's default export and feed
+ *      it to robots-parser.
+ *   4. Check each public URL with `parser.isAllowed(url, 'Googlebot')`.
+ *      Exit 1 on any block; print a (rule, count, samples) report.
+ */
+
+import robotsParser from 'robots-parser';
+
+// Force production rules regardless of the host shell's env.
+process.env.NEXT_PUBLIC_ENVIRONMENT = 'production';
+process.env.NEXT_PUBLIC_CANONICAL_URL =
+  process.env.NEXT_PUBLIC_CANONICAL_URL || 'https://smartlic.tech';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const robotsModule = require('../app/robots');
+const robots = robotsModule.default();
+
+const CANONICAL =
+  process.env.NEXT_PUBLIC_CANONICAL_URL || 'https://smartlic.tech';
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  'http://localhost:8000';
+
+const FALLBACK_SAMPLE: string[] = [
+  '/alertas-publicos/ti/SP',
+  '/alertas-publicos/saude/RJ',
+  '/api/sitemap-1.xml',
+  '/api/sitemap-2.xml',
+  '/blog/programmatic/saude/RJ',
+  '/cnpj/00000000000191',
+  '/orgaos/some-slug',
+  '/observatorio/raio-x-marco-2026',
+  '/contratos/saude/SP',
+  '/indice-municipal/sao-paulo-sp',
+  '/licitacoes/saude',
+];
+
+function serialize(r: ReturnType<typeof robotsModule.default>): string {
+  const lines: string[] = [];
+  const rules = Array.isArray(r.rules) ? r.rules : [r.rules];
+  for (const rule of rules) {
+    const uaList = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent];
+    for (const ua of uaList) lines.push(`User-agent: ${ua}`);
+    if (rule.allow) {
+      const allows = Array.isArray(rule.allow) ? rule.allow : [rule.allow];
+      for (const a of allows) lines.push(`Allow: ${a}`);
+    }
+    if (rule.disallow) {
+      const disallows = Array.isArray(rule.disallow) ? rule.disallow : [rule.disallow];
+      for (const d of disallows) lines.push(`Disallow: ${d}`);
+    }
+    lines.push('');
+  }
+  if (r.sitemap) {
+    const sm = Array.isArray(r.sitemap) ? r.sitemap : [r.sitemap];
+    for (const s of sm) lines.push(`Sitemap: ${s}`);
+  }
+  if (r.host) lines.push(`Host: ${r.host}`);
+  return lines.join('\n');
+}
+
+async function fetchSampleFromBackend(): Promise<string[] | null> {
+  const endpoints = [
+    '/v1/sitemap/licitacoes-indexable',
+    '/v1/sitemap/orgaos',
+  ];
+  const collected: string[] = [];
+  for (const ep of endpoints) {
+    try {
+      const url = `${BACKEND_URL}${ep}`;
+      const resp = await fetch(url, {
+        signal: AbortSignal.timeout(8000),
+      });
+      if (!resp.ok) continue;
+      const data = (await resp.json()) as unknown;
+      // Best-effort extraction: support {urls: [...]}, [...] arrays of strings or {url}/{loc}.
+      const items = Array.isArray(data)
+        ? data
+        : Array.isArray((data as { urls?: unknown[] })?.urls)
+          ? (data as { urls: unknown[] }).urls
+          : [];
+      for (const item of items.slice(0, 25)) {
+        if (typeof item === 'string') collected.push(item);
+        else if (item && typeof item === 'object') {
+          const u =
+            (item as { url?: string; loc?: string; path?: string }).url ||
+            (item as { url?: string; loc?: string; path?: string }).loc ||
+            (item as { url?: string; loc?: string; path?: string }).path;
+          if (u) collected.push(u);
+        }
+      }
+    } catch {
+      // Try next endpoint
+    }
+  }
+  if (collected.length === 0) return null;
+  // Strip absolute URLs to paths for parser consumption
+  return collected.map((u) => {
+    try {
+      return new URL(u, CANONICAL).pathname + (new URL(u, CANONICAL).search || '');
+    } catch {
+      return u.startsWith('/') ? u : `/${u}`;
+    }
+  });
+}
+
+async function main() {
+  const robotsTxt = serialize(robots);
+  const parser = robotsParser(`${CANONICAL}/robots.txt`, robotsTxt);
+
+  let sample = await fetchSampleFromBackend();
+  let source = 'backend';
+  if (!sample || sample.length === 0) {
+    sample = FALLBACK_SAMPLE;
+    source = 'fallback (backend unreachable)';
+  }
+
+  console.log(`# SEO-PROG-007 AC6 — robots.txt coverage audit`);
+  console.log(`# canonical: ${CANONICAL}`);
+  console.log(`# sample source: ${source} (n=${sample.length})`);
+  console.log('');
+
+  const blocked: { url: string }[] = [];
+  for (const path of sample) {
+    const url = `${CANONICAL}${path.startsWith('/') ? path : `/${path}`}`;
+    const allowed = parser.isAllowed(url, 'Googlebot');
+    if (!allowed) blocked.push({ url });
+  }
+
+  if (blocked.length === 0) {
+    console.log(`OK: 0 / ${sample.length} sample URLs blocked by Disallow rules.`);
+    console.log('');
+    console.log('Sample (first 5):');
+    for (const p of sample.slice(0, 5)) {
+      console.log(`  allowed  ${p}`);
+    }
+    process.exit(0);
+  }
+
+  console.error(`FAIL: ${blocked.length} / ${sample.length} public URLs blocked.`);
+  console.error('');
+  console.error('Blocked URLs:');
+  for (const b of blocked) console.error(`  blocked  ${b.url}`);
+  console.error('');
+  console.error('Robots.txt rendered:');
+  console.error(robotsTxt);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('audit-robots-coverage.ts crashed:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Substitui `public/robots.txt` estático por `app/robots.ts` route handler env-aware. Fix AC6 over-blocking que afeta 464 páginas SEO em GSC.

- `frontend/app/robots.ts` (92L) — `MetadataRoute.Robots`, `force-static`, env gate, `SITEMAP_USE_INDEX_VARIANT` flag
- **AC6 path-exato** — `PRIVATE_PATHS` com trailing slash:
  - `/alertas/` (não `/alertas`) → desbloqueia `/alertas-publicos/[setor]/[uf]`
  - `/api/auth/`, `/api/admin/`, `/api/csp-report` (específicos) → desbloqueia `/api/sitemap-*`
  - `/buscar` + `/buscar/` ambos bloqueados (SPA shell autenticado, sem SEO público)
- `frontend/__tests__/app/robots.test.ts` — 40 tests (production/preview/legacy/index variants + AC6 regression)
- `frontend/scripts/audit-robots-coverage.ts` — exit 0 se 0/N URLs SEO matcham Disallow
- `frontend/e2e-tests/seo/robots.spec.ts` — Playwright (preview test gated por `PREVIEW_BASE_URL`)
- `docs/analysis/seo-robots-audit-2026-04.md` — tabela Disallow + 10 GSC URL Inspector samples

## Context

GSC empírico 2026-04-28: 464 páginas em "Bloqueada pelo robots.txt" (9.8% das 4.714 não indexadas). Causa: prefix-match RFC 9309 §2.2.2 — `/alertas` bloqueia `/alertas-publicos/*`, `/api` bloqueia `/api/sitemap-*`. Trailing slash converge para path-exato.

Decisão divergente AC2 (flag para @po): `host: BASE_URL` declarado em preview (semântica `MetadataRoute.Robots`). Reversível.

`public/robots.txt` retido — delete em PR follow-up +7d post-deploy estável.

## Testing Plan

- [x] `npm test -- robots.test` — 40/40 passing, 0.7s
- [x] `tsc --noEmit` — clean
- [x] `npx tsx scripts/audit-robots-coverage.ts` — 0/11 sample URLs blocked (`/alertas-publicos/ti/SP`, `/api/sitemap-1.xml`, `/blog/programmatic/saude/RJ`, etc.)
- [x] CodeRabbit pre-commit — no findings

**Pós-deploy verify**:
\`\`\`bash
curl -s https://smartlic.tech/robots.txt | grep -E "^Disallow: /alertas/$"
npx robots-parser https://smartlic.tech/robots.txt /alertas-publicos/ti/SP Googlebot
# expected: allowed
\`\`\`

## Closes

SEO-PROG-007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-aware robots.txt: production selective-indexing with canonical host and sitemap variant; non-production/preview block-all; explicit AI-crawler blocking and clarified path-exact rules (incl. `/buscar` stance).
* **Tests**
  * Added unit and E2E suites validating robots output, sitemap variants, user-agent rules, and regression guards.
* **Chores**
  * Audit script to detect unexpected blocked URLs and fail CI on regressions.
* **Documentation**
  * SEO robots audit and updated planning story with acceptance criteria and operational guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->