### PR TITLE
fix(seo): SEO-026 — Allow /alertas-publicos in robots.txt (RFC 9309 prefix-match fix)

### DIFF
--- a/docs/stories/STORY-SEO-026-robots-alertas-prefix-match-fix.md
+++ b/docs/stories/STORY-SEO-026-robots-alertas-prefix-match-fix.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Ready (GO @po 2026-04-27)** — promovida Draft → Ready; ver §"Verdict @po" abaixo
+**InReview**
 
 ## Prioridade
 
@@ -48,14 +48,10 @@ Frontend tem rotas reais:
 
 ## Critérios de Aceite
 
-- [ ] **AC1:** robots.txt em produção (https://smartlic.tech/robots.txt) bloqueia `/alertas` (raiz privada) sem prefix-match em `/alertas-publicos`
-- [ ] **AC2:** Solução escolhida e justificada inline:
-  - Opção A: `Disallow: /alertas/` (com slash final — bloqueia `/alertas/foo` mas não `/alertas-publicos`)
-  - Opção B: `Disallow: /alertas$` (Google extension — match exato)
-  - Opção C: listar rotas privadas explicitamente (`Disallow: /alertas/page`, etc.)
-  - Opção D: adicionar `Allow: /alertas-publicos` defensivo (override por specificity)
-- [ ] **AC3:** Validação via Google Robots Testing Tool (ou equivalente curl + parser): `/alertas-publicos/saude/sp` permitido; `/alertas` (raiz privada) ainda bloqueada
-- [ ] **AC4:** Teste backend: snapshot de robots.txt commitado em `backend/tests/test_robots_txt.py` ou `frontend/__tests__/robots.test.ts` validando os 4 casos (alertas blocked, alertas-publicos allowed, etc.)
+- [x] **AC1:** robots.txt em produção (https://smartlic.tech/robots.txt) bloqueia `/alertas` (raiz privada) sem prefix-match em `/alertas-publicos`
+- [x] **AC2:** Solução escolhida: **Opção D** — `Allow: /alertas-publicos` adicionado antes de `Disallow: /alertas`. Longest-match RFC 9309: Allow=16 chars > Disallow=8 chars → Allow vence para qualquer path /alertas-publicos/*. Mais portable e semântico que Opção A (trailing slash).
+- [ ] **AC3:** Validação via Google Robots Testing Tool pós-deploy: `/alertas-publicos/saude/sp` permitido; `/alertas` (raiz privada) ainda bloqueada
+- [x] **AC4:** Teste `frontend/__tests__/seo/robots-txt.test.ts` — 32 casos cobrindo private blocked (13) + alertas-publicos allowed (7) + other public allowed (10) + directive checks (2). 32/32 PASS.
 - [ ] **AC5:** Pós-deploy: GSC > Indexação > "Bloqueada pelo robots.txt" cai para <50 URLs em 21 dias (excluindo `/api/og`)
 - [ ] **AC6:** Pós-deploy: Solicitar reindexação via GSC para as 5 URLs do cluster "Indexada mas bloqueada" (`/alertas-publicos/materiais_eletricos/{ac,rr,ba,am,pe}`)
 
@@ -120,3 +116,4 @@ Frontend tem rotas reais:
 |------|--------|------|
 | 2026-04-27 | @sm (River) | Story criada a partir do brief GSC root-cause §3.3 + S3 |
 | 2026-04-27 | @po (Sarah) | **Validação 6-section: 6/6 PASS → GO**. Status: Draft → Ready. Não bloqueada por incident backend. ADAPT de SEO-022 (Done) — IDS-compliant. |
+| 2026-05-01 | @dev (Dex) | Implementação: `Allow: /alertas-publicos` adicionado em `frontend/public/robots.txt` (Opção D — longest-match RFC 9309). Teste `frontend/__tests__/seo/robots-txt.test.ts` — 32/32 PASS. Status: Ready → InReview. |

--- a/frontend/__tests__/seo/robots-txt.test.ts
+++ b/frontend/__tests__/seo/robots-txt.test.ts
@@ -1,0 +1,161 @@
+/**
+ * STORY-SEO-026: robots.txt prefix-match fix for /alertas-publicos
+ *
+ * Validates RFC 9309 §2.2.2 longest-match semantics so that:
+ * - /alertas (private logged-in panel) stays BLOCKED
+ * - /alertas-publicos/* (public SEO pages) are ALLOWED
+ *
+ * Reference: https://www.rfc-editor.org/rfc/rfc9309#name-the-allow-and-disallow-line
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Minimal RFC 9309 parser (User-agent: * block only)
+// ---------------------------------------------------------------------------
+
+type Rule = { allow: boolean; path: string };
+
+function parseRobotsForUserAgentStar(content: string): Rule[] {
+  const lines = content.split("\n").map((l) => l.trim());
+  const rules: Rule[] = [];
+  let inStarBlock = false;
+
+  for (const line of lines) {
+    if (line.startsWith("#") || line === "") continue;
+
+    if (line.toLowerCase().startsWith("user-agent:")) {
+      const ua = line.split(":")[1].trim();
+      inStarBlock = ua === "*";
+      continue;
+    }
+
+    if (!inStarBlock) continue;
+
+    if (line.toLowerCase().startsWith("allow:")) {
+      rules.push({ allow: true, path: line.split(":")[1].trim() });
+    } else if (line.toLowerCase().startsWith("disallow:")) {
+      rules.push({ allow: false, path: line.split(":")[1].trim() });
+    }
+  }
+
+  return rules;
+}
+
+/**
+ * RFC 9309 §2.2.2: longest matching path wins; on tie Allow wins.
+ * Returns true if the path is allowed.
+ */
+function isAllowed(rules: Rule[], urlPath: string): boolean {
+  let bestMatchLen = -1;
+  let bestMatchAllow = true; // default allow
+
+  for (const rule of rules) {
+    const rp = rule.path;
+    if (rp === "" || rp === "/") {
+      if (rp === "/") {
+        if (rp.length > bestMatchLen || (rp.length === bestMatchLen && rule.allow)) {
+          bestMatchLen = rp.length;
+          bestMatchAllow = rule.allow;
+        }
+      }
+      continue;
+    }
+    if (urlPath.startsWith(rp)) {
+      if (rp.length > bestMatchLen || (rp.length === bestMatchLen && rule.allow)) {
+        bestMatchLen = rp.length;
+        bestMatchAllow = rule.allow;
+      }
+    }
+  }
+
+  return bestMatchAllow;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("robots.txt — SEO-026 prefix-match fix", () => {
+  let rules: Rule[];
+
+  beforeAll(() => {
+    const robotsPath = path.join(__dirname, "../../public/robots.txt");
+    const content = fs.readFileSync(robotsPath, "utf8");
+    rules = parseRobotsForUserAgentStar(content);
+  });
+
+  describe("private routes remain BLOCKED", () => {
+    const privateRoutes = [
+      "/alertas",
+      "/admin",
+      "/api/anything",
+      "/dashboard",
+      "/conta",
+      "/buscar",
+      "/pipeline",
+      "/historico",
+      "/mensagens",
+      "/onboarding",
+      "/recuperar-senha",
+      "/redefinir-senha",
+      "/auth/callback",
+    ];
+
+    it.each(privateRoutes)("%s is blocked", (route) => {
+      expect(isAllowed(rules, route)).toBe(false);
+    });
+  });
+
+  describe("public SEO routes are ALLOWED — SEO-026 fix", () => {
+    const publicSeoRoutes = [
+      "/alertas-publicos",
+      "/alertas-publicos/saude/sp",
+      "/alertas-publicos/materiais_eletricos/ac",
+      "/alertas-publicos/materiais_eletricos/rr",
+      "/alertas-publicos/materiais_eletricos/ba",
+      "/alertas-publicos/materiais_eletricos/am",
+      "/alertas-publicos/materiais_eletricos/pe",
+    ];
+
+    it.each(publicSeoRoutes)("%s is allowed (was blocked before SEO-026)", (route) => {
+      expect(isAllowed(rules, route)).toBe(true);
+    });
+  });
+
+  describe("other public pages remain ALLOWED", () => {
+    const publicPages = [
+      "/",
+      "/planos",
+      "/ajuda",
+      "/termos",
+      "/privacidade",
+      "/observatorio/raio-x-saude-sp",
+      "/licitacoes/saude",
+      "/contratos/saude/sp",
+      "/blog/licitacoes/saude",
+      "/cnpj/12345678901234",
+    ];
+
+    it.each(publicPages)("%s is allowed", (route) => {
+      expect(isAllowed(rules, route)).toBe(true);
+    });
+  });
+
+  it("robots.txt contains explicit Allow: /alertas-publicos directive", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "../../public/robots.txt"),
+      "utf8"
+    );
+    expect(content).toMatch(/Allow:\s*\/alertas-publicos/);
+  });
+
+  it("robots.txt still contains Disallow: /alertas to block private panel", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "../../public/robots.txt"),
+      "utf8"
+    );
+    expect(content).toMatch(/Disallow:\s*\/alertas/);
+  });
+});

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -12,6 +12,7 @@ Disallow: /buscar
 Disallow: /pipeline
 Disallow: /historico
 Disallow: /mensagens
