### PR TITLE
feat(frontend): cherry-pick safeFetch+fetchWithBudget to main (FOUND-SCALE-002)

### DIFF
--- a/docs/audit/frontend-sentry-init-status.md
+++ b/docs/audit/frontend-sentry-init-status.md
@@ -1,0 +1,100 @@
+# Audit: Frontend Sentry SDK Init Status (FOUND-SCALE-002 AC1)
+
+**Date:** 2026-04-29
+**Story:** [FOUND-SCALE-002](../stories/2026-04/FOUND-SCALE-002-frontend-sentry-ssg-isr-init.story.md)
+**Trigger:** memory `feedback_frontend_sentry_silent_buildtime` — 0 events em 24h apesar de sitemap-4.xml=0 confirmado em prod (Stage 7 wedge 2026-04-29).
+
+---
+
+## Resumo Executivo
+
+**Status do gap original:** PARCIALMENTE FECHADO antes desta story.
+
+Investigação empírica revela que **a maior parte da infra Sentry SSG/ISR já estava ativa** mas faltavam wrappers reusáveis para fetches críticos fora do `sitemap.ts` (cnpj/[cnpj], orgaos/[slug], itens/[catmat]). Esta story fecha esse gap via `frontend/lib/safe-fetch.ts::safeFetch` + `fetchWithBudget`.
+
+---
+
+## Estado pré-FOUND-SCALE-002
+
+### ✅ Sentry SDK config — todos 3 runtimes inicializados
+
+| Arquivo | Status | DSN env var | Notes |
+|---------|--------|-------------|-------|
+| `frontend/sentry.server.config.ts` | ✅ existe (13 LOC) | `SENTRY_DSN` | tracesSampleRate 0.1 |
+| `frontend/sentry.client.config.ts` | ✅ existe (58 LOC) | `NEXT_PUBLIC_SENTRY_DSN` | beforeSend filter sofisticado (STORY-422 — drop USER_CANCELLED, AbortError, SSE pipe errors com timeout >110s) |
+| `frontend/sentry.edge.config.ts` | ✅ existe (12 LOC) | `SENTRY_DSN` | Edge runtime |
+
+### ✅ instrumentation.ts (Next.js 13+ pattern)
+
+`frontend/instrumentation.ts` — 36 LOC.
+
+- `register()` async importa sentry configs dinamicamente per runtime (nodejs / edge)
+- **Linhas 14-31:** valida BACKEND_URL no startup. Se vazio ou formato inválido, loga CRÍTICO + propaga para startup fail. Já cobre AC2 (build-time SSG init validation).
+- `onRequestError = Sentry.captureRequestError` ativa capture automático para Server Components + API routes.
+
+### ✅ next.config.js Sentry wrapper
+
+- `withSentryConfig()` ativo (linha 113)
+- Source map upload configurado: `tunnelRoute: "/monitoring"`, `hideSourceMaps: true`, `widenClientFileUpload: true`
+- Sentry org/project/authToken via env vars (linhas 114-116)
+
+### ✅ sitemap.ts já tinha pattern reusable
+
+`frontend/app/sitemap.ts:21-121` (STORY-SEO-001 + SEN-BE-007):
+
+- `fetchSitemapJson<T>()` (linhas 21-98): observable wrapper com `Sentry.captureException()` em HTTP error + timeout/network. Tags: `sitemap_endpoint`, `sitemap_outcome ∈ {success, http_error, timeout, empty_data}`.
+- `fetchSitemapJsonWithRetry<T>()` (linhas 103-121): 1× retry com 2s backoff. Captura `sitemap_retry_exhausted_*` warning.
+- Breadcrumbs estruturados (linhas 81-92): `category: 'sitemap'`, `level: 'info'|'warning'`, `data: { sitemap_outcome, status_code, latency_ms, url_count, endpoint }`.
+
+### ❌ Gap real
+
+**Fetches críticos fora do sitemap.ts NÃO usavam o pattern observable.**
+
+Antes desta story:
+- `frontend/app/cnpj/[cnpj]/page.tsx::fetchPerfil` — silent `try { ... } catch { return null; }`. Zero Sentry capture.
+- `frontend/app/orgaos/[slug]/page.tsx::fetchOrgaoStats` — same.
+- `frontend/app/itens/[catmat]/page.tsx::fetchProfile` + `generateStaticParams` — same. Pior: `generateStaticParams` usa `cache: 'no-store'` (memory `feedback_isr_fetch_cache_alignment_next16` antipattern).
+
+Esses paths SSG/ISR são build-time + ISR refresh. Falhas silenciam Sentry → memory `feedback_frontend_sentry_silent_buildtime` recidiva.
+
+---
+
+## Estado pós-FOUND-SCALE-002 (esta story)
+
+### `frontend/lib/safe-fetch.ts` (NEW)
+
+Generaliza `fetchSitemapJson` para uso em qualquer SSG/ISR fetch:
+
+- `safeFetch(url, options)` — Response | null com Sentry instrumentation (HTTP error → captureMessage; network/timeout → captureException; breadcrumb estruturado em finally)
+- `fetchWithBudget<T>(url, opts)` — typed JSON wrapper com retry exponential backoff, fallback, ISR-friendly defaults (`next: { revalidate: 3600 }`).
+
+### Migrações
+
+- `frontend/app/cnpj/[cnpj]/page.tsx::fetchPerfil` → `fetchWithBudget` (label `cnpj-perfil`, retries 1, revalidate 86400)
+- `frontend/app/orgaos/[slug]/page.tsx::fetchOrgaoStats` → `fetchWithBudget` (label `orgao-stats`)
+- `frontend/app/itens/[catmat]/page.tsx::fetchProfile` → `fetchWithBudget` (label `item-profile`)
+- `frontend/app/itens/[catmat]/page.tsx::generateStaticParams` → `fetchWithBudget` com `revalidate` em vez de `cache: 'no-store'` (fix antipattern bonus)
+
+### Tests
+
+`frontend/__tests__/lib/safe-fetch.test.ts` — 9 test cases:
+- safeFetch: 200 OK, HTTP error, network error, timeout
+- fetchWithBudget: success no retry, retry success on 2nd, fallback after exhausted, extract transformer, default revalidate 3600
+
+### CI smoke (AC5) — defer
+
+Smoke test "build com BACKEND_URL=invalid → expect Sentry events count >0 via Sentry API" foi deferido para PR follow-up porque:
+- Requires Sentry API integration test setup (token + project filter)
+- WSL build OOM em monorepo 3k+ pages (memory `feedback_wsl_next16_build_inviavel`) → CI-only test
+- Alternativa robusta: Playwright E2E em staging post-deploy (pós-merge)
+
+---
+
+## Conclusão
+
+Antes desta story, o gap reportado em `feedback_frontend_sentry_silent_buildtime` era localizado: **infra Sentry estava OK mas pattern observable não era reusável fora do sitemap.ts**. Esta story extrai o pattern proven em `sitemap.ts` para `lib/safe-fetch.ts` e migra os 3 paths SSG/ISR críticos para usá-lo, fechando o gap real.
+
+**Próximos passos (defer pós-merge):**
+- AC5 CI smoke test integration
+- Migrate restantes pages SSG/ISR (`fornecedores/[cnpj]`, `municipios/[slug]`, observatório routes) — story dedicada se quiser cobertura 100%.
+- SEN-FE-002 + SEN-FE-003 reusam `fetchWithBudget` agora foundation-ready.

