### PR TITLE
feat(frontend): Clarity trial+onboarding tagging + first-analysis Mixpanel lifecycle (CONV-INST-005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Analytics & Instrumentação
+- **Clarity trial+onboarding tagging + first-analysis Mixpanel lifecycle (CONV-INST-005 #572)** — `claritySet('onboarding_step', 'N/3')` nos 3 steps do onboarding; `clarityEvent('trial_started')` + `claritySet('trial_started_at')` pós first-analysis 2xx; eventos Mixpanel `first_analysis_completed/empty/failed` no SSE handler com guard `useRef` anti-double-fire e `viability_high_count` (score ≥ 0.7); `claritySet('trial_days_remaining')` no `AnalyticsProvider` com null-skip para admins.
+
 ### Fixed — SEO
 - **Meta descriptions CTR (#641)** — 5 páginas GSC P0 (>200 impressões, CTR <1%) reescritas com copy data-driven: número real + benefício + CTA implícito, 120–155 chars. Afeta `/blog/pncp-guia-completo-empresas`, `/blog/licitacoes-engenharia-2026`, `/blog/como-consultar-contratos-publicos-pncp`, `/blog/subcontratacao-licitacoes-regras-lei-14133`, `/perguntas/prazo-publicacao-edital`.
 

--- a/frontend/__tests__/buscar/first-analysis-completed.test.tsx
+++ b/frontend/__tests__/buscar/first-analysis-completed.test.tsx
@@ -16,28 +16,13 @@ import { renderHook, act } from '@testing-library/react';
 const mockTrackEvent = jest.fn();
 const mockRefreshQuota = jest.fn().mockResolvedValue(undefined);
 
-jest.mock('../../../hooks/useAnalytics', () => ({
+jest.mock('../../hooks/useAnalytics', () => ({
   useAnalytics: () => ({ trackEvent: mockTrackEvent }),
 }));
 
-jest.mock('../../../hooks/useQuota', () => ({
+jest.mock('../../hooks/useQuota', () => ({
   useQuota: () => ({ refresh: mockRefreshQuota }),
 }));
-
-// Mock fetch for /api/buscar-results
-global.fetch = jest.fn().mockImplementation((url: string) => {
-  if (url.includes('buscar-results')) {
-    return Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve({
-        licitacoes: [{ pncp_id: 'bid-1', viability_score: 0.8 }],
-        total_filtrado: 1,
-        total_raw: 5,
-      }),
-    });
-  }
-  return Promise.resolve({ ok: false });
-});
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -101,7 +86,19 @@ function makeErrorEvent() {
 describe('CONV-INST-005: first_analysis_completed event (AC4)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (global.fetch as jest.Mock).mockClear();
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes('buscar-results')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            licitacoes: [{ pncp_id: 'bid-1', viability_score: 0.8 }],
+            total_filtrado: 1,
+            total_raw: 5,
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
   });
 
   it('fires first_analysis_completed when isAutoAnalysis=true + search_complete with results', async () => {

--- a/frontend/__tests__/buscar/first-analysis-completed.test.tsx
+++ b/frontend/__tests__/buscar/first-analysis-completed.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * CONV-INST-005: first-analysis Mixpanel lifecycle events via useSearchSSEHandler (AC4)
+ *
+ * Tests:
+ * 1. When isAutoAnalysis=true + search_complete with results → trackEvent('first_analysis_completed')
+ * 2. When isAutoAnalysis=true + search_complete without results → trackEvent('first_analysis_empty')
+ * 3. When isAutoAnalysis=true + error stage → trackEvent('first_analysis_failed')
+ * 4. Double-fire protection: first_analysis_completed fires only once even if SSE fires twice
+ * 5. When isAutoAnalysis=false → none of the first_analysis_* events fire
+ */
+
+import { renderHook, act } from '@testing-library/react';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockTrackEvent = jest.fn();
+const mockRefreshQuota = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({ trackEvent: mockTrackEvent }),
+}));
+
+jest.mock('../../../hooks/useQuota', () => ({
+  useQuota: () => ({ refresh: mockRefreshQuota }),
+}));
+
+// Mock fetch for /api/buscar-results
+global.fetch = jest.fn().mockImplementation((url: string) => {
+  if (url.includes('buscar-results')) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        licitacoes: [{ pncp_id: 'bid-1', viability_score: 0.8 }],
+        total_filtrado: 1,
+        total_raw: 5,
+      }),
+    });
+  }
+  return Promise.resolve({ ok: false });
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    session: { access_token: 'test-token' },
+    searchId: 'search-abc',
+    searchMode: 'setor' as const,
+    ufsSelecionadasSize: 2,
+    result: null,
+    setResult: jest.fn(),
+    setRawCount: jest.fn(),
+    setError: jest.fn(),
+    setLoading: jest.fn(),
+    setSearchId: jest.fn(),
+    setAsyncSearchActive: jest.fn(),
+    asyncSearchActiveRef: { current: true },
+    asyncSearchIdRef: { current: 'search-abc' },
+    sseTerminalReceivedRef: { current: false },
+    llmTimeoutRef: { current: null },
+    setRetryCountdown: jest.fn(),
+    setRetryMessage: jest.fn(),
+    setRetryExhausted: jest.fn(),
+    retryTimerRef: { current: null },
+    handleExcelFailureRef: { current: null },
+    excelFailCountRef: { current: 0 },
+    excelToastFiredRef: { current: false },
+    setLiveFetchInProgress: jest.fn(),
+    liveFetchSearchIdRef: { current: null },
+    ...overrides,
+  };
+}
+
+function makeSearchCompleteEvent(hasResults: boolean) {
+  return {
+    stage: 'search_complete' as const,
+    progress: 100,
+    message: 'done',
+    detail: {
+      has_results: hasResults,
+      search_id: 'search-abc',
+      total_results: hasResults ? 1 : 0,
+    },
+  };
+}
+
+function makeErrorEvent() {
+  return {
+    stage: 'error' as const,
+    progress: 0,
+    message: 'error',
+    detail: {
+      error: 'pipeline_error',
+      error_code: 'PIPELINE_TIMEOUT',
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CONV-INST-005: first_analysis_completed event (AC4)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('fires first_analysis_completed when isAutoAnalysis=true + search_complete with results', async () => {
+    const { useSearchSSEHandler } = require('../../app/buscar/hooks/useSearchSSEHandler');
+    const { result } = renderHook(() =>
+      useSearchSSEHandler({ ...makeParams(), isAutoAnalysis: true })
+    );
+
+    await act(async () => {
+      await result.current.handleSseEvent(makeSearchCompleteEvent(true));
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'first_analysis_completed',
+      expect.objectContaining({
+        search_id: 'search-abc',
+        results_count: expect.any(Number),
+        time_total_ms: expect.any(Number),
+        viability_high_count: expect.any(Number),
+      })
+    );
+  });
+
+  it('fires first_analysis_empty when isAutoAnalysis=true + search_complete without results', async () => {
+    const { useSearchSSEHandler } = require('../../app/buscar/hooks/useSearchSSEHandler');
+    const { result } = renderHook(() =>
+      useSearchSSEHandler({ ...makeParams(), isAutoAnalysis: true })
+    );
+
+    await act(async () => {
+      await result.current.handleSseEvent(makeSearchCompleteEvent(false));
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'first_analysis_empty',
+      expect.objectContaining({
+        search_id: expect.anything(),
+        time_total_ms: expect.any(Number),
+      })
+    );
+  });
+
+  it('fires first_analysis_failed when isAutoAnalysis=true + error event', async () => {
+    const { useSearchSSEHandler } = require('../../app/buscar/hooks/useSearchSSEHandler');
+    const { result } = renderHook(() =>
+      useSearchSSEHandler({ ...makeParams(), isAutoAnalysis: true })
+    );
+
+    await act(async () => {
+      await result.current.handleSseEvent(makeErrorEvent());
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'first_analysis_failed',
+      expect.objectContaining({
+        search_id: 'search-abc',
+        error_code: 'PIPELINE_TIMEOUT',
+        time_total_ms: expect.any(Number),
+      })
+    );
+  });
+
+  it('does NOT double-fire first_analysis_completed on repeated search_complete events', async () => {
+    const { useSearchSSEHandler } = require('../../app/buscar/hooks/useSearchSSEHandler');
+    const { result } = renderHook(() =>
+      useSearchSSEHandler({ ...makeParams(), isAutoAnalysis: true })
+    );
+
+    await act(async () => {
+      await result.current.handleSseEvent(makeSearchCompleteEvent(true));
+      await result.current.handleSseEvent(makeSearchCompleteEvent(true));
+    });
+
+    const completedCalls = mockTrackEvent.mock.calls.filter(
+      ([eventName]) => eventName === 'first_analysis_completed'
+    );
+    expect(completedCalls).toHaveLength(1);
+  });
+
+  it('does NOT fire first_analysis_* events when isAutoAnalysis=false', async () => {
+    const { useSearchSSEHandler } = require('../../app/buscar/hooks/useSearchSSEHandler');
+    const { result } = renderHook(() =>
+      useSearchSSEHandler({ ...makeParams(), isAutoAnalysis: false })
+    );
+
+    await act(async () => {
+      await result.current.handleSseEvent(makeSearchCompleteEvent(true));
+    });
+
+    const firstAnalysisCalls = mockTrackEvent.mock.calls.filter(
+      ([eventName]) => eventName.startsWith('first_analysis_')
+    );
+    expect(firstAnalysisCalls).toHaveLength(0);
+  });
+});

--- a/frontend/__tests__/onboarding/onboarding-step-tagging.test.tsx
+++ b/frontend/__tests__/onboarding/onboarding-step-tagging.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * CONV-INST-005: Clarity onboarding step tagging (AC1)
+ *
+ * Tests:
+ * 1. claritySet('onboarding_step', '1/3') fires when step 0→1 transitions
+ * 2. claritySet('onboarding_step', '2/3') fires when step 1→2 transitions
+ * 3. claritySet('onboarding_step', '3/3') fires when step 2→submit
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockClaritySet = jest.fn();
+const mockClarityEvent = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockRouterPush = jest.fn();
+const mockRouterReplace = jest.fn();
+
+jest.mock('../../hooks/useClarity', () => ({
+  useClarity: () => ({
+    clarityEvent: mockClarityEvent,
+    claritySet: mockClaritySet,
+    clarityIdentify: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+  }),
+  getDaysInTrial: jest.fn().mockReturnValue(14),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: mockRouterReplace,
+  }),
+}));
+
+jest.mock('../../app/components/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: 'user-test', created_at: '2026-04-01T00:00:00Z' },
+    session: { access_token: 'test-token' },
+    loading: false,
+  }),
+}));
+
+// Suppress react-hook-form zod resolver dep warning in tests
+jest.mock('@hookform/resolvers/zod', () => ({
+  zodResolver: () => async () => ({ values: {}, errors: {} }),
+}));
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../../lib/storage', () => ({
+  safeSetItem: jest.fn(),
+}));
+
+jest.mock('../../lib/analytics-helpers', () => ({
+  getDaysInTrial: jest.fn().mockReturnValue(14),
+}));
+
+// Mock child step components to avoid complex rendering
+jest.mock('../../app/onboarding/components/OnboardingProgress', () => ({
+  OnboardingProgress: () => <div data-testid="progress" />,
+}));
+
+jest.mock('../../app/onboarding/components/OnboardingStep1', () => ({
+  OnboardingStep1: ({ onChange }: { onChange: (d: Record<string, unknown>) => void }) => (
+    <div data-testid="step1">
+      <button
+        onClick={() => onChange({ cnae: '4120400', objetivo_principal: 'Construção civil' })}
+        data-testid="fill-step1"
+      >
+        Fill Step 1
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('../../app/onboarding/components/OnboardingStep2', () => ({
+  OnboardingStep2: ({ onChange }: { onChange: (d: Record<string, unknown>) => void }) => (
+    <div data-testid="step2">
+      <button
+        onClick={() => onChange({ ufs_atuacao: ['SP'], faixa_valor_min: 100000, faixa_valor_max: 500000 })}
+        data-testid="fill-step2"
+      >
+        Fill Step 2
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('../../app/onboarding/components/OnboardingStep3', () => ({
+  OnboardingStep3: () => <div data-testid="step3" />,
+}));
+
+// Mock fetch for profile-context load + first-analysis
+global.fetch = jest.fn().mockImplementation((url: string) => {
+  if (url === '/api/profile-context') {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ context_data: {} }) });
+  }
+  return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('CONV-INST-005: onboarding step Clarity tagging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('claritySet onboarding_step=1/3 fires on step 0→1 transition', async () => {
+    const OnboardingPage = require('../../app/onboarding/page').default;
+    render(<OnboardingPage />);
+
+    // Fill step 1 data so canProceed() = true
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('fill-step1'));
+    });
+
+    // Click Continuar
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btn-continuar'));
+    });
+
+    await waitFor(() => {
+      expect(mockClaritySet).toHaveBeenCalledWith('onboarding_step', '1/3');
+    });
+  });
+
+  it('claritySet onboarding_step=2/3 fires on step 1→2 transition', async () => {
+    const OnboardingPage = require('../../app/onboarding/page').default;
+    render(<OnboardingPage />);
+
+    // Advance to step 1
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('fill-step1'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btn-continuar'));
+    });
+
+    // Fill step 2
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('fill-step2'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btn-continuar'));
+    });
+
+    await waitFor(() => {
+      expect(mockClaritySet).toHaveBeenCalledWith('onboarding_step', '2/3');
+    });
+  });
+
+  it('claritySet onboarding_step=3/3 fires on step 2→submit', async () => {
+    const OnboardingPage = require('../../app/onboarding/page').default;
+    render(<OnboardingPage />);
+
+    // Advance to step 1
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('fill-step1'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btn-continuar'));
+    });
+
+    // Advance to step 2
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('fill-step2'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btn-continuar'));
+    });
+
+    // On step 3, click submit — mocked fetch will return 500, but claritySet should still fire
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('btn-continuar'));
+    });
+
+    await waitFor(() => {
+      expect(mockClaritySet).toHaveBeenCalledWith('onboarding_step', '3/3');
+    });
+  });
+});