+Allow: /alertas-publicos
 Disallow: /alertas
 Disallow: /onboarding
 Disallow: /recuperar-senha


### PR DESCRIPTION
## Context

`Disallow: /alertas` in robots.txt was prefix-matching `/alertas-publicos/*` per RFC 9309 §2.2.2, blocking ~280 public SEO pages from Google crawl. GSC reported these in the "Bloqueada pelo robots.txt" cluster.

Affected cluster (GSC evidence from 2026-04-27 brief):
- ~280 URLs `/alertas-publicos/{setor}/{uf}` blocked
- 5 URLs already indexed with "Indexada, mas bloqueada" status

## Changes

- `frontend/public/robots.txt` — Added `Allow: /alertas-publicos` before `Disallow: /alertas`. RFC 9309 longest-match: `Allow: /alertas-publicos` (16 chars) > `Disallow: /alertas` (8 chars) → Allow wins for any `/alertas-publicos/*` path.
- `frontend/__tests__/seo/robots-txt.test.ts` — 32-case Jest test suite with RFC 9309 parser validating private blocked + public allowed + regression cases.
- `docs/stories/STORY-SEO-026-robots-alertas-prefix-match-fix.md` — Status: Ready → InReview, AC1/AC2/AC4 checked.

## Testing Plan

- [x] 32 Jest tests passing (13 private blocked + 7 alertas-publicos allowed + 10 other public + 2 directive checks)
- [x] Local RFC 9309 parser validates longest-match semantics correctly
- [ ] AC3: Google Robots Testing Tool validation post-deploy (manual, @devops)
- [ ] AC5: GSC "Bloqueada pelo robots.txt" decay <50 URLs in 21d (post-deploy monitoring)
- [ ] AC6: Request reindexation for 5 "Indexada mas bloqueada" URLs

## Risks & Rollback

- Risk: Google re-fetch robots.txt takes 24-72h — no immediate GSC impact visible
- Rollback: revert `Allow: /alertas-publicos` line (1-line change)
- Zero risk of false unblocking: `/alertas` and `/alertas/` remain Disallowed

## Closes

STORY-SEO-026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search-engine crawling rules to block private alert routes while explicitly allowing public alert content (/alertas-publicos).

* **Tests**
  * Added comprehensive verification tests for crawling rule behavior; all checks pass (32/32).

* **Documentation**
  * Changelog updated and story status moved to InReview; post-deploy verification via external robots testing remains pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->