### PR TITLE
fix(backend): RES-BE-015 sweep — _run_with_budget across 15 SEO long-tail routes + audit gate

### DIFF
--- a/.github/workflows/audit-execute-without-budget.yml
+++ b/.github/workflows/audit-execute-without-budget.yml
@@ -1,0 +1,163 @@
+name: "Audit .execute() without _run_with_budget (RES-BE-001 / RES-BE-015)"
+
+# Guards against a regression of the 2026-04-27 to 2026-04-30 outage cycle
+# (Stage 2-8). Bare ``.execute()`` in an async route — or
+# ``asyncio.wait_for(asyncio.to_thread(...))`` — leaks the Supabase pool slot
+# until ``statement_timeout=15s`` fires server-side, and the cancelled
+# future's cleanup blocks the event loop.
+#
+# This workflow runs on every PR that touches ``backend/routes/`` or the
+# audit script itself, posts a sticky PR comment with any findings, and
+# fails (exit 1) if violations are found in the RES-BE-015 sweep scope.
+
+on:
+  pull_request:
+    paths:
+      - 'backend/routes/**'
+      - 'backend/scripts/audit_execute_without_budget.py'
+      - '.github/workflows/audit-execute-without-budget.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/routes/**'
+      - 'backend/scripts/audit_execute_without_budget.py'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: audit-execute-budget-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit routes for unprotected .execute()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run audit (RES-BE-015 scope)
+        id: audit
+        run: |
+          set +e
+          python backend/scripts/audit_execute_without_budget.py --json \
+            > /tmp/audit-violations.jsonl
+          STATUS=$?
+          set -e
+
+          # Emit a human-readable summary to the job log too.
+          python backend/scripts/audit_execute_without_budget.py \
+            > /tmp/audit-violations.txt 2>&1 || true
+          cat /tmp/audit-violations.txt
+
+          COUNT=$(wc -l < /tmp/audit-violations.jsonl | tr -d ' ')
+          if [ -z "$COUNT" ]; then COUNT=0; fi
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "has_violations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_violations=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Emit GitHub annotations
+        if: steps.audit.outputs.has_violations == 'true'
+        run: |
+          # One ::error:: per violation so reviewers see them inline on the
+          # Files Changed tab.
+          python - <<'PY'
+          import json, sys
+          with open("/tmp/audit-violations.jsonl") as fh:
+              for line in fh:
+                  v = json.loads(line)
+                  # Strip leading workspace path so file= matches the repo path.
+                  rel = v["file"].split("/backend/", 1)[-1]
+                  rel = "backend/" + rel if not rel.startswith("backend/") else rel
+                  print(
+                      "::error file={f},line={l},col={c}::[{k}] {d}".format(
+                          f=rel, l=v["line"], c=max(1, v["col"] + 1),
+                          k=v["kind"], d=v["detail"],
+                      )
+                  )
+          PY
+
+      - name: Post / update PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const hasViolations = '${{ steps.audit.outputs.has_violations }}' === 'true';
+            const count = '${{ steps.audit.outputs.count }}';
+
+            const marker = '<!-- audit-execute-without-budget -->';
+            const okBody = `${marker}
+            ## Audit \`.execute()\` without \`_run_with_budget\` — PASS
+
+            Zero violations in the RES-BE-015 sweep scope (11 long-tail SEO
+            programmatic routes). The Stage 2-8 antipattern
+            (\`asyncio.wait_for(asyncio.to_thread(...))\` and bare sync
+            \`.execute()\` in async routes) is not present.
+
+            > Run locally with \`python backend/scripts/audit_execute_without_budget.py\`.`;
+
+            let body = okBody;
+            if (hasViolations) {
+              const raw = fs.readFileSync('/tmp/audit-violations.txt', 'utf8');
+              body = `${marker}
+            ## Audit \`.execute()\` without \`_run_with_budget\` — **FAIL** (${count} violation(s))
+
+            The 2026-04-27 to 2026-04-30 outage cycle (Stage 2-8) was caused
+            by sync \`.execute()\` in async route handlers. This PR introduces
+            (or retains) the same anti-pattern. Wrap each callsite in
+            \`pipeline.budget._run_with_budget(asyncio.to_thread(_sync_query),
+            budget=N, phase='route', source='<module>.<endpoint>')\`.
+
+            <details><summary>Violations</summary>
+
+            \`\`\`
+            ${raw.slice(0, 60_000)}
+            \`\`\`
+
+            </details>
+
+            Run locally:
+            \`\`\`
+            python backend/scripts/audit_execute_without_budget.py
+            \`\`\``;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on violations
+        if: steps.audit.outputs.has_violations == 'true'
+        run: exit 1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "external: Tests that hit live external APIs (opt-in via RUN_LIVE_CONTRACT_TESTS=1)",
     "parity: CRIT-DATA-PARITY-001 entity endpoint parity tests (hit live target via PARITY_TARGET_URL — skipped when unset)",
     "fuzz: Property-based fuzz tests using Hypothesis (STORY-6.7)",
+    "load: Load / fan-out reproduction tests (RES-BE-015 — requires explicit `-m load` selection)",
 ]
 
 # pytest-asyncio configuration

--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -36,11 +36,15 @@ _CACHE_TTL_SECONDS = 6 * 60 * 60
 # from re-saturating Supabase pool while letting the next crawl wave probe
 # again after a short window.
 _NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
-# Hard budget for a single contratos query. Sync .execute() runs in a
-# worker thread (asyncio.to_thread) so the event loop stays responsive
-# even when the query saturates; wait_for caps total wall-clock so the
-# Railway proxy 15s healthcheck timeout never trips.
-_CONTRATOS_QUERY_BUDGET_S = 10.0
+# Hard budget for a single contratos query. RES-BE-015: tightened from 10s
+# to 5s and routed through ``pipeline.budget._run_with_budget`` so the
+# Prometheus counter ``smartlic_pipeline_budget_exceeded_total`` discriminates
+# saturation per endpoint. Budget MUST be < Supabase service_role
+# ``statement_timeout`` (15s, FLOOR) so the SQL still fires server-side and
+# closes the connection — caller-side cancel via ``wait_for`` alone leaves
+# the thread holding the pool slot until ``statement_timeout`` (the 2026-04-27
+# Stage 2 root cause). See memory ``feedback_pool_leak_caller_timeout_vs_sql_timeout``.
+_CONTRATOS_QUERY_BUDGET_S = 5.0
 _blog_cache: dict[str, tuple[dict, float, float]] = {}  # (data, stored_at, ttl_seconds)
 
 # All 27 Brazilian UFs
@@ -953,6 +957,7 @@ async def _compute_contratos_stats(
     *,
     uf: Optional[str] = None,
     municipio_pattern: Optional[str] = None,
+    source: str = "blog_stats.contratos",
 ) -> tuple[dict, bool]:
     """Query pncp_supplier_contracts and aggregate.
 
@@ -961,27 +966,36 @@ async def _compute_contratos_stats(
     fallback shape. Callers should cache the partial response under a
     shorter TTL (``_NEGATIVE_CACHE_TTL_SECONDS``) so Googlebot retry storms
     don't keep hitting the slow query path.
+
+    RES-BE-015: routed through ``_run_with_budget`` so every saturation event
+    increments ``smartlic_pipeline_budget_exceeded_total{phase,source}`` —
+    callers pass a granular ``source`` label so Prometheus can pinpoint which
+    endpoint family is wedging.
     """
+    from pipeline.budget import _run_with_budget
+
     try:
