### PR TITLE
fix(backend): strip top_result_* columns from search_sessions (#541)

### DIFF
--- a/backend/routes/analytics.py
+++ b/backend/routes/analytics.py
@@ -318,7 +318,6 @@ async def get_top_dimensions(
 class TopOpportunity(BaseModel):
     title: str
     value: float
-    # STORY-371: Real edital fields
     objeto: str | None = None
     orgao_nome: str | None = None
     numero_controle: str | None = None
@@ -351,12 +350,8 @@ async def get_trial_value(user: dict = Depends(require_auth), db=Depends(get_db)
         trial_start = profile.get("created_at")
         trial_end = profile.get("trial_expires_at")
 
-        # Query search sessions within trial period.
-        # STORY-371: Include optional top_result_* columns for personalization.
-        # These columns may not exist on older DB versions — if the query fails,
-        # the outer try/except will surface a 503 which is the existing behavior.
         query = db.table("search_sessions").select(
-            "total_filtered, valor_total, created_at, sectors, top_result_objeto, top_result_orgao, top_result_numero_controle, top_result_data_encerramento, top_result_modalidade"
+            "total_filtered, valor_total, created_at, sectors"
         ).eq("user_id", user_id)
 
         if trial_start:
@@ -381,30 +376,20 @@ async def get_trial_value(user: dict = Depends(require_auth), db=Depends(get_db)
         searches_executed = len(sessions)
         avg_opportunity_value = total_value / total_opportunities if total_opportunities > 0 else 0.0
 
-        # Top opportunity = session with highest valor_total.
-        # STORY-412: ``objeto_resumo`` removed from the query above, so
-        # the title is always the literal fallback. Keeping the literal
-        # here (instead of interpolating any session field) avoids
-        # accidental PII leakage through search titles and matches the
-        # copy already reviewed by product.
         top_session = sessions[0] if sessions else None
         top_opportunity = None
         if top_session and float(Decimal(str(top_session.get("valor_total") or 0))) > 0:
             top_value = float(Decimal(str(top_session.get("valor_total") or 0)))
-            # STORY-371 AC1: Use real edital fields if available
-            objeto_raw = top_session.get("top_result_objeto") or "Oportunidade identificada"
-            from utils.formatters import truncate_text, dias_ate_data
-            data_enc = top_session.get("top_result_data_encerramento")
             top_opportunity = TopOpportunity(
-                title=truncate_text(objeto_raw, 120),
+                title="Oportunidade identificada",
                 value=top_value,
-                objeto=truncate_text(objeto_raw, 120),
-                orgao_nome=top_session.get("top_result_orgao"),
-                numero_controle=top_session.get("top_result_numero_controle"),
-                data_encerramento=data_enc,
-                dias_ate_encerramento=dias_ate_data(data_enc),
+                objeto="Oportunidade identificada",
+                orgao_nome=None,
+                numero_controle=None,
+                data_encerramento=None,
+                dias_ate_encerramento=None,
                 setor=(top_session.get("sectors") or [None])[0],
-                modalidade=top_session.get("top_result_modalidade"),
+                modalidade=None,
             )
 
         logger.info(

--- a/backend/services/trial_email_sequence.py
+++ b/backend/services/trial_email_sequence.py
@@ -160,14 +160,14 @@ def get_coupon_checkout_url() -> str:
 # ============================================================================
 
 def _get_top_trial_opportunity(user_id: str) -> dict | None:
-    """STORY-371 AC1: Get the highest-value trial opportunity for email personalization."""
+    """Get the highest-value trial session for email personalization."""
     from supabase_client import get_supabase
-    from utils.formatters import truncate_text, dias_ate_data, format_brl
+    from utils.formatters import format_brl
     try:
         sb = get_supabase()
         result = (
             sb.table("search_sessions")
-            .select("valor_total, top_result_objeto, top_result_orgao, top_result_numero_controle, top_result_data_encerramento")
+            .select("valor_total")
             .eq("user_id", user_id)
             .gt("valor_total", 0)
             .order("valor_total", desc=True)
@@ -180,17 +180,14 @@ def _get_top_trial_opportunity(user_id: str) -> dict | None:
         valor = float(row.get("valor_total") or 0)
         if valor <= 0:
             return None
-        data_enc = row.get("top_result_data_encerramento")
-        dias = dias_ate_data(data_enc)
-        objeto = truncate_text(row.get("top_result_objeto") or "", 120)
         return {
-            "objeto": objeto,
-            "orgao_nome": row.get("top_result_orgao") or "",
+            "objeto": "",
+            "orgao_nome": "",
             "valor_formatado": format_brl(valor),
             "valor": valor,
-            "data_encerramento": data_enc,
-            "dias_ate_encerramento": dias,
-            "numero_controle": row.get("top_result_numero_controle") or "",
+            "data_encerramento": None,
+            "dias_ate_encerramento": None,
+            "numero_controle": "",
         }
     except Exception as e:
         logger.debug(f"Could not fetch top opportunity for email: {e}")

--- a/backend/tests/test_trial_value_top_opportunity.py
+++ b/backend/tests/test_trial_value_top_opportunity.py
@@ -1,7 +1,6 @@
-"""Tests for STORY-371: trial-value endpoint with real top_opportunity."""
+"""Tests for trial-value endpoint top_opportunity (issue #541 — Option B: columns stripped)."""
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from decimal import Decimal
+from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 from main import app
 from auth import require_auth
@@ -27,7 +26,7 @@ def client():
 
 
 class TestTrialValueTopOpportunity:
-    def test_returns_real_objeto_when_available(self, client):
+    def test_returns_top_opportunity_with_value(self, client):
         mock_db = MagicMock()
 
         profile_result = MagicMock()
@@ -39,12 +38,7 @@ class TestTrialValueTopOpportunity:
                 "total_filtered": 5,
                 "valor_total": "87000.00",
                 "created_at": "2026-04-05T00:00:00Z",
-                "setor": "limpeza",
-                "top_result_objeto": "Pregão Eletrônico de Limpeza Predial",
-                "top_result_orgao": "Prefeitura de Curitiba",
-                "top_result_numero_controle": "PNCP-2026-001",
-                "top_result_data_encerramento": "2026-12-31",
-                "top_result_modalidade": "Pregão Eletrônico",
+                "sectors": ["limpeza"],
             }
         ]
 
@@ -64,9 +58,9 @@ class TestTrialValueTopOpportunity:
         assert resp.status_code == 200
         data = resp.json()
         assert data["top_opportunity"] is not None
-        assert data["top_opportunity"]["objeto"] == "Pregão Eletrônico de Limpeza Predial"
-        assert data["top_opportunity"]["orgao_nome"] == "Prefeitura de Curitiba"
-        assert data["top_opportunity"]["numero_controle"] == "PNCP-2026-001"
+        assert data["top_opportunity"]["value"] == 87000.0
+        assert data["top_opportunity"]["setor"] == "limpeza"
+        assert data["top_opportunity"]["objeto"] == "Oportunidade identificada"
 
     def test_returns_null_when_no_sessions(self, client):
         mock_db = MagicMock()


### PR DESCRIPTION
## Context

Issue #541: STORY-371 shipped code that SELECTs 5 non-existent columns (`top_result_objeto`, `top_result_orgao`, `top_result_numero_controle`, `top_result_data_encerramento`, `top_result_modalidade`) from `search_sessions`. Migration was never applied → 5 Sentry errors/24h + broken trial email personalization.

**Decision:** Option B (strip code) over Option A (migration + populator). Rationale: n<30 paid users, personalization ROI marginal; stopping Sentry noise takes priority. STORY-371 can be properly reopened with migration + populator when n≥30.

## Changes

- `backend/routes/analytics.py`: remove `top_result_*` from SELECT in `/v1/analytics/trial-value`; `TopOpportunity` returns `"Oportunidade identificada"` placeholder
- `backend/services/trial_email_sequence.py`: `_get_top_trial_opportunity()` SELECTs only `valor_total`; returns generic dict without edital fields
- `backend/tests/test_trial_value_top_opportunity.py`: update assertions to match new fallback behavior; remove unused imports

## Testing Plan

- [x] 8/8 tests in `test_trial_value_top_opportunity.py` passing
- [x] 204/204 analytics + trial_email tests passing (no regressions)
- [x] `ruff check` clean on all 3 files
- [x] No `top_result_*` references remain in backend codebase

## Risks & Rollback

**Risk:** Trial email "top opportunity" section shows generic text instead of real edital name. This was already the fallback behavior (column `top_result_objeto` was always NULL since migration never ran). No regression vs production behavior.

**Rollback:** `git revert e7912026` — safe, additive change only.

## Closes

Closes #541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trial-period opportunities now display simplified information with only generic descriptions and monetary values, removing detailed contract data (agency names, control numbers, dates).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->