### PR TITLE
feat(auth): email confirmation lifecycle + DB-backed resend [CONV-INST-003]

### DIFF
--- a/backend/routes/auth_email.py
+++ b/backend/routes/auth_email.py
@@ -2,12 +2,14 @@
 Email confirmation recovery endpoints.
 
 GTM-FIX-009: Fix email confirmation dead end.
+CONV-INST-003: DB-backed resend cooldown (persists across Railway redeploys).
 
 Endpoints:
 - POST /auth/resend-confirmation — Resend signup confirmation email (60s rate limit)
 - GET  /auth/status              — Check if email has been confirmed
 """
 
+import datetime
 import logging
 import time
 from typing import Dict
@@ -21,7 +23,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth-email"])
 
-# In-memory rate-limit store: email -> last_resend_timestamp
+# In-memory fallback: used when Supabase is unavailable (fail-open strategy).
+# Primary cooldown storage is user_email_actions table (CONV-INST-003).
 _resend_timestamps: Dict[str, float] = {}
 RESEND_COOLDOWN = 60  # seconds
 
@@ -38,6 +41,73 @@ class ResendResponse(BaseModel):
 class AuthStatusResponse(BaseModel):
     confirmed: bool
     user_id: str | None = None
+
+
+def _check_resend_cooldown_db(email_lower: str, supabase) -> int | None:
+    """Check resend cooldown from DB. Returns remaining seconds or None if allowed.
+
+    Fails open (returns None / allows) if DB query fails.
+    """
+    try:
+        result = (
+            supabase.table("user_email_actions")
+            .select("created_at")
+            .eq("email", email_lower)
+            .eq("action_type", "resend")
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        rows = getattr(result, "data", []) or []
+        if not rows:
+            return None
+        last_sent_str = rows[0]["created_at"]
+        # Parse ISO timestamp from Supabase (UTC)
+        last_sent = datetime.datetime.fromisoformat(last_sent_str.replace("Z", "+00:00"))
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+        elapsed = (now_utc - last_sent).total_seconds()
+        if elapsed < RESEND_COOLDOWN:
+            return int(RESEND_COOLDOWN - elapsed)
+        return None
+    except Exception as e:
+        logger.warning(f"DB cooldown check failed, falling back to in-memory: {type(e).__name__}")
+        return None
+
+
+def _record_resend_db(email_lower: str, supabase) -> bool:
+    """Record a resend action in DB. Returns True on success."""
+    try:
+        supabase.table("user_email_actions").insert(
+            {"email": email_lower, "action_type": "resend"}
+        ).execute()
+        return True
+    except Exception as e:
+        logger.warning(f"DB resend record failed: {type(e).__name__}")
+        return False
+
+
+def _record_confirm_db(email_lower: str, supabase) -> bool:
+    """Record an email confirmation in DB (idempotent). Returns True if first confirm."""
+    try:
+        # Check if already confirmed
+        result = (
+            supabase.table("user_email_actions")
+            .select("id")
+            .eq("email", email_lower)
+            .eq("action_type", "confirm")
+            .limit(1)
+            .execute()
+        )
+        rows = getattr(result, "data", []) or []
+        if rows:
+            return False  # Already recorded — idempotent
+        supabase.table("user_email_actions").insert(
+            {"email": email_lower, "action_type": "confirm"}
+        ).execute()
+        return True
+    except Exception as e:
+        logger.warning(f"DB confirm record failed: {type(e).__name__}")
+        return False
 
 
 @router.post("/validate-signup-email")
@@ -81,21 +151,36 @@ async def resend_confirmation(
 ):
     """Resend signup confirmation email with 60s rate limiting.
 
+    CONV-INST-003: Cooldown persisted in Supabase user_email_actions table.
+    In-memory _resend_timestamps used as fallback when DB is unavailable.
     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
-    AC4: Calls Supabase auth.resend({ type: 'signup', email }).
-    AC1-AC6: Frontend uses this with countdown timer.
     """
     email_lower = request.email.lower().strip()
     now = time.time()
 
-    # Check rate limit
-    last_sent = _resend_timestamps.get(email_lower)
-    if last_sent and (now - last_sent) < RESEND_COOLDOWN:
-        remaining = int(RESEND_COOLDOWN - (now - last_sent))
-        raise HTTPException(
-            status_code=429,
-            detail=f"Aguarde {remaining}s antes de reenviar."
-        )
+    # Primary: DB-backed cooldown
+    try:
+        from supabase_client import get_supabase
+        supabase = get_supabase()
+
+        remaining = _check_resend_cooldown_db(email_lower, supabase)
+        if remaining is not None:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Aguarde {remaining}s antes de reenviar."
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"DB cooldown check unavailable, using in-memory fallback: {type(e).__name__}")
+        # Fallback to in-memory cooldown
+        last_sent = _resend_timestamps.get(email_lower)
+        if last_sent and (now - last_sent) < RESEND_COOLDOWN:
+            remaining_fallback = int(RESEND_COOLDOWN - (now - last_sent))
+            raise HTTPException(
+                status_code=429,
+                detail=f"Aguarde {remaining_fallback}s antes de reenviar."
+            )
 
     try:
         from supabase_client import get_supabase
@@ -107,7 +192,15 @@ async def resend_confirmation(
         logger.error(f"Failed to resend confirmation: {type(e).__name__}")
         raise HTTPException(status_code=500, detail="Erro ao reenviar email.")
 
-    _resend_timestamps[email_lower] = now
+    # Record in DB (primary); fall back to in-memory if DB fails
+    try:
+        from supabase_client import get_supabase
+        supabase = get_supabase()
+        if not _record_resend_db(email_lower, supabase):
+            _resend_timestamps[email_lower] = now
+    except Exception:
+        _resend_timestamps[email_lower] = now
+
     logger.info(f"Confirmation email resent for {email_lower[:4]}***")
 
     return ResendResponse(
@@ -122,6 +215,8 @@ async def auth_status(email: str = Query(..., description="Email to check")):
 
     AC8: Returns { confirmed: boolean, user_id?: string }.
     AC7/AC9: Frontend polls this every 5s for auto-redirect.
+    CONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side
+    on first confirmation (idempotent via user_email_actions table).
     """
     email_lower = email.lower().strip()
 
@@ -137,6 +232,28 @@ async def auth_status(email: str = Query(..., description="Email to check")):
             if user_email and user_email.lower() == email_lower:
                 confirmed_at = getattr(user, "email_confirmed_at", None)
                 if confirmed_at:
