### PR TITLE
hotfix(sitemap): pre-flight probe — abort entity sitemap if backend unreachable

### DIFF
--- a/backend/routes/contratos_publicos.py
+++ b/backend/routes/contratos_publicos.py
@@ -273,14 +273,17 @@ async def orgao_contratos_stats(cnpj: str):
 
     now = datetime.now(timezone.utc)
     trend = []
-    for i in range(12):
-        d = now - timedelta(days=30 * i)
-        month_key = d.strftime("%Y-%m")
+    year, month = now.year, now.month
+    for _ in range(12):
+        month_key = f"{year:04d}-{month:02d}"
         trend.append({
             "month": month_key,
             "count": monthly.get(month_key, 0),
             "value": round(monthly_values.get(month_key, 0.0), 2),
         })
+        month -= 1
+        if month == 0:
+            month, year = 12, year - 1
     trend.reverse()
 
     sample_contracts = []
@@ -384,12 +387,12 @@ async def contratos_stats(setor: str, uf: str):
     # Top 10 fornecedores by value
     top_fornecedores = sorted(forn_agg.values(), key=lambda x: x["valor"], reverse=True)[:10]
 
-    # Monthly trend (last 12 months)
+    # Monthly trend (last 12 calendar months — see blog_stats.py for context)
     now = datetime.now(timezone.utc)
     trend = []
-    for i in range(12):
-        d = now - timedelta(days=30 * i)
-        month_key = d.strftime("%Y-%m")
+    year, month = now.year, now.month
+    for _ in range(12):
+        month_key = f"{year:04d}-{month:02d}"
         cnt = monthly.get(month_key, 0)
         # Sum values for that month
         month_val = sum(
@@ -398,6 +401,9 @@ async def contratos_stats(setor: str, uf: str):
             if (r.get("data_assinatura") or "")[:7] == month_key
         )
         trend.append({"month": month_key, "count": cnt, "value": round(month_val, 2)})
+        month -= 1
+        if month == 0:
+            month, year = 12, year - 1
     trend.reverse()
 
     # Sample contracts (10 most recent)

--- a/frontend/__tests__/app/sitemap-parallel-fetch.test.ts
+++ b/frontend/__tests__/app/sitemap-parallel-fetch.test.ts
@@ -67,6 +67,10 @@ function makeFastFetchMock() {
   (global.fetch as jest.Mock).mockImplementation(
     (url: string | URL | Request, _init?: RequestInit) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
+      // HOTFIX 2026-04-30: pre-flight probe /health/live precede entity fetches.
+      if (urlStr.includes('/health/live')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) } as Response);
+      }
       const allEndpoints = [...ENTITY_ENDPOINTS, '/v1/sitemap/licitacoes-indexable'];
       const endpoint = allEndpoints.find((e) => urlStr.includes(e));
       const payload = endpoint ? PAYLOAD_BY_ENDPOINT[endpoint] : {};
