### PR TITLE
fix(tests): use fake timers em LicitacaoCard-deadline-clarity (Issue #550)

### DIFF
--- a/frontend/__tests__/components/LicitacaoCard-deadline-clarity.test.tsx
+++ b/frontend/__tests__/components/LicitacaoCard-deadline-clarity.test.tsx
@@ -26,6 +26,19 @@ const mockLicitacao: LicitacaoItem = {
 };
 
 describe('LicitacaoCard - Deadline Terminology Clarity', () => {
+  // Issue #550 — fix date-bomb: mockLicitacao.data_encerramento = "2026-04-30T18:00:00"
+  // is exactly today's date once the calendar reaches 2026-04-30, leaving <24h until
+  // deadline. The component renders "horas" instead of "X dia(s)" and the regex
+  // /Você tem \d+ dia/ stops matching. Fake the system clock to a fixed point well
+  // before encerramento so the test is deterministic regardless of the real wall clock.
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-02-10T10:00:00'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe('Clear terminology requirements', () => {
     it('deve exibir "Recebe propostas" ao invés de termos ambíguos', () => {
       render(<LicitacaoCard licitacao={mockLicitacao} />);


### PR DESCRIPTION
## Summary

Fix date-bomb flake em `frontend/__tests__/components/LicitacaoCard-deadline-clarity.test.tsx`.

`mockLicitacao.data_encerramento = "2026-04-30T18:00:00"` virou date-bomb quando calendário real atingiu 30/04/2026 — <24h restante força componente a renderizar "horas" em vez de "X dia(s)" e regex `/Você tem \d+ dia/` deixa de matchear.

**Fix**: `jest.useFakeTimers().setSystemTime(new Date('2026-02-10T10:00:00'))` em `beforeAll` no describe top-level + `jest.useRealTimers()` em `afterAll`. Teste agora determinístico independente do wall clock real.

## Context

- Issue raised in chief-drift-paulo session (PR #549 blocked 11h por mesmo flake após RES-BE-002b sweep CI runs)
- Memory `feedback_jwt_base64url_flaky_test` aplica padrão analogous (date/clock dependencies cause non-deterministic CI failure)
- Edge case `data_encerramento: "2020-01-01"` (already past) continua funcionando — past dates remain past mesmo com fake clock em Fev/2026

## Testing Plan

- [x] Local `npx jest LicitacaoCard-deadline-clarity` — 13/13 passed em 76s
- [ ] CI Frontend Tests passa neste PR
- [ ] Após merge, PR #549 (RES-BE-002b sweep) re-run FT → unblock e merge

## Closes

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of deadline-related test cases through deterministic time handling to ensure consistent test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->