### PR TITLE
feat(ops-ci-002): weekly load test Stage 4-7 reproducer

### DIFF
--- a/.github/workflows/load-test-weekly.yml
+++ b/.github/workflows/load-test-weekly.yml
@@ -1,0 +1,71 @@
+name: Weekly Load Test — Stage 4-7 Pattern
+
+on:
+  schedule:
+    # Sun 02:00 UTC = Sat 23:00 BRT (low-traffic window)
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Target API URL'
+        required: false
+        default: 'https://api.smartlic.tech'
+      users:
+        description: 'Concurrent users'
+        required: false
+        default: '50'
+      duration:
+        description: 'Test duration (e.g., 10m)'
+        required: false
+        default: '10m'
+
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install Locust
+        run: pip install locust==2.32.0
+      - name: Run Stage 4-7 reproducer
+        env:
+          TARGET_URL: ${{ github.event.inputs.target_url || 'https://api.smartlic.tech' }}
+          USERS: ${{ github.event.inputs.users || '50' }}
+          DURATION: ${{ github.event.inputs.duration || '10m' }}
+        run: |
+          cd backend/tests/load
+          locust -f stage_4_7_pattern.py \
+            --host "$TARGET_URL" \
+            --users "$USERS" \
+            --spawn-rate 5 \
+            --run-time "$DURATION" \
+            --headless \
+            --csv=load-test-results \
+            --html=load-test-report.html \
+            --exit-code-on-error 1
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results-${{ github.run_id }}
+          path: |
+            backend/tests/load/load-test-results_*.csv
+            backend/tests/load/load-test-report.html
+          retention-days: 30
+      - name: Sentry alert on failure
+        if: failure()
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_BACKEND }}
+        run: |
+          if [[ -n "$SENTRY_DSN" ]]; then
+            pip install sentry-sdk==2.18.0
+            python -c "
+            import sentry_sdk, os
+            sentry_sdk.init(dsn=os.environ['SENTRY_DSN'])
+            sentry_sdk.capture_message('Weekly load test failed — Stage 4-7 pattern reproducer', level='error')
+            "
+          fi

--- a/backend/tests/load/README.md
+++ b/backend/tests/load/README.md
@@ -1,0 +1,26 @@
+# Backend Load Tests — Stage Pattern Reproducers
+
+Locust scenarios reproduzem padrões de saturação observados em prod.
+
+## Stage 4-7 Pattern (`stage_4_7_pattern.py`)
+
+Reproduz wedge backend 2026-04-27 a 29:
+- SSG burst (31 workers, weight=5)
+- Googlebot crawl (weight=4)
+- Health probe (weight=1, monitoring)
+
+### Local smoke
+```bash
+pip install locust==2.32.0
+cd backend/tests/load
+locust -f stage_4_7_pattern.py --host http://localhost:8000 --users 5 --run-time 30s --headless
+```
+
+### Weekly CI
+Workflow `.github/workflows/load-test-weekly.yml` cron Sun 02:00 UTC contra `https://api.smartlic.tech`.
+
+### Thresholds
+- p95 latency: <5000ms
+- error_rate: <5%
+
+Falha CI publica Sentry alert.