--- a/docs/runbooks/frontend-sentry-coverage.md
+++ b/docs/runbooks/frontend-sentry-coverage.md
@@ -1,0 +1,148 @@
+# Runbook: Frontend Sentry Coverage (qual contexto SDK ativo)
+
+**Story:** [FOUND-SCALE-002](../stories/2026-04/FOUND-SCALE-002-frontend-sentry-ssg-isr-init.story.md)
+**Created:** 2026-04-29
+**Audience:** dev/oncall investigando "por que Sentry não capturou X em prod"
+
+---
+
+## Contextos de execução Next.js 16 + Sentry SDK status
+
+| Contexto | Runtime | Sentry SDK init | Captura automática | Wrappers manuais necessários |
+|----------|---------|-----------------|---------------------|-----------------------------|
+| **Server Components / Server Actions** | nodejs | `instrumentation.ts::register()` carrega `sentry.server.config.ts` | `Sentry.captureRequestError` via `onRequestError` export | Não — captura é hook-driven |
+| **API Routes (`app/api/*/route.ts`)** | nodejs | idem | idem | Não |
+| **SSG (`generateStaticParams`, `generateMetadata`, page server fns)** | nodejs (build context) | idem (build runs `register()`) | **NÃO automático** — tu deve `try/catch + Sentry.captureException` ou usar `fetchWithBudget` | **SIM — use `fetchWithBudget`** (fechado em FOUND-SCALE-002) |
+| **ISR refresh** | nodejs (revalidation context) | idem | **NÃO automático** | **SIM — use `fetchWithBudget`** |
+| **Client Components ('use client')** | browser | `sentry.client.config.ts` via `_app` instrumentation | Sim — error boundary + global error handler | Não para erros runtime; mas para fetch errors silentes (`try/catch` swallowed) → use `safeFetch` ou explicit `Sentry.captureException` |
+| **Edge Runtime (`runtime: 'edge'`)** | edge | `sentry.edge.config.ts` via `register()` | Sim para uncaught | Wrappers OK também |
+
+---
+
+## Quando Sentry NÃO captura automaticamente (gaps históricos)
+
+### Gap 1: SSG/ISR fetch silent failures
+
+**Sintoma observado em prod (Stage 7, 2026-04-29):** sitemap-4.xml=0 entries, mas zero Sentry events em 24h.
+
+**Root cause:** SSG fetches em `try/catch` que retornam `null` ou `[]` silenciosamente.
+
+```typescript
+// ❌ ANTIPATTERN — Sentry nunca vê falha
+async function fetchPerfil(cnpj: string): Promise<Profile | null> {
+  try {
+    const resp = await fetch(`${BACKEND_URL}/v1/empresa/${cnpj}/perfil`);
+    if (!resp.ok) return null;  // silent
+    return await resp.json();
+  } catch {
+    return null;  // silent
+  }
+}
+```
+
+**Fix (FOUND-SCALE-002):**
+
+```typescript
+// ✅ Use fetchWithBudget — observability built-in
+import { fetchWithBudget } from '@/lib/safe-fetch';
+import { getBackendUrl } from '@/lib/backend-url';
+
+async function fetchPerfil(cnpj: string): Promise<Profile | null> {
+  return fetchWithBudget<Profile>(`${getBackendUrl()}/v1/empresa/${cnpj}/perfil`, {
+    timeout: 10000,
+    retries: 1,
+    revalidate: 86400,
+    label: 'cnpj-perfil',
+  });
+}
+```
+
+### Gap 2: `cache: 'no-store'` em SSG
+
+**Sintoma:** SSG renderiza vazio, ISR não revalida coerentemente.
+
+**Memory ref:** `feedback_isr_fetch_cache_alignment_next16` — `revalidate=N` + `cache: 'no-store'` quebra SSG.
+
+**Fix:** sempre `next: { revalidate: N }`. `fetchWithBudget` força esse default — NUNCA aceita `cache: 'no-store'`.
+
+### Gap 3: Build-time env var ausente
+
+**Sintoma:** `BACKEND_URL` ausente → fetch cai em `localhost:8000` → build inteiro silently corrompido.
+
+**Status atual:** `frontend/instrumentation.ts:14-31` valida BACKEND_URL no startup. Falha startup se env var inválida. `frontend/Dockerfile:138-153` falha build em prod se BACKEND_URL ausente. Helper `getBackendUrl()` em `frontend/lib/backend-url.ts` codifica chain canônica.
+
+---
+
+## Como verificar coverage em runtime
+
+### 1. Force trigger Sentry event em SSG
+
+Local (dev):
+
+```bash
+# Force fetch fail no build:
+BACKEND_URL=http://invalid:8000 npm run build 2>&1 | grep -i "sentry\|fetch_outcome"
+```
+
+Verificar evento na dashboard Sentry: https://sentry.io/organizations/confenge/issues/?project=smartlic-frontend
+
+### 2. Sentry breadcrumb em ISR refresh
+
+Cada `fetchWithBudget` call emite breadcrumb mesmo em sucesso (`fetch_outcome: success`). Útil para traçar latência ISR pós-fact em sessões com erro downstream.
+
+### 3. Audit grep — paths que ainda usam fetch raw
+
+```bash
+cd frontend
+grep -rEn "await fetch\(" app --include="*.ts" --include="*.tsx" \
+  | grep -v "node_modules" \
+  | grep -v "__tests__" \
+  | grep -v "sentry.client.config" \
+  | head -20
+```
+
+Cada match é candidato a migrar para `safeFetch` ou `fetchWithBudget`. Não obrigatório (client components com error boundary já cobertos). Foco: SSG/ISR build paths + critical user flows.
+
+---
+
+## Tags Sentry úteis para queries
+
+Convenção via `safeFetch` / `fetchWithBudget`:
+
+| Tag | Valores | Uso |
+|-----|---------|-----|
+| `fetch_label` | string ad-hoc | identifica call site (e.g. `cnpj-perfil`) |
+| `fetch_outcome` | `success` \| `http_error` \| `timeout` \| `network_error` \| `parse_error` \| `budget_exhausted` | filtra por tipo de falha |
+| `sitemap_outcome` | `success` \| `http_error` \| `timeout` \| `empty_data` | sitemap.ts legacy (preservado para back-compat) |
+| `sitemap_endpoint` | string label | sitemap.ts legacy |
+
+Sentry query exemplo:
+
+```
+project:smartlic-frontend fetch_outcome:budget_exhausted
+project:smartlic-frontend fetch_label:cnpj-perfil fetch_outcome:timeout
+```
+
+---
+
+## Falsos negativos comuns
+
+- **`fetch_outcome: success` mas dados vazios:** wrappers só sinalizam falha de transporte. Validação de payload (e.g. `array.length === 0`) é responsabilidade do caller.
+- **Sentry rate limit (free tier):** projetos free têm cap de events/mês. Sob outage longo, eventos podem ser droppados. Verificar dashboard Sentry → Stats → "Rate Limited".
+- **`tracesSampleRate: 0.1`** em `sentry.server.config.ts`: 90% de traces são sampled out. Erros (captureException) NÃO são afetados — só performance traces.
+
+---
+
+## Refs
+
+- Memory: `feedback_frontend_sentry_silent_buildtime` (2026-04-27)
+- Memory: `feedback_build_hammers_backend_cascade` (2026-04-27)
+- Memory: `feedback_isr_fetch_cache_alignment_next16` (2026-04-24)
+- Memory: `feedback_wsl_next16_build_inviavel` (2026-04-24)
+- Memory: `reference_frontend_dockerfile_backend_url_gap` (2026-04-24)
+- Story: [FOUND-SCALE-002](../stories/2026-04/FOUND-SCALE-002-frontend-sentry-ssg-isr-init.story.md)
+- Story: [SEO-PROG-008](../stories/2026-04/SEO-PROG-008-dockerfile-backend-url.md) — `getBackendUrl()` helper
+- Code: `frontend/lib/safe-fetch.ts` — wrappers
+- Code: `frontend/lib/backend-url.ts` — env chain helper
+- Code: `frontend/instrumentation.ts` — startup validation
+- Code: `frontend/sentry.{client,server,edge}.config.ts` — SDK init

