### PR TITLE
fix(frontend): set s-maxage on sitemap sub-routes — fix GSC fetch failure

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -216,6 +216,15 @@ export async function middleware(request: NextRequest) {
     return addSecurityHeaders(NextResponse.next());
   }
 
+  // SEO-SITEMAP-CACHE: sitemap sub-routes have '.' in path (e.g. /sitemap/0.xml)
+  // and would be caught by the static-asset early-return below, bypassing the
+  // isPublicContentRoute check. Handle them explicitly so GSC can cache them.
+  if (pathname.startsWith('/sitemap/') && pathname.endsWith('.xml')) {
+    const response = addSecurityHeaders(NextResponse.next());
+    response.headers.set('Cache-Control', 'public, max-age=3600, s-maxage=86400');
+    return response;
+  }
+
   // Allow static assets and Next.js internals
   if (
     pathname.startsWith("/_next") ||


### PR DESCRIPTION
## Summary

- **Root cause:** `middleware.ts` exited early on `pathname.includes(".")`, bypassing `isPublicContentRoute` check for `/sitemap/[0-4].xml`
- **Symptom:** GSC "Não foi possível buscar" on `/sitemap/0.xml` and `/sitemap/4.xml` → 0 indexed pages for 4+ days
- **Fix:** Explicit early-return for `/sitemap/*.xml` paths setting `Cache-Control: public, max-age=3600, s-maxage=86400` (matches `/sitemap.xml` index route handler)

**Before:** `cache-control: public, max-age=0, must-revalidate` (Next.js ISR default, CDN cannot cache)  
**After:** `cache-control: public, max-age=3600, s-maxage=86400` (CDN caches 24h, browser revalidates after 1h)

## Testing Plan

- [ ] `curl -si https://smartlic.tech/sitemap/0.xml | grep -i cache-control` → shows `s-maxage=86400` after deploy
- [ ] `curl -si https://smartlic.tech/sitemap/4.xml | grep -i cache-control` → same
- [ ] `/sitemap.xml` index still shows `max-age=3600, s-maxage=86400` (no regression)
- [ ] Frontend Tests CI pass (middleware change is header-only, no auth logic touched)

## Closes

Resolves GSC "Não foi possível buscar" for sub-sitemaps. Related: `project_gsc_subsitemap_fetch_failure_2026_04_30` memory entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sitemap XML file handling to properly apply security headers and caching policies, enabling optimal content delivery for search engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->