### PR TITLE
fix(frontend): improve trial upsell copy — accents + loss aversion CTAs

### DIFF
--- a/frontend/components/billing/TrialUpsellCTA.tsx
+++ b/frontend/components/billing/TrialUpsellCTA.tsx
@@ -49,27 +49,27 @@ function getVariantCopy(variant: UpsellVariant, ctx: UpsellContextData) {
   switch (variant) {
     case "post-search":
       return {
-        message: `Voce encontrou ${ctx.opportunities ?? 0} oportunidades! Com o SmartLic Pro, analise ilimitada.`,
-        cta: "Ver planos",
+        message: `Você encontrou ${ctx.opportunities ?? 0} oportunidades! No trial, buscas são limitadas — no Pro, análise ilimitada.`,
+        cta: "Garantir acesso Pro",
       };
     case "post-download":
       return {
-        message: `Relatorio exportado! No plano Pro, exporte ate ${ctx.exportLimit ?? 1000} por mes.`,
-        cta: "Assinar SmartLic Pro",
+        message: `Relatório exportado! Após o trial, exporte até ${ctx.exportLimit ?? 1000} relatórios/mês com o Pro.`,
+        cta: "Manter acesso após trial",
       };
     case "post-pipeline":
       return {
-        message: `Pipeline ativo! Com o Pro, acompanhe ate ${ctx.pipelineLimit ?? 1000} oportunidades simultaneas.`,
-        cta: "Conhecer plano Pro",
+        message: `Pipeline ativo! No Pro, gerencie oportunidades sem limite — não perca o acesso quando o trial terminar.`,
+        cta: "Continuar com Pro",
       };
     case "dashboard":
       return {
-        message: `Voce ja analisou R$${ctx.valor ?? "0"} em oportunidades. Continue sem limites.`,
-        cta: "Assinar agora",
+        message: `Você já analisou R$${ctx.valor ?? "0"} em oportunidades. Não perca acesso quando o trial terminar.`,
+        cta: "Assinar antes do trial expirar",
       };
     case "quota":
       return {
-        message: `Voce usou ${ctx.usageLabel ?? "?/?"}  buscas. Atualize para continuar sem interrupcao.`,
+        message: `Você usou ${ctx.usageLabel ?? "?/?"} buscas. Atualize para continuar sem interrupção.`,
         cta: "Atualizar plano",
       };
   }


### PR DESCRIPTION
## Summary

- Fix missing accents across all 5 `TrialUpsellCTA` variants (`Você`, `análise`, `até`, `interrupção`, `já`)
- Rewrite messages to add trial urgency and loss aversion framing (\"Não perca acesso quando o trial terminar\")
- Update CTAs to be action-driven: \"Ver planos\" → \"Garantir acesso Pro\", \"Assinar agora\" → \"Assinar antes do trial expirar\"
- No logic changes — pure copy update

## North Star

north_star: retention

## Testing

- [x] 38/38 unit tests passing (`__tests__/billing/trial-upsell-cta.test.tsx`)
- [x] story320-paywall tests unaffected (those check `SearchResults.tsx` CTA, not this component)
- [ ] Verify in staging with active trial account

## Closes

Closes #N/A — discovered via Phase 0 UX audit (n_trial_active=3, signups_7d=0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified trial lifecycle messaging to distinguish trial-limited vs Pro unlimited access.
  * Revised upsell CTAs across post-search, post-download, post-pipeline, and dashboard to more specific actions that emphasize preserving access after trial end.
  * Updated pipeline wording to "sem limite" and fixed Portuguese accenting in the quota message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->