--- a/docs/stories/2026-04/FOUND-SCALE-002-frontend-sentry-ssg-isr-init.story.md
+++ b/docs/stories/2026-04/FOUND-SCALE-002-frontend-sentry-ssg-isr-init.story.md
@@ -1,9 +1,9 @@
 # FOUND-SCALE-002: Frontend Sentry SDK Init em SSG Build + ISR Runtime
 
-**Priority:** P1 (observability gap)
+**Priority:** P0 (Stage 7 wedge 2026-04-29 reforçou — observability gap blind durante outage)
 **Effort:** M (2-4 dias)
 **Squad:** @dev + @architect
-**Status:** Ready
+**Status:** Done
 **Epic:** [EPIC-RES-BE-2026-Q2](EPIC-RES-BE-2026-Q2.md)
 **Sprint:** Sprint 3
 **Dependências bloqueadoras:** Sentry credentials configurados (memory `reference_sentry_credentials`)
@@ -73,6 +73,23 @@ Distinto de RES-BE-013 (audit prod env vars `PYTHONASYNCIODEBUG=1` etc.): essa c
 ### AC6: Docs
 
 - [ ] `docs/runbooks/frontend-sentry-coverage.md` — qual contexto SDK ativo, qual silencioso
+
+### AC7: `fetchWithBudget` reusable wrapper
+
+- [ ] Estender `frontend/lib/safe-fetch.ts` para exportar `fetchWithBudget(url, { timeout, retries, fallback })`:
+  ```typescript
+  export async function fetchWithBudget<T>(
+    url: string,
+    opts: {
+      timeout?: number;        // default 10000ms
+      retries?: number;        // default 1
+      fallback?: T | null;     // default null
+      revalidate?: number;     // Next.js ISR — default 3600
+    } = {}
+  ): Promise<T | null>
+  ```
+- [ ] Foundation para SEN-FE-002 AC2 (consolidar helper) e SEN-FE-003 (SSG decouple)
+- [ ] Test coverage: timeout, retry, fallback path, Sentry tag emission
 
 ---
 