-        rows = await asyncio.wait_for(
+        rows = await _run_with_budget(
             asyncio.to_thread(
                 _query_contratos_sync,
                 uf=uf,
                 municipio_pattern=municipio_pattern,
             ),
-            timeout=_CONTRATOS_QUERY_BUDGET_S,
+            budget=_CONTRATOS_QUERY_BUDGET_S,
+            phase="route",
+            source=source,
         )
     except asyncio.TimeoutError:
         logger.warning(
-            "contratos query exceeded %.0fs budget (sector=%s uf=%s municipio=%s)",
-            _CONTRATOS_QUERY_BUDGET_S,
+            "contratos query exceeded %.1fs budget (source=%s sector=%s uf=%s municipio=%s)",
+            _CONTRATOS_QUERY_BUDGET_S, source,
             sector.id if sector else None, uf, municipio_pattern,
         )
         return _empty_contratos_stats(), True
     except Exception as e:
         logger.error(
-            "contratos DB query failed (sector=%s uf=%s municipio=%s): %s",
-            sector.id if sector else None, uf, municipio_pattern, e,
+            "contratos DB query failed (source=%s sector=%s uf=%s municipio=%s): %s",
+            source, sector.id if sector else None, uf, municipio_pattern, e,
         )
         return _empty_contratos_stats(), True
 
@@ -1117,7 +1131,10 @@ async def get_contratos_setor_stats(setor_id: str):
     if cached:
         return ContratosSetorStats(**cached)
 
-    base, partial = await _compute_contratos_stats(sector)
+    base, partial = await _compute_contratos_stats(
+        sector,
+        source="blog_stats.contratos_setor",
+    )
     data = {"sector_id": sector.id, "sector_name": sector.name, **base}
     _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if partial else _CACHE_TTL_SECONDS)
     return ContratosSetorStats(**data)
@@ -1141,7 +1158,11 @@ async def get_contratos_setor_uf_stats(setor_id: str, uf: str):
     if cached:
         return ContratosSetorUfStats(**cached)
 
-    base, partial = await _compute_contratos_stats(sector, uf=uf)
+    base, partial = await _compute_contratos_stats(
+        sector,
+        uf=uf,
+        source="blog_stats.contratos_setor_uf",
+    )
     # Drop by_uf (always single UF in this scope — keeps payload lean)
     base.pop("by_uf", None)
     data = {
@@ -1181,7 +1202,11 @@ async def get_contratos_cidade_stats(cidade: str):
     )
 
     # Filter by UF first (indexed) + ilike on municipio (free-text)
-    base, partial = await _compute_contratos_stats(uf=uf, municipio_pattern=municipio_display)
+    base, partial = await _compute_contratos_stats(
+        uf=uf,
+        municipio_pattern=municipio_display,
+        source="blog_stats.contratos_cidade",
+    )
     base.pop("by_uf", None)
     data = {
         "cidade": municipio_display,
@@ -1220,7 +1245,12 @@ async def get_contratos_cidade_setor_stats(cidade: str, setor_id: str):
         or cidade.replace("-", " ").title()
     )
 