--- a/backend/tests/load/stage_4_7_pattern.py
+++ b/backend/tests/load/stage_4_7_pattern.py
@@ -1,0 +1,146 @@
+"""Stage 4-7 wedge pattern reproducer.
+
+Simula concorrência observada nos incidents 2026-04-27 a 29:
+- 31 workers SSG burst (sitemap fetchers)
+- Googlebot crawl
+- ARQ cron paralelas
+
+Memory: project_backend_outage_2026_04_29_stage5, feedback_build_hammers_backend_cascade.
+"""
+
+from locust import HttpUser, task, between, events
+import random
+
+SAMPLE_CNPJS = [
+    "10000000000100", "20000000000200", "30000000000300",
+    "40000000000400", "50000000000500",
+]
+
+SAMPLE_ORGAO_SLUGS = [
+    "ministerio-da-fazenda", "tribunal-de-contas-uniao",
+    "agencia-nacional-de-aguas",
+]
+
+SAMPLE_SECTORS = [
+    "construcao", "informatica", "alimentos", "limpeza", "vestuario",
+]
+
+
+class SSGSitemapBurstUser(HttpUser):
+    """Simula 31 workers SSG fan-out: 6 endpoints sequenciais por shard."""
+
+    weight = 5
+    wait_time = between(0.5, 2.0)
+
+    @task
+    def sitemap_fanout(self):
+        for endpoint in [
+            "/v1/sitemap/contratos-orgao",
+            "/v1/sitemap/cnpjs",
+            "/v1/sitemap/orgaos",
+            "/v1/sitemap/municipios",
+            "/v1/sitemap/fornecedores-cnpj",
+            "/v1/sitemap/itens",
+            "/v1/sitemap/licitacoes-indexable",
+        ]:
+            with self.client.get(
+                endpoint,
+                name=f"SSG {endpoint}",
+                catch_response=True,
+                timeout=15,
+            ) as r:
+                if r.status_code in (200, 304):
+                    r.success()
+                elif r.status_code == 404:
+                    r.success()  # endpoint pode não existir ainda
+                else:
+                    r.failure(f"sitemap fan-out {r.status_code}")
+
+
+class GooglebotCrawlerUser(HttpUser):
+    """Simula Googlebot crawl em rotas SEO programmatic."""
+
+    weight = 4
+    wait_time = between(1.0, 3.0)
+
+    def on_start(self):
+        self.client.headers["User-Agent"] = (
+            "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        )
+
+    @task(3)
+    def cnpj_profile(self):
+        cnpj = random.choice(SAMPLE_CNPJS)
+        with self.client.get(
+            f"/v1/empresa/{cnpj}",
+            name="Googlebot /v1/empresa/[cnpj]",
+            catch_response=True,
+            timeout=20,
+        ) as r:
+            if r.status_code in (200, 404):
+                r.success()
+            else:
+                r.failure(f"{r.status_code}")
+
+    @task(2)
+    def orgao_profile(self):
+        slug = random.choice(SAMPLE_ORGAO_SLUGS)
+        with self.client.get(
+            f"/v1/orgaos/{slug}",
+            name="Googlebot /v1/orgaos/[slug]",
+            catch_response=True,
+            timeout=20,
+        ) as r:
+            if r.status_code in (200, 404):
+                r.success()
+            else:
+                r.failure(f"{r.status_code}")
+
+    @task(2)
+    def sector_observatorio(self):
+        sector = random.choice(SAMPLE_SECTORS)
+        with self.client.get(
+            f"/v1/observatorio/{sector}",
+            name="Googlebot /v1/observatorio/[setor]",
+            catch_response=True,
+            timeout=20,
+        ) as r:
+            if r.status_code in (200, 404):
+                r.success()
+            else:
+                r.failure(f"{r.status_code}")
+
+
+class HealthProbeUser(HttpUser):
+    """Probe paralelo /health/ready (deveria SEMPRE retornar 200 <2s)."""
+
+    weight = 1
+    wait_time = between(5.0, 10.0)
+
+    @task
+    def health_ready(self):
+        with self.client.get(
+            "/health/ready",
+            name="health/ready",
+            catch_response=True,
+            timeout=5,
+        ) as r:
+            if r.status_code == 200 and r.elapsed.total_seconds() < 2.0:
+                r.success()
+            else:
+                r.failure(f"health degraded {r.status_code} {r.elapsed.total_seconds():.2f}s")
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    """Print summary stats; fail run if p95 > 5s ou error_rate > 5%."""
+    stats = environment.stats.total
+    p95 = stats.get_response_time_percentile(0.95)
+    error_rate = stats.fail_ratio * 100
+    print("\n=== Stage 4-7 Reproducer Summary ===")
+    print(f"Total requests: {stats.num_requests}")
+    print(f"P95 latency: {p95:.0f} ms")
+    print(f"Error rate: {error_rate:.2f}%")
+    if p95 > 5000 or error_rate > 5:
+        print(f"FAIL: p95={p95}ms (>5000) or error_rate={error_rate}% (>5%)")
+        environment.process_exit_code = 1


### PR DESCRIPTION
## Summary

- `.github/workflows/load-test-weekly.yml` (NEW, 71 LOC): cron Sun 02:00 UTC + workflow_dispatch, Python 3.12 + Locust 2.32.0, artifact upload (30d), Sentry alert on failure.
- `backend/tests/load/stage_4_7_pattern.py` (NEW, 146 LOC): 3 user classes (SSGSitemapBurstUser weight=5, GooglebotCrawlerUser weight=4, HealthProbeUser weight=1).
- `backend/tests/load/README.md` (NEW): local smoke + CI docs.

## Context

Reproducer Locust automatizado para detectar regressões wedge pattern (Stage 4-7) antes de prod. Memory `project_backend_outage_2026_04_29_stage5` + `feedback_build_hammers_backend_cascade` documentam padrão saturação.

Thresholds enforced via `events.test_stop` listener: p95 < 5000ms + error_rate < 5%. Falha CI publica Sentry alert via SDK.

Story: `docs/stories/2026-04/OPS-CI-002-weekly-load-test-stage-pattern.story.md`

## Testing Plan

- [x] Locust syntax: `python3 -c "ast.parse(...)"` → OK
- [x] YAML parse: `python3 -c "yaml.safe_load(...)"` → OK
- [x] actionlint via Docker: 0 errors
- [ ] CI dispatch dry-run com `--users 5 --run-time 30s` post-merge
- [ ] First weekly cron Sun next post-merge

## Closes

- `docs/stories/2026-04/OPS-CI-002-weekly-load-test-stage-pattern.story.md`

## Notes

- **CONFLICT WARNING**: `backend/tests/load/stage_4_7_pattern.py` também existe na branch `feat/sen-be-010-memory-snapshot` (PR #554). Order matters pós-merge: se #554 mergear primeiro, este PR precisa rebase + conflict resolve. Se este PR mergear primeiro, #554 idem.
- Story doc spec workflow filename `load-stage-test.yml` + locust path `load_tests/`; orchestrator overrode para `load-test-weekly.yml` + `backend/tests/load/`. Followed orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a weekly scheduled load-testing workflow that runs configurable headless performance tests and uploads CSV/HTML reports (retained 30 days).
  * Optional error-reporting integration on CI failure.

* **Tests**
  * Introduced a reproducible Stage 4–7 saturation test pattern with configurable target, users, and duration; fails CI on p95 or error-rate breaches.

* **Documentation**
  * Added load-test README with run instructions and CI pass/fail thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->