@@ -151,3 +168,16 @@ Status: Draft → Ready.
 |---|---|---|---|
 | 2026-04-28 | 1.0 | Story criada via batch. Origem: `_reversa_sdd/sm-briefing-refactor.md` FOUND-SCALE-002. | @sm (River) |
 | 2026-04-28 | 1.1 | PO validation: GO (10/10). Status: Draft → Ready. | @po (Pax) |
+| 2026-04-29 | 1.2 | **Stage 7 wedge ground + sm-briefing-100pct refresh**. **Trigger:** sm-briefing-100pct.md §3.3.2. **Ground:** Stage 7 wedge sustained 12:29-15:10+ UTC com 0 events Sentry frontend em 24h apesar de sitemap-4=0 confirmado em prod (memory `feedback_frontend_sentry_silent_buildtime`). **Priority bump:** P1→**P0** (foundation para SEN-FE-002+SEN-FE-003 — outras stories dependem do `safeFetch`). **AC additions:** AC7 nova exporta `fetchWithBudget(url, {timeout, retries, fallback})` reusable. **Cross-ref:** SEN-FE-002 AC2 consolida; SEN-FE-003 usa wrapper em SSG decouple. | @sm (River) |
+| 2026-04-29 | 1.3 | v1.2 refresh validation: GO (10/10). Stage 7 ground + bump P0 foundation + AC7 wrapper consistentes. Status mantém Ready. | @po (Pax) |
+| 2026-04-29 | 1.4 | **Implementado Wave 3 — zany-kurzweil session.** AC2+AC3 (build/runtime SDK init) já pre-existing — empírico confirmado: `instrumentation.ts:14-31` valida BACKEND_URL startup; `sentry.{client,server,edge}.config.ts` ativos; `sitemap.ts:21-121` `fetchSitemapJson` + retry com Sentry breadcrumbs (STORY-SEO-001 + SEN-BE-007). AC1+AC4+AC6+AC7 done: helper `frontend/lib/safe-fetch.ts::safeFetch + fetchWithBudget` generalizando pattern do sitemap. 9 test cases pass. Migrate 3 SSG paths (cnpj, orgaos, itens × 2) para `fetchWithBudget`. Audit doc + runbook coverage criados. AC5 CI smoke deferred (Sentry API integration test pós-merge — alternative Playwright E2E staging). Status: Ready → Done. | @dev (James) |
+
+## File List
+
+- `frontend/lib/safe-fetch.ts` (NEW) — `safeFetch` + `fetchWithBudget` wrappers (AC4 + AC7)
+- `frontend/__tests__/lib/safe-fetch.test.ts` (NEW) — 9 test cases (AC4 + AC7 coverage)
+- `frontend/app/cnpj/[cnpj]/page.tsx` (refactor `fetchPerfil` → `fetchWithBudget` label `cnpj-perfil`)
+- `frontend/app/orgaos/[slug]/page.tsx` (refactor `fetchOrgaoStats` → `fetchWithBudget` label `orgao-stats`)
+- `frontend/app/itens/[catmat]/page.tsx` (refactor `fetchProfile` + `generateStaticParams` → `fetchWithBudget`; bonus fix `cache: 'no-store'` antipattern)
+- `docs/audit/frontend-sentry-init-status.md` (NEW) — audit AC1
+- `docs/runbooks/frontend-sentry-coverage.md` (NEW) — coverage runbook AC6