-    base, partial = await _compute_contratos_stats(sector, uf=uf, municipio_pattern=municipio_display)
+    base, partial = await _compute_contratos_stats(
+        sector,
+        uf=uf,
+        municipio_pattern=municipio_display,
+        source="blog_stats.contratos_cidade_setor",
+    )
     base.pop("by_uf", None)
     data = {
         "cidade": municipio_display,

--- a/backend/routes/compliance_publicos.py
+++ b/backend/routes/compliance_publicos.py
@@ -13,6 +13,7 @@ Endpoint:
   GET /v1/compliance/{cnpj}/profile  — perfil de due diligence B2G
 """
 
+import asyncio
 import logging
 import re
 import time
@@ -23,6 +24,8 @@ import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from pipeline.budget import _run_with_budget
+
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["compliance-publicos"])
 
@@ -31,6 +34,10 @@ _compliance_cache: dict[str, tuple[dict, float]] = {}
 
 _CNPJ_RE = re.compile(r"^\d{14}$")
 _HTTP_TIMEOUT = 10.0
+# RES-BE-015: budget for Supabase enriched_entities lookup. MUST be <
+# Supabase service_role ``statement_timeout=15s`` (FLOOR validated;
+# memory feedback_pool_leak_caller_timeout_vs_sql_timeout).
+_RAZAO_SOCIAL_QUERY_BUDGET_S = 5.0
 
 _PORTAL_BASE = "https://api.portaldatransparencia.gov.br"
 
@@ -164,8 +171,11 @@ async def compliance_profile(cnpj: str):
 
 async def _fetch_razao_social(cnpj: str) -> str:
     """Tenta obter a razao social de enriched_entities (Supabase) ou BrasilAPI."""
-    # 1. enriched_entities
-    try:
+    # 1. enriched_entities — RES-BE-015: ``_run_with_budget`` + ``to_thread``
+    # so the sync supabase-py client never blocks the event loop and any
+    # saturation increments
+    # ``smartlic_pipeline_budget_exceeded_total{phase=route,source=compliance_publicos.razao_social}``.
+    def _sync_query() -> list[dict]:
         from supabase_client import get_supabase
         sb = get_supabase()
         resp = (
@@ -176,11 +186,25 @@ async def _fetch_razao_social(cnpj: str) -> str:
             .limit(1)
             .execute()
         )
-        if resp.data:
-            data = resp.data[0].get("data") or {}
+        return resp.data or []
+
+    try:
+        rows = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=_RAZAO_SOCIAL_QUERY_BUDGET_S,
+            phase="route",
+            source="compliance_publicos.razao_social",
+        )
+        if rows:
+            data = rows[0].get("data") or {}
             nome = data.get("razao_social") or ""
             if nome:
                 return nome
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[Compliance] enriched_entities lookup exceeded %.1fs budget for %s",
+            _RAZAO_SOCIAL_QUERY_BUDGET_S, cnpj,
+        )
     except Exception as e:
         logger.debug("[Compliance] enriched_entities lookup falhou para %s: %s", cnpj, e)
 

--- a/backend/routes/contratos_publicos.py
+++ b/backend/routes/contratos_publicos.py
@@ -22,6 +22,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from pipeline.budget import _run_with_budget
 from sectors import SECTORS
 
 logger = logging.getLogger(__name__)
@@ -34,9 +35,13 @@ _NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
 # Hard request budget for fornecedor_profile (Googlebot-hit programmatic SEO route).
 _FORNECEDOR_PROFILE_BUDGET_S = 30.0
 # Budget for _fetch_sector_contracts + orgao_contratos_stats sync queries.
-# sync .execute() runs in asyncio.to_thread; wait_for caps wall-clock so the
-# Railway 120s proxy timeout never trips on these Googlebot-heavy routes.
-_SECTOR_QUERY_BUDGET_S = 10.0
+# RES-BE-015: tightened from 10s -> 5s and routed through ``_run_with_budget``.
+# Budget MUST be < Supabase service_role ``statement_timeout=15s`` (FLOOR
+# validated; see memory ``feedback_pool_leak_caller_timeout_vs_sql_timeout``).
+# Caller-side ``wait_for`` alone cancels the await but the Python thread
+# holds the pool slot until ``statement_timeout`` fires server-side — that
+# was the Stage 2-8 root cause.
+_SECTOR_QUERY_BUDGET_S = 5.0
 _contratos_cache: dict[str, tuple[dict, float]] = {}
 _fornecedores_cache: dict[str, tuple[dict, float]] = {}
 _orgao_contratos_cache: dict[str, tuple[dict, float]] = {}
@@ -196,13 +201,15 @@ async def _fetch_sector_contracts(
         return resp.data or []
 
     try:
-        rows = await asyncio.wait_for(
+        rows = await _run_with_budget(
             asyncio.to_thread(_sync_query),
-            timeout=_SECTOR_QUERY_BUDGET_S,
+            budget=_SECTOR_QUERY_BUDGET_S,
+            phase="route",
+            source="contratos_publicos.sector_contracts",
         )
     except asyncio.TimeoutError:
         logger.warning(
-            "contratos_publicos sector query exceeded %.0fs budget for %s/%s",
+            "contratos_publicos sector query exceeded %.1fs budget for %s/%s",
             _SECTOR_QUERY_BUDGET_S, sector_id_clean, uf_upper,
         )
         return [], True
@@ -276,13 +283,15 @@ async def orgao_contratos_stats(cnpj: str):
         return resp.data or []
 
     try:
-        rows = await asyncio.wait_for(
+        rows = await _run_with_budget(
             asyncio.to_thread(_sync_query_orgao),
-            timeout=_SECTOR_QUERY_BUDGET_S,
+            budget=_SECTOR_QUERY_BUDGET_S,
+            phase="route",
+            source="contratos_publicos.orgao_contratos_stats",
         )
     except asyncio.TimeoutError:
         logger.warning(
-            "orgao_contratos query exceeded %.0fs budget for %s", _SECTOR_QUERY_BUDGET_S, cnpj_clean,
+            "orgao_contratos query exceeded %.1fs budget for %s", _SECTOR_QUERY_BUDGET_S, cnpj_clean,
         )
         partial = _build_orgao_unavailable(cnpj_clean)
         _set_cached(_orgao_contratos_cache, cache_key, partial, ttl=_NEGATIVE_CACHE_TTL_SECONDS)

--- a/backend/routes/itens_publicos.py
+++ b/backend/routes/itens_publicos.py
@@ -22,6 +22,7 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, HTTPException, Response
 
+from pipeline.budget import _run_with_budget
 from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 from pydantic import BaseModel
 
@@ -39,10 +40,15 @@ _itens_sitemap_cache: dict[str, tuple[dict, float]] = {}
 _CATMAT_RE = re.compile(r"^\d{1,9}$")
 _HTTP_TIMEOUT = 5.0
 _CATMAT_API_BASE = "https://api.compras.dados.gov.br"
-# Budget for pncp_supplier_contracts query — sync .execute() runs in
-# asyncio.to_thread so the event loop stays unblocked; wait_for caps total
-# wall-clock. Stage 8 2026-04-30: bare .execute() wedged the event loop.
-_PRICE_QUERY_BUDGET_S = 10.0
+# Budget for pncp_supplier_contracts query.
+# RES-BE-015: tightened from 10s -> 5s and routed through ``_run_with_budget``
+# so saturation is observable per route via
+# ``smartlic_pipeline_budget_exceeded_total{phase=route,source=...}``.
+# Budget MUST be < Supabase service_role ``statement_timeout=15s`` (FLOOR).
+# Caller-side ``wait_for`` alone leaves the thread holding the pool slot
+# until ``statement_timeout`` fires server-side — Stage 2-8 root cause
+# (memory feedback_pool_leak_caller_timeout_vs_sql_timeout).
+_PRICE_QUERY_BUDGET_S = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -443,12 +449,17 @@ async def _fetch_price_data(nome_item: str) -> tuple[list[float], list[dict]]:
         return resp.data or []
 
     try:
-        rows = await asyncio.wait_for(
+        rows = await _run_with_budget(
             asyncio.to_thread(_sync_fetch),
-            timeout=_PRICE_QUERY_BUDGET_S,
+            budget=_PRICE_QUERY_BUDGET_S,
+            phase="route",
+            source="itens_publicos.fetch_price_data",
         )
     except asyncio.TimeoutError:
-        logger.warning("[Itens] price_data query exceeded %.0fs budget for '%s'", _PRICE_QUERY_BUDGET_S, nome_item)
+        logger.warning(
+            "[Itens] price_data query exceeded %.1fs budget for '%s'",
+            _PRICE_QUERY_BUDGET_S, nome_item,
+        )
         return [], []
     except Exception as e:
         logger.error("[Itens] price_data query falhou para '%s': %s", nome_item, e)

--- a/backend/routes/municipios_publicos.py
+++ b/backend/routes/municipios_publicos.py
@@ -23,13 +23,26 @@ from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
+from pipeline.budget import _run_with_budget
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["municipios-publicos"])
 
 _CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h
+# RES-BE-015: short TTL for failure paths so Googlebot retry storms cannot
+# re-saturate the pool while a healthy crawl wave can refresh normally.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
 _municipio_profile_cache: dict[str, tuple[dict, float]] = {}
 _municipio_sitemap_cache: dict[str, tuple[dict, float]] = {}
+
+# RES-BE-015 budgets. Both MUST be < Supabase service_role
+# ``statement_timeout=15s`` (FLOOR validated; memory
+# feedback_pool_leak_caller_timeout_vs_sql_timeout).
+# AC3 of the story explicitly grants budget=8.0 for the bids query because
+# ``pncp_raw_bids`` filtered by uf+is_active without a covering index can be
+# slow on cold cache. Enriched entity lookup uses the standard 5s.
+_ENRICHED_QUERY_BUDGET_S = 5.0
+_BIDS_QUERY_BUDGET_S = 8.0
 
 # Seed: 200 municipios de maior relevancia B2G (capitais + polos regionais)
 # Formato: (slug, ibge_code, nome_display, uf, populacao_estimada)
@@ -362,14 +375,22 @@ async def municipio_profile(slug: str):
     nome = meta["nome"]
     uf = meta["uf"]
     populacao = meta["populacao"]
+    # RES-BE-015: track whether the bids query degraded (timeout/exception).
+    # When True, the cache entry uses _NEGATIVE_CACHE_TTL_SECONDS so the next
+    # crawl wave can refresh sooner instead of being stuck with an empty
+    # payload for 24h.
+    bids_query_degraded = False
 
-    from supabase_client import get_supabase
-    sb = get_supabase()
-
-    # Dados enriquecidos do IBGE (enriched_entities)
+    # Dados enriquecidos do IBGE (enriched_entities) — RES-BE-015: routed
+    # through ``_run_with_budget(asyncio.to_thread(...))`` so the sync
+    # supabase-py client never blocks the event loop and saturation is
+    # observable per route.
     pib_per_capita: Optional[float] = None
-    try:
-        enrich_resp = (
+
+    def _enriched_query_sync() -> list[dict]:
+        from supabase_client import get_supabase
+        sb = get_supabase()
+        resp = (
             sb.table("enriched_entities")
             .select("data")
             .eq("entity_type", "municipio")
@@ -377,10 +398,24 @@ async def municipio_profile(slug: str):
             .limit(1)
             .execute()
         )
-        if enrich_resp.data:
-            enrich_data = enrich_resp.data[0].get("data") or {}
+        return resp.data or []
+
+    try:
+        enriched_rows = await _run_with_budget(
+            asyncio.to_thread(_enriched_query_sync),
+            budget=_ENRICHED_QUERY_BUDGET_S,
+            phase="route",
+            source="municipios_publicos.enriched_entities",
+        )
+        if enriched_rows:
+            enrich_data = enriched_rows[0].get("data") or {}
             pib_per_capita = enrich_data.get("pib_per_capita")
             populacao = enrich_data.get("populacao") or populacao
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[Municipios] enriched_entities exceeded %.1fs budget for %s",
+            _ENRICHED_QUERY_BUDGET_S, ibge_code,
+        )
     except Exception as e:
         logger.warning(
             "[Municipios] enriched_entities falhou para %s (continuando sem enrichment): %s",
@@ -389,13 +424,21 @@ async def municipio_profile(slug: str):
 
     # Licitacoes abertas no datalake (pncp_raw_bids)
     # STORY-425: use correct column name `data_publicacao` (not `data_publicacao_pncp` — never existed)
-    # STORY-426: wrap in asyncio.wait_for to guard against statement_timeout (57014)
-    _BIDS_QUERY_TIMEOUT_S = float(os.getenv("MUNICIPIOS_BIDS_QUERY_TIMEOUT_S", "6.0"))
+    # RES-BE-015: replaced asyncio.wait_for(asyncio.to_thread(...)) with
+    # _run_with_budget so the cancelled future does not leak the Supabase
+    # connection until statement_timeout fires (memory
+    # feedback_pool_leak_caller_timeout_vs_sql_timeout — Stage 2-8 root cause).
+    # Budget=8s honours story AC3 (JOIN heavy). Env var override preserved
+    # for emergency tightening; defaults to the new budget.
+    _BIDS_QUERY_TIMEOUT_S = float(os.getenv("MUNICIPIOS_BIDS_QUERY_TIMEOUT_S", str(_BIDS_QUERY_BUDGET_S)))
     total_licitacoes = 0
     valor_total = 0.0
     licitacoes_recentes: list[dict] = []
-    try:
-        _query = (
+
+    def _bids_query_sync() -> list[dict]:
+        from supabase_client import get_supabase
+        sb = get_supabase()
+        resp = (
             sb.table("pncp_raw_bids")
             .select(
                 "objeto_compra,orgao_razao_social,valor_total_estimado,"
@@ -405,12 +448,17 @@ async def municipio_profile(slug: str):
             .eq("is_active", True)
             .order("data_publicacao", desc=True)
             .limit(500)
+            .execute()
         )
-        bids_resp = await asyncio.wait_for(
-            asyncio.to_thread(_query.execute),
-            timeout=_BIDS_QUERY_TIMEOUT_S,
+        return resp.data or []
+
+    try:
+        rows = await _run_with_budget(
+            asyncio.to_thread(_bids_query_sync),
+            budget=_BIDS_QUERY_TIMEOUT_S,
+            phase="route",
+            source="municipios_publicos.bids",
         )
-        rows = bids_resp.data or []
         total_licitacoes = len(rows)
         for row in rows:
             v = _safe_float(row.get("valor_total_estimado"))
@@ -428,7 +476,9 @@ async def municipio_profile(slug: str):
                 "modalidade": (row.get("modalidade_nome") or "").strip() or "Nao informado",
             })
     except asyncio.TimeoutError:
-        # STORY-426 AC2: degraded response on timeout — return empty bid lists, no 500
+        # STORY-426 AC2 + RES-BE-015: degraded response on timeout — return
+        # empty bid lists, no 500. Caller MUST cache under the negative TTL.
+        bids_query_degraded = True
         try:
             from metrics import SUPABASE_QUERY_TIMEOUT_TOTAL
             SUPABASE_QUERY_TIMEOUT_TOTAL.labels(endpoint="municipios_stats").inc()
@@ -440,6 +490,7 @@ async def municipio_profile(slug: str):
         )
         # total_licitacoes / valor_total / licitacoes_recentes keep their zero defaults
     except Exception as e:
+        bids_query_degraded = True
         logger.error("[Municipios] pncp_raw_bids query falhou para uf=%s: %s", uf, e)
 
     faq_items = _build_faq(nome, uf, total_licitacoes, populacao)
@@ -463,7 +514,16 @@ async def municipio_profile(slug: str):
         ),
     }
 
-    _set_cached(_municipio_profile_cache, cache_key, response_data)
+    if bids_query_degraded:
+        # RES-BE-015: persist with a "stale" timestamp so the existing TTL
+        # check (``time.time() - ts >= _CACHE_TTL_SECONDS``) treats this as
+        # expiring after _NEGATIVE_CACHE_TTL_SECONDS instead of 24h.
+        _municipio_profile_cache[cache_key] = (
+            response_data,
+            time.time() - _CACHE_TTL_SECONDS + _NEGATIVE_CACHE_TTL_SECONDS,
+        )
+    else:
+        _set_cached(_municipio_profile_cache, cache_key, response_data)
     return MunicipioProfileResponse(**response_data)
 
 

--- a/backend/routes/observatorio.py
+++ b/backend/routes/observatorio.py
@@ -26,12 +26,19 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from metrics import OBSERVATORIO_BUDGET_EXCEEDED
+from pipeline.budget import _run_with_budget
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["observatorio"])
 
-# STORY-431 AC10: 15s hard budget per Supabase round-trip (current+prev month)
-_QUERY_BUDGET_S = 15.0
+# STORY-431 AC10 + RES-BE-015: hard budget per Supabase round-trip
+# (current+prev month). Tightened from 15.0s to 8.0s — the previous value
+# tied the budget at the Supabase service_role ``statement_timeout`` floor
+# (15s) which means the cancelled future cleanup ran on the event loop just
+# as the SQL was firing server-side. New floor is < statement_timeout so the
+# DB closes its side of the connection before Python tries to clean up
+# (memory feedback_pool_leak_caller_timeout_vs_sql_timeout).
+_QUERY_BUDGET_S = 8.0
 _CACHE_TTL_SECONDS = 24 * 60 * 60  # 24h on success
 # STORY-431 AC10: negative cache TTL on timeout/error — same pattern as PR #535 (sitemap)
 _NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
@@ -362,13 +369,19 @@ async def _generate_relatorio(mes: int, ano: int) -> dict:
     results: list[dict] = []
     prev_results: list[dict] = []
 
-    # STORY-431 AC10: hard 15s budget per Supabase round-trip with negative cache.
-    # Pattern from PR #535 (sitemap fix): wait_for + label-aware Counter + Sentry tag.
+    # STORY-431 AC10 + RES-BE-015: hard budget per Supabase round-trip with
+    # negative cache. ``_run_with_budget(asyncio.to_thread(...))`` increments
+    # ``smartlic_pipeline_budget_exceeded_total{phase=route,source=observatorio.*}``
+    # AND avoids the wait_for+to_thread pool leak (caller cancel does not stop
+    # the Python thread; the cancelled future cleanup ran inline on the event
+    # loop and was the Stage 2-8 freeze).
     if is_historical:
         try:
-            results = await asyncio.wait_for(
+            results = await _run_with_budget(
                 asyncio.to_thread(_query_historical_sync, data_inicial, data_final),
-                timeout=_QUERY_BUDGET_S,
+                budget=_QUERY_BUDGET_S,
+                phase="route",
+                source="observatorio.relatorio_historical",
             )
             logger.info(
                 "observatorio: historical query for %d/%d returned %d rows",
@@ -421,9 +434,11 @@ async def _generate_relatorio(mes: int, ano: int) -> dict:
     prev_is_historical = (today - date(prev_ano, prev_mes, 1)).days > 30
     if prev_is_historical:
         try:
-            prev_results = await asyncio.wait_for(
+            prev_results = await _run_with_budget(
                 asyncio.to_thread(_query_historical_sync, prev_inicial, prev_final),
-                timeout=_QUERY_BUDGET_S,
+                budget=_QUERY_BUDGET_S,
+                phase="route",
+                source="observatorio.relatorio_prev_month_historical",
             )
         except asyncio.TimeoutError:
             logger.warning(

--- a/backend/routes/orgao_publico.py
+++ b/backend/routes/orgao_publico.py
@@ -5,6 +5,7 @@ from the local pncp_raw_bids datalake. Queries only local DB — no
 external API calls. Public (no auth). Cache: InMemory 24h TTL per CNPJ.
 """
 
+import asyncio
 import logging
 import re
 import time
@@ -14,6 +15,8 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+
+from pipeline.budget import _run_with_budget
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["orgao-publico"])
@@ -95,6 +98,14 @@ class OrgaoStatsResponse(BaseModel):
 _REDIS_CACHE_TTL_SECONDS = 15 * 60  # 15 minutes
 _REDIS_CACHE_PREFIX = "orgao_stats:v1:"
 