+                    # CONV-INST-003 AC6: Emit server-side analytics on first confirmation.
+                    # Idempotent: _record_confirm_db returns False if already recorded.
+                    try:
+                        from supabase_client import get_supabase as _get_sb
+                        sb = _get_sb()
+                        is_first_confirm = _record_confirm_db(email_lower, sb)
+                        if is_first_confirm:
+                            from analytics_events import track_event
+                            user_id = getattr(user, "id", None)
+                            track_event(
+                                "email_verification_completed",
+                                {
+                                    "user_id": str(user_id) if user_id else "unknown",
+                                    "email_domain": email_lower.split("@")[1],
+                                    "source": "server_side",
+                                },
+                            )
+                    except Exception as e:
+                        logger.debug(
+                            f"Server-side email_verification_completed emit failed: {type(e).__name__}"
+                        )
+
                     # CRIT-SEC: Do NOT expose user_id — prevents enumeration
                     return AuthStatusResponse(
                         confirmed=True,

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -14221,7 +14221,7 @@
     },
     "/v1/auth/resend-confirmation": {
       "post": {
-        "description": "Resend signup confirmation email with 60s rate limiting.\n\nMED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.\nAC4: Calls Supabase auth.resend({ type: 'signup', email }).\nAC1-AC6: Frontend uses this with countdown timer.",
+        "description": "Resend signup confirmation email with 60s rate limiting.\n\nCONV-INST-003: Cooldown persisted in Supabase user_email_actions table.\nIn-memory _resend_timestamps used as fallback when DB is unavailable.\nMED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.",
         "operationId": "resend_confirmation_v1_auth_resend_confirmation_post",
         "requestBody": {
           "content": {
@@ -14305,7 +14305,7 @@
     },
     "/v1/auth/status": {
       "get": {
-        "description": "Check if a signup email has been confirmed.\n\nAC8: Returns { confirmed: boolean, user_id?: string }.\nAC7/AC9: Frontend polls this every 5s for auto-redirect.",
+        "description": "Check if a signup email has been confirmed.\n\nAC8: Returns { confirmed: boolean, user_id?: string }.\nAC7/AC9: Frontend polls this every 5s for auto-redirect.\nCONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side\non first confirmation (idempotent via user_email_actions table).",
         "operationId": "auth_status_v1_auth_status_get",
         "parameters": [
           {

--- a/backend/tests/test_auth_email.py
+++ b/backend/tests/test_auth_email.py
@@ -53,9 +53,36 @@ class TestResendConfirmation:
 
     @patch("supabase_client.get_supabase")
     def test_resend_rate_limited_within_60s(self, mock_get_supabase, client):
-        """Second resend within 60s should be blocked (429)."""
-        mock_supabase = MagicMock()
-        mock_get_supabase.return_value = mock_supabase
+        """Second resend within 60s should be blocked (429).
+
+        CONV-INST-003: Cooldown is now DB-backed. We simulate the sequence by:
+        1st call: DB returns no row → allowed; record inserted.
+        2nd call: DB returns a row 5s ago → still within 60s → 429.
+        """
+        import datetime as dt
+
+        five_secs_ago = (
+            dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=5)
+        ).isoformat()
+
+        call_count = [0]
+
+        def mock_execute():
+            mock_result = MagicMock()
+            if call_count[0] == 0:
+                # First cooldown check: no rows (first resend allowed)
+                mock_result.data = []
+            else:
+                # Subsequent checks: row exists (within cooldown)
+                mock_result.data = [{"created_at": five_secs_ago}]
+            call_count[0] += 1
+            return mock_result
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.side_effect = mock_execute
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+        mock_sb.auth.resend.return_value = None
+        mock_get_supabase.return_value = mock_sb
 
         # First request succeeds
         client.post(
@@ -93,11 +120,35 @@ class TestResendConfirmation:
 
     @patch("supabase_client.get_supabase")
     def test_resend_case_insensitive(self, mock_get_supabase, client):
-        """Rate limiting should be case-insensitive."""
-        mock_supabase = MagicMock()
-        mock_get_supabase.return_value = mock_supabase
+        """Rate limiting should be case-insensitive.
 
-        # First request with lowercase
+        CONV-INST-003: DB-backed cooldown normalizes to lowercase.
+        Simulate: first call no rows, second call finds recent row.
+        """
+        import datetime as dt
+
+        five_secs_ago = (
+            dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=5)
+        ).isoformat()
+
+        call_count = [0]
+
+        def mock_execute():
+            mock_result = MagicMock()
+            if call_count[0] == 0:
+                mock_result.data = []
+            else:
+                mock_result.data = [{"created_at": five_secs_ago}]
+            call_count[0] += 1
+            return mock_result
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.side_effect = mock_execute
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+        mock_sb.auth.resend.return_value = None
+        mock_get_supabase.return_value = mock_sb
+
+        # First request with mixed case
         client.post(
             "/v1/auth/resend-confirmation",
             json={"email": "Test@Example.COM"}

--- a/backend/tests/test_auth_email_resend_cooldown.py
+++ b/backend/tests/test_auth_email_resend_cooldown.py
@@ -1,0 +1,319 @@
+"""
+Tests for CONV-INST-003: DB-backed resend cooldown.
+
+Verifies that:
+- Cooldown is checked against user_email_actions table (not just _resend_timestamps)
+- Fail-open: if DB is down, in-memory fallback is used
+- _record_confirm_db is idempotent (returns False on second call)
+- Server-side Mixpanel event fires on first confirmation only
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch, call
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create test client with auth_email router and clean in-memory state."""
+    from fastapi import FastAPI
+    from routes.auth_email import router, _resend_timestamps
+
+    app = FastAPI()
+    app.include_router(router, prefix="/v1")
+    _resend_timestamps.clear()
+    yield TestClient(app)
+    _resend_timestamps.clear()
+
+
+# ---------------------------------------------------------------------------
+# _check_resend_cooldown_db helpers
+# ---------------------------------------------------------------------------
+
+class TestCheckResendCooldownDb:
+    """Unit tests for _check_resend_cooldown_db helper."""
+
+    def test_no_rows_returns_none(self):
+        """If no DB rows exist, cooldown is not active (allow resend)."""
+        from routes.auth_email import _check_resend_cooldown_db
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = []
+
+        result = _check_resend_cooldown_db("test@example.com", mock_sb)
+        assert result is None
+
+    def test_recent_row_returns_remaining_seconds(self):
+        """If last resend was <60s ago, returns remaining cooldown seconds."""
+        from routes.auth_email import _check_resend_cooldown_db
+
+        # Simulate row created 30 seconds ago
+        thirty_seconds_ago = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=30)
+        ).isoformat()
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = [
+            {"created_at": thirty_seconds_ago}
+        ]
+
+        result = _check_resend_cooldown_db("test@example.com", mock_sb)
+        assert result is not None
+        assert 25 <= result <= 35  # ~30 seconds remaining (with timing tolerance)
+
+    def test_old_row_returns_none(self):
+        """If last resend was >60s ago, cooldown is not active."""
+        from routes.auth_email import _check_resend_cooldown_db
+
+        two_minutes_ago = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=120)
+        ).isoformat()
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = [
+            {"created_at": two_minutes_ago}
+        ]
+
+        result = _check_resend_cooldown_db("test@example.com", mock_sb)
+        assert result is None
+
+    def test_db_exception_returns_none_fail_open(self):
+        """If DB throws, return None (fail-open = allow resend)."""
+        from routes.auth_email import _check_resend_cooldown_db
+
+        mock_sb = MagicMock()
+        mock_sb.table.side_effect = Exception("DB connection error")
+
+        result = _check_resend_cooldown_db("test@example.com", mock_sb)
+        assert result is None  # fail-open
+
+
+# ---------------------------------------------------------------------------
+# _record_resend_db helpers
+# ---------------------------------------------------------------------------
+
+class TestRecordResendDb:
+    """Unit tests for _record_resend_db helper."""
+
+    def test_records_resend_action(self):
+        """Should insert resend action into user_email_actions."""
+        from routes.auth_email import _record_resend_db
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+
+        result = _record_resend_db("test@example.com", mock_sb)
+
+        assert result is True
+        mock_sb.table.assert_called_once_with("user_email_actions")
+        mock_sb.table.return_value.insert.assert_called_once_with(
+            {"email": "test@example.com", "action_type": "resend"}
+        )
+
+    def test_db_exception_returns_false(self):
+        """If DB fails to record, return False (caller falls back to in-memory)."""
+        from routes.auth_email import _record_resend_db
+
+        mock_sb = MagicMock()
+        mock_sb.table.side_effect = Exception("DB error")
+
+        result = _record_resend_db("test@example.com", mock_sb)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _record_confirm_db helpers
+# ---------------------------------------------------------------------------
+
+class TestRecordConfirmDb:
+    """Unit tests for _record_confirm_db helper (idempotency)."""
+
+    def test_first_confirm_inserts_and_returns_true(self):
+        """First confirmation should insert record and return True."""
+        from routes.auth_email import _record_confirm_db
+
+        mock_sb = MagicMock()
+        # No existing confirm row
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value.data = []
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+
+        result = _record_confirm_db("user@example.com", mock_sb)
+        assert result is True
+
+    def test_second_confirm_returns_false_no_insert(self):
+        """Second confirmation should return False without inserting."""
+        from routes.auth_email import _record_confirm_db
+
+        mock_sb = MagicMock()
+        # Existing confirm row found
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value.data = [
+            {"id": 42}
+        ]
+
+        result = _record_confirm_db("user@example.com", mock_sb)
+        assert result is False
+        # insert should NOT have been called
+        mock_sb.table.return_value.insert.assert_not_called()
+
+    def test_db_exception_returns_false(self):
+        """If DB throws on confirm, return False gracefully."""
+        from routes.auth_email import _record_confirm_db
+
+        mock_sb = MagicMock()
+        mock_sb.table.side_effect = Exception("DB error")
+
+        result = _record_confirm_db("user@example.com", mock_sb)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: resend endpoint uses DB-backed cooldown
+# ---------------------------------------------------------------------------
+
+class TestResendCooldownDbBacked:
+    """Integration tests: POST /auth/resend-confirmation reads DB for cooldown."""
+
+    @patch("supabase_client.get_supabase")
+    def test_first_resend_succeeds_db_backed(self, mock_get_supabase, client):
+        """First resend with empty DB should succeed."""
+        mock_sb = MagicMock()
+        # No existing resend rows
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = []
+        # Insert succeeds
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+        mock_sb.auth.resend.return_value = None
+        mock_get_supabase.return_value = mock_sb
+
+        response = client.post(
+            "/v1/auth/resend-confirmation",
+            json={"email": "test@example.com"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    @patch("supabase_client.get_supabase")
+    def test_second_resend_within_60s_blocked(self, mock_get_supabase, client):
+        """Second resend within 60s returns 429 (cooldown from DB)."""
+        import datetime as dt
+
+        # Simulate row created 10 seconds ago
+        ten_secs_ago = (
+            dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=10)
+        ).isoformat()
+
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = [
+            {"created_at": ten_secs_ago}
+        ]
+        mock_get_supabase.return_value = mock_sb
+
+        response = client.post(
+            "/v1/auth/resend-confirmation",
+            json={"email": "test@example.com"}
+        )
+
+        assert response.status_code == 429
+        assert "aguarde" in response.json()["detail"].lower()
+
+    @patch("supabase_client.get_supabase")
+    def test_resend_db_down_uses_inmemory_fallback(self, mock_get_supabase, client):
+        """If DB is down, in-memory fallback is used (fail-open for resend)."""
+        mock_sb = MagicMock()
+        # DB fails for cooldown check → should fall through to in-memory
+        mock_sb.table.side_effect = Exception("DB connection failed")
+        mock_get_supabase.side_effect = Exception("DB unavailable")
+
+        # With no in-memory state, first request should succeed (fail-open)
+        # But supabase.auth.resend also fails — so 500 is expected here
+        response = client.post(
+            "/v1/auth/resend-confirmation",
+            json={"email": "test@example.com"}
+        )
+
+        # The endpoint will fail at auth.resend (also DB-backed), which raises 500
+        # What matters: the cooldown check did NOT block with 429
+        assert response.status_code != 429
+
+    @patch("supabase_client.get_supabase")
+    def test_resend_records_db_action(self, mock_get_supabase, client):
+        """Successful resend should INSERT a row in user_email_actions."""
+        mock_sb = MagicMock()
+        # Empty cooldown
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = []
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+        mock_sb.auth.resend.return_value = None
+        mock_get_supabase.return_value = mock_sb
+
+        response = client.post(
+            "/v1/auth/resend-confirmation",
+            json={"email": "store@example.com"}
+        )
+
+        assert response.status_code == 200
+        # Insert was called
+        mock_sb.table.return_value.insert.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration: /auth/status fires Mixpanel on first confirm only
+# ---------------------------------------------------------------------------
+
+class TestAuthStatusServerSideEvent:
+    """AC6: Server-side Mixpanel email_verification_completed on first confirm."""
+
+    @patch("analytics_events.track_event")
+    @patch("supabase_client.get_supabase")
+    def test_first_confirm_fires_mixpanel_event(
+        self, mock_get_supabase, mock_track_event, client
+    ):
+        """First polling confirm → Mixpanel event fired once."""
+        mock_user = MagicMock()
+        mock_user.email = "newuser@example.com"
+        mock_user.email_confirmed_at = "2026-04-30T12:00:00Z"
+        mock_user.id = "user-abc-123"
+
+        mock_sb = MagicMock()
+        mock_sb.auth.admin.list_users.return_value = [mock_user]
+        # No existing confirm row (first time)
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value.data = []
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+        mock_get_supabase.return_value = mock_sb
+
+        response = client.get("/v1/auth/status?email=newuser@example.com")
+
+        assert response.status_code == 200
+        assert response.json()["confirmed"] is True
+        mock_track_event.assert_called_once()
+        call_args = mock_track_event.call_args
+        assert call_args[0][0] == "email_verification_completed"
+        props = call_args[0][1]
+        assert props["email_domain"] == "example.com"
+        assert props["source"] == "server_side"
+
+    @patch("analytics_events.track_event")
+    @patch("supabase_client.get_supabase")
+    def test_second_polling_confirm_does_not_re_fire_event(
+        self, mock_get_supabase, mock_track_event, client
+    ):
+        """Second poll after already confirmed → Mixpanel event NOT fired again."""
+        mock_user = MagicMock()
+        mock_user.email = "repeat@example.com"
+        mock_user.email_confirmed_at = "2026-04-30T12:00:00Z"
+        mock_user.id = "user-xyz-999"
+
+        mock_sb = MagicMock()
+        mock_sb.auth.admin.list_users.return_value = [mock_user]
+        # Existing confirm row (already emitted)
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value.data = [
+            {"id": 5}
+        ]
+        mock_get_supabase.return_value = mock_sb
+
+        response = client.get("/v1/auth/status?email=repeat@example.com")
+
+        assert response.status_code == 200
+        assert response.json()["confirmed"] is True
+        mock_track_event.assert_not_called()

--- a/frontend/__tests__/signup/SignupSuccess.test.tsx
+++ b/frontend/__tests__/signup/SignupSuccess.test.tsx
@@ -13,7 +13,7 @@ import { render, screen, act } from "@testing-library/react";
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 const mockTrackEvent = jest.fn();
-jest.mock("../../../hooks/useAnalytics", () => ({
+jest.mock("../../hooks/useAnalytics", () => ({
   useAnalytics: () => ({ trackEvent: mockTrackEvent }),
 }));
 
@@ -27,7 +27,7 @@ jest.mock("next/link", () => {
 });
 
 // EmailDeadEndModal: stub so we don't need to test its internals here
-jest.mock("../../../app/signup/components/EmailDeadEndModal", () => ({
+jest.mock("../../app/signup/components/EmailDeadEndModal", () => ({
   EmailDeadEndModal: ({ onClose }: { onClose: () => void }) => (
     <div data-testid="email-dead-end-modal">
       <button onClick={onClose}>Close</button>

--- a/frontend/__tests__/signup/SignupSuccess.test.tsx
+++ b/frontend/__tests__/signup/SignupSuccess.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * CONV-INST-003 AC1+AC8: SignupSuccess component instrumentation tests.
+ *
+ * AC1: email_verification_pending fires ONCE on mount (useRef gate).
+ * AC8: Required test as per story acceptance criteria.
+ *
+ * Pattern: render <SignupSuccess> with mocked useAnalytics, assert event fired exactly once.
+ */
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockTrackEvent = jest.fn();
+jest.mock("../../../hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ trackEvent: mockTrackEvent }),
+}));
+
+// next/link: render as <a> to avoid router context requirement
+jest.mock("next/link", () => {
+  const MockLink = ({ href, children, ...rest }: { href: string; children: React.ReactNode; [k: string]: unknown }) => (
+    <a href={href} {...rest}>{children}</a>
+  );
+  MockLink.displayName = "MockLink";
+  return MockLink;
+});
+
+// EmailDeadEndModal: stub so we don't need to test its internals here
+jest.mock("../../../app/signup/components/EmailDeadEndModal", () => ({
+  EmailDeadEndModal: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="email-dead-end-modal">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+import { SignupSuccess } from "../../app/signup/components/SignupSuccess";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderSuccess(overrides: Partial<Parameters<typeof SignupSuccess>[0]> = {}) {
+  const defaults = {
+    email: "test@example.com",
+    isConfirmed: false,
+    countdown: 60,
+    isResending: false,
+    onResend: jest.fn(),
+    onChangeEmail: jest.fn(),
+    signupStartedAt: Date.now(),
+    rolloutBranch: "legacy",
+  };
+  return render(<SignupSuccess {...defaults} {...overrides} />);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("SignupSuccess — AC1: email_verification_pending", () => {
+  it("fires email_verification_pending ONCE on mount", () => {
+    renderSuccess();
+
+    const calls = mockTrackEvent.mock.calls.filter(
+      (c: unknown[]) => c[0] === "email_verification_pending"
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  it("includes email_domain (not full email) in payload — LGPD compliance", () => {
+    renderSuccess({ email: "user@smartlic.tech", rolloutBranch: "legacy" });
+
+    const call = mockTrackEvent.mock.calls.find(
+      (c: unknown[]) => c[0] === "email_verification_pending"
+    );
+    expect(call).toBeDefined();
+    const payload = call![1] as Record<string, unknown>;
+    expect(payload.email_domain).toBe("smartlic.tech");
+    // Must NOT contain the full email
+    expect(JSON.stringify(payload)).not.toContain("user@smartlic.tech");
+  });
+
+  it("includes rollout_branch and signup_method in payload", () => {
+    renderSuccess({ rolloutBranch: "card" });
+
+    const call = mockTrackEvent.mock.calls.find(
+      (c: unknown[]) => c[0] === "email_verification_pending"
+    );
+    expect(call).toBeDefined();
+    const payload = call![1] as Record<string, unknown>;
+    expect(payload.rollout_branch).toBe("card");
+    expect(payload.signup_method).toBe("email");
+  });
+
+  it("does NOT fire email_verification_pending twice on re-render", () => {
+    const { rerender } = renderSuccess({ countdown: 60 });
+    rerender(
+      <SignupSuccess
+        email="test@example.com"
+        isConfirmed={false}
+        countdown={59}
+        isResending={false}
+        onResend={jest.fn()}
+        onChangeEmail={jest.fn()}
+        signupStartedAt={Date.now()}
+        rolloutBranch="legacy"
+      />
+    );
+
+    const pendingCalls = mockTrackEvent.mock.calls.filter(
+      (c: unknown[]) => c[0] === "email_verification_pending"
+    );
+    expect(pendingCalls).toHaveLength(1); // Still exactly 1 — useRef gate works
+  });
+
+  it("shows mail icon and polling indicator when not confirmed", () => {
+    renderSuccess();
+    expect(screen.getByTestId("mail-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("polling-indicator")).toBeInTheDocument();
+  });
+
+  it("shows confirmed icon when isConfirmed=true", () => {
+    renderSuccess({ isConfirmed: true });
+    expect(screen.getByTestId("confirmed-icon")).toBeInTheDocument();
+  });
+});
+
+describe("SignupSuccess — confirmed state does not fire pending", () => {
+  it("still fires pending when isConfirmed=true (mount is before confirmation UI change)", () => {
+    renderSuccess({ isConfirmed: true });
+    // The pending event fires on mount regardless of isConfirmed
+    // (component was just mounted after signup, regardless of polling state)
+    const pendingCalls = mockTrackEvent.mock.calls.filter(
+      (c: unknown[]) => c[0] === "email_verification_pending"
+    );
+    expect(pendingCalls).toHaveLength(1);
+  });
+});

--- a/frontend/__tests__/signup/email-confirmation-flow.test.tsx
+++ b/frontend/__tests__/signup/email-confirmation-flow.test.tsx
@@ -16,7 +16,7 @@ import userEvent from "@testing-library/user-event";
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 const mockTrackEvent = jest.fn();
-jest.mock("../../../hooks/useAnalytics", () => ({
+jest.mock("../../hooks/useAnalytics", () => ({
   useAnalytics: () => ({ trackEvent: mockTrackEvent }),
 }));
 

--- a/frontend/__tests__/signup/email-confirmation-flow.test.tsx
+++ b/frontend/__tests__/signup/email-confirmation-flow.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * CONV-INST-003 AC3+AC8: Email confirmation flow — 5-min timeout → modal + event.
+ *
+ * Uses jest.useFakeTimers() to advance 5 minutes and assert:
+ *   - email_verification_timeout event fires
+ *   - <EmailDeadEndModal> becomes visible
+ *
+ * Per advisor: wrap timer advance in `act(async () => { jest.advanceTimersByTime(...) })`
+ * and flush microtasks after to avoid spurious failures.
+ */
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockTrackEvent = jest.fn();
+jest.mock("../../../hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ trackEvent: mockTrackEvent }),
+}));
+
+jest.mock("next/link", () => {
+  const MockLink = ({ href, children, ...rest }: { href: string; children: React.ReactNode; [k: string]: unknown }) => (
+    <a href={href} {...rest}>{children}</a>
+  );
+  MockLink.displayName = "MockLink";
+  return MockLink;
+});
+
+// Use real EmailDeadEndModal so we can assert its presence
+// but mock next/link inside it via the above mock already registered.
+
+import { SignupSuccess } from "../../app/signup/components/SignupSuccess";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const DEFAULT_PROPS = {
+  email: "user@acme.com",
+  isConfirmed: false,
+  countdown: 60,
+  isResending: false,
+  onResend: jest.fn(),
+  onChangeEmail: jest.fn(),
+  rolloutBranch: "legacy" as const,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("Email confirmation flow — 5-minute timeout", () => {
+  it("does NOT show dead-end modal before 5 minutes", () => {
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={Date.now()}
+      />
+    );
+
+    // Advance 4 minutes — modal should NOT appear
+    act(() => {
+      jest.advanceTimersByTime(4 * 60 * 1000);
+    });
+
+    expect(screen.queryByTestId("email-dead-end-modal")).not.toBeInTheDocument();
+  });
+
+  it("shows dead-end modal after 5 minutes without confirmation", async () => {
+    const startedAt = Date.now();
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={startedAt}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS + 100);
+      await Promise.resolve(); // flush microtasks
+    });
+
+    expect(screen.getByTestId("email-dead-end-modal")).toBeInTheDocument();
+  });
+
+  it("fires email_verification_timeout event at 5 minutes", async () => {
+    const startedAt = Date.now();
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={startedAt}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS + 100);
+      await Promise.resolve();
+    });
+
+    const timeoutCalls = mockTrackEvent.mock.calls.filter(
+      (c: unknown[]) => c[0] === "email_verification_timeout"
+    );
+    expect(timeoutCalls).toHaveLength(1);
+    const payload = timeoutCalls[0][1] as Record<string, unknown>;
+    expect(payload.email_domain).toBe("acme.com");
+  });
+
+  it("fires email_verification_timeout only ONCE (not twice)", async () => {
+    const startedAt = Date.now();
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={startedAt}
+      />
+    );
+
+    // Advance twice past 5 minutes
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS + 100);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS);
+      await Promise.resolve();
+    });
+
+    const timeoutCalls = mockTrackEvent.mock.calls.filter(
+      (c: unknown[]) => c[0] === "email_verification_timeout"
+    );
+    expect(timeoutCalls).toHaveLength(1); // timeoutFiredRef prevents double-fire
+  });
+
+  it("does NOT fire timeout if email is confirmed before 5 minutes", async () => {
+    const { rerender } = render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={Date.now()}
+        isConfirmed={false}
+      />
+    );
+
+    // Confirm at 3 minutes
+    act(() => {
+      jest.advanceTimersByTime(3 * 60 * 1000);
+    });
+
+    rerender(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={Date.now() - 3 * 60 * 1000}
+        isConfirmed={true}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(3 * 60 * 1000); // advance past original 5min
+      await Promise.resolve();
+    });
+
+    const timeoutCalls = mockTrackEvent.mock.calls.filter(
+      (c: unknown[]) => c[0] === "email_verification_timeout"
+    );
+    expect(timeoutCalls).toHaveLength(0);
+    expect(screen.queryByTestId("email-dead-end-modal")).not.toBeInTheDocument();
+  });
+
+  it("modal has 3 actions: check spam, resend, support link", async () => {
+    const startedAt = Date.now();
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={startedAt}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS + 100);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("email-dead-end-modal")).toBeInTheDocument();
+    // (a) Verificar SPAM
+    expect(screen.getByTestId("dead-end-check-spam")).toBeInTheDocument();
+    // (b) Reenviar email
+    expect(screen.getByTestId("dead-end-resend")).toBeInTheDocument();
+    // (c) Falar com suporte
+    expect(screen.getByTestId("dead-end-support")).toBeInTheDocument();
+  });
+
+  it("modal closes on ESC key", async () => {
+    const startedAt = Date.now();
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={startedAt}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS + 100);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("email-dead-end-modal")).toBeInTheDocument();
+
+    await act(async () => {
+      const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true });
+      document.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId("email-dead-end-modal")).not.toBeInTheDocument();
+  });
+});
+
+describe("EmailDeadEndModal — accessibility", () => {
+  it("has role=dialog and aria-modal attributes", async () => {
+    const startedAt = Date.now();
+    render(
+      <SignupSuccess
+        {...DEFAULT_PROPS}
+        signupStartedAt={startedAt}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(FIVE_MINUTES_MS + 100);
+      await Promise.resolve();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -1750,9 +1750,9 @@ export interface paths {
          * Resend Confirmation
          * @description Resend signup confirmation email with 60s rate limiting.
          *
+         *     CONV-INST-003: Cooldown persisted in Supabase user_email_actions table.
+         *     In-memory _resend_timestamps used as fallback when DB is unavailable.
          *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
-         *     AC4: Calls Supabase auth.resend({ type: 'signup', email }).
-         *     AC1-AC6: Frontend uses this with countdown timer.
          */
         post: operations["resend_confirmation_v1_auth_resend_confirmation_post"];
         delete?: never;
@@ -1801,6 +1801,8 @@ export interface paths {
          *
          *     AC8: Returns { confirmed: boolean, user_id?: string }.
          *     AC7/AC9: Frontend polls this every 5s for auto-redirect.
+         *     CONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side
+         *     on first confirmation (idempotent via user_email_actions table).
          */
         get: operations["auth_status_v1_auth_status_get"];
         put?: never;

--- a/frontend/app/signup/components/EmailDeadEndModal.tsx
+++ b/frontend/app/signup/components/EmailDeadEndModal.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import Link from "next/link";
+
+interface EmailDeadEndModalProps {
+  onClose: () => void;
+  onResend: () => void;
+  isResending: boolean;
+  countdown: number;
+}
+
+/**
+ * CONV-INST-003 AC3: Dead-end modal shown after 5min without email confirmation.
+ *
+ * Accessibility: role="dialog", aria-modal, aria-labelledby, ESC key, focus trap.
+ * LGPD: no full email logged or displayed in tracking events.
+ */
+export function EmailDeadEndModal({
+  onClose,
+  onResend,
+  isResending,
+  countdown,
+}: EmailDeadEndModalProps) {
+  const headingId = "email-dead-end-title";
+  const firstFocusRef = useRef<HTMLButtonElement>(null);
+  const lastFocusRef = useRef<HTMLAnchorElement>(null);
+
+  // Focus first element on mount
+  useEffect(() => {
+    firstFocusRef.current?.focus();
+  }, []);
+
+  // ESC key closes modal
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  // Focus trap: Tab cycles within modal
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "Tab") return;
+    const focusable = [firstFocusRef.current, lastFocusRef.current].filter(Boolean);
+    if (focusable.length < 2) return;
+    if (e.shiftKey) {
+      if (document.activeElement === focusable[0]) {
+        e.preventDefault();
+        focusable[focusable.length - 1]?.focus();
+      }
+    } else {
+      if (document.activeElement === focusable[focusable.length - 1]) {
+        e.preventDefault();
+        focusable[0]?.focus();
+      }
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      aria-hidden="false"
+      data-testid="email-dead-end-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        className="relative w-full max-w-sm mx-4 bg-surface-0 rounded-card shadow-xl p-6"
+        onKeyDown={handleKeyDown}
+        data-testid="email-dead-end-modal"
+      >
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          aria-label="Fechar"
+          className="absolute top-3 right-3 text-ink-muted hover:text-ink text-xl leading-none"
+        >
+          &times;
+        </button>
+
+        {/* Icon */}
+        <div className="text-3xl text-center mb-3" aria-hidden="true">
+          &#9993;
+        </div>
+
+        {/* Headline */}
+        <h2
+          id={headingId}
+          className="text-lg font-semibold text-ink text-center mb-2"
+        >
+          Email não chegou?
+        </h2>
+
+        <p className="text-sm text-ink-secondary text-center mb-5">
+          Já se passaram 5 minutos. Tente uma das opções abaixo:
+        </p>
+
+        {/* Action (a): Check spam */}
+        <button
+          ref={firstFocusRef}
+          data-testid="dead-end-check-spam"
+          className="w-full py-2.5 mb-2 border border-divider rounded-button text-sm
+                     text-ink hover:bg-surface-1 transition-colors"
+          onClick={onClose}
+        >
+          Verificar SPAM
+        </button>
+
+        {/* Action (b): Resend email */}
+        <button
+          data-testid="dead-end-resend"
+          disabled={countdown > 0 || isResending}
+          onClick={() => {
+            onResend();
+            onClose();
+          }}
+          className="w-full py-2.5 mb-2 bg-brand-blue text-white rounded-button text-sm
+                     font-semibold disabled:bg-gray-300 disabled:text-gray-500
+                     disabled:cursor-not-allowed hover:opacity-90 transition-colors"
+        >
+          {isResending
+            ? "Reenviando..."
+            : countdown > 0
+              ? `Reenviar em ${countdown}s`
+              : "Reenviar email"}
+        </button>
+
+        {/* Action (c): Support */}
+        <Link
+          ref={lastFocusRef}
+          href="/ajuda"
+          data-testid="dead-end-support"
+          className="block w-full py-2.5 border border-divider rounded-button text-sm
+                     text-ink-secondary text-center hover:bg-surface-1 transition-colors"
+        >
+          Falar com suporte
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/signup/components/SignupSuccess.tsx
+++ b/frontend/app/signup/components/SignupSuccess.tsx
@@ -1,4 +1,9 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { useAnalytics } from "../../../hooks/useAnalytics";
+import { EmailDeadEndModal } from "./EmailDeadEndModal";
 
 interface SignupSuccessProps {
   email: string;
@@ -7,7 +12,17 @@ interface SignupSuccessProps {
   isResending: boolean;
   onResend: () => void;
   onChangeEmail: () => void;
+  /** Timestamp (ms) when setSuccess(true) was called — used for timeout calculation. */
+  signupStartedAt: number;
+  /** Rollout branch from page.tsx state — included in email_verification_pending event. */
+  rolloutBranch?: string | null;
+  /** Shared ref so page.tsx polling increments and SignupSuccess reads. */
+  pollingIterationsRef?: React.MutableRefObject<number>;
+  /** Shared ref updated by page.tsx handleResend — used in timeout event payload. */
+  lastResendAtRef?: React.MutableRefObject<number | null>;
 }
+
+const TIMEOUT_5MIN_MS = 5 * 60 * 1000;
 
 export function SignupSuccess({
   email,
@@ -16,9 +31,84 @@ export function SignupSuccess({
   isResending,
   onResend,
   onChangeEmail,
+  signupStartedAt,
+  rolloutBranch,
+  pollingIterationsRef,
+  lastResendAtRef,
 }: SignupSuccessProps) {
+  const { trackEvent } = useAnalytics();
+  const pendingFiredRef = useRef(false);
+  const timeoutFiredRef = useRef(false);
+  const [showDeadEndModal, setShowDeadEndModal] = useState(false);
+  const emailDomain = email.split("@")[1] ?? "";
+
+  // AC1: Fire email_verification_pending ONCE on mount.
+  // useRef gate prevents double-fire in React StrictMode.
+  // LGPD: only email_domain is logged, never full email.
+  useEffect(() => {
+    if (pendingFiredRef.current) return;
+    pendingFiredRef.current = true;
+    trackEvent("email_verification_pending", {
+      email_domain: emailDomain,
+      rollout_branch: rolloutBranch ?? "unknown",
+      signup_method: "email", // Google OAuth goes through /auth/callback — never reaches this screen
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // AC3: After 5min without confirmation, fire timeout event + show dead-end modal.
+  useEffect(() => {
+    if (isConfirmed || timeoutFiredRef.current) return;
+
+    const elapsed = Date.now() - signupStartedAt;
+    const remainingMs = TIMEOUT_5MIN_MS - elapsed;
+    if (remainingMs <= 0) {
+      // Already past 5min (e.g. component remounted) — fire immediately
+      if (!timeoutFiredRef.current) {
+        timeoutFiredRef.current = true;
+        const lastResendMs = lastResendAtRef?.current
+          ? Date.now() - lastResendAtRef.current
+          : null;
+        trackEvent("email_verification_timeout", {
+          email_domain: emailDomain,
+          polling_iterations: pollingIterationsRef?.current ?? 0,
+          last_resend_attempt_ms_ago: lastResendMs,
+        });
+        setShowDeadEndModal(true);
+      }
+      return;
+    }
+
+    const timerId = setTimeout(() => {
+      if (isConfirmed || timeoutFiredRef.current) return;
+      timeoutFiredRef.current = true;
+
+      const lastResendMs = lastResendAtRef?.current
+        ? Date.now() - lastResendAtRef.current
+        : null;
+
+      trackEvent("email_verification_timeout", {
+        email_domain: emailDomain,
+        polling_iterations: pollingIterationsRef?.current ?? 0,
+        last_resend_attempt_ms_ago: lastResendMs,
+      });
+
+      setShowDeadEndModal(true);
+    }, remainingMs);
+
+    return () => clearTimeout(timerId);
+  }, [isConfirmed]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-canvas">
+      {showDeadEndModal && (
+        <EmailDeadEndModal
+          onClose={() => setShowDeadEndModal(false)}
+          onResend={onResend}
+          isResending={isResending}
+          countdown={countdown}
+        />
+      )}
+
       <div className="w-full max-w-md p-8 bg-surface-0 rounded-card shadow-lg text-center">
         {/* AC10: Confirmed transition */}
         {isConfirmed ? (

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import * as Sentry from "@sentry/nextjs";
 import { useAuth } from "../components/AuthProvider";
 import { useAnalytics, getStoredUTMParams } from "../../hooks/useAnalytics";
 import { translateAuthError } from "../../lib/error-messages";
@@ -72,6 +73,14 @@ export default function SignupPage() {
   const [isResending, setIsResending] = useState(false);
   const [isConfirmed, setIsConfirmed] = useState(false);
 
+  // CONV-INST-003: Timestamp when success screen was shown (for 5-min timeout calculation)
+  const [signupStartedAt, setSignupStartedAt] = useState<number>(0);
+  // Shared refs for SignupSuccess instrumentation
+  const pollingIterationsRef = useRef<number>(0);
+  const lastResendAtRef = useRef<number | null>(null);
+  // Tracks resend attempt count for email_verification_resent event
+  const resendAttemptRef = useRef<number>(0);
+
   const passwordMeetsPolicy =
     password.length >= 8 && /[A-Z]/.test(password) && /\d/.test(password);
   const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -93,31 +102,63 @@ export default function SignupPage() {
   }, [success, countdown]);
 
   // GTM-FIX-009 AC7/AC9: Poll for confirmation every 5s
+  // CONV-INST-003 AC2+AC7: Instrument polling — track iterations and fire
+  // email_verification_completed + email_verification_pending events.
   useEffect(() => {
     if (!success || isConfirmed) return;
+    const pollingStarted = signupStartedAt || Date.now();
     const interval = setInterval(async () => {
+      pollingIterationsRef.current += 1;
       try {
         const response = await fetch(
           `/api/auth/status?email=${encodeURIComponent(email)}`
         );
         const data = await response.json();
         if (data.confirmed) {
+          // AC2: Fire email_verification_completed
+          trackEvent("email_verification_completed", {
+            time_to_confirm_ms: Date.now() - pollingStarted,
+            email_domain: email.split("@")[1] ?? "",
+            polling_iterations: pollingIterationsRef.current,
+          });
           setIsConfirmed(true);
           clearInterval(interval);
           toast.success("Email confirmado! Redirecionando...");
           setTimeout(() => router.push("/onboarding"), 1500);
         }
       } catch {
-        // Silently retry on next interval
+        // AC7: Sentry breadcrumb on polling silent catch — NOT captureException (noise)
+        try {
+          Sentry.addBreadcrumb({
+            category: "auth",
+            message: "email_polling_iteration_failed",
+            level: "info",
+          });
+        } catch {
+          // Sentry unavailable — ignore
+        }
       }
     }, 5000);
     return () => clearInterval(interval);
-  }, [success, isConfirmed, email, router]);
+  }, [success, isConfirmed, email, router]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // GTM-FIX-009 AC3/AC5: Resend handler
+  // CONV-INST-003 AC4: Track email_verification_resent on each call
   const handleResend = async () => {
     if (countdown > 0 || isResending) return;
     setIsResending(true);
+    resendAttemptRef.current += 1;
+    const attemptNumber = resendAttemptRef.current;
+    const timeSinceSignupMs = signupStartedAt ? Date.now() - signupStartedAt : 0;
+
+    // AC4: Track before network call (captures attempt even if request fails)
+    trackEvent("email_verification_resent", {
+      email_domain: email.split("@")[1] ?? "",
+      attempt_number: attemptNumber,
+      time_since_signup_ms: timeSinceSignupMs,
+      success: false, // will be overridden below if ok
+    });
+
     try {
       const response = await fetch("/api/auth/resend-confirmation", {
         method: "POST",
@@ -125,6 +166,14 @@ export default function SignupPage() {
         body: JSON.stringify({ email }),
       });
       if (response.ok) {
+        lastResendAtRef.current = Date.now();
+        // AC4: Re-fire with success=true
+        trackEvent("email_verification_resent", {
+          email_domain: email.split("@")[1] ?? "",
+          attempt_number: attemptNumber,
+          time_since_signup_ms: timeSinceSignupMs,
+          success: true,
+        });
         toast.success("Email reenviado! Verifique sua caixa de entrada.");
         setCountdown(60); // AC5: Reset countdown
       } else {
@@ -142,6 +191,7 @@ export default function SignupPage() {
   // the card branch is disabled (PCT=0).
   const runLegacySignup = async (data: SignupFormData) => {
     await signUpWithEmail(data.email, data.password, data.fullName);
+    setSignupStartedAt(Date.now()); // CONV-INST-003: capture before setSuccess
     setSuccess(true);
     trackEvent('signup_completed', {
       method: "email",
@@ -167,6 +217,7 @@ export default function SignupPage() {
       const body = await res.json().catch(() => ({}));
       throw new Error(body?.detail ?? `signup-trial falhou (${res.status})`);
     }
+    setSignupStartedAt(Date.now()); // CONV-INST-003: capture before setSuccess
     setSuccess(true);
     trackEvent('signup_completed', {
       method: "email",
@@ -325,6 +376,10 @@ export default function SignupPage() {
           setSuccess(false);
           setCountdown(60);
         }}
+        signupStartedAt={signupStartedAt}
+        rolloutBranch={rolloutBranch}
+        pollingIterationsRef={pollingIterationsRef}
+        lastResendAtRef={lastResendAtRef}
       />
     );
   }

--- a/supabase/migrations/20260430120000_user_email_actions.down.sql
+++ b/supabase/migrations/20260430120000_user_email_actions.down.sql
@@ -1,0 +1,2 @@
+-- 20260430120000_user_email_actions.down.sql
+DROP TABLE IF EXISTS public.user_email_actions CASCADE;

--- a/supabase/migrations/20260430120000_user_email_actions.sql
+++ b/supabase/migrations/20260430120000_user_email_actions.sql
@@ -1,0 +1,21 @@
+-- 20260430120000_user_email_actions.sql
+-- CONV-INST-003: Persist email resend cooldown + confirm events in DB
+-- so they survive Railway redeploys (previously in-memory _resend_timestamps reset 2-3x/week).
+CREATE TABLE IF NOT EXISTS public.user_email_actions (
+  id BIGSERIAL PRIMARY KEY,
+  email TEXT NOT NULL,
+  action_type TEXT NOT NULL CHECK (action_type IN ('resend','confirm')),
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_email_actions_email_created
+  ON public.user_email_actions (email, created_at DESC);
+
+ALTER TABLE public.user_email_actions ENABLE ROW LEVEL SECURITY;
+
+-- service_role only (backend writes); deny anon/authenticated direct access
+CREATE POLICY "service_role_insert" ON public.user_email_actions
+  FOR INSERT TO service_role WITH CHECK (true);
+
+CREATE POLICY "service_role_select" ON public.user_email_actions
+  FOR SELECT TO service_role USING (true);


### PR DESCRIPTION
## Summary

Instruments the email confirmation flow (lifecycle events + 5-min UI dead-end modal) and migrates the resend cooldown from an in-memory dict (reset on every Railway redeploy 2-3x/week) to a Supabase table. Replaces silent polling catch with Sentry breadcrumb.

## Context

EPIC-CONV-DIAG-2026-04-30 W1 story CONV-INST-003. 3 surfaces: migration + backend + frontend.

**AC6 server-side webhook recon:** No Supabase auth webhook handler exists in `webhooks/handlers/`. Pragmatic interpretation used: server-side `email_verification_completed` is emitted from the existing `/auth/status` endpoint when `confirmed: true` is first detected. Idempotency via `user_email_actions` table (inserts `action_type='confirm'`, skips emit if row already exists). Uses existing `analytics_events.track_event()` (fire-and-forget, lazy-inits Mixpanel, never raises).

**Migration discipline (memory `reference_supabase_down_sql_schema_conflict.md`):** Paired `.sql` + `.down.sql` committed but `supabase db push` NOT run here — orchestrator/CI applies via `deploy.yml`.

**Fail-open design:** In-memory `_resend_timestamps` retained as fallback. If Supabase is down during cooldown check, code falls through to in-memory map instead of blocking the user. Cooldown is a UX guard, not a security boundary (IP rate-limit via `require_rate_limit` is the real abuse defense).

## Migration

- `20260430120000_user_email_actions.sql` (+ paired `.down.sql`)
- RLS: service_role only (backend INSERT/SELECT)
- Cooldown 60s persists across Railway deploys

## Testing Plan

- [x] 15 new backend tests: cooldown helper units + DB-backed integration + server-side event idempotency — 15/15 pass
- [x] 12 existing `test_auth_email.py` tests updated for DB-backed cooldown — 12/12 still pass
- [x] Frontend: SignupSuccess.test — mount fires email_verification_pending 1x (useRef gate), LGPD compliance (no full email in payload)
- [x] Frontend: email-confirmation-flow.test — fake timers 5min → modal visible + email_verification_timeout fires
- [x] LGPD: only email_domain in all event payloads, never full email address
- [x] Sentry breadcrumb (not exception) on polling silent catch
- [x] Modal a11y: role=dialog, aria-modal=true, aria-labelledby, ESC closes, focus trap

## Closes

CONV-INST-003 (EPIC-CONV-DIAG-2026-04-30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side 60s resend cooldown (DB-persisted with resilient fallback).
  * Dismissible "Email não chegou?" modal after 5 minutes with resend and support actions.
  * Enhanced confirmation polling and analytics: timing, attempt counts, and resend tracking.

* **Bug Fixes**
  * Confirmation completion recorded idempotently; completion analytics fire only once.
  * Improved error handling and quieter logging on transient failures.

* **Tests**
  * Expanded tests for resend cooldown, confirmation idempotency, polling, timeout, and modal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->