--- a/frontend/__tests__/lib/safe-fetch.test.ts
+++ b/frontend/__tests__/lib/safe-fetch.test.ts
@@ -1,0 +1,180 @@
+/**
+ * FOUND-SCALE-002: Tests for safeFetch + fetchWithBudget wrappers.
+ */
+import { safeFetch, fetchWithBudget } from '../../lib/safe-fetch';
+import * as Sentry from '@sentry/nextjs';
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+
+const SentryMock = Sentry as unknown as {
+  captureException: jest.Mock;
+  captureMessage: jest.Mock;
+  addBreadcrumb: jest.Mock;
+};
+
+// jsdom does not provide a global `Response` constructor. Build minimal
+// mock matching Response shape we use (`ok`, `status`, `json()`).
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('safeFetch (FOUND-SCALE-002 AC4)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    SentryMock.captureException.mockReset();
+    SentryMock.captureMessage.mockReset();
+    SentryMock.addBreadcrumb.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns Response on 200 OK', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      mockResponse({ ok: true }, 200),
+    ) as jest.Mock;
+    const resp = await safeFetch('https://api.test/x');
+    expect(resp).not.toBeNull();
+    expect(resp?.status).toBe(200);
+    expect(SentryMock.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'fetch',
+        level: 'info',
+      }),
+    );
+  });
+
+  it('returns null on HTTP error and emits Sentry message', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      mockResponse({ error: true }, 502),
+    ) as jest.Mock;
+    const resp = await safeFetch('https://api.test/x', { label: 'test-502' });
+    expect(resp).toBeNull();
+    expect(SentryMock.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP 502'),
+      expect.objectContaining({
+        tags: expect.objectContaining({ fetch_outcome: 'http_error' }),
+      }),
+    );
+  });
+
+  it('returns null on network error and emits Sentry exception', async () => {
+    const networkErr = new Error('ECONNREFUSED');
+    global.fetch = jest.fn().mockRejectedValue(networkErr) as jest.Mock;
+    const resp = await safeFetch('https://api.test/x', { label: 'test-net' });
+    expect(resp).toBeNull();
+    expect(SentryMock.captureException).toHaveBeenCalledWith(
+      networkErr,
+      expect.objectContaining({
+        tags: expect.objectContaining({ fetch_outcome: 'network_error' }),
+      }),
+    );
+  });
+
+  it('returns null on TimeoutError and tags as timeout', async () => {
+    const timeoutErr = new Error('signal timed out');
+    timeoutErr.name = 'TimeoutError';
+    global.fetch = jest.fn().mockRejectedValue(timeoutErr) as jest.Mock;
+    const resp = await safeFetch('https://api.test/x', { label: 'test-timeout' });
+    expect(resp).toBeNull();
+    expect(SentryMock.captureException).toHaveBeenCalledWith(
+      timeoutErr,
+      expect.objectContaining({
+        tags: expect.objectContaining({ fetch_outcome: 'timeout' }),
+      }),
+    );
+  });
+});
+
+describe('fetchWithBudget (FOUND-SCALE-002 AC7)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    SentryMock.captureException.mockReset();
+    SentryMock.captureMessage.mockReset();
+    SentryMock.addBreadcrumb.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns parsed JSON on success (no retry)', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      mockResponse({ value: 42 }, 200),
+    ) as jest.Mock;
+    const result = await fetchWithBudget<{ value: number }>('https://api.test/x', {
+      label: 'test',
+      retries: 0,
+    });
+    expect(result).toEqual({ value: 42 });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once and succeeds on 2nd attempt', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse({}, 502))
+      .mockResolvedValueOnce(mockResponse({ value: 1 }, 200)) as jest.Mock;
+    const result = await fetchWithBudget<{ value: number }>('https://api.test/x', {
+      label: 'test-retry',
+      retries: 1,
+    });
+    expect(result).toEqual({ value: 1 });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns fallback after all attempts fail', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(mockResponse({}, 503)) as jest.Mock;
+    const fallback = { value: 0, fallback: true };
+    const result = await fetchWithBudget('https://api.test/x', {
+      label: 'test-exhausted',
+      retries: 1,
+      fallback,
+    });
+    expect(result).toEqual(fallback);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(SentryMock.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('fetchWithBudget_exhausted_test-exhausted'),
+      expect.objectContaining({
+        tags: expect.objectContaining({ fetch_outcome: 'budget_exhausted' }),
+      }),
+    );
+  });
+
+  it('applies extract transformer on parsed data', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      mockResponse({ items: [{ id: 1 }, { id: 2 }] }, 200),
+    ) as jest.Mock;
+    const result = await fetchWithBudget<number[]>('https://api.test/x', {
+      label: 'test-extract',
+      retries: 0,
+      extract: (data) => (data as { items: { id: number }[] }).items.map((i) => i.id),
+    });
+    expect(result).toEqual([1, 2]);
+  });
+
+  it('uses next.revalidate by default 3600s', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse({ ok: true }, 200));
+    global.fetch = fetchMock as jest.Mock;
+    await fetchWithBudget('https://api.test/x', { label: 'test-isr', retries: 0 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/x',
+      expect.objectContaining({
+        next: expect.objectContaining({ revalidate: 3600 }),
+      }),
+    );
+  });
+});

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import CnpjPerfilClient from './CnpjPerfilClient';
 import { LeadCapture } from '@/components/LeadCapture';
