### PR TITLE
fix(backend): /health/ready use sb_execute_direct + 5s Supabase timeout [MON-FN-005]

### DIFF
--- a/backend/routes/health_core.py
+++ b/backend/routes/health_core.py
@@ -19,7 +19,7 @@ router = APIRouter(tags=["health-core"])
 
 # HARDEN-016 AC3: Individual dependency timeouts
 _READINESS_REDIS_TIMEOUT_S = 2.0
-_READINESS_SUPABASE_TIMEOUT_S = 3.0
+_READINESS_SUPABASE_TIMEOUT_S = 5.0  # increased from 3s to reduce false-503 under bot-driven pool saturation
 
 
 def _inc_health_failure(check: str) -> None:
@@ -83,9 +83,9 @@ async def health_ready(response: Response):
     # Supabase check
     sb_start = time.monotonic()
     try:
-        from supabase_client import get_supabase, sb_execute
+        from supabase_client import get_supabase, sb_execute_direct
         sb = get_supabase()
-        await asyncio.wait_for(sb_execute(sb.table("profiles").select("id").limit(1)), timeout=_READINESS_SUPABASE_TIMEOUT_S)
+        await asyncio.wait_for(sb_execute_direct(sb.table("profiles").select("id").limit(1)), timeout=_READINESS_SUPABASE_TIMEOUT_S)
         checks["supabase"] = {"status": "up", "latency_ms": round((time.monotonic() - sb_start) * 1000)}
     except asyncio.TimeoutError:
         checks["supabase"] = {"status": "down", "error": "timeout", "latency_ms": round((time.monotonic() - sb_start) * 1000)}

--- a/backend/tests/test_health_ready.py
+++ b/backend/tests/test_health_ready.py
@@ -81,7 +81,7 @@ class TestHealthReady:
         mock_response = MagicMock()
         mock_response.data = [{"id": "test"}]
         return patch(
-            "supabase_client.sb_execute",
+            "supabase_client.sb_execute_direct",
             new_callable=AsyncMock,
             return_value=mock_response,
         ), patch("supabase_client.get_supabase", return_value=mock_sb)
@@ -91,7 +91,7 @@ class TestHealthReady:
         mock_sb = MagicMock()
         mock_sb.table.return_value.select.return_value.limit.return_value = MagicMock()
         return patch(
-            "supabase_client.sb_execute",
+            "supabase_client.sb_execute_direct",
             new_callable=AsyncMock,
             side_effect=ConnectionError(error),
         ), patch("supabase_client.get_supabase", return_value=mock_sb)
@@ -216,9 +216,9 @@ class TestHealthReadyTimeouts:
         assert _READINESS_REDIS_TIMEOUT_S == 2.0
 
     def test_supabase_timeout_constant(self):
-        """AC3: Supabase timeout is 3s."""
+        """AC3: Supabase timeout is 5s (increased from 3s to reduce false-503 under bot load)."""
         from routes.health_core import _READINESS_SUPABASE_TIMEOUT_S
-        assert _READINESS_SUPABASE_TIMEOUT_S == 3.0
+        assert _READINESS_SUPABASE_TIMEOUT_S == 5.0
 
     def test_ready_503_on_redis_timeout(self):
         """AC3/AC7: Redis timeout produces 503 with 'timeout' error."""
@@ -235,7 +235,7 @@ class TestHealthReadyTimeouts:
             mock_resp = MagicMock()
             mock_resp.data = [{"id": "x"}]
             with (
-                patch("supabase_client.sb_execute", new_callable=AsyncMock, return_value=mock_resp),
+                patch("supabase_client.sb_execute_direct", new_callable=AsyncMock, return_value=mock_resp),
                 patch("supabase_client.get_supabase", return_value=mock_sb),
             ):
                 from main import app
@@ -260,7 +260,7 @@ class TestHealthReadyTimeouts:
             patch("startup.state.startup_time", time.monotonic()),
             patch("routes.health_core._READINESS_SUPABASE_TIMEOUT_S", 0.01),
             patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis),
-            patch("supabase_client.sb_execute", new_callable=AsyncMock, side_effect=slow_supabase),
+            patch("supabase_client.sb_execute_direct", new_callable=AsyncMock, side_effect=slow_supabase),
             patch("supabase_client.get_supabase", return_value=mock_sb),
         ):
             from main import app
@@ -291,7 +291,7 @@ class TestHealthReadyResponseBody:
         with (
             patch("startup.state.startup_time", time.monotonic()),
             patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis),
-            patch("supabase_client.sb_execute", new_callable=AsyncMock, return_value=mock_resp),
+            patch("supabase_client.sb_execute_direct", new_callable=AsyncMock, return_value=mock_resp),
             patch("supabase_client.get_supabase", return_value=mock_sb),
         ):
             from main import app


### PR DESCRIPTION
## Summary

- Switch Supabase readiness probe from `sb_execute` (circuit-breaker path) to `sb_execute_direct` (bypasses CB)
- Increase Supabase timeout 3s→5s to tolerate brief httpx pool contention under bot-driven traffic without false-503
- Fix: `/health/ready` returned 503 under Googlebot load, triggering Railway unhealthy restarts

## Root cause

Bot traffic saturated httpx pool → health check waited >3s for pool slot → `asyncio.wait_for` timed out → repeated timeouts tripped production circuit breaker via `sb_execute` → cascading failures.

## Testing Plan

- [x] 15 tests in `backend/tests/test_health_ready.py` all passing
- [ ] Deploy and verify: `curl -sf https://api.smartlic.tech/health/ready` returns `ready:true`

## Closes

MON-FN-005 regression (internal story — no GitHub issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)