+# RES-BE-015: Negative-cache TTL for DB saturation paths.
+# 5min keeps Googlebot retry storms from re-saturating the pool while a
+# successful crawl wave can refresh the cache normally.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
+# Per-query budget. MUST be < Supabase service_role ``statement_timeout=15s``
+# (FLOOR validated; memory feedback_pool_leak_caller_timeout_vs_sql_timeout).
+_ORGAO_QUERY_BUDGET_S = 5.0
+
 
 async def _redis_get(cnpj: str) -> Optional[dict]:
     try:
@@ -154,9 +165,15 @@ async def orgao_stats(cnpj: str):
         _set_cached(cnpj_clean, redis_cached)
         return OrgaoStatsResponse(**redis_cached)
 
-    data = await _build_orgao_stats(cnpj_clean)
-    _set_cached(cnpj_clean, data)
-    await _redis_set(cnpj_clean, data)
+    data, partial = await _build_orgao_stats(cnpj_clean)
+    if partial:
+        # RES-BE-015: cache the unavailable shape under a short TTL so a
+        # Googlebot retry storm does not re-saturate the pool, but the
+        # next non-degraded request can still refresh the cache.
+        _orgao_cache[cnpj_clean] = (data, time.time() - _CACHE_TTL_SECONDS + _NEGATIVE_CACHE_TTL_SECONDS)
+    else:
+        _set_cached(cnpj_clean, data)
+        await _redis_set(cnpj_clean, data)
     return OrgaoStatsResponse(**data)
 
 
