### PR TITLE
feat(data-drift-001): paywall canonical consolidation + trigger sync

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -1107,7 +1107,19 @@ async def get_at_risk_trials(
 
 
 def _assign_plan(sb, user_id: str, plan_id: str):
-    """Internal: assign plan creating subscription record."""
+    """Internal: assign plan creating subscription record.
+
+    Writes ONLY to ``user_subscriptions`` — the canonical source-of-truth read
+    by ``quota.plan_enforcement.check_quota``.
+
+    DATA-DRIFT-001: ``profiles.trial_expires_at`` is the read-only mirror,
+    kept in sync by the Postgres trigger ``trg_sync_trial_expires_at``
+    (migration ``20260429230000_data_drift_001_trigger_sync.sql``). Do NOT
+    add a parallel write to ``profiles.trial_expires_at`` here — that would
+    re-introduce the dual source-of-truth drift documented in
+    ``docs/adr/SCHEMA-DRIFT.md`` (Option A canonical + mirror).
+    Memory: ``project_paulo_paywall_bypass_root_cause_2026_04_29``.
+    """
     from datetime import datetime, timezone, timedelta
 
     plan = sb.table("plans").select("*").eq("id", plan_id).single().execute()
@@ -1122,7 +1134,8 @@ def _assign_plan(sb, user_id: str, plan_id: str):
     # Deactivate previous
     sb.table("user_subscriptions").update({"is_active": False}).eq("user_id", user_id).eq("is_active", True).execute()
 
-    # Create new
+    # Create new — canonical write only. Trigger trg_sync_trial_expires_at
+    # mirrors expires_at -> profiles.trial_expires_at automatically.
     sb.table("user_subscriptions").insert({
         "user_id": user_id,
         "plan_id": plan_id,

--- a/backend/services/trial_extension.py
+++ b/backend/services/trial_extension.py
@@ -137,6 +137,14 @@ async def extend_trial(user_id: str, condition: str) -> dict:
     """Extend a user's trial by completing a condition.
 
     Returns dict with extension result or raises ValueError/RuntimeError.
+
+    DATA-DRIFT-001: the underlying ``extend_trial_atomic`` RPC writes the
+    canonical ``user_subscriptions.expires_at`` first (the trigger
+    ``trg_sync_trial_expires_at`` then mirrors to ``profiles.trial_expires_at``).
+    The eligibility pre-check below still reads ``profiles.trial_expires_at`` —
+    that is safe because the mirror is now guaranteed in sync after the fix
+    in migration ``20260429230000_data_drift_001_trigger_sync.sql``.
+    Memory: ``project_paulo_paywall_bypass_root_cause_2026_04_29``.
     """
     from config.features import (
         TRIAL_EXTENSION_ENABLED,

--- a/backend/tests/integration/test_data_drift_001_consolidation.py
+++ b/backend/tests/integration/test_data_drift_001_consolidation.py
@@ -1,0 +1,222 @@
+"""Integration tests — DATA-DRIFT-001 paywall consolidation.
+
+Validates the canonical/mirror invariant established by migration
+``20260429230000_data_drift_001_trigger_sync.sql``:
+
+* canonical: ``user_subscriptions.expires_at`` (read by check_quota)
+* mirror:    ``profiles.trial_expires_at`` (auto-synced via Postgres trigger)
+
+Memory: ``project_paulo_paywall_bypass_root_cause_2026_04_29``
+ADR:    ``docs/adr/SCHEMA-DRIFT.md`` (Option A — canonical + mirror)
+
+These tests have two layers:
+
+* Unit-style behavior assertions on ``_assign_plan`` and ``extend_trial``
+  using the integration suite's mock Supabase fixture — confirms the Python
+  callers do NOT write directly to ``profiles.trial_expires_at``.
+* SQL-level assertions documented as ``xfail``/``skip`` placeholders that
+  require a live Postgres test container. They are kept here so a future
+  ``pytest-postgresql`` / ``testcontainers`` setup can drop them in without
+  re-discovering the contract.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Python caller behavior — no direct profiles writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestAdminAssignPlanCanonicalOnly:
+    """``_assign_plan`` must write only to ``user_subscriptions``.
+
+    The Postgres trigger ``trg_sync_trial_expires_at`` is responsible for
+    mirroring to ``profiles.trial_expires_at``. A direct write from Python
+    would re-introduce dual source-of-truth drift.
+    """
+
+    def _build_mock_supabase(self) -> MagicMock:
+        """Build a Supabase mock that records every .table() call."""
+        sb = MagicMock(name="supabase")
+
+        # plan lookup returns a 30-day plan
+        plan_query = MagicMock()
+        plan_query.execute.return_value.data = {
+            "id": "smartlic_pro",
+            "max_searches": 1000,
+            "duration_days": 30,
+        }
+        sb.table.return_value.select.return_value.eq.return_value.single.return_value = plan_query
+
+        # all other chained calls (update, insert) return MagicMock
+        return sb
+
+    def test_assign_plan_writes_only_user_subscriptions(self):
+        import admin
+
+        sb = self._build_mock_supabase()
+
+        admin._assign_plan(sb, user_id="u-test", plan_id="smartlic_pro")
+
+        # Collect the table names touched
+        table_calls = [c.args[0] for c in sb.table.call_args_list if c.args]
+
+        assert "user_subscriptions" in table_calls, (
+            "Canonical table must be written"
+        )
+        assert "profiles" not in table_calls, (
+            "DATA-DRIFT-001: _assign_plan must NOT write profiles.trial_expires_at "
+            "directly — that is the trigger's job. See migration "
+            "20260429230000_data_drift_001_trigger_sync.sql."
+        )
+
+    def test_assign_plan_deactivates_previous_then_inserts(self):
+        import admin
+
+        sb = self._build_mock_supabase()
+        admin._assign_plan(sb, user_id="u-test", plan_id="smartlic_pro")
+
+        # Verify update(deactivate) and insert(new) were both invoked
+        update_called = any(
+            "is_active" in str(c)
+            for c in sb.table.return_value.update.call_args_list
+        )
+        insert_called = sb.table.return_value.insert.called
+
+        assert update_called or insert_called, (
+            "Expected deactivate-then-insert flow to invoke at least one of "
+            "update/insert on user_subscriptions"
+        )
+
+
+@pytest.mark.integration
+class TestExtendTrialCallerNoDirectProfileWrite:
+    """The Python ``extend_trial`` wrapper delegates to the SQL RPC.
+
+    The RPC (post-DATA-DRIFT-001) writes canonical first; trigger mirrors.
+    The Python layer must NOT shortcut around the RPC and write profiles
+    directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_extend_trial_calls_rpc_only(self):
+        from services import trial_extension
+
+        # Build mock supabase
+        sb = MagicMock(name="supabase")
+
+        # profile lookup → user is on free_trial, not yet expired
+        profile_query = MagicMock()
+        profile_query.data = {
+            "plan_type": "free_trial",
+            "trial_expires_at": (
+                datetime.now(timezone.utc) + timedelta(days=3)
+            ).isoformat(),
+        }
+
+        # feedback lookup (eligibility) → user has 1 feedback
+        feedback_query = MagicMock()
+        feedback_query.count = 1
+        feedback_query.data = []
+
+        # rpc result
+        rpc_result = MagicMock()
+        rpc_result.data = {
+            "days_added": 2,
+            "total_extended": 2,
+            "new_expires_at": (
+                datetime.now(timezone.utc) + timedelta(days=5)
+            ).isoformat(),
+            "canonical_updated": True,
+        }
+
+        async def fake_sb_execute(query):
+            # crude routing by query type str
+            q = str(type(query))
+            if "profile" in q.lower():
+                return profile_query
+            if "feedback" in q.lower():
+                return feedback_query
+            return rpc_result
+
+        with (
+            patch.object(trial_extension, "get_supabase", return_value=sb),
+            patch.object(
+                trial_extension, "sb_execute", side_effect=lambda q: _async_return(_route(q, profile_query, feedback_query, rpc_result))
+            ),
+            patch(
+                "config.features.TRIAL_EXTENSION_ENABLED", True, create=True
+            ),
+            patch(
+                "config.features.TRIAL_EXTENSION_MAX_DAYS", 7, create=True
+            ),
+        ):
+            # Skip — the routing is too coarse for a stable test without
+            # a richer fixture. Documented as TODO for the next iteration.
+            pytest.skip(
+                "Requires routed sb_execute fixture — defer until "
+                "shared trial_extension fixture lands"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: SQL-level invariants (require live Postgres)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skip(
+    reason="Requires live Postgres test container — implement once "
+    "testcontainers/pytest-postgresql fixtures are wired in conftest"
+)
+class TestTriggerSyncSqlLevel:
+    """SQL-level invariants for ``trg_sync_trial_expires_at``.
+
+    Skipped today; preserved as a contract record for the future test DB
+    fixture. When wiring: apply migration ``20260429230000`` to a scratch
+    schema, then run these.
+    """
+
+    async def test_insert_user_subscription_populates_profile_trial(self):
+        """INSERT into user_subscriptions → profile.trial_expires_at populated."""
+        ...
+
+    async def test_update_subscription_expires_at_propagates(self):
+        """UPDATE user_subscriptions.expires_at → profile.trial_expires_at follows."""
+        ...
+
+    async def test_extend_trial_atomic_v2_writes_canonical_first(self):
+        """RPC writes user_subscriptions; trigger mirrors profile."""
+        ...
+
+    async def test_extend_trial_atomic_falls_back_to_profiles_when_no_subscription(self):
+        """Legacy state (no active subscription row) → RPC still extends profile mirror."""
+        ...
+
+    async def test_backfill_idempotent(self):
+        """Running migration twice should not double-update profiles rows."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _route(query, profile_query, feedback_query, rpc_result):  # pragma: no cover - helper
+    q = str(query).lower()
+    if "profile" in q:
+        return profile_query
+    if "feedback" in q:
+        return feedback_query
+    return rpc_result
+
+
+async def _async_return(value):  # pragma: no cover - helper
+    return value

--- a/supabase/migrations/20260429230000_data_drift_001_trigger_sync.down.sql
+++ b/supabase/migrations/20260429230000_data_drift_001_trigger_sync.down.sql
@@ -1,0 +1,49 @@
+-- Rollback DATA-DRIFT-001: paywall consolidation
+--
+-- Restores extend_trial_atomic to its original profiles-only behavior
+-- (from migration 20260407000000_trial_extensions.sql) and drops the
+-- canonical -> mirror sync trigger.
+--
+-- NOTE: backfilled profiles.trial_expires_at values are NOT reverted —
+-- the data is correct (mirrors canonical); reverting would re-introduce drift.
+
+BEGIN;
+
+-- 1. Drop sync trigger and function
+DROP TRIGGER IF EXISTS trg_sync_trial_expires_at ON user_subscriptions;
+DROP FUNCTION IF EXISTS sync_trial_expires_at_from_subscriptions();
+
+-- 2. Restore extend_trial_atomic to original (profiles-only) version
+CREATE OR REPLACE FUNCTION extend_trial_atomic(
+  p_user_id UUID, p_condition TEXT, p_days INT, p_max_total INT
+) RETURNS JSONB AS $$
+DECLARE
+  v_total INT;
+  v_new_expires TIMESTAMPTZ;
+BEGIN
+  SELECT COALESCE(SUM(days_added), 0) INTO v_total
+  FROM trial_extensions WHERE user_id = p_user_id;
+
+  IF v_total + p_days > p_max_total THEN
+    RETURN jsonb_build_object('error', 'max_extension_reached', 'total_extended', v_total);
+  END IF;
+
+  INSERT INTO trial_extensions (user_id, condition, days_added)
+  VALUES (p_user_id, p_condition, p_days);
+
+  UPDATE profiles
+  SET trial_expires_at = trial_expires_at + (p_days || ' days')::INTERVAL
+  WHERE id = p_user_id
+  RETURNING trial_expires_at INTO v_new_expires;
+
+  RETURN jsonb_build_object(
+    'days_added', p_days,
+    'total_extended', v_total + p_days,
+    'new_expires_at', v_new_expires
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260429230000_data_drift_001_trigger_sync.sql
+++ b/supabase/migrations/20260429230000_data_drift_001_trigger_sync.sql
@@ -1,0 +1,136 @@
+-- DATA-DRIFT-001: Consolidate trial expiration canonical source
+--
+-- Canonical: user_subscriptions.expires_at (source-of-truth, read by quota/plan_enforcement.check_quota)
+-- Mirror:    profiles.trial_expires_at  (read-only mirror, auto-synced via trigger)
+--
+-- Root cause memory: project_paulo_paywall_bypass_root_cause_2026_04_29
+-- ADR:               docs/adr/SCHEMA-DRIFT.md (Option A canonical + mirror)
+--
+-- Drift mechanism prior to this fix:
+--   * admin._assign_plan writes only user_subscriptions       -> profiles.trial_expires_at goes stale
+--   * extend_trial_atomic RPC writes only profiles            -> user_subscriptions.expires_at unchanged
+--   * check_quota reads user_subscriptions.expires_at         -> trial extensions invisible to paywall
+--
+-- Bounded scope (Stage 6 audit): 2 users (Paulo + 1 other).
+--
+-- Memory references:
+--   * reference_supabase_down_sql_schema_conflict (CLI 2.x bug — stash .down.sql before db push)
+--   * reference_supabase_management_api_query     (workaround if CLI rejects)
+--   * feedback_schema_drift_psql_discriminator    (validate via information_schema before NOTIFY pgrst)
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Backfill profiles.trial_expires_at from canonical user_subscriptions
+--    Idempotent: only updates rows where mirror diverges from canonical.
+-- ---------------------------------------------------------------------------
+UPDATE profiles AS p
+SET trial_expires_at = us.expires_at
+FROM user_subscriptions AS us
+WHERE us.user_id = p.id
+  AND us.is_active = TRUE
+  AND us.expires_at IS NOT NULL
+  AND p.trial_expires_at IS DISTINCT FROM us.expires_at;
+
+-- ---------------------------------------------------------------------------
+-- 2. Trigger function: sync canonical -> mirror after INSERT/UPDATE
+--    SECURITY DEFINER so the trigger runs with table owner privileges
+--    regardless of the originating role (service_role, admin, RPC caller).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION sync_trial_expires_at_from_subscriptions()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only sync for trial/billing-relevant statuses where expires_at matters.
+  -- is_active is the equivalent flag in this schema; preserve sync on
+  -- newly-created subscriptions (is_active=TRUE) and reactivations.
+  IF NEW.is_active = TRUE AND NEW.expires_at IS NOT NULL THEN
+    UPDATE profiles
+    SET trial_expires_at = NEW.expires_at
+    WHERE id = NEW.user_id
+      AND (trial_expires_at IS DISTINCT FROM NEW.expires_at);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION sync_trial_expires_at_from_subscriptions IS
+  'DATA-DRIFT-001: keeps profiles.trial_expires_at mirror in sync with canonical user_subscriptions.expires_at. Memory: project_paulo_paywall_bypass_root_cause_2026_04_29';
+
+-- ---------------------------------------------------------------------------
+-- 3. Trigger: AFTER INSERT OR UPDATE OF expires_at, is_active
+--    Drop first (idempotent re-run), then create.
+-- ---------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS trg_sync_trial_expires_at ON user_subscriptions;
+CREATE TRIGGER trg_sync_trial_expires_at
+  AFTER INSERT OR UPDATE OF expires_at, is_active
+  ON user_subscriptions
+  FOR EACH ROW
+  EXECUTE FUNCTION sync_trial_expires_at_from_subscriptions();
+
+-- ---------------------------------------------------------------------------
+-- 4. Update extend_trial_atomic RPC to write canonical (user_subscriptions).
+--    Trigger above will mirror to profiles automatically.
+--
+--    Replaces version from 20260407000000_trial_extensions.sql.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION extend_trial_atomic(
+  p_user_id UUID, p_condition TEXT, p_days INT, p_max_total INT
+) RETURNS JSONB AS $$
+DECLARE
+  v_total INT;
+  v_new_expires TIMESTAMPTZ;
+  v_subscription_found BOOLEAN := FALSE;
+BEGIN
+  -- Cap check
+  SELECT COALESCE(SUM(days_added), 0) INTO v_total
+  FROM trial_extensions WHERE user_id = p_user_id;
+
+  IF v_total + p_days > p_max_total THEN
+    RETURN jsonb_build_object('error', 'max_extension_reached', 'total_extended', v_total);
+  END IF;
+
+  -- Audit row first (preserves UNIQUE(user_id, condition) semantics)
+  INSERT INTO trial_extensions (user_id, condition, days_added)
+  VALUES (p_user_id, p_condition, p_days);
+
+  -- Write canonical first: user_subscriptions.expires_at += interval
+  -- Trigger trg_sync_trial_expires_at mirrors to profiles automatically.
+  UPDATE user_subscriptions
+  SET expires_at = expires_at + (p_days || ' days')::INTERVAL
+  WHERE user_id = p_user_id
+    AND is_active = TRUE
+    AND expires_at IS NOT NULL
+  RETURNING expires_at INTO v_new_expires;
+
+  IF FOUND THEN
+    v_subscription_found := TRUE;
+  END IF;
+
+  -- Fallback: if no active subscription row exists (legacy state — pre
+  -- billing webhook), still extend the profile mirror so the user is not
+  -- blocked. Surfaced in the result so callers can detect the legacy case.
+  IF NOT v_subscription_found THEN
+    UPDATE profiles
+    SET trial_expires_at = COALESCE(trial_expires_at, NOW()) + (p_days || ' days')::INTERVAL
+    WHERE id = p_user_id
+    RETURNING trial_expires_at INTO v_new_expires;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'days_added', p_days,
+    'total_extended', v_total + p_days,
+    'new_expires_at', v_new_expires,
+    'canonical_updated', v_subscription_found
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION extend_trial_atomic IS
+  'DATA-DRIFT-001 v2: writes canonical user_subscriptions.expires_at (trigger mirrors to profiles). Falls back to profiles-only when no active subscription row exists (legacy state). Memory: project_paulo_paywall_bypass_root_cause_2026_04_29';
+
+-- ---------------------------------------------------------------------------
+-- 5. Reload PostgREST schema cache so RPC + trigger are visible immediately.
+-- ---------------------------------------------------------------------------
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- `supabase/migrations/20260429230000_data_drift_001_trigger_sync.sql` (NEW, 136 LOC): trigger sync canonical `user_subscriptions.expires_at` → mirror `profiles.trial_expires_at` + idempotent backfill + RPC v2 `extend_trial_atomic` com `canonical_updated` boolean.
- `supabase/migrations/20260429230000_data_drift_001_trigger_sync.down.sql` (NEW, 49 LOC): rollback paired (CRIT-050).
- `backend/admin.py` (+15/-2): `_assign_plan` docstring documenta canonical-only writes (mirror via trigger).
- `backend/services/trial_extension.py` (+8): docstring clarifica eligibility check é safe pós-sync mirror.
- `backend/tests/integration/test_data_drift_001_consolidation.py` (NEW, 222 LOC): 2 pass + 6 skipped (pending shared `sb_execute` fixture + testcontainers/pytest-postgresql).

## Context

Memory `project_paulo_paywall_bypass_root_cause_2026_04_29` documentou drift mechanism: `_assign_plan` grava `user_subscriptions` (canonical), `extend_trial_atomic` legacy gravava `profiles.trial_expires_at` (mirror). `check_quota` lê canonical → trial extensions invisíveis ao paywall. Bounded 2 users (Paulo + 1).

ADR: `docs/adr/SCHEMA-DRIFT.md` (Option A — canonical user_subscriptions + auto-synced mirror profiles).

### Discriminator findings (pre-implementation)

| Site | Reads | Writes |
|------|-------|--------|
| `_assign_plan` (backend/admin.py:1109) | — | **canonical only** (`user_subscriptions`) ✅ |
| `extend_trial_atomic` RPC (legacy) | profiles | **mirror only** (`profiles.trial_expires_at`) ❌ stale canonical |
| `check_quota` (backend/quota/plan_enforcement.py:92) | **canonical** (`user_subscriptions.expires_at`) | — |

Schema discovery: `user_subscriptions` usa `is_active BOOLEAN` (não `status TEXT`); trigger gate atualizado.

Story: `docs/stories/2026-04/DATA-DRIFT-001-paywall-consolidation-paulo.story.md`

## Testing Plan

- [x] SQL balance: BEGIN/COMMIT balanced, 2 `LANGUAGE plpgsql` (sync fn + RPC v2) up; 1 down (restored RPC).
- [x] Backfill idempotency: `IS DISTINCT FROM` guard prevents no-op re-runs.
- [x] Trigger column gate: `AFTER INSERT OR UPDATE OF expires_at, is_active` (não fires em credits/plan_id).
- [x] pytest integration test: 2 pass + 6 skipped (documented contract).
- [x] Ruff check: All checks passed.
- [ ] Apply migration via `supabase db push` em local DB; verify trigger fires.
- [ ] Backfill audit: SELECT COUNT(*) WHERE profiles.trial_expires_at IS DISTINCT FROM user_subscriptions.expires_at — esperado >0 pre, =0 post.
- [ ] 24h post-deploy validation: Sentry watch + reverify Paulo bypass cleared.

## Closes

- `docs/stories/2026-04/DATA-DRIFT-001-paywall-consolidation-paulo.story.md`

## Risk

**MEDIUM** — production migration. Mitigation:
- Trigger idempotente (IS DISTINCT FROM guard)
- Backfill in-transaction (atomic)
- `.down.sql` paired (rollback safe; data preservation = backfilled rows NOT reverted)
- Bounded blast radius (n=2 users affected by drift; backfill expands to all rows but is no-op for synced)

## Notes

- **WARNING (memory `reference_supabase_down_sql_schema_conflict`):** Supabase CLI 2.x trata `.sql` + `.down.sql` paired como 2 migrations mesmo timestamp → `schema_migrations_pkey` duplicate. **Operator deve stash `.down.sql` antes de `supabase db push`** (`mv ...down.sql /tmp && db push && mv back`).
- AC0 (Phase 0 audit) e AC7 (24h validation) são operational steps fora deste commit.
- AC3 (`scripts/backfill_paywall_drift.py` standalone) NOT delivered — migration's `UPDATE ... FROM user_subscriptions` performs backfill in-transaction; redundant para escopo bounded.
- Schema drift atual zero (verified pre-impl); CRIT-050 não dispara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for subscription and trial extension data validation

* **Chores**
  * Updated backend documentation clarifying data synchronization architecture
  * Implemented database schema updates to ensure trial expiration data consistency across related tables
  * Added rollback migration support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->