### PR TITLE
docs(gap-setores-001): sync 15→20 sectors count em 3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Funcionalidades Principais
 
 - **Busca multi-fonte** — Agrega PNCP + PCP v2 + ComprasGov v3 com deduplicacao inteligente
-- **15 setores** — Vestuario, alimentos, informatica, engenharia, saude, vigilancia, transporte, e 8 outros
+- **20 setores** — Vestuario, alimentos, informatica, engenharia, saude, vigilancia, transporte, e 13 outros
 - **Classificacao IA** — GPT-4.1-nano classifica relevancia setorial (keyword + zero-match)
 - **Analise de viabilidade** — 4 fatores: modalidade (30%), timeline (25%), valor (25%), geografia (20%)
 - **Pipeline de oportunidades** — Kanban com drag-and-drop para gerenciar editais
@@ -157,7 +157,7 @@ pncp-poc/
 │   ├── job_queue.py           # ARQ background jobs
 │   ├── metrics.py             # Prometheus exporter
 │   ├── telemetry.py           # OpenTelemetry tracing
-│   ├── sectors_data.yaml      # 15 setores (keywords, exclusoes)
+│   ├── sectors_data.yaml      # 20 setores (keywords, exclusoes)
 │   ├── routes/                # 19 route modules (49 endpoints)
 │   ├── clients/               # PCP, ComprasGov, etc.
 │   ├── services/              # Billing, sanctions

--- a/_reversa_sdd/domain.md
+++ b/_reversa_sdd/domain.md
@@ -334,7 +334,7 @@ fresh (0-6h) ──► stale (6-24h) ──► expired (>24h)
 | **CNPJ** | Cadastro Nacional Pessoa Jurídica (14 dígitos) |
 | **CNAE** | Classificação Nacional de Atividades Econômicas (5 dígitos) |
 | **B2G** | Business-to-Government |
-| **Setor** | Categoria de atuação (15 setores em `sectors_data.yaml`); ex: Limpeza, Uniformes, TI |
+| **Setor** | Categoria de atuação (20 setores em `sectors_data.yaml`); ex: Limpeza, Uniformes, TI |
 | **Viabilidade** | Score 4-fator HIGH/MEDIUM/LOW |
 | **Pipeline** | Funil kanban de oportunidades user-tracked |
 | **Trial** | 14 dias gratis sem cartão |
@@ -361,7 +361,7 @@ fresh (0-6h) ──► stale (6-24h) ──► expired (>24h)
 - 🔴 **Partner program**: dashboard + admin endpoints existem; commission %, payout cycle, attribution rules?
 - 🔴 **CNAE→Setor mapping**: hardcoded em `utils/cnae_mapping.py`; cobertura completa? fallback "diversos"?
 - 🟡 **`estimated_hours_saved`**: constante 2.5h/search — base empírica? 
-- 🟡 **15 vs 20 setores**: CLAUDE.md menciona 15 setores; modules.json menciona 20. Inconsistência?
+- 🟢 ~~**15 vs 20 setores**~~ Resolvido (GAP-SETORES-001 2026-04-29): source-of-truth `backend/sectors_data.yaml` = 20 setores. CLAUDE.md, README.md, system-architecture.md sincronizados. Frontend `SETORES_FALLBACK` já em 20.
 - 🔴 **Webhook HMAC verify gap** (Resend `/trial-emails/webhook`) — security hole?
 - 🔴 **Admin role granularity**: all-or-nothing — compliance concern?
 - 🟡 **Pricing R$397/297/...**: source of truth `plan_billing_periods` table sync com Stripe — quando sync corre?

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -47,7 +47,7 @@ Auditoria compreensiva do sistema inteiro (sem filtro de PRD). Cobertura:
 - **Background Jobs**: `backend/job_queue.py` (ARQ WorkerSettings), `backend/cron_jobs.py`
 - **Billing**: `backend/services/billing.py`, `backend/webhooks/stripe.py`
 - **Observability**: `backend/metrics.py` (Prometheus), `backend/telemetry.py` (OpenTelemetry), Sentry initialized in `main.py`
-- **Sectors**: `backend/sectors.py` + `backend/sectors_data.yaml` (15 setores com keywords + exclusões)
+- **Sectors**: `backend/sectors.py` + `backend/sectors_data.yaml` (20 setores com keywords + exclusões)
 
 ### Key Algorithms
 
@@ -165,7 +165,7 @@ PNCP-poc/
 │   ├── email_service.py       # Resend wrapper
 │   ├── feedback_analyzer.py   # Bi-gram pattern analysis
 │   ├── excel.py, google_sheets.py, report_generator.py
-│   ├── sectors.py, sectors_data.yaml # 15 setores
+│   ├── sectors.py, sectors_data.yaml # 20 setores
 │   ├── log_sanitizer.py       # PII redaction
 │   ├── templates/emails/      # HTML email templates
 │   ├── migrations/            # Python-based migrations (7+)


### PR DESCRIPTION
## Summary

- 6 alterações em 3 arquivos: `README.md` (2), `_reversa_sdd/domain.md` (2), `docs/architecture/system-architecture.md` (2).
- Discriminator 2-method confirmou source-of-truth = **20** sectors (yaml + frontend `SETORES_FALLBACK`).
- Source-of-truth files NÃO modificados (`backend/sectors_data.yaml` + `frontend/app/buscar/hooks/filters/sectorData.ts`).

## Context

Doc drift histórico: 4 arquivos referenciavam "15 sectors" obsoleto pós-expansão. Memory `feedback_inventory_double_verify` aplicada — 2 métodos independentes (yaml count + frontend grep) ambos retornaram 20 antes de qualquer mudança.

Histórico legítimo preservado: `docs/audit/sector-coverage-audit-2026-02-22.md`, `docs/archive/**`, `docs/beta-testing/session-*`, `docs/gtm-fixes-summary.md` (descreve bug histórico "All 15 sectors returning 0"), playbooks com math claims (out-of-scope; separate story).

Story: `docs/stories/2026-04/GAP-SETORES-001-15-vs-20-sectors-sync.story.md`

## Testing Plan

- [x] Discriminator 2-method: `python yaml.safe_load` → 20 + `grep -cE` SETORES_FALLBACK → 20
- [x] Pós-fix: `grep -rn "15 sectors\|15 setores"` em paths target retorna 0 (excluindo histórico legítimo)
- [x] CLAUDE.md já estava correto antes (parcialmente fixado); esta story fechou os 3 docs remanescentes

## Closes

- `docs/stories/2026-04/GAP-SETORES-001-15-vs-20-sectors-sync.story.md`

## Notes

- README.md linha 17 nomeia "saude" entre setores listados, mas yaml não tem `saude` key (tem `medicamentos`, `equipamentos_medicos`, `insumos_hospitalares`). Inaccuracy pre-existente, fora scope (count-sync, não nomenclatura) — separate story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to consistently reflect support for 20 sectors across all reference materials, resolving prior alignment gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->