### PR TITLE
feat(frontend): hero+footer CTAs on /contratos/orgao/[cnpj] — CONV-CTA-001

### DIFF
--- a/docs/stories/2026-04/CONV-CTA-002-audit-programmatic-templates.story.md
+++ b/docs/stories/2026-04/CONV-CTA-002-audit-programmatic-templates.story.md
@@ -1,0 +1,74 @@
+# CONV-CTA-002 — Audit and Add CTAs to All Programmatic SEO Templates
+
+**Epic:** EPIC-CONV-DIAG-2026-04-30
+**Status:** Draft
+**Priority:** T1
+**Created:** 2026-04-30
+**Depends on:** CONV-CTA-001 (TrackingLink component + pattern validated)
+
+---
+
+## Context
+
+CONV-CTA-001 validated the CTA insertion pattern on `/contratos/orgao/[cnpj]` (4 of top-10 GSC URLs, ~12 clicks/month). This story extends the same `TrackingLink` + hero/footer CTA pattern to the remaining programmatic SEO templates that have organic traffic but zero conversion touchpoints.
+
+---
+
+## Goal
+
+Add hero CTA + footer CTA (using `TrackingLink`) to all high-traffic programmatic SEO page templates. Reuse the visual pattern and UTM structure established in CONV-CTA-001.
+
+---
+
+## Programmatic Templates to Audit
+
+| Template | Route Pattern | Priority |
+|----------|--------------|----------|
+| Fornecedor | `/cnpj/[cnpj]` and `/fornecedores/[cnpj]` | High |
+| Orgao publico | `/orgaos/[slug]` | High |
+| Municipio | `/municipios/[slug]` | High |
+| Observatorio item | `/observatorio/[slug]` | Medium |
+| Observatorio raio-x | `/observatorio/raio-x-*/[id]` | Medium |
+| Contratos por setor | `/contratos/[setor]` | Medium |
+| Contratos setor × UF | `/contratos/[setor]/[uf]` | Medium |
+| Blog contratos | `/blog/contratos/[setor]` | Low |
+| Blog licitacoes | `/blog/licitacoes/[setor]` | Low |
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC1 — Each template receives a hero CTA block (below H1/subtitle, above main content)
+- [ ] AC2 — Each template receives a footer CTA block (above or replacing LeadCapture secondary)
+- [ ] AC3 — All CTAs use `TrackingLink` from `@/components/TrackingLink`
+- [ ] AC4 — UTM params follow pattern: `utm_source=programmatic&utm_medium=cta&utm_campaign=conv-cta-002&utm_content={template-slug}&page_{id_type}={id_value}`
+- [ ] AC5 — `eventProps` includes `{ cta_name: '{template}_{hero|footer}', placement: 'hero'|'footer', page_{id_type}: id }`
+- [ ] AC6 — Page files remain server components (no `'use client'` added to page.tsx)
+- [ ] AC7 — Tests added: one test file per template verifying 2 CTAs present + UTM correctness
+- [ ] AC8 — `revalidate` values unchanged across all modified templates
+- [ ] AC9 — Existing tests pass (0 regressions)
+
+---
+
+## Implementation Notes
+
+- Reuse `TrackingLink` created in CONV-CTA-001 (`frontend/components/TrackingLink.tsx`)
+- Visual template: `bg-blue-50 rounded-lg p-6 text-center` (from `/contratos/orgao/[cnpj]`)
+- Button: `px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors`
+- WCAG: `<section aria-labelledby="{placement}-cta-heading">` + matching `id` on h2
+- Mobile touch target: `min-h-[44px]` on the anchor
+
+---
+
+## File List
+
+_(to be filled during implementation)_
+
+- `frontend/app/cnpj/[cnpj]/page.tsx`
+- `frontend/app/fornecedores/[cnpj]/page.tsx`
+- `frontend/app/orgaos/[slug]/page.tsx`
+- `frontend/app/municipios/[slug]/page.tsx`
+- `frontend/app/observatorio/[slug]/page.tsx`
+- `frontend/app/contratos/[setor]/page.tsx` _(if exists)_
+- `frontend/app/contratos/[setor]/[uf]/page.tsx` _(if exists)_
+- `frontend/__tests__/contratos/cta-*.test.tsx` _(per template)_

