### PR TITLE
fix: blog_stats date-bomb + LicitacaoCard fake timers (unblock 11 PRs + Issue #550)

### DIFF
--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -1050,17 +1050,28 @@ async def _compute_contratos_stats(
     top_fornecedores = sorted(forn_agg.values(), key=lambda x: x["valor"], reverse=True)[:10]
     by_uf = sorted(uf_agg.values(), key=lambda x: x["valor"], reverse=True)
 
-    # Monthly trend (last 12 months)
+    # Monthly trend (last 12 calendar months).
+    # Walk year/month explicitly: timedelta(days=30*i) overlaps long months
+    # (Jan/Mar) and skips Feb (28d) at certain calendar positions, e.g. on
+    # 2026-04-30 days*30 strides land at "2026-04, 2026-03, 2026-03, 2026-01"
+    # — "2026-02" never appears, so contracts assinados em Feb são excluídos
+    # do summary totalmente, e contratos em Mar são double-counted via
+    # `sum(t["count"] for t in trend)` abaixo. Bug afeta produção em janelas
+    # curtas (5 failing tests em `test_blog_stats.py::TestContratos*` são
+    # sintoma, não causa). Fix: enumerar 12 meses calendário únicos.
     now = datetime.now(timezone.utc)
     trend = []
-    for i in range(12):
-        d = now - timedelta(days=30 * i)
-        month_key = d.strftime("%Y-%m")
+    year, month = now.year, now.month
+    for _ in range(12):
+        month_key = f"{year:04d}-{month:02d}"
         trend.append({
             "month": month_key,
             "count": monthly.get(month_key, 0),
             "value": round(monthly_values.get(month_key, 0.0), 2),
         })
+        month -= 1
+        if month == 0:
+            month, year = 12, year - 1
     trend.reverse()
 
     # Recalculate summary totals from the trend window (last 12 months, contracts

--- a/frontend/__tests__/components/LicitacaoCard-deadline-clarity.test.tsx
+++ b/frontend/__tests__/components/LicitacaoCard-deadline-clarity.test.tsx
@@ -26,6 +26,19 @@ const mockLicitacao: LicitacaoItem = {
 };
 
 describe('LicitacaoCard - Deadline Terminology Clarity', () => {
+  // Issue #550 — fix date-bomb: mockLicitacao.data_encerramento = "2026-04-30T18:00:00"
+  // is exactly today's date once the calendar reaches 2026-04-30, leaving <24h until
+  // deadline. The component renders "horas" instead of "X dia(s)" and the regex
+  // /Você tem \d+ dia/ stops matching. Fake the system clock to a fixed point well
+  // before encerramento so the test is deterministic regardless of the real wall clock.
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-02-10T10:00:00'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe('Clear terminology requirements', () => {
     it('deve exibir "Recebe propostas" ao invés de termos ambíguos', () => {
       render(<LicitacaoCard licitacao={mockLicitacao} />);


### PR DESCRIPTION
## Summary

Bundle de 2 fixes date-bomb que cross-blockam todos os PRs em flight:
- **Backend** (`backend/routes/blog_stats.py`): stride `timedelta(days=30 * i)` em 12-month trend skip Feb (28d) e duplica Mar/Dez em 2026-04-30 → under-count + double-count em produção + 5 failing tests
- **Frontend** (`__tests__/components/LicitacaoCard-deadline-clarity.test.tsx`): `data_encerramento: "2026-04-30T18:00:00"` virou date-bomb hoje (<24h restante) → componente renderiza "horas" em vez de "X dia(s)" → regex `/Você tem \d+ dia/` falha → 2 tests fail

Originalmente eram 2 PRs (#564 frontend fix, #565 backend fix), mas cross-blockam: #564 BT falha pelo blog_stats, #565 FT falha pelo LicitacaoCard. Combine resolve.

## Context — date-bomb backend (blog_stats)

Em **2026-04-30 02:52 UTC**, days*30 strides geram:

```
['2026-04', '2026-03', '2026-03', '2026-01', '2025-12', '2025-12', ...]
```

`2026-02` skip, `2026-03`/`2025-12` duplicate. `total_contracts = sum(t["count"] for t in trend)` então under-count Feb + double-count Mar/Dez.

Ontem 14:15 UTC main passou (i=2 caía em "2026-02-28"). Hoje 02:52 UTC bug ativou.

## Context — date-bomb frontend (LicitacaoCard)

`mockLicitacao.data_encerramento = "2026-04-30T18:00:00"` virou date-bomb quando calendar atinge 30/04/2026 — <24h restante força componente a renderizar "horas" em vez de "X dia(s)" e regex `/Você tem \d+ dia/` falha.

Fix: `jest.useFakeTimers().setSystemTime('2026-02-10')` em `beforeAll`/`afterAll`.

## Impact

| Camada | Bug |
|---|---|
| **Produção backend** | Endpoints `/v1/blog/stats/contratos/*` sub-contam SEO programmatic data desde ~2026-04-29 14h UTC |
| **CI backend** | 5 failing tests em `test_blog_stats.py::TestContratos*` bloqueiam 11 PRs (#549, #554-#564) |
| **CI frontend** | 2 failing tests em `LicitacaoCard-deadline-clarity` bloqueiam todos os PRs com FT como required check |
| **SEO** | Memory `project_sentry_tripwire_fired_2026_04_30` documenta 208 slow_request events 24h em `/v1/blog/stats/contratos/cidade/*setor*` |

## Testing

```
# Backend
pytest tests/test_blog_stats.py --timeout=30 -q
============================= 96 passed in 11.79s ==============================

# Frontend
npx jest __tests__/components/LicitacaoCard-deadline-clarity.test.tsx
Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

## Test plan

- [x] Local backend 96/96 PASS em test_blog_stats.py
- [x] Local frontend 13/13 PASS em LicitacaoCard-deadline-clarity
- [ ] CI Backend Tests green
- [ ] CI Frontend Tests green
- [ ] Após merge: validate `/v1/blog/stats/contratos/*` em prod retorna 12 meses únicos
- [ ] Após merge: PR #564 redundante (close), Wave PRs (#549, #553-563) sync main + re-run

Closes #550

## Authority

- Code edit por /chief (allowed per `agent-authority.md`)
- Push + PR creation por @devops (Gage)
- Hotfix critical-path sem story formal — mesmo padrão PR #564

## Out of scope

- Antipattern idêntico em `_estimate_trend` linha 521 em blog_stats.py — defer
- Fix idêntico em `routes/contratos_publicos.py` linhas 277, 391 — separately em PR #566 (silent prod chart bug, não CI-blocking)
- `MOCK_CONTRACT_ROWS` calendar-fragile — defer com freezegun

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected contract statistics to use the last 12 calendar months, fixing monthly buckets and ensuring totals and 12-month averages are accurate.
* **Tests**
  * Made deadline-related tests deterministic by controlling system time during the suite to prevent date-dependent flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->