@@ -123,6 +127,10 @@ describe('sitemap() — fetch behavior (signal + serialization)', () => {
     (global.fetch as jest.Mock).mockImplementation(
       (url: string | URL | Request) => {
         const urlStr = typeof url === 'string' ? url : url.toString();
+        // HOTFIX 2026-04-30: probe /health/live precede entity fetches; resolve sync.
+        if (urlStr.includes('/health/live')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) } as Response);
+        }
         const endpoint = ENTITY_ENDPOINTS.find((e) => urlStr.includes(e));
         if (endpoint) {
           initiated.push(endpoint);

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -795,6 +795,42 @@ export default async function sitemap(props: { id: Promise<string> }): Promise<M
     case 4: {
       // 6 fetches paralelos saturavam o backend (todos timeoutavam em ~30s+) → sitemap vazio em produção.
       // Serializados: 5-7s cada, total ~30-45s, dentro do orçamento de runtime ISR.
+      //
+      // HOTFIX 2026-04-30 (Stage 8 wedge): build-time pre-flight probe.
+      // Backend saturado pelo SSG fan-out (4146 pages) → cascade timeout em sitemap/4.xml
+      // → Next.js worker mata route em 60s × 3 attempts → build FAILED.
+      // Memory: feedback_build_hammers_backend_cascade. Probe 3s cheap; abort entity
+      // sitemap quando backend unreachable evita 6×(15+2+15)s = 192s wasted hammering.
+      // ISR revalidate=3600 garante recovery automática quando backend voltar saudável.
+      {
+        const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+        try {
+          const probe = await fetch(`${backendUrl}/health/live`, {
+            signal: AbortSignal.timeout(3000),
+            cache: 'no-store',
+          });
+          if (!probe.ok) {
+            const err = new Error(`sitemap/4 probe HTTP ${probe.status}`);
+            console.warn('[sitemap/4] backend probe non-ok — skipping entity sitemap', probe.status);
+            Sentry.captureMessage('sitemap_4_backend_probe_failed', {
+              level: 'warning',
+              tags: { sitemap_id: '4', sitemap_outcome: 'probe_http_error', status: String(probe.status) },
+              contexts: { sitemap: { url: `${backendUrl}/health/live` } },
+            });
+            void err;
+            return [];
+          }
+        } catch (e) {
+          console.warn('[sitemap/4] backend probe timeout/error — skipping entity sitemap', e);
+          Sentry.captureMessage('sitemap_4_backend_probe_failed', {
+            level: 'warning',
+            tags: { sitemap_id: '4', sitemap_outcome: 'probe_timeout' },
+            contexts: { sitemap: { url: `${backendUrl}/health/live` } },
+          });
+          return [];
+        }
+      }
+
       const cnpjList = await fetchSitemapCnpjs();
       const contratosOrgaoList = await fetchContratosOrgaoIndexable();
       const orgaoList = await fetchSitemapOrgaos();


### PR DESCRIPTION
## Summary

Stage 8 wedge 2026-04-30: backend saturated → frontend build SSG (4146 pages) hammered cascade → `/sitemap/4.xml` timeout 60s × 3 attempts → build FAILED twice (deploys `c9ecb84f` + `d118aade`).

**Root cause feedback loop**: build runs → 6 entity fetches × N workers parallel → backend overwhelmed → next fetch timeout → Next.js worker mata route → build fails. Even after `WC=4→1` + redeploy backend (hot routes recovered: `/contratos/orgao/{cnpj}/stats` 583s→157ms), subsequent build re-saturated backend within minutes.

**Fix**: build-time pre-flight probe `/health/live` 3s timeout before 6 entity fetches in `case 4` of sitemap generator. If 5xx/timeout → return `[]` + Sentry warning (`sitemap_4_backend_probe_failed`). ISR `revalidate=3600` re-attempts hourly — auto-recovery when backend stable.

## Context

- Memory `feedback_build_hammers_backend_cascade` (2026-04-27) — exact pattern documented previously
- Memory `feedback_chief_warm_stage5plus_no_pivot` — band-aids Stage 5+ failed 7×; pivot mandatory
- Memory `reference_smartlic_baseline_2026_04_24` — `sitemap-4` already 0 URLs in prod for days; trade-off favorable vs build failures blocking deploys
- Memory `project_backend_outage_2026_04_29_stage5` — same wedge class

## Testing Plan

- [ ] BT + FT pass
- [ ] Post-merge: Railway frontend rebuild SUCCESS (no SSG cascade)
- [ ] Post-merge: `/sitemap.xml` HTTP 200 (sitemap index intact)
- [ ] Post-merge: `/sitemap/4.xml` HTTP 200 (empty if backend still saturated; populated when ISR refetch finds backend healthy)
- [ ] Post-merge: backend `/health/live` HTTP 200 < 1s sustained 30min
- [ ] Sentry filter: `sitemap_4_backend_probe_failed` events appear during incident windows, absent when backend healthy

## Out of Scope

- Hardening Phase 2 (sweep `_run_with_budget` em 11 routes uncovered) — separate story RES-BE-002d
- OBS-001 PR `feat/obs-001-bot-rate-limit-tier` merge — separate
- Capacity audit (Hobby→Pro / Cloudflare bot management) — strategic decision

## Closes

Unblocks frontend deploys post Stage 8 wedge. No issue ID — incident hotfix.