--- a/frontend/__tests__/components/TrackingLink.test.tsx
+++ b/frontend/__tests__/components/TrackingLink.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TrackingLink } from '@/components/TrackingLink';
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('@/hooks/useAnalytics', () => ({
+  useAnalytics: () => ({ trackEvent: mockTrackEvent }),
+}));
+
+jest.mock('next/link', () => {
+  const MockLink = ({ href, children, className, onClick, ...rest }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    onClick?: () => void;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} className={className} onClick={onClick} {...rest}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+describe('TrackingLink', () => {
+  beforeEach(() => {
+    mockTrackEvent.mockClear();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <TrackingLink href="/signup" eventName="cta_clicked">
+        Teste gratis
+      </TrackingLink>
+    );
+    expect(screen.getByText('Teste gratis')).toBeInTheDocument();
+  });
+
+  it('renders with correct href', () => {
+    render(
+      <TrackingLink href="/signup?utm_campaign=test" eventName="cta_clicked">
+        Click
+      </TrackingLink>
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/signup?utm_campaign=test');
+  });
+
+  it('applies className prop', () => {
+    render(
+      <TrackingLink href="/signup" eventName="cta_clicked" className="btn-primary">
+        Click
+      </TrackingLink>
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('btn-primary');
+  });
+
+  it('calls trackEvent with eventName on click', () => {
+    render(
+      <TrackingLink href="/signup" eventName="cta_clicked">
+        Click
+      </TrackingLink>
+    );
+    fireEvent.click(screen.getByRole('link'));
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith('cta_clicked', undefined);
+  });
+
+  it('calls trackEvent with eventProps on click', () => {
+    const props = { cta_name: 'hero', page_cnpj: '12345678000100' };
+    render(
+      <TrackingLink href="/signup" eventName="cta_clicked" eventProps={props}>
+        Click
+      </TrackingLink>
+    );
+    fireEvent.click(screen.getByRole('link'));
+    expect(mockTrackEvent).toHaveBeenCalledWith('cta_clicked', props);
+  });
+
+  it('passes additional props to link', () => {
+    render(
+      <TrackingLink href="/signup" eventName="cta_clicked" data-testid="tracking-link">
+        Click
+      </TrackingLink>
+    );
+    expect(screen.getByTestId('tracking-link')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/contratos/orgao-cta.test.tsx
+++ b/frontend/__tests__/contratos/orgao-cta.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * CONV-CTA-001: Validates hero + footer CTAs on /contratos/orgao/[cnpj] page.
+ *
+ * Tests:
+ * - 2 TrackingLink CTAs present (hero + footer)
+ * - UTM params correct in both hrefs
+ * - page_cnpj param present
+ * - trackEvent fired with correct eventProps on click
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('@/hooks/useAnalytics', () => ({
+  useAnalytics: () => ({ trackEvent: mockTrackEvent }),
+}));
+
+jest.mock('next/link', () => {
+  const MockLink = ({ href, children, className, onClick, ...rest }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    onClick?: () => void;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} className={className} onClick={onClick} {...rest}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+jest.mock('@/components/LeadCapture', () => ({
+  LeadCapture: ({ heading }: { heading: string }) => <div data-testid="lead-capture">{heading}</div>,
+}));
+
+jest.mock('@/app/components/landing/LandingNavbar', () => ({
+  __esModule: true,
+  default: () => <nav data-testid="navbar" />,
+}));
+
+jest.mock('@/app/components/Footer', () => ({
+  __esModule: true,
+  default: () => <footer data-testid="footer" />,
+}));
+
+// Mock fetch for page data
+const mockStats = {
+  orgao_nome: 'Prefeitura Municipal de Teste',
+  orgao_cnpj: '12345678000100',
+  total_contracts: 42,
+  total_value: 1000000,
+  avg_value: 23809,
+  top_fornecedores: [],
+  monthly_trend: [],
+  sample_contracts: [],
+  last_updated: '2026-04-01T00:00:00Z',
+  aviso_legal: 'Dados de carater informativo.',
+};
+
+beforeEach(() => {
+  mockTrackEvent.mockClear();
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => mockStats,
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function renderPage(cnpj = '12345678000100') {
+  const { default: OrgaoContratosPage } = await import(
+    '@/app/contratos/orgao/[cnpj]/page'
+  );
+  const props = { params: Promise.resolve({ cnpj }) };
+  const jsx = await OrgaoContratosPage(props);
+  return render(jsx as React.ReactElement);
+}
+
+describe('CONV-CTA-001: /contratos/orgao/[cnpj] CTAs', () => {
+  it('renders hero CTA with correct text', async () => {
+    await renderPage();
+    expect(screen.getByText('Teste gratis por 14 dias')).toBeInTheDocument();
+  });
+
+  it('renders footer CTA with correct text', async () => {
+    await renderPage();
+    expect(screen.getByText('Comecar teste gratis')).toBeInTheDocument();
+  });
+
+  it('both CTAs have UTM params in href', async () => {
+    const cnpj = '12345678000100';
+    await renderPage(cnpj);
+
+    const links = screen.getAllByRole('link', {
+      name: /teste gratis|comecar teste gratis/i,
+    });
+    expect(links).toHaveLength(2);
+
+    for (const link of links) {
+      const href = link.getAttribute('href') ?? '';
+      expect(href).toContain('utm_source=programmatic');
+      expect(href).toContain('utm_medium=cta');
+      expect(href).toContain('utm_campaign=conv-cta-001');
+      expect(href).toContain('utm_content=contratos-orgao');
+      expect(href).toContain(`page_cnpj=${cnpj}`);
+    }
+  });
+
+  it('hero CTA fires cta_clicked with hero placement on click', async () => {
+    await renderPage();
+    const heroLink = screen.getByText('Teste gratis por 14 dias');
+    fireEvent.click(heroLink);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'cta_clicked',
+      expect.objectContaining({ cta_name: 'contratos_orgao_hero', placement: 'hero' })
+    );
+  });
+
+  it('footer CTA fires cta_clicked with footer placement on click', async () => {
+    await renderPage();
+    const footerLink = screen.getByText('Comecar teste gratis');
+    fireEvent.click(footerLink);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'cta_clicked',
+      expect.objectContaining({ cta_name: 'contratos_orgao_footer', placement: 'footer' })
+    );
+  });
+
+  it('LeadCapture still renders as secondary element', async () => {
+    await renderPage();
+    expect(screen.getByTestId('lead-capture')).toBeInTheDocument();
+  });
+});

--- a/frontend/app/contratos/orgao/[cnpj]/page.tsx
+++ b/frontend/app/contratos/orgao/[cnpj]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { buildCanonical } from '@/lib/seo';
 import { LeadCapture } from '@/components/LeadCapture';
+import { TrackingLink } from '@/components/TrackingLink';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
 
@@ -167,6 +168,24 @@ export default async function OrgaoContratosPage({ params }: Props) {
               CNPJ: {stats.orgao_cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5')}
               {' · '}Atualizado em {new Date(stats.last_updated).toLocaleDateString('pt-BR')}
             </p>
+
+            {/* Hero CTA — CONV-CTA-001 */}
+            <section aria-labelledby="hero-cta-heading" className="mt-6 bg-blue-50 rounded-lg p-6 text-center">
+              <h2 id="hero-cta-heading" className="text-lg font-semibold text-blue-900 mb-2">
+                Monitore licitacoes deste orgao em tempo real
+              </h2>
+              <p className="text-sm text-blue-700 mb-4">
+                Descubra oportunidades antes da concorrencia. Teste gratis por 14 dias, sem cartao.
+              </p>
+              <TrackingLink
+                href={`/signup?utm_source=programmatic&utm_medium=cta&utm_campaign=conv-cta-001&utm_content=contratos-orgao&page_cnpj=${cnpj}`}
+                eventName="cta_clicked"
+                eventProps={{ cta_name: 'contratos_orgao_hero', page_cnpj: cnpj, placement: 'hero' }}
+                className="inline-block min-h-[44px] px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                Teste gratis por 14 dias
+              </TrackingLink>
+            </section>
           </div>
         </div>
 
@@ -277,7 +296,25 @@ export default async function OrgaoContratosPage({ params }: Props) {
           {/* Aviso Legal */}
           <p className="text-xs text-ink-secondary italic">{stats.aviso_legal}</p>
 
-          {/* Lead Capture */}
+          {/* Footer CTA — CONV-CTA-001 */}
+          <section aria-labelledby="footer-cta-heading" className="bg-blue-50 rounded-lg p-6 text-center">
+            <h2 id="footer-cta-heading" className="text-xl font-bold text-blue-900 mb-2">
+              Encontre oportunidades com {stats.orgao_nome}
+            </h2>
+            <p className="text-sm text-blue-700 mb-4">
+              Acesse licitacoes abertas, analise viabilidade e monitore contratos. 14 dias gratis, sem cartao.
+            </p>
+            <TrackingLink
+              href={`/signup?utm_source=programmatic&utm_medium=cta&utm_campaign=conv-cta-001&utm_content=contratos-orgao&page_cnpj=${cnpj}`}
+              eventName="cta_clicked"
+              eventProps={{ cta_name: 'contratos_orgao_footer', page_cnpj: cnpj, placement: 'footer' }}
+              className="inline-block min-h-[44px] px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Comecar teste gratis
+            </TrackingLink>
+          </section>
+
+          {/* Lead Capture (secondary) */}
           <LeadCapture
             source="contratos-orgao"
             heading="Monitore contratos deste orgao"

--- a/frontend/components/TrackingLink.tsx
+++ b/frontend/components/TrackingLink.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import type { ComponentProps } from 'react';
+import { useAnalytics } from '../hooks/useAnalytics';
+
+type LinkProps = ComponentProps<typeof Link>;
+
+interface TrackingLinkProps extends Omit<LinkProps, 'onClick'> {
+  /** Mixpanel event name to fire on click */
+  eventName: string;
+  /** Additional properties to include in the Mixpanel event */
+  eventProps?: Record<string, unknown>;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * TrackingLink — Client component wrapper around next/link that fires a
+ * Mixpanel event on click.
+ *
+ * CONV-CTA-001: Used for programmatic SEO pages to track CTA interactions.
+ *
+ * @example
+ * <TrackingLink
+ *   href="/signup?utm_campaign=conv-cta-001"
+ *   eventName="cta_clicked"
+ *   eventProps={{ cta_name: 'contratos_orgao_hero', page_cnpj: cnpj }}
+ *   className="..."
+ * >
+ *   Teste grátis por 14 dias
+ * </TrackingLink>
+ */
+export function TrackingLink({
+  href,
+  eventName,
+  eventProps,
+  children,
+  className,
+  ...rest
+}: TrackingLinkProps) {
+  const { trackEvent } = useAnalytics();
+
+  return (
+    <Link
+      href={href}
+      className={className}
+      onClick={() => trackEvent(eventName, eventProps)}
+      {...rest}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default TrackingLink;


### PR DESCRIPTION
## Summary

- **New component:** `frontend/components/TrackingLink.tsx` — `'use client'` wrapper around `next/link` that fires `trackEvent('cta_clicked', {...})` via `useAnalytics()` on click (LGPD consent-gated)
- **Hero CTA:** Inserted inside hero block of `/contratos/orgao/[cnpj]` page, below the CNPJ/Atualizado paragraph — `utm_campaign=conv-cta-001`, `placement: 'hero'`
- **Footer CTA:** Inserted above `<LeadCapture>` (demoted to secondary) — same UTM, `placement: 'footer'`
- **Page remains a server component** — no `'use client'` added to `page.tsx`
- **ISR preserved:** `revalidate = 14400` unchanged
- **Tests:** `TrackingLink.test.tsx` (6 cases) + `contratos/orgao-cta.test.tsx` (6 cases)
- **W2 placeholder:** `CONV-CTA-002` Draft story for auditing remaining programmatic templates

## Motivation

`/contratos/orgao/[cnpj]` represents 4 of top-10 GSC URLs (~12 clicks/month combined). These pages had zero signup/trial CTAs. Adding hero + footer CTAs provides the first measurable conversion touchpoint on these high-intent public contract pages.

## Test plan

- [ ] `npm test -- __tests__/components/TrackingLink.test.tsx` — 6 tests pass
- [ ] `npm test -- __tests__/contratos/orgao-cta.test.tsx` — 6 tests pass
- [ ] `npm test -- __tests__/contratos-orgao.test.tsx` — existing test still passes (revalidate, generateStaticParams, generateMetadata)
- [ ] CI frontend-tests.yml passes (0 regressions)
- [ ] Visually: `/contratos/orgao/12345678000100` shows blue hero CTA above KPI cards and blue footer CTA above LeadCapture
- [ ] Mixpanel: clicking either CTA fires `cta_clicked` event with correct `cta_name` and `placement`

**DO NOT MERGE** — pending CI green + human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)