+import { fetchWithBudget } from '@/lib/safe-fetch';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
@@ -51,16 +52,12 @@ export function generateStaticParams() {
 }
 
 async function fetchPerfil(cnpj: string): Promise<PerfilB2G | null> {
-  try {
-    const resp = await fetch(`${BACKEND_URL}/v1/empresa/${cnpj}/perfil-b2g`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!resp.ok) return null;
-    return await resp.json();
-  } catch {
-    return null;
-  }
+  return fetchWithBudget<PerfilB2G>(`${BACKEND_URL}/v1/empresa/${cnpj}/perfil-b2g`, {
+    timeout: 10000,
+    retries: 1,
+    revalidate: 86400,
+    label: 'cnpj-perfil',
+  });
 }
 
 export async function generateMetadata({

--- a/frontend/app/itens/[catmat]/page.tsx
+++ b/frontend/app/itens/[catmat]/page.tsx
@@ -2,6 +2,9 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
+import { fetchWithBudget } from '@/lib/safe-fetch';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
 
@@ -44,34 +47,29 @@ interface ItemProfile {
 }
 
 async function fetchProfile(catmat: string): Promise<ItemProfile | null> {
-  const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
-  try {
-    const res = await fetch(`${backendUrl}/v1/itens/${catmat}/profile`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
-    });
-    if (res.status === 404 || res.status === 400) return null;
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+  return fetchWithBudget<ItemProfile>(`${BACKEND_URL}/v1/itens/${catmat}/profile`, {
+    timeout: 10000,
+    retries: 1,
+    revalidate: 86400,
+    label: 'item-profile',
+  });
 }
 
+// Memory feedback_isr_fetch_cache_alignment_next16: usar `next.revalidate` em vez de
+// `cache: 'no-store'` — alinha com semântica ISR (revalidate=86400 abaixo).
 export async function generateStaticParams() {
-  const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
-  try {
-    const res = await fetch(`${backendUrl}/v1/sitemap/itens`, {
-      cache: 'no-store',
-      signal: AbortSignal.timeout(15000),
-    });
-    if (!res.ok) return [];
-    const data = await res.json();
-    const catmats: string[] = (data.catmats || []).slice(0, _MAX_STATIC_CATMATS);
-    return catmats.map((catmat) => ({ catmat }));
-  } catch {
-    return [];
-  }
+  const data = await fetchWithBudget<{ catmats?: string[] }>(
+    `${BACKEND_URL}/v1/sitemap/itens`,
+    {
+      timeout: 15000,
+      retries: 0,
+      revalidate: 86400,
+      label: 'sitemap-itens-static',
+      fallback: { catmats: [] },
+    },
+  );
+  const catmats: string[] = (data?.catmats || []).slice(0, _MAX_STATIC_CATMATS);
+  return catmats.map((catmat) => ({ catmat }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import OrgaoPerfilClient from './OrgaoPerfilClient';
 import { LeadCapture } from '@/components/LeadCapture';
+import { fetchWithBudget } from '@/lib/safe-fetch';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
@@ -46,16 +47,12 @@ export function generateStaticParams() {
 }
 
 async function fetchOrgaoStats(slug: string): Promise<OrgaoStats | null> {
-  try {
-    const resp = await fetch(`${BACKEND_URL}/v1/orgao/${slug}/stats`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!resp.ok) return null;
-    return await resp.json();
-  } catch {
-    return null;
-  }
+  return fetchWithBudget<OrgaoStats>(`${BACKEND_URL}/v1/orgao/${slug}/stats`, {
+    timeout: 10000,
+    retries: 1,
+    revalidate: 86400,
+    label: 'orgao-stats',
+  });
 }
 
 export async function generateMetadata({

--- a/frontend/lib/safe-fetch.ts
+++ b/frontend/lib/safe-fetch.ts
@@ -1,0 +1,171 @@
+/**
+ * safeFetch + fetchWithBudget — observable fetch wrappers with Sentry instrumentation.
+ *
+ * FOUND-SCALE-002: foundation para SEN-FE-002 (consolidação) + SEN-FE-003 (SSG decouple).
+ * Generaliza o pattern proven em `frontend/app/sitemap.ts::fetchSitemapJson` (STORY-SEO-001 +
+ * SEN-BE-007) para uso em qualquer SSG/ISR fetch fora do sitemap.
+ *
+ * Memory references:
+ *   - feedback_frontend_sentry_silent_buildtime — 0 events em 24h apesar de sitemap-4=0
+ *     em prod; observability gap blind durante outage.
+ *   - feedback_build_hammers_backend_cascade — SSG 4146 pages sem timeout/abort saturou
+ *     backend hobby DB pool; AbortSignal.timeout obrigatório.
+ *   - feedback_isr_fetch_cache_alignment_next16 — `revalidate=N` + `cache: 'no-store'`
+ *     quebra SSG; usar `next: { revalidate: N }`.
+ */
+import * as Sentry from '@sentry/nextjs';
+
+export type SafeFetchOutcome =
+  | 'success'
+  | 'http_error'
+  | 'timeout'
+  | 'network_error';
+
+export interface SafeFetchOptions extends RequestInit {
+  /** Sentry tag for this call site (e.g. "cnpj-profile", "orgao-list"). */
+  label?: string;
+  /** Timeout in ms (default 15000ms). */
+  timeout?: number;
+}
+
+/**
+ * Fetch wrapper with AbortSignal timeout, Sentry exception capture, and structured
+ * breadcrumb. Returns null on any failure (HTTP error, timeout, network error).
+ *
+ * Use this as the building block. For typed JSON responses with retry/fallback,
+ * use {@link fetchWithBudget}.
+ */
+export async function safeFetch(
+  url: string,
+  options: SafeFetchOptions = {},
+): Promise<Response | null> {
+  const { label = url, timeout = 15000, ...init } = options;
+  const startedAt = Date.now();
+  let outcome: SafeFetchOutcome = 'success';
+  let statusCode = 0;
+
+  try {
+    const resp = await fetch(url, {
+      signal: AbortSignal.timeout(timeout),
+      ...init,
+    });
+    statusCode = resp.status;
+    if (!resp.ok) {
+      outcome = 'http_error';
+      Sentry.captureMessage(`safeFetch ${label} HTTP ${resp.status}`, {
+        level: 'warning',
+        tags: { fetch_label: label, fetch_outcome: 'http_error' },
+        contexts: { fetch: { url, status: resp.status } },
+      });
+      return null;
+    }
+    return resp;
+  } catch (err) {
+    const errName = (err as Error)?.name || '';
+    outcome =
+      errName === 'TimeoutError' || errName === 'AbortError'
+        ? 'timeout'
+        : 'network_error';
+    Sentry.captureException(err, {
+      tags: { fetch_label: label, fetch_outcome: outcome },
+      contexts: { fetch: { url } },
+    });
+    return null;
+  } finally {
+    Sentry.addBreadcrumb({
+      category: 'fetch',
+      message: `safeFetch ${label}`,
+      level: outcome === 'success' ? 'info' : 'warning',
+      data: {
+        fetch_outcome: outcome,
+        status_code: statusCode,
+        latency_ms: Date.now() - startedAt,
+        url,
+      },
+    });
+  }
+}
+
+export interface FetchBudgetOptions<T> {
+  /** Timeout per attempt in ms (default 10000ms). */
+  timeout?: number;
+  /** Retry count after first failure (default 1 — total 2 attempts). */
+  retries?: number;
+  /** Fallback value if all attempts fail (default null). */
+  fallback?: T | null;
+  /** Next.js ISR revalidate window in seconds (default 3600). */
+  revalidate?: number;
+  /** Sentry tag (default url). */
+  label?: string;
+  /**
+   * Optional response shape transformer. Receives parsed JSON, must return
+   * the typed value or throw on shape mismatch.
+   */
+  extract?: (data: unknown) => T;
+}
+
+/**
+ * Typed JSON fetch wrapper with retry, fallback, and Sentry observability.
+ *
+ * Defaults to Next.js ISR-friendly cache: `next: { revalidate: 3600 }`.
+ * NEVER pass `cache: 'no-store'` in conjunction with `revalidate` — quebra SSG
+ * (memory `feedback_isr_fetch_cache_alignment_next16`).
+ *
+ * Returns the typed value, or `fallback` if all attempts fail.
+ *
+ * @example
+ *   const profile = await fetchWithBudget<Profile>(
+ *     `${getBackendUrl()}/v1/empresa/${cnpj}/perfil-b2g`,
+ *     { timeout: 10000, retries: 1, fallback: null, label: 'cnpj-profile' }
+ *   );
+ */
+export async function fetchWithBudget<T>(
+  url: string,
+  opts: FetchBudgetOptions<T> = {},
+): Promise<T | null> {
+  const {
+    timeout = 10000,
+    retries = 1,
+    fallback = null,
+    revalidate = 3600,
+    label = url,
+    extract,
+  } = opts;
+
+  const totalAttempts = retries + 1;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    const attemptLabel = attempt === 1 ? label : `${label}-retry-${attempt - 1}`;
+    const resp = await safeFetch(url, {
+      label: attemptLabel,
+      timeout,
+      next: { revalidate },
+    });
+
+    if (resp !== null) {
+      try {
+        const data = (await resp.json()) as unknown;
+        return extract ? extract(data) : (data as T);
+      } catch (err) {
+        // JSON parse error — treat as failure attempt.
+        Sentry.captureException(err, {
+          tags: { fetch_label: attemptLabel, fetch_outcome: 'parse_error' },
+          contexts: { fetch: { url } },
+        });
+      }
+    }
+
+    if (attempt < totalAttempts) {
+      // Exponential backoff: 2s, 4s, 8s, ...
+      const backoffMs = 2000 * 2 ** (attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+
+  Sentry.captureMessage(`fetchWithBudget_exhausted_${label}`, {
+    level: 'warning',
+    tags: { fetch_label: label, fetch_outcome: 'budget_exhausted' },
+    contexts: { fetch: { url, total_attempts: totalAttempts } },
+  });
+  return fallback;
+}


### PR DESCRIPTION
## Summary

Cherry-pick of `8a142c7f` (PR #553 — FOUND-SCALE-002) which was merged into wrong base (`feat/seo-prog-008-helper` instead of `main`). This PR replays the same change directly onto `main`.

## Context

- PR #553 squash-merged 2026-04-30T21:33:50Z but `baseRefName=feat/seo-prog-008-helper`, leaving `main` HEAD at `88671be7` and `safeFetch` absent from production.
- During backend wedge incident (2026-04-30 — see `docs/sessions/2026-04/2026-04-30-auditoria-forense-backend-wedge.md`), need `safeFetch`/`fetchWithBudget` Sentry wrappers in `main` to prevent silent SSG fetch failures.

## Changes

- New `frontend/lib/safe-fetch.ts` (171 lines) — `safeFetch` + `fetchWithBudget<T>` typed JSON wrapper with retry exponential backoff, fallback, ISR-friendly default `next.revalidate=3600`, Sentry breadcrumb instrumentation
- New `frontend/__tests__/lib/safe-fetch.test.ts` — 9/9 tests cover all outcomes
- Migrate 3 SSG paths to `fetchWithBudget`:
  - `frontend/app/cnpj/[cnpj]/page.tsx::fetchPerfil`
  - `frontend/app/orgaos/[slug]/page.tsx::fetchOrgaoStats`
  - `frontend/app/itens/[catmat]/page.tsx::fetchProfile + generateStaticParams` (bonus fix `cache: 'no-store'` antipattern → `next.revalidate`)
- New `docs/audit/frontend-sentry-init-status.md`
- New `docs/runbooks/frontend-sentry-coverage.md`

## Conflicts resolved

`feat/seo-prog-008-helper` introduced `frontend/lib/backend-url.ts` (`getBackendUrl()` helper) which does NOT exist on `main`. Resolved by:
- Removing `import { getBackendUrl } from '@/lib/backend-url'` from `cnpj/[cnpj]`, `orgaos/[slug]`, `itens/[catmat]`
- Replacing `${getBackendUrl()}` calls with existing `${BACKEND_URL}` const (already declared inline as `process.env.BACKEND_URL || 'http://localhost:8000'`)

`fetchWithBudget` semantics preserved (timeout, retries, revalidate, label, fallback).

## Testing Plan

- [ ] CI Backend Tests pass
- [ ] CI Frontend Tests pass (safe-fetch.test.ts 9/9)
- [ ] Validate `frontend/app/cnpj/[cnpj]/page.tsx` builds without `getBackendUrl` import
- [ ] Post-merge: monitor Sentry for `cnpj-perfil` / `orgao-stats` / `item-profile` breadcrumb events

## Closes

Continuação operacional de #553 (mergeado em base errada, redirecionado a `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced data fetching with automatic retry logic and timeout protection for improved reliability across pages.
  * Integrated monitoring and diagnostics for better visibility into data fetch operations.

* **Tests**
  * Added comprehensive test suite for fetch operations.

* **Documentation**
  * Added audit documentation for frontend monitoring status.
  * Created runbook for diagnosing data fetch issues.
  * Updated project story with completion status and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->