@@ -201,9 +218,47 @@ def _extract_top_setores(rows: list[dict], top_n: int = 5) -> list[str]:
 # Build stats
 # ---------------------------------------------------------------------------
 
-async def _build_orgao_stats(cnpj: str) -> dict:
-    """Query pncp_raw_bids and aggregate stats for a single órgão."""
-    try:
+def _build_orgao_unavailable(cnpj: str) -> dict:
+    """Minimal partial response when DB saturates / times out.
+
+    Returns a payload that still validates against ``OrgaoStatsResponse`` so
+    Googlebot receives a valid 200 (cached for 5 min) instead of 502 — a 502
+    storm during the 2026-04-29 Stage 5 outage was the trigger that wedged
+    the worker. Caller marks the result with negative-cache TTL.
+    """
+    return {
+        "nome": "Órgão",
+        "cnpj": cnpj,
+        "esfera": "Não informado",
+        "uf": "",
+        "municipio": "Não informado",
+        "total_licitacoes": 0,
+        "licitacoes_30d": 0,
+        "licitacoes_90d": 0,
+        "licitacoes_365d": 0,
+        "valor_medio_estimado": 0.0,
+        "valor_total_estimado": 0.0,
+        "top_modalidades": [],
+        "top_setores": [],
+        "ultimas_licitacoes": [],
+        "top_fornecedores": [],
+        "total_contratos_24m": 0,
+        "valor_total_contratos_24m": 0.0,
+        "aviso_legal": (
+            "Dados temporariamente indisponíveis. Tente novamente em alguns minutos."
+        ),
+    }
+
+
+async def _build_orgao_stats(cnpj: str) -> tuple[dict, bool]:
+    """Query pncp_raw_bids and aggregate stats for a single órgão.
+
+    Returns ``(data, partial)`` where ``partial=True`` means the underlying
+    query exceeded ``_ORGAO_QUERY_BUDGET_S`` or failed; ``data`` is then a
+    valid-shape unavailable payload. Callers should cache partial responses
+    under ``_NEGATIVE_CACHE_TTL_SECONDS``.
+    """
+    def _sync_query() -> list[dict]:
         from supabase_client import get_supabase
 
         sb = get_supabase()
@@ -224,11 +279,25 @@ async def _build_orgao_stats(cnpj: str) -> dict:
             .limit(5000)
             .execute()
         )
+        return resp.data or []
+
+    try:
+        rows = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=_ORGAO_QUERY_BUDGET_S,
+            phase="route",
+            source="orgao_publico.orgao_stats",
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "orgao_stats query exceeded %.1fs budget for %s — returning unavailable partial",
+            _ORGAO_QUERY_BUDGET_S, cnpj,
+        )
+        return _build_orgao_unavailable(cnpj), True
     except Exception as e:
         logger.error("orgao_stats DB query failed for %s: %s", cnpj, e)
-        raise HTTPException(status_code=502, detail="Erro ao consultar o datalake")
+        return _build_orgao_unavailable(cnpj), True
 
-    rows = resp.data or []
     if not rows:
         raise HTTPException(status_code=404, detail="Órgão não encontrado no datalake")
 
@@ -350,20 +419,21 @@ async def _build_orgao_stats(cnpj: str) -> dict:
             "Dados de fontes públicas: Portal Nacional de Contratações Públicas (PNCP). "
             "Atualização diária."
         ),
-    }
+    }, False
 
 
 async def _fetch_contracts_data(orgao_cnpj: str, limit: int = 10) -> dict:
     """Query pncp_supplier_contracts for top suppliers and aggregate contract stats.
 
     Returns dict with 'top_fornecedores', 'total_contratos_24m', 'valor_total_contratos_24m'.
-    Returns empty/zero gracefully when table is empty (during/before backfill).
+    Returns empty/zero gracefully when table is empty (during/before backfill) or
+    when the query exceeds ``_ORGAO_QUERY_BUDGET_S`` (RES-BE-015 negative cache).
     """
     result = {"top_fornecedores": [], "total_contratos_24m": 0, "valor_total_contratos_24m": 0.0}
-    try:
+
+    def _sync_query() -> list[dict]:
         from supabase_client import get_supabase
         sb = get_supabase()
-
         # Aggregate by supplier CNPJ — Supabase doesn't support GROUP BY directly,
         # so we fetch up to 2000 rows and aggregate in Python (table grows large post-backfill;
         # a proper RPC would be ideal but this is zero-infra and works for cache=24h).
@@ -375,8 +445,15 @@ async def _fetch_contracts_data(orgao_cnpj: str, limit: int = 10) -> dict:
             .limit(2000)
             .execute()
         )
+        return resp.data or []
 
-        rows = resp.data or []
+    try:
+        rows = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=_ORGAO_QUERY_BUDGET_S,
+            phase="route",
+            source="orgao_publico.contracts_data",
+        )
         if not rows:
             return result
 
@@ -418,6 +495,11 @@ async def _fetch_contracts_data(orgao_cnpj: str, limit: int = 10) -> dict:
             if t["valor"] > 0
         ]
 
+    except asyncio.TimeoutError:
+        logger.warning(
+            "contracts_data query exceeded %.1fs budget for %s",
+            _ORGAO_QUERY_BUDGET_S, orgao_cnpj,
+        )
     except Exception as exc:
         logger.warning("contracts_data query failed for %s: %s", orgao_cnpj, exc)
 

--- a/backend/scripts/audit_execute_without_budget.py
+++ b/backend/scripts/audit_execute_without_budget.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""RES-BE-015 / RES-BE-001: Audit raw `.execute()` and `wait_for(to_thread(...))`
+in `backend/routes/*.py` that lack `_run_with_budget` protection.
+
+The 2026-04-27 to 2026-04-30 outage cycle (Stage 2-8) traced back to this anti-
+pattern: sync supabase `.execute()` in an `async def` handler, optionally
+wrapped only in `asyncio.wait_for(asyncio.to_thread(...))`. The caller-side
+`wait_for` cancels the *await* but never the underlying Python thread, and the
+thread keeps consuming a Supabase connection until the server statement_timeout
+(15s) fires. Cleanup of the cancelled future then runs **inline** on the event
+loop, blocking ticks for 14-48s and freezing every Railway proxy probe. The
+fix is `_run_with_budget(asyncio.to_thread(...), budget=<budget>)` plus an
+explicit ``try/except asyncio.TimeoutError: return _empty_response()``.
+
+This script is deterministic, AST-based, and used both as a developer CLI and
+as a CI gate (`.github/workflows/audit-execute-without-budget.yml`). It exits
+non-zero when any violation is found in the routes listed in
+``TARGET_ROUTES`` (which corresponds 1:1 with the RES-BE-015 sweep scope).
+
+Usage
+-----
+
+    # Audit every route file (default scope):
+    python backend/scripts/audit_execute_without_budget.py
+
+    # Audit a single file (path can be relative to repo root or to backend):
+    python backend/scripts/audit_execute_without_budget.py --file routes/blog_stats.py
+
+    # Emit JSON for CI annotations (one line per violation):
+    python backend/scripts/audit_execute_without_budget.py --json
+
+    # Audit ALL routes (not only the RES-BE-015 sweep scope):
+    python backend/scripts/audit_execute_without_budget.py --all-routes
+
+Exit codes
+----------
+
+    0   no violations in the configured scope
+    1   one or more violations found
+    2   invalid invocation / IO error
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+# ---------------------------------------------------------------------------
+# Configuration: scope of the sweep (RES-BE-015 + RES-BE-001).
+# ---------------------------------------------------------------------------
+
+# Files in scope for the CI gate. Listed without the `routes/` prefix so the
+# script can run from either the repo root or the `backend/` directory.
+TARGET_ROUTES: tuple[str, ...] = (
+    "blog_stats.py",
+    "contratos_publicos.py",
+    "empresa_publica.py",
+    "orgao_publico.py",
+    "observatorio.py",
+    "dados_publicos.py",
+    "municipios_publicos.py",
+    "itens_publicos.py",
+    "compliance_publicos.py",
+    "alertas_publicos.py",
+    "sectors_public.py",
+)
+
+
+# ---------------------------------------------------------------------------
+# Violation record.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    col: int
+    kind: str  # "bare_execute" | "wait_for_to_thread"
+    detail: str
+
+    def format_human(self) -> str:
+        return f"{self.file}:{self.line}:{self.col}: [{self.kind}] {self.detail}"
+
+
+# ---------------------------------------------------------------------------
+# AST helpers.
+# ---------------------------------------------------------------------------
+
+
+def _attr_chain(node: ast.AST) -> Optional[str]:
+    """Return ``a.b.c`` for a chained ``Attribute`` node, else ``None``."""
+    parts: list[str] = []
+    cur: ast.AST = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _is_call_to(node: ast.Call, *names: str) -> bool:
+    """True iff ``node.func`` resolves to ``a.b...`` ending in any ``names``.
+
+    Matches dotted names (``asyncio.wait_for``) and bare names (``wait_for``).
+    """
+    chain = _attr_chain(node.func) if isinstance(node.func, ast.Attribute) else None
+    if chain is not None:
+        for name in names:
+            if chain == name or chain.endswith("." + name):
+                return True
+    if isinstance(node.func, ast.Name):
+        for name in names:
+            if node.func.id == name or name.endswith("." + node.func.id):
+                return True
+    return False
+
+
+def _is_run_with_budget(node: ast.Call) -> bool:
+    return _is_call_to(node, "_run_with_budget", "pipeline.budget._run_with_budget")
+
+
+def _is_to_thread_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and _is_call_to(node, "asyncio.to_thread", "to_thread")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Visitors.
+# ---------------------------------------------------------------------------
+
+
+class _RouteVisitor(ast.NodeVisitor):
+    """Walks a single route file and collects violations.
+
+    Violations:
+      1. ``wait_for_to_thread`` — ``asyncio.wait_for(asyncio.to_thread(...))``
+         anywhere in the file. This pattern is unconditionally banned: the
+         caller-side cancel does not release the Supabase connection. (See the
+         module docstring.)
+      2. ``bare_execute`` — a ``.execute()`` method call that:
+         * is **not** wrapped by an enclosing ``_run_with_budget`` call, and
+         * is **not** an argument to ``sb_execute(...)`` /
+           ``sb_execute_direct(...)`` / ``await asyncio.to_thread(...)``-style
+           helpers that already enforce a budget.
+    """
+
+    def __init__(self, file: str, source: str) -> None:
+        self.file = file
+        self._lines = source.splitlines()
+        self.violations: list[Violation] = []
+        # Stack of "in scope" guards: True iff a ``_run_with_budget`` call is
+        # an *ancestor* of the current node (e.g. the visitor is inside the
+        # awaitable being budgeted).
+        self._budget_stack: list[bool] = []
+
+    # -- core node walks --------------------------------------------------
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Pattern 1: asyncio.wait_for(asyncio.to_thread(...), ...)
+        if _is_call_to(node, "asyncio.wait_for", "wait_for"):
+            inner = node.args[0] if node.args else None
+            if inner is not None and _is_to_thread_call(inner):
+                self.violations.append(
+                    Violation(
+                        file=self.file,
+                        line=node.lineno,
+                        col=node.col_offset,
+                        kind="wait_for_to_thread",
+                        detail=(
+                            "asyncio.wait_for(asyncio.to_thread(...)) — caller "
+                            "cancel does not release the Supabase connection. "
+                            "Use _run_with_budget(asyncio.to_thread(...), "
+                            "budget=N) instead."
+                        ),
+                    )
+                )
+
+        # Pattern 2: bare .execute() not wrapped in _run_with_budget /
+        # sb_execute / asyncio.to_thread.
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "execute"
+            and not node.args  # .execute() takes no positional args
+            and not any(self._budget_stack)  # not inside _run_with_budget
+        ):
+            # Skip if this .execute() is itself the argument to a helper that
+            # offloads to a thread (sb_execute / sb_execute_direct /
+            # asyncio.to_thread / _run_with_budget). The visitor's budget_stack
+            # only reflects ancestors; the immediate parent check is done via
+            # ``_skip_by_parent`` in the wrapping pass below.
+            self.violations.append(
+                Violation(
+                    file=self.file,
+                    line=node.lineno,
+                    col=node.col_offset,
+                    kind="bare_execute",
+                    detail=(
+                        "bare .execute() in async route — wrap with "
+                        "_run_with_budget(asyncio.to_thread(_sync_query), "
+                        "budget=5.0, phase='route', source='<module>.<endpoint>'). "
+                        "The sync supabase-py client blocks the event loop."
+                    ),
+                )
+            )
+
+        # Recurse — but mark "inside budget" if this call IS _run_with_budget.
+        is_budget = _is_run_with_budget(node)
+        self._budget_stack.append(is_budget)
+        try:
+            self.generic_visit(node)
+        finally:
+            self._budget_stack.pop()
+
+
+def _strip_protected_executes(source: str, violations: list[Violation]) -> list[Violation]:
+    """Second pass: drop ``bare_execute`` violations whose immediate textual
+    context shows the caller IS already a protected helper.
+
+    The AST visitor errs on the side of false positives because it cannot
+    cheaply determine "this Call's parent is `sb_execute(...)` or
+    `asyncio.to_thread(...)`" — those wrap the *whole call chain*, not just
+    the trailing `.execute()`. We do a conservative line-window check:
+
+    * If the line containing the `.execute()` is the *last* line of a call
+      chain whose start is `sb_execute(` or `asyncio.to_thread(` or
+      `await asyncio.to_thread(`, treat as protected.
+    * If the bare `.execute()` is inside a sync `def _query_sync(...):`
+      function (no `async`), it's by-design called via
+      `asyncio.to_thread(_query_sync)` — treat as protected.
+
+    Otherwise, the violation stands.
+    """
+    lines = source.splitlines()
+    survivors: list[Violation] = []
+
+    # Pre-compute for each line index, whether its enclosing function is
+    # synchronous (def, not async def). This is a cheap line-scan upward.
+    def _enclosing_def(line_no: int) -> Optional[tuple[str, int]]:
+        """Walk upward to find the closest function definition. Returns
+        (kind, indent) where kind is 'def' | 'async def'.
+        """
+        target_indent = None
+        for i in range(line_no - 1, -1, -1):
+            line = lines[i]
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(line) - len(stripped)
+            if target_indent is None:
+                target_indent = indent
+            if indent < target_indent and (
+                stripped.startswith("def ") or stripped.startswith("async def ")
+            ):
+                kind = "async def" if stripped.startswith("async def") else "def"
+                return (kind, indent)
+            if indent == 0 and (
+                stripped.startswith("def ") or stripped.startswith("async def ")
+            ):
+                kind = "async def" if stripped.startswith("async def") else "def"
+                return (kind, indent)
+        return None
+
+    def _line_window_starts_with(line_no: int, prefixes: Iterable[str]) -> bool:
+        """Look at the (up to) 25 lines preceding (and including) ``line_no``
+        for an unindented ``await sb_execute(`` / ``asyncio.to_thread(`` /
+        ``await asyncio.to_thread(`` opener that would textually wrap the
+        ``.execute()`` at ``line_no``.
+        """
+        prefixes = tuple(prefixes)
+        for i in range(max(0, line_no - 25), line_no):
+            stripped = lines[i].strip()
+            if any(stripped.startswith(p) for p in prefixes):
+                return True
+            # Also accept assignment forms: ``x = await sb_execute(``
+            for p in prefixes:
+                if f"= {p}" in stripped or f"=await {p}" in stripped or f"= await {p}" in stripped:
+                    return True
+        return False
+
+    for v in violations:
+        if v.kind != "bare_execute":
+            survivors.append(v)
+            continue
+
+        enc = _enclosing_def(v.line)
+        if enc is not None and enc[0] == "def":
+            # Sync helper — caller is responsible for offloading via to_thread.
+            continue
+
+        if _line_window_starts_with(
+            v.line,
+            (
+                "await sb_execute(",
+                "sb_execute(",
+                "await sb_execute_direct(",
+                "sb_execute_direct(",
+                "await asyncio.to_thread(",
+                "asyncio.to_thread(",
+                "await _run_with_budget(",
+                "_run_with_budget(",
+            ),
+        ):
+            continue
+
+        survivors.append(v)
+
+    return survivors
+
+
+# ---------------------------------------------------------------------------
+# Driver.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_routes_dir() -> Path:
+    """Find ``backend/routes`` relative to this script."""
+    here = Path(__file__).resolve()
+    # Script lives in backend/scripts/...
+    backend_dir = here.parent.parent
+    routes = backend_dir / "routes"
+    if not routes.is_dir():
+        raise SystemExit(f"routes directory not found at {routes}")
+    return routes
+
+
+def audit_file(path: Path) -> list[Violation]:
+    """Audit a single Python file. Returns a list of violations."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"failed to read {path}: {exc}") from exc
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        raise SystemExit(f"syntax error in {path}: {exc}") from exc
+
+    visitor = _RouteVisitor(file=str(path), source=source)
+    visitor.visit(tree)
+    return _strip_protected_executes(source, visitor.violations)
+
+
+def audit_paths(paths: Iterable[Path]) -> list[Violation]:
+    out: list[Violation] = []
+    for p in paths:
+        out.extend(audit_file(p))
+    return out
+
+
+def _select_files(args: argparse.Namespace) -> list[Path]:
+    routes_dir = _resolve_routes_dir()
+
+    if args.file:
+        # Accept relative paths from repo root, backend/, or just basename.
+        candidates: list[Path] = []
+        raw = Path(args.file)
+        candidates.append(raw)
+        candidates.append(routes_dir / raw.name)
+        candidates.append(routes_dir.parent / raw)
+        for c in candidates:
+            if c.is_file():
+                return [c.resolve()]
+        raise SystemExit(f"file not found: {args.file}")
+
+    if args.all_routes:
+        return sorted(p for p in routes_dir.glob("*.py") if p.name != "__init__.py")
+
+    # Default: only the RES-BE-015 sweep scope.
+    return [routes_dir / name for name in TARGET_ROUTES if (routes_dir / name).is_file()]
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit `.execute()` callsites in routes/ that lack _run_with_budget."
+    )
+    parser.add_argument("--file", help="Path to a single file (overrides default scope).")
+    parser.add_argument(
+        "--all-routes",
+        action="store_true",
+        help="Audit every routes/*.py (default: only RES-BE-015 scope).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit one JSON object per line for machine consumers / CI annotations.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the human-readable summary; useful with --json.",
+    )
+    args = parser.parse_args(argv)
+
+    files = _select_files(args)
+    violations = audit_paths(files)
+
+    # Stable, deterministic order.
+    violations.sort(key=lambda v: (v.file, v.line, v.col, v.kind))
+
+    if args.json:
+        for v in violations:
+            print(json.dumps(asdict(v), ensure_ascii=False))
+
+    if not args.quiet:
+        per_file: dict[str, int] = {}
+        for v in violations:
+            per_file[v.file] = per_file.get(v.file, 0) + 1
+        if not args.json:
+            for v in violations:
+                print(v.format_human())
+        if per_file:
+            print()
+            print(f"== Audit summary ({len(files)} files scanned) ==")
+            for f in sorted(per_file):
+                rel = os.path.relpath(f)
+                print(f"  {rel}: {per_file[f]} violation(s)")
+            print(f"  total: {sum(per_file.values())}")
+        else:
+            scope = "all routes" if args.all_routes else "RES-BE-015 scope"
+            print(f"OK: zero violations across {len(files)} files ({scope}).")
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/load/test_googlebot_fanout_longtail.py
+++ b/backend/tests/load/test_googlebot_fanout_longtail.py
@@ -1,0 +1,207 @@
+"""RES-BE-015 AC5 — Reproducible load test for the Stage 8 wedge pattern.
+
+The 2026-04-30 Stage 8 outage was caused by Googlebot crawling 7+ long-tail
+SEO programmatic routes concurrently against ``WEB_CONCURRENCY=1``. Sync
+``.execute()`` calls in async handlers blocked the event loop end-to-end;
+``/health/live`` started failing the Railway 15s probe and the worker was
+restarted — taking the whole site with it.
+
+This test loads the FastAPI app in-process (no Railway proxy / Gunicorn /
+uvicorn workers) and dispatches a Stage 8-shaped concurrent fan-out at the
+ASGI layer using ``httpx.AsyncClient`` + ``ASGITransport``. It DOES NOT make
+real database calls — Supabase clients are stubbed by ``conftest.py`` and the
+in-process app simply exercises the *handler* logic.
+
+What the test actually proves
+-----------------------------
+
+The test is intentionally LOW-fidelity (vs. a real Locust run) and exists to:
+
+* Lock in the import contract — every refactored route module imports cleanly
+  with the new ``pipeline.budget._run_with_budget`` callsite signature. A
+  silent ``ImportError`` here would mean a deployed module crash on first
+  request.
+* Exercise that no handler raises an unhandled exception when the underlying
+  Supabase client is unreachable. Anything other than 200 / 404 / 503 / 500
+  with a structured body is a regression.
+* Catch any handler that re-introduces ``asyncio.wait_for(asyncio.to_thread(
+  ...))`` — those would either hang or block the loop, blowing the per-test
+  pytest timeout.
+
+What it does NOT prove
+----------------------
+
+* Wall-clock latency under real Supabase saturation — that requires a Locust
+  + production-shape worker setup outside this test suite.
+* Event-loop tick durations — measuring those reliably needs ``loop.set_debug``
+  + an external sampler; flaky inside pytest.
+
+Usage
+-----
+
+The test is gated by ``@pytest.mark.load`` so it does NOT run in the default
+suite. Trigger it explicitly:
+
+    pytest backend/tests/load/test_googlebot_fanout_longtail.py -m load -v
+
+To run a quick smoke (just import + fixture wiring) without ``-m load``:
+
+    pytest backend/tests/load/test_googlebot_fanout_longtail.py::test_imports_resolve -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Ensure backend package root is importable regardless of where pytest is run.
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+
+# ---------------------------------------------------------------------------
+# A canonical Stage 8 fan-out pattern. Same path shapes as the route inventory
+# in the RES-BE-015 story; values picked to be syntactically valid (so the
+# handler reaches the DB call) but harmless if upstream is stubbed.
+# ---------------------------------------------------------------------------
+
+LONGTAIL_PATHS: tuple[str, ...] = (
+    # blog_stats.contratos_setor (Sentry P0 Stage 8 root cause)
+    "/v1/blog/stats/contratos/saude",
+    # blog_stats.contratos_setor_uf
+    "/v1/blog/stats/contratos/saude/uf/sp",
+    # blog_stats.contratos_cidade
+    "/v1/blog/stats/contratos/cidade/sao-paulo",
+    # blog_stats.contratos_cidade_setor
+    "/v1/blog/stats/contratos/cidade/sao-paulo/setor/saude",
+    # contratos_publicos.orgao_contratos_stats
+    "/v1/contratos/orgao/00000000000000/stats",
+    # observatorio.relatorio (mes 1 = recent month → may hit live datalake)
+    "/v1/observatorio/relatorio/2026/1",
+    # municipios_publicos.municipio_profile (canonical capital slug)
+    "/v1/municipios/sao-paulo-sp/profile",
+)
+
+
+# ---------------------------------------------------------------------------
+# Smoke: every route module imports cleanly with the refactored signature.
+# ---------------------------------------------------------------------------
+
+
+def test_imports_resolve() -> None:
+    """All sweep-scope route modules import without error.
+
+    A silent ``ImportError`` on a new ``from pipeline.budget import
+    _run_with_budget`` line would crash production at the first matching
+    request — this guard runs in the default suite (no ``load`` marker).
+    """
+    import importlib
+
+    for module_name in (
+        "routes.blog_stats",
+        "routes.contratos_publicos",
+        "routes.empresa_publica",
+        "routes.orgao_publico",
+        "routes.observatorio",
+        "routes.dados_publicos",
+        "routes.municipios_publicos",
+        "routes.itens_publicos",
+        "routes.compliance_publicos",
+        "routes.alertas_publicos",
+        "routes.sectors_public",
+    ):
+        importlib.import_module(module_name)
+
+
+def test_run_with_budget_signature() -> None:
+    """`_run_with_budget` keeps the kwargs the sweep depends on."""
+    from pipeline.budget import _run_with_budget
+    import inspect
+
+    sig = inspect.signature(_run_with_budget)
+    expected = {"coro", "budget", "phase", "source", "fallback"}
+    assert expected.issubset(sig.parameters.keys()), (
+        f"_run_with_budget signature drifted; have {set(sig.parameters)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Heavy: actual fan-out against the in-process ASGI app. Marked ``load`` so
+# pytest selects it only when explicitly requested.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.load
+@pytest.mark.timeout(60)
+def test_googlebot_fanout_longtail_no_unhandled_exceptions() -> None:
+    """Fan out 7 long-tail paths concurrently against the in-process app.
+
+    Asserts that:
+      * no request raises an unhandled exception (every response has a status
+        code, even when the handler degrades to a partial),
+      * every status code is in the "expected universe" (200, 404, 422, 500,
+        503) — anything else means a regression in error handling,
+      * the whole batch completes within ``WALL_BUDGET_S`` so a regression
+        introducing ``wait_for(asyncio.to_thread(...))`` blocks the event
+        loop and times out instead of silently passing.
+
+    The test does NOT require a real database — Supabase clients fail open in
+    these handlers and return the negative-cache shape.
+    """
+    httpx = pytest.importorskip("httpx")
+    pytest.importorskip("fastapi")
+
+    # Per-handler hard ceiling = max(budget) + headroom (8s budget for
+    # observatorio + municipios bids + serialization). Leave generous slack
+    # because the in-process ASGI dispatch adds non-trivial overhead under
+    # pytest debug mode.
+    PER_REQUEST_BUDGET_S = 12.0
+    # Total wall-clock for the whole fan-out. With 7 concurrent requests on
+    # a single event loop and budgets <= 8s each, anything above this points
+    # at a serialization bug (handlers running sequentially → wait_for+to_thread
+    # antipattern reintroduced).
+    WALL_BUDGET_S = 30.0
+
+    # Suppress optional integrations that bloat startup but add no signal here.
+    os.environ.setdefault("DATALAKE_ENABLED", "false")
+    os.environ.setdefault("DATALAKE_QUERY_ENABLED", "false")
+    os.environ.setdefault("SENTRY_DSN", "")
+
+    from main import app  # noqa: E402  — env vars must be set first
+
+    async def _run() -> list[tuple[str, Any]]:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            timeout=PER_REQUEST_BUDGET_S,
+        ) as client:
+            tasks = [client.get(p) for p in LONGTAIL_PATHS]
+            return list(zip(LONGTAIL_PATHS, await asyncio.gather(*tasks, return_exceptions=True)))
+
+    start = time.monotonic()
+    results = asyncio.run(_run())
+    elapsed = time.monotonic() - start
+
+    assert elapsed < WALL_BUDGET_S, (
+        f"fan-out took {elapsed:.1f}s (>{WALL_BUDGET_S}s) — likely "
+        "serialization regression (wait_for+to_thread antipattern reintroduced)"
+    )
+
+    allowed_status = {200, 304, 400, 404, 422, 500, 502, 503}
+    for path, response in results:
+        assert not isinstance(response, BaseException), (
+            f"{path} raised {type(response).__name__}: {response} — handler "
+            "must return a structured response, never propagate."
+        )
+        assert response.status_code in allowed_status, (
+            f"{path} returned unexpected status {response.status_code}; body="
+            f"{response.text[:200]!r}"
+        )


### PR DESCRIPTION
## Summary

Wraps 15 SEO long-tail routes em `_run_with_budget` para prevenir wedge de event loop sob saturação de Googlebot fan-out.

## Context

Sweep contínuo do incident Stage 4-8 (memory `project_backend_outage_2026_04_30_stage8`). Fecha gap de cobertura RES-BE-015 — 15 rotas DB-bound em `routes/*_publicos.py` que ainda executavam `.execute()` sem time-budget wrapper, vulneráveis ao mesmo padrão wedge dos Stages 4-7.

## Testing Plan

- [ ] Backend Tests (CI required gate) green
- [ ] Audit gate `Audit routes for unprotected .execute()` green (CI workflow)
- [ ] Local: `pytest backend/tests/ -k "test_seo or test_route_budget" --timeout=30`
- [ ] Soak 24h post-merge: monitorar `smartlic_pipeline_budget_exceeded_total{phase,source}` em Prometheus

## Closes

Closes RES-BE-015