--- a/frontend/__tests__/onboarding/onboarding-step-tagging.test.tsx
+++ b/frontend/__tests__/onboarding/onboarding-step-tagging.test.tsx
@@ -100,19 +100,18 @@ jest.mock('../../app/onboarding/components/OnboardingStep3', () => ({
   OnboardingStep3: () => <div data-testid="step3" />,
 }));
 
-// Mock fetch for profile-context load + first-analysis
-global.fetch = jest.fn().mockImplementation((url: string) => {
-  if (url === '/api/profile-context') {
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({ context_data: {} }) });
-  }
-  return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
-});
-
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 describe('CONV-INST-005: onboarding step Clarity tagging', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // resetMocks:true in jest.config resets implementations — re-set per test
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url === '/api/profile-context') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ context_data: {} }) });
+      }
+      return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+    });
   });
 
   it('claritySet onboarding_step=1/3 fires on step 0→1 transition', async () => {

--- a/frontend/app/buscar/hooks/useSearch.ts
+++ b/frontend/app/buscar/hooks/useSearch.ts
@@ -68,6 +68,8 @@ interface UseSearchParams {
   setValorMax: (v: number | null) => void;
   setEsferas: (e: Esfera[]) => void;
   setMunicipios: (m: Municipio[]) => void;
+  // AC4: first-analysis auto flow flag
+  isAutoAnalysis?: boolean;
 }
 
 /**
@@ -243,6 +245,7 @@ export function useSearch(filters: UseSearchParams): UseSearchReturn {
     excelToastFiredRef,
     setLiveFetchInProgress: execution.setLiveFetchInProgress,
     liveFetchSearchIdRef: execution.liveFetchSearchIdRef,
+    isAutoAnalysis: filters.isAutoAnalysis,
   });
 
   // ── 5. SSE connection ──

--- a/frontend/app/buscar/hooks/useSearchOrchestration.ts
+++ b/frontend/app/buscar/hooks/useSearchOrchestration.ts
@@ -153,7 +153,8 @@ export function useSearchOrchestration() {
   // ── Search Core ─────────────────────────────────────────────────────
   const clearResultRef = useRef<() => void>(() => {});
   const filters = useSearchFilters(() => clearResultRef.current());
-  const search = useSearch(filters);
+  // AC4: pass auto-analysis flag so SSE handler fires first_analysis_* Mixpanel events
+  const search = useSearch({ ...filters, isAutoAnalysis: isAutoSearch });
   clearResultRef.current = () => search.setResult(null);
 
   // ── SSE / Backend Status / Progress ─────────────────────────────────

--- a/frontend/app/buscar/hooks/useSearchSSEHandler.ts
+++ b/frontend/app/buscar/hooks/useSearchSSEHandler.ts
@@ -36,6 +36,8 @@ interface UseSearchSSEHandlerParams {
   // UX-435: clear live-fetch banner on SSE terminal event
   setLiveFetchInProgress: (v: boolean) => void;
   liveFetchSearchIdRef: React.MutableRefObject<string | null>;
+  // AC4: first-analysis auto flow detection
+  isAutoAnalysis?: boolean;
 }
 
 export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
@@ -47,10 +49,16 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
     setRetryCountdown, setRetryMessage, setRetryExhausted, retryTimerRef,
     handleExcelFailureRef, excelFailCountRef, excelToastFiredRef,
     setLiveFetchInProgress, liveFetchSearchIdRef,
+    isAutoAnalysis = false,
   } = params;
 
   const { refresh: refreshQuota } = useQuota();
   const { trackEvent } = useAnalytics();
+
+  // AC4: useRef flag to prevent double-fire of first_analysis events
+  const firstAnalysisFiredRef = useRef(false);
+  // AC4: capture start time for time_total_ms
+  const firstAnalysisStartRef = useRef<number | null>(null);
 
   // F-01 AC21: Handle background job completion via SSE
   // GTM-ARCH-001 AC3/AC4: Also handles search_complete from async Worker
@@ -58,6 +66,11 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
     // CRIT-SSE-FIX AC2: Track terminal SSE events so finally block knows when SSE is done
     if (['complete', 'error', 'degraded', 'search_complete'].includes(event.stage)) {
       sseTerminalReceivedRef.current = true;
+    }
+
+    // AC4: capture first-analysis start time on first non-terminal event
+    if (isAutoAnalysis && firstAnalysisStartRef.current === null && !firstAnalysisFiredRef.current) {
+      firstAnalysisStartRef.current = Date.now();
     }
 
     // UX-435 AC1: Clear live-fetch banner when SSE terminal event arrives for
@@ -114,6 +127,22 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
               search_mode: searchMode,
               async_mode: true,
             });
+
+            // AC4: first-analysis completed event (auto=true flow, fired once)
+            if (isAutoAnalysis && !firstAnalysisFiredRef.current) {
+              firstAnalysisFiredRef.current = true;
+              const startTs = firstAnalysisStartRef.current ?? Date.now();
+              const viabilityHighCount = fetchedData.licitacoes?.filter(
+                (l) => (l as { viability_score?: number }).viability_score != null &&
+                  (l as { viability_score: number }).viability_score >= 0.7
+              ).length ?? 0;
+              trackEvent('first_analysis_completed', {
+                search_id: sid,
+                results_count: fetchedData.total_filtrado || 0,
+                time_total_ms: Date.now() - startTs,
+                viability_high_count: viabilityHighCount,
+              });
+            }
           }
         } catch (e) {
           console.warn('[ARCH-001] Error fetching async search results:', e);
@@ -125,6 +154,22 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
           setSearchId(null);
         }
       }
+    } else if (event.stage === 'search_complete' && !event.detail.has_results) {
+      // AC4: first-analysis empty (auto=true flow, no results)
+      if (isAutoAnalysis && !firstAnalysisFiredRef.current) {
+        firstAnalysisFiredRef.current = true;
+        const startTs = firstAnalysisStartRef.current ?? Date.now();
+        const sid = event.detail.search_id || asyncSearchIdRef.current || searchId;
+        trackEvent('first_analysis_empty', {
+          search_id: sid,
+          time_total_ms: Date.now() - startTs,
+        });
+      }
+      setAsyncSearchActive(false);
+      asyncSearchActiveRef.current = false;
+      asyncSearchIdRef.current = null;
+      setLoading(false);
+      setSearchId(null);
     } else if (event.stage === 'llm_ready' && event.detail.resumo) {
       // AC3: AI summary arrived — clear timeout and update silently
       if (llmTimeoutRef.current) {
@@ -224,6 +269,16 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
       }
     } else if (event.stage === 'error' && asyncSearchActiveRef.current) {
       // GTM-ARCH-001: Worker error during async search
+      // AC4: first-analysis failed event (auto=true flow, fired once)
+      if (isAutoAnalysis && !firstAnalysisFiredRef.current) {
+        firstAnalysisFiredRef.current = true;
+        const startTs = firstAnalysisStartRef.current ?? Date.now();
+        trackEvent('first_analysis_failed', {
+          search_id: searchId,
+          error_code: event.detail.error_code || null,
+          time_total_ms: Date.now() - startTs,
+        });
+      }
       setAsyncSearchActive(false);
       asyncSearchActiveRef.current = false;
       asyncSearchIdRef.current = null;
@@ -247,6 +302,7 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
     setRetryCountdown, setRetryMessage, setRetryExhausted, retryTimerRef,
     handleExcelFailureRef, excelFailCountRef, excelToastFiredRef,
     setLiveFetchInProgress, liveFetchSearchIdRef,
+    isAutoAnalysis,
   ]);
 
   return { handleSseEvent };

--- a/frontend/app/components/AnalyticsProvider.tsx
+++ b/frontend/app/components/AnalyticsProvider.tsx
@@ -185,6 +185,12 @@ export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
       claritySet('plan_type', planId);
       claritySet('is_trial', String(isTrial));
       claritySet('user_segment', isTrial ? 'trial' : 'paid');
+      // AC6: trial_days_remaining — admin users have no trial_expires_at, skip gracefully
+      const trialExpiresAt = profileData.trial_expires_at as string | null | undefined;
+      if (trialExpiresAt) {
+        const daysRemaining = Math.floor((Date.parse(trialExpiresAt) - Date.now()) / 86400000);
+        claritySet('trial_days_remaining', String(daysRemaining));
+      }
     }
 
     clarityIdentifiedRef.current = true;

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../components/AuthProvider";
 import { toast } from "sonner";
 import { safeSetItem } from "../../lib/storage";
 import { useAnalytics } from "../../hooks/useAnalytics";
+import { useClarity } from "../../hooks/useClarity";
 import { getDaysInTrial } from "../../lib/analytics-helpers";
 import {
   onboardingStep1Schema,
@@ -30,6 +31,7 @@ export default function OnboardingPage() {
   const router = useRouter();
   const { user, session, loading: authLoading } = useAuth();
   const { trackEvent } = useAnalytics();
+  const { clarityEvent, claritySet } = useClarity();
   const [currentStep, setCurrentStep] = useState(0);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
@@ -174,6 +176,9 @@ export default function OnboardingPage() {
         // Zero-churn P1 §6.1: Detect trial expired (403)
         if (analysisRes.status === 403) {
           setAnalysisError("trial_expired");
+          // AC5: track trial_expired denial
+          trackEvent('onboarding_first_analysis_denied', { reason: 'trial_expired' });
+          clarityEvent('first_analysis_trial_expired');
           setIsAnalyzing(false);
           return;
         }
@@ -185,15 +190,38 @@ export default function OnboardingPage() {
 
       const { search_id } = await analysisRes.json();
 
+      // AC2: Fire trial_started after first-analysis 2xx
+      clarityEvent('trial_started');
+      claritySet('trial_started_at', new Date().toISOString());
+
+      // AC3: Fire first_analysis_dispatched with search_id
+      clarityEvent('first_analysis_dispatched');
+      claritySet('first_analysis_search_id', search_id);
+
       // 3. Redirect to search with auto flag
       toast.success("Perfil salvo! Analisando suas oportunidades...");
       router.push(`/buscar?auto=true&search_id=${search_id}`);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {
+        // AC5: timeout error tracking
         setAnalysisError("timeout");
+        trackEvent('onboarding_first_analysis_timeout', { timeout_ms: 30000 });
+        clarityEvent('first_analysis_timeout');
       } else {
         toast.error("Erro ao configurar perfil. Tente novamente.");
         setAnalysisError("generic");
+        // AC5: generic error tracking with hashed message
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        let errorHash = '';
+        try {
+          const encoded = new TextEncoder().encode(errorMessage);
+          const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);
+          errorHash = Array.from(new Uint8Array(hashBuffer)).slice(0, 8).map(b => b.toString(16).padStart(2, '0')).join('');
+        } catch {
+          errorHash = errorMessage.length.toString(16);
+        }
+        trackEvent('onboarding_first_analysis_error', { error_message_hash: errorHash });
+        clarityEvent('first_analysis_error');
       }
       setIsAnalyzing(false);
     } finally {
@@ -219,6 +247,7 @@ export default function OnboardingPage() {
         objetivo_principal: data.objetivo_principal,
         days_in_trial: getDaysInTrial(user?.created_at),
       });
+      claritySet('onboarding_step', '1/3');
       setCurrentStep(1);
     } else if (currentStep === 1) {
       // Trigger zod validation for step 2
@@ -235,6 +264,7 @@ export default function OnboardingPage() {
         faixa_valor_max: data.faixa_valor_max,
         days_in_trial: getDaysInTrial(user?.created_at),
       });
+      claritySet('onboarding_step', '2/3');
       setCurrentStep(2);
     } else {
       trackEvent('onboarding_step_completed', {
@@ -242,6 +272,7 @@ export default function OnboardingPage() {
         total_steps: 3,
         days_in_trial: getDaysInTrial(user?.created_at),
       });
+      claritySet('onboarding_step', '3/3');
       submitAndAnalyze();
     }
   };


### PR DESCRIPTION
## Summary

- **AC1** `claritySet('onboarding_step', 'N/3')` alongside each `trackEvent` in `nextStep()` — fires on step transitions 1/3, 2/3, 3/3
- **AC2** `clarityEvent('trial_started')` + `claritySet('trial_started_at')` after `/api/first-analysis` returns 2xx
- **AC3** `clarityEvent('first_analysis_dispatched')` + `claritySet('first_analysis_search_id', search_id)` after dispatch
- **AC4** `first_analysis_completed` / `first_analysis_empty` / `first_analysis_failed` Mixpanel events in `useSearchSSEHandler` gated by `isAutoAnalysis=true` (threaded from `useSearchOrchestration` → `useSearch` → handler); `useRef` double-fire guard; `time_total_ms` via start timestamp ref
- **AC5** Silent catch in `submitAndAnalyze` replaced: 403→`onboarding_first_analysis_denied`+`first_analysis_trial_expired`, AbortError→`onboarding_first_analysis_timeout`, generic→`onboarding_first_analysis_error` with SHA-256 hash
- **AC6** `claritySet('trial_days_remaining', String(days))` in `AnalyticsProvider.tsx` using `profileData.trial_expires_at`; graceful null-skip for admin users (no `trial_expires_at`)
- **AC7** Reuses existing `useClarity()` hook — no new hook
- **AC8** LGPD already gated inside `useClarity` via `hasAnalyticsConsent()` — no changes needed
- **AC9** Two test files: `onboarding-step-tagging.test.tsx` and `first-analysis-completed.test.tsx`

## Files Changed

- `frontend/app/onboarding/page.tsx` — AC1, AC2, AC3, AC5
- `frontend/app/components/AnalyticsProvider.tsx` — AC6
- `frontend/app/buscar/hooks/useSearchSSEHandler.ts` — AC4 events + `isAutoAnalysis` param
- `frontend/app/buscar/hooks/useSearch.ts` — thread `isAutoAnalysis` to SSE handler
- `frontend/app/buscar/hooks/useSearchOrchestration.ts` — pass `isAutoAnalysis: isAutoSearch`
- `frontend/__tests__/onboarding/onboarding-step-tagging.test.tsx` — AC9
- `frontend/__tests__/buscar/first-analysis-completed.test.tsx` — AC9

## Testing Plan

- [ ] Run `npm test -- --testPathPatterns="onboarding-step-tagging|first-analysis-completed"` in CI
- [ ] Verify `claritySet('onboarding_step', '1/3')` fires on Clarity dashboard after step 1
- [ ] Verify `clarityEvent('trial_started')` fires in Clarity session recordings after onboarding submit
- [ ] Verify `first_analysis_completed` event appears in Mixpanel after first search from onboarding
- [ ] Verify `trial_days_remaining` Clarity tag is set for trial users but not admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating auto-analysis Mixpanel lifecycle events and onboarding step Clarity tagging.

* **New Features**
  * Onboarding analytics: emits step progression markers and richer first-analysis signals (completed, empty, failed, timeout/denied).
  * Search auto-analysis: when enabled, triggers a single first-analysis event with timing and result metrics.
  * Analytics enrichment: conditionally reports remaining trial days during user identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Closes

N/A — story CONV-INST-005 (no linked issue)