### PR TITLE
fix(backend): DEBT-OBS-001 — observatorio is_historical last-day boundary

### DIFF
--- a/backend/routes/observatorio.py
+++ b/backend/routes/observatorio.py
@@ -138,7 +138,8 @@ def _is_period_historical(mes: int, ano: int) -> bool:
     200+is_empty_period (historical empty).
     """
     try:
-        return (date.today() - date(ano, mes, 1)).days > 30
+        _, last_day = calendar.monthrange(ano, mes)
+        return date.today() > date(ano, mes, last_day)
     except ValueError:
         return False
 
@@ -361,9 +362,9 @@ async def _generate_relatorio(mes: int, ano: int) -> dict:
     prev_inicial = f"{prev_ano:04d}-{prev_mes:02d}-01"
     prev_final = f"{prev_ano:04d}-{prev_mes:02d}-{prev_last:02d}"
 
-    # Detect if month is historical (>30 days ago — data may be soft-deleted)
+    # Detect if month is historical (last day of month is in the past)
     today = date.today()
-    is_historical = (today - date(ano, mes, 1)).days > 30
+    is_historical = today > date(ano, mes, last_day)
 
     # Query current month
     results: list[dict] = []
@@ -431,7 +432,7 @@ async def _generate_relatorio(mes: int, ano: int) -> dict:
 
     # Previous month: best-effort under the same budget. A failure here only
     # degrades the "setores em alta" comparison — not a fatal error.
-    prev_is_historical = (today - date(prev_ano, prev_mes, 1)).days > 30
+    prev_is_historical = today > date(prev_ano, prev_mes, prev_last)
     if prev_is_historical:
         try:
             prev_results = await _run_with_budget(

--- a/backend/routes/observatorio.py
+++ b/backend/routes/observatorio.py
@@ -132,7 +132,7 @@ class RelatorioMensal(BaseModel):
 # ---------------------------------------------------------------------------
 
 def _is_period_historical(mes: int, ano: int) -> bool:
-    """STORY-431 AC11: treat months >30d in the past as historical.
+    """STORY-431 AC11: treat a month as historical only after its last calendar day.
 
     Used by route handler to choose between 404 (current empty) and
     200+is_empty_period (historical empty).

--- a/backend/tests/test_observatorio.py
+++ b/backend/tests/test_observatorio.py
@@ -191,10 +191,28 @@ class TestObservatorioBudgetAndEmptyPeriod:
         return today.month, today.year
 
     def _historical_month_year(self):
-        """Pick a (mes, ano) > 30 days in the past so AC11 routes it as historical."""
+        """Pick a (mes, ano) whose last day is in the past (historical)."""
         from datetime import date, timedelta
         ref = date.today() - timedelta(days=60)
         return ref.month, ref.year
+
+    def test_is_period_historical_boundary(self):
+        """DEBT-OBS-001: last day of month is the correct historical boundary.
+
+        Regression guard: days-from-month-start > 30 caused April to be treated
+        as current on May 1 (delta = 30, not > 30). Last-day comparison fixes it.
+        """
+        import calendar
+        from datetime import date
+        from unittest.mock import patch
+        from routes.observatorio import _is_period_historical
+
+        # May 1 → April 30 is in the past → historical
+        with patch("routes.observatorio.date") as mock_date:
+            mock_date.today.return_value = date(2026, 5, 1)
+            mock_date.side_effect = lambda *a, **k: date(*a, **k)
+            assert _is_period_historical(4, 2026) is True, "April 2026 must be historical on May 1"
+            assert _is_period_historical(5, 2026) is False, "May 2026 must be current on May 1"
 
     def test_empty_current_month_returns_404(self, mock_datalake_empty, client):
         """AC11: current month with zero data → 404 + X-Robots-Tag noindex,nofollow.


### PR DESCRIPTION
## Summary
- `_is_period_historical` usava `(date.today() - date(ano, mes, 1)).days > 30` — em 2026-05-01, Abril retorna delta=30, não >30 → falso \"current\" → query sem modo histórico → 0 resultados → 404
- 3 ocorrências corrigidas: `_is_period_historical()` L141, `_generate_relatorio()` L366 (usa `last_day` existente), L435 (`prev_is_historical` usa `prev_last` existente)
- Fix semântico correto: \"mês é histórico quando seu último dia já passou\"
- Adicionado `test_is_period_historical_boundary` que pina Abril 2026 como histórico em 1 de maio (regressão guard)

## Impacto
- CI `deploy.yml` quebrava em main a cada deploy (smoke test retornava 404 para URLs de Abril)
- URLs observatório Abril 2026 retornavam 404 → SEO damage (55.537 rows disponíveis no DB)

## Testing Plan
- [x] 14/14 testes `test_observatorio.py` passando
- [x] Novo `test_is_period_historical_boundary` — pina boundary exato
- [x] Probe live: endpoint retornava 404 para `/v1/observatorio/raio-x-setor/construcao?ano=2026&mes=4` (confirmado antes do fix)

## Closes
DEBT-OBS-001 — discovered 2026-05-01 sessão 029

north_star: unblock_cash
tags: safety, seo, observatorio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected historical-period detection so months become historical only after their final calendar day, ensuring correct content routing, response behavior, and data selection for past months.

* **Tests**
  * Added regression tests to lock in the corrected historical vs. current period classification and prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->