### PR TITLE
fix(contratos_publicos): trend 12m calendar months (silent prod chart bug)

### DIFF
--- a/backend/routes/contratos_publicos.py
+++ b/backend/routes/contratos_publicos.py
@@ -273,14 +273,17 @@ async def orgao_contratos_stats(cnpj: str):
 
     now = datetime.now(timezone.utc)
     trend = []
-    for i in range(12):
-        d = now - timedelta(days=30 * i)
-        month_key = d.strftime("%Y-%m")
+    year, month = now.year, now.month
+    for _ in range(12):
+        month_key = f"{year:04d}-{month:02d}"
         trend.append({
             "month": month_key,
             "count": monthly.get(month_key, 0),
             "value": round(monthly_values.get(month_key, 0.0), 2),
         })
+        month -= 1
+        if month == 0:
+            month, year = 12, year - 1
     trend.reverse()
 
     sample_contracts = []
@@ -384,12 +387,12 @@ async def contratos_stats(setor: str, uf: str):
     # Top 10 fornecedores by value
     top_fornecedores = sorted(forn_agg.values(), key=lambda x: x["valor"], reverse=True)[:10]
 
-    # Monthly trend (last 12 months)
+    # Monthly trend (last 12 calendar months — see blog_stats.py for context)
     now = datetime.now(timezone.utc)
     trend = []
-    for i in range(12):
-        d = now - timedelta(days=30 * i)
-        month_key = d.strftime("%Y-%m")
+    year, month = now.year, now.month
+    for _ in range(12):
+        month_key = f"{year:04d}-{month:02d}"
         cnt = monthly.get(month_key, 0)
         # Sum values for that month
         month_val = sum(
@@ -398,6 +401,9 @@ async def contratos_stats(setor: str, uf: str):
             if (r.get("data_assinatura") or "")[:7] == month_key
         )
         trend.append({"month": month_key, "count": cnt, "value": round(month_val, 2)})
+        month -= 1
+        if month == 0:
+            month, year = 12, year - 1
     trend.reverse()
 
     # Sample contracts (10 most recent)


### PR DESCRIPTION
## Summary

Same date-bomb antipattern fixed em PR #565 (`blog_stats.py`), agora em **outros 2 endpoints SEO programmatic públicos** que usam o mesmo stride defeituoso `timedelta(days=30 * i)` — encontrados via grep proativo durante PR #565 review.

## Endpoints afetados

- `/v1/contratos/orgao/{cnpj}` (linha 274-284 em `contratos_publicos.py`)
- `/v1/contratos/{setor}/{uf}` (linha 388-401 em `contratos_publicos.py`)

## Diferença vs PR #565

Em `blog_stats.py`, `total_contracts = sum(t["count"] for t in trend)` (recompute do trend window) → bug afetava summary card (under-count + double-count).

Em `contratos_publicos.py`, `total_contracts = len(rows)` (independente do trend) → **summary card está correto**, mas **chart visual de 12 meses está errado**: usuários veem "Feb=0, Mar=2x" desde ~2026-04-29 14h UTC.

Bug silent em testes (nenhum test asserta month keys específicos no trend).

## Why grep ahead

Memory `feedback_timedelta_days30_antipattern` (criada hoje após PR #565):
> Como detectar próximas instâncias: `grep -rn 'timedelta(days=30.*i\|timedelta(days=30\s*\*' backend/`

Resultado:
- `routes/blog_stats.py:521` (3-entry trend, defer separate PR)
- `routes/contratos_publicos.py:277` ✅ fix
- `routes/contratos_publicos.py:391` ✅ fix

## Testing

```
pytest tests/test_contratos_orgao.py tests/test_contratos_publicos.py --timeout=30 -q
============================== 14 passed in 9.97s ==============================
```

Baseline 14/14 PASS preservado (mecânico fix, sem behavior change semântica esperada).

## Test plan

- [x] Local 14/14 PASS em test suites cobrindo ambos endpoints
- [ ] CI Backend Tests green
- [ ] CI Frontend Tests green
- [ ] Após merge: validate `/v1/contratos/orgao/{cnpj}` e `/v1/contratos/{setor}/{uf}` em produção retornam trend com 12 meses calendário únicos

## Authority

- Code edit por /chief (allowed per `agent-authority.md`)
- Push + PR creation por @devops (Gage)
- Hotfix critical-path sem story formal (mesmo padrão PR #564, #565)

## Out of scope

- `routes/blog_stats.py:521` (`_estimate_trend`, 3-entry trend usado em `trend_90d`) — não testado por assertion atual; story Draft separada para refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of monthly trend calculations by using actual calendar months instead of approximated 30-day intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->