### PR TITLE
fix(backend): PNCPRateLimitError carries retry_after; raised on 429 exhaustion

### DIFF
--- a/backend/clients/pncp/async_client.py
+++ b/backend/clients/pncp/async_client.py
@@ -28,7 +28,7 @@ from config import (
     PNCP_BATCH_SIZE,
     PNCP_BATCH_DELAY_S,
 )
-from exceptions import PNCPAPIError
+from exceptions import PNCPAPIError, PNCPRateLimitError
 from middleware import request_id_var
 
 from clients.pncp.circuit_breaker import _circuit_breaker  # noqa: F401
@@ -431,6 +431,8 @@ class AsyncPNCPClient(_PNCPParallelMixin):
         format_rotation = _get_format_rotation()
         format_idx = 0
 
+        last_was_rate_limit = False
+        last_retry_after = 60
         for attempt in range(self.config.max_retries + 1):
             try:
                 logger.debug(
@@ -450,10 +452,13 @@ class AsyncPNCPClient(_PNCPParallelMixin):
 
                 # Handle rate limiting
                 if response.status_code == 429:
-                    retry_after = int(response.headers.get("Retry-After", 60))
-                    logger.debug(f"Rate limited (429). Waiting {retry_after}s")
-                    await asyncio.sleep(retry_after)
+                    last_retry_after = int(response.headers.get("Retry-After", 60))
+                    last_was_rate_limit = True
+                    logger.debug(f"Rate limited (429). Waiting {last_retry_after}s")
+                    await asyncio.sleep(last_retry_after)
                     continue
+
+                last_was_rate_limit = False
 
                 # Success
                 if response.status_code == 200:
@@ -620,6 +625,11 @@ class AsyncPNCPClient(_PNCPParallelMixin):
                 else:
                     raise PNCPAPIError(f"HTTP error after retries: {e}") from e
 
+        if last_was_rate_limit:
+            raise PNCPRateLimitError(
+                f"Rate limit persists after {self.config.max_retries + 1} attempts",
+                retry_after=last_retry_after,
+            )
         raise PNCPAPIError("Unexpected: exhausted retries without result")
 
     async def _fetch_single_modality(

--- a/backend/clients/pncp/sync_client.py
+++ b/backend/clients/pncp/sync_client.py
@@ -15,7 +15,7 @@ from config import (
     DEFAULT_MODALIDADES,
     MODALIDADES_EXCLUIDAS,
 )
-from exceptions import PNCPAPIError
+from exceptions import PNCPAPIError, PNCPRateLimitError
 from middleware import request_id_var
 
 from clients.pncp.retry import (
@@ -178,6 +178,8 @@ class PNCPClient:
         format_rotation = _get_format_rotation()
         format_idx = 0
 
+        last_was_rate_limit = False
+        last_retry_after = 60
         for attempt in range(self.config.max_retries + 1):
             try:
                 logger.debug(
@@ -192,13 +194,16 @@ class PNCPClient:
 
                 # Handle rate limiting specifically
                 if response.status_code == 429:
-                    retry_after = int(response.headers.get("Retry-After", 60))
+                    last_retry_after = int(response.headers.get("Retry-After", 60))
+                    last_was_rate_limit = True
                     logger.debug(
-                        f"Rate limited (429). Waiting {retry_after}s "
+                        f"Rate limited (429). Waiting {last_retry_after}s "
                         f"(Retry-After header)"
                     )
-                    time.sleep(retry_after)
+                    time.sleep(last_retry_after)
                     continue
+
+                last_was_rate_limit = False
 
                 # Success case
                 if response.status_code == 200:
@@ -361,7 +366,11 @@ class PNCPClient:
                     logger.error(error_msg)
                     raise PNCPAPIError(error_msg) from e
 
-        # Should never reach here, but just in case
+        if last_was_rate_limit:
+            raise PNCPRateLimitError(
+                f"Rate limit persists after {self.config.max_retries + 1} attempts",
+                retry_after=last_retry_after,
+            )
         raise PNCPAPIError("Unexpected: exhausted retries without raising exception")
 
     @staticmethod

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -10,7 +10,9 @@ class PNCPAPIError(Exception):
 class PNCPRateLimitError(PNCPAPIError):
     """Raised when API rate limit is exceeded (HTTP 429)."""
 
-    pass
+    def __init__(self, *args, retry_after: int = 60):
+        super().__init__(*args)
+        self.retry_after = retry_after
 
 
 class PNCPTimeoutError(PNCPAPIError):

--- a/backend/tests/test_pncp_rate_limit_retry_after.py
+++ b/backend/tests/test_pncp_rate_limit_retry_after.py
@@ -1,0 +1,139 @@
+"""Tests for issue #209 — PNCPRateLimitError carries retry_after on 429 exhaustion."""
+import asyncio
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from exceptions import PNCPAPIError, PNCPRateLimitError
+
+
+class TestPNCPRateLimitErrorAttribute:
+    def test_has_retry_after_default(self):
+        err = PNCPRateLimitError("rate limited")
+        assert err.retry_after == 60
+
+    def test_has_retry_after_custom(self):
+        err = PNCPRateLimitError("rate limited", retry_after=120)
+        assert err.retry_after == 120
+
+    def test_is_subclass_of_pncp_api_error(self):
+        err = PNCPRateLimitError("x")
+        assert isinstance(err, PNCPAPIError)
+
+
+class TestSyncClientRateLimitExhaustion:
+    def _make_response(self, status_code, retry_after=None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        headers = {}
+        if retry_after is not None:
+            headers["Retry-After"] = str(retry_after)
+        resp.headers = headers
+        return resp
+
+    def test_all_429_raises_rate_limit_error(self):
+        from clients.pncp.sync_client import PNCPClient
+        from config import RetryConfig
+
+        config = RetryConfig(max_retries=1)
+        client = PNCPClient(config=config)
+
+        resp_429 = self._make_response(429, retry_after=30)
+        with patch.object(client.session, "get", return_value=resp_429), \
+             patch("time.sleep"):
+            with pytest.raises(PNCPRateLimitError) as exc_info:
+                client.fetch_page("2026-01-01", "2026-01-10", 6, uf="SP")
+
+        assert exc_info.value.retry_after == 30
+
+    def test_429_then_500_raises_api_error(self):
+        from clients.pncp.sync_client import PNCPClient
+        from config import RetryConfig
+
+        config = RetryConfig(max_retries=1)
+        client = PNCPClient(config=config)
+
+        resp_429 = self._make_response(429, retry_after=15)
+        resp_500 = self._make_response(500)
+        responses = iter([resp_429, resp_500])
+
+        with patch.object(client.session, "get", side_effect=lambda *a, **kw: next(responses)), \
+             patch("time.sleep"):
+            with pytest.raises(PNCPAPIError) as exc_info:
+                client.fetch_page("2026-01-01", "2026-01-10", 6, uf="SP")
+
+        assert not isinstance(exc_info.value, PNCPRateLimitError)
+
+    def test_429_then_200_returns_result(self):
+        from clients.pncp.sync_client import PNCPClient
+        from config import RetryConfig
+
+        config = RetryConfig(max_retries=1)
+        client = PNCPClient(config=config)
+
+        resp_429 = self._make_response(429, retry_after=5)
+
+        resp_200 = self._make_response(200)
+        resp_200.headers = {"content-type": "application/json"}
+        resp_200.json.return_value = {"data": [], "totalRegistros": 0, "totalPaginas": 1}
+
+        responses = iter([resp_429, resp_200])
+
+        with patch.object(client.session, "get", side_effect=lambda *a, **kw: next(responses)), \
+             patch("time.sleep"):
+            result = client.fetch_page("2026-01-01", "2026-01-10", 6, uf="SP")
+
+        assert result["totalRegistros"] == 0
+
+
+class TestAsyncClientRateLimitExhaustion:
+    def _make_response(self, status_code, retry_after=None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        headers = {}
+        if retry_after is not None:
+            headers["Retry-After"] = str(retry_after)
+        resp.headers = headers
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_all_429_raises_rate_limit_error(self):
+        from clients.pncp.async_client import AsyncPNCPClient
+        from config import RetryConfig
+        import httpx
+
+        config = RetryConfig(max_retries=1)
+
+        resp_429 = self._make_response(429, retry_after=45)
+        mock_get = AsyncMock(return_value=resp_429)
+
+        async with AsyncPNCPClient(config=config) as client:
+            with patch.object(client._client, "get", mock_get), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(PNCPRateLimitError) as exc_info:
+                    await client._fetch_page_async("2026-01-01", "2026-01-10", 6, uf="SP")
+
+        assert exc_info.value.retry_after == 45
+
+    @pytest.mark.asyncio
+    async def test_429_then_200_returns_result(self):
+        from clients.pncp.async_client import AsyncPNCPClient
+        from config import RetryConfig
+
+        config = RetryConfig(max_retries=1)
+
+        resp_429 = self._make_response(429, retry_after=5)
+        resp_200 = self._make_response(200)
+        resp_200.headers = {"content-type": "application/json"}
+        resp_200.json.return_value = {"data": [], "totalRegistros": 0, "totalPaginas": 1}
+
+        responses = iter([resp_429, resp_200])
+
+        async def side_effect(*a, **kw):
+            return next(responses)
+
+        async with AsyncPNCPClient(config=config) as client:
+            with patch.object(client._client, "get", side_effect=side_effect), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await client._fetch_page_async("2026-01-01", "2026-01-10", 6, uf="SP")
+
+        assert result["totalRegistros"] == 0


### PR DESCRIPTION
## Context

`PNCPRateLimitError` never carried a `retry_after` attribute, and was never actually raised when the API exhausted all retry attempts with 429 responses. Both sync and async clients fell through to `raise PNCPAPIError(\"Unexpected: exhausted retries\")`, making the `except PNCPRateLimitError` branch in the search route state machine permanently dead code. The `getattr(e, \"retry_after\", 60)` safety net in `routes/search/__init__.py` was compensating but never triggering.

## Changes

- `backend/exceptions.py` — add `retry_after: int = 60` to `PNCPRateLimitError.__init__`
- `backend/clients/pncp/sync_client.py` — track `last_was_rate_limit` + `last_retry_after` across retry loop; raise `PNCPRateLimitError` with correct value when all attempts exhaust on 429; import `PNCPRateLimitError`
- `backend/clients/pncp/async_client.py` — same pattern (async); import `PNCPRateLimitError`
- `backend/tests/test_pncp_rate_limit_retry_after.py` — 8 new tests covering: attribute default/custom, all-429→PNCPRateLimitError with correct retry_after, 429+500→PNCPAPIError (not PNCPRateLimitError), 429+200→success (sync and async)

## Testing Plan

- [x] 8 new unit tests passing (`test_pncp_rate_limit_retry_after.py`)
- [x] 33 existing `test_pncp_client.py` tests passing — no regressions
- [x] `getattr(e, "retry_after", 60)` pattern in search route now receives the real value instead of always defaulting to 60

## Risks & Rollback

Minimal risk — the fallthrough `raise PNCPAPIError` is preserved; only the new conditional above it can raise `PNCPRateLimitError`. The only behavioral change is: when all retry attempts hit 429, callers now receive `PNCPRateLimitError` (correct type) instead of `PNCPAPIError` (wrong type). Rollback: revert commit `ec3f7841`.

## Closes

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to distinguish rate-limiting failures from other retry exhaustion scenarios. When rate limits are encountered, the API now raises a dedicated rate-limit error with `retry_after` timing information sourced from response headers.

* **Tests**
  * Added comprehensive test coverage for rate-limit error handling in both synchronous and asynchronous client scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->