### PR TITLE
fix(backend): RES-BE-015 sweep — wrap remaining 19 bare .execute() in _run_with_budget

### DIFF
--- a/.github/workflows/audit-execute-without-budget.yml
+++ b/.github/workflows/audit-execute-without-budget.yml
@@ -1,4 +1,4 @@
-name: "Audit .execute() without _run_with_budget (RES-BE-001 / RES-BE-015)"
+name: "Audit .execute() without _run_with_budget (RES-BE-001 / RES-BE-015 / #600)"
 
 # Guards against a regression of the 2026-04-27 to 2026-04-30 outage cycle
 # (Stage 2-8). Bare ``.execute()`` in an async route — or
@@ -6,9 +6,12 @@ name: "Audit .execute() without _run_with_budget (RES-BE-001 / RES-BE-015)"
 # until ``statement_timeout=15s`` fires server-side, and the cancelled
 # future's cleanup blocks the event loop.
 #
+# Scope expanded from RES-BE-015 (11 files) to --all-routes (all 67 route files)
+# as part of issue #600.
+#
 # This workflow runs on every PR that touches ``backend/routes/`` or the
 # audit script itself, posts a sticky PR comment with any findings, and
-# fails (exit 1) if violations are found in the RES-BE-015 sweep scope.
+# fails (exit 1) if violations are found.
 
 on:
   pull_request:
@@ -44,17 +47,17 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Run audit (RES-BE-015 scope)
+      - name: Run audit (all routes)
         id: audit
         run: |
           set +e
-          python backend/scripts/audit_execute_without_budget.py --json \
+          python backend/scripts/audit_execute_without_budget.py --all-routes --json \
             > /tmp/audit-violations.jsonl
           STATUS=$?
           set -e
 
           # Emit a human-readable summary to the job log too.
-          python backend/scripts/audit_execute_without_budget.py \
+          python backend/scripts/audit_execute_without_budget.py --all-routes \
             > /tmp/audit-violations.txt 2>&1 || true
           cat /tmp/audit-violations.txt
 
@@ -103,12 +106,11 @@ jobs:
             const okBody = `${marker}
             ## Audit \`.execute()\` without \`_run_with_budget\` — PASS
 
-            Zero violations in the RES-BE-015 sweep scope (11 long-tail SEO
-            programmatic routes). The Stage 2-8 antipattern
+            Zero violations across all routes. The Stage 2-8 antipattern
             (\`asyncio.wait_for(asyncio.to_thread(...))\` and bare sync
             \`.execute()\` in async routes) is not present.
 
-            > Run locally with \`python backend/scripts/audit_execute_without_budget.py\`.`;
+            > Run locally with \`python backend/scripts/audit_execute_without_budget.py --all-routes\`.`;
 
             let body = okBody;
             if (hasViolations) {
@@ -132,7 +134,7 @@ jobs:
 
             Run locally:
             \`\`\`
-            python backend/scripts/audit_execute_without_budget.py
+            python backend/scripts/audit_execute_without_budget.py --all-routes
             \`\`\``;
             }
 

--- a/backend/routes/comparador.py
+++ b/backend/routes/comparador.py
@@ -9,8 +9,11 @@ Endpoints:
 Cache: InMemory 1h TTL.
 """
 
+import asyncio
 import logging
 import time
+
+from pipeline.budget import _run_with_budget
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 
@@ -162,7 +165,16 @@ async def get_bids_by_ids(
     # Query supabase directly for exact pncp_id matches
     try:
         sb = get_supabase()
-        result = sb.table("pncp_raw_bids").select("*").in_("pncp_id", id_list).execute()
+
+        def _sync_query():
+            return sb.table("pncp_raw_bids").select("*").in_("pncp_id", id_list).execute()
+
+        result = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=5.0,
+            phase="route",
+            source="comparador.comparador_bids",
+        )
         rows = result.data or []
     except Exception as e:
         logger.warning("Failed to query pncp_raw_bids for ids=%s: %s", id_list, e)

--- a/backend/routes/export.py
+++ b/backend/routes/export.py
@@ -7,6 +7,8 @@ asyncio.to_thread) with a 10-second timeout.
 
 import asyncio
 import logging
+
+from pipeline.budget import _run_with_budget
 import re
 import unicodedata
 from typing import Optional
@@ -77,9 +79,11 @@ async def export_edital_pdf(
     try:
         from pdf_generator_edital import generate_edital_pdf
 
-        pdf_bytes = await asyncio.wait_for(
+        pdf_bytes = await _run_with_budget(
             asyncio.to_thread(generate_edital_pdf, bid_data, plan_type),
-            timeout=10.0,
+            budget=10.0,
+            phase="route",
+            source="export.export_edital_pdf",
         )
     except asyncio.TimeoutError:
         logger.warning(

--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -13,8 +13,11 @@ see `docs/runbooks/stripe-coupons.md`.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+
+from pipeline.budget import _run_with_budget
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -153,13 +156,21 @@ async def founding_checkout(
             detail="Este email já possui conta SmartLic. Faça login para gerenciar sua assinatura.",
         )
 
-    bp_result = (
-        sb.table("plan_billing_periods")
-        .select("stripe_price_id")
-        .eq("plan_id", FOUNDING_PLAN_ID)
-        .eq("billing_period", FOUNDING_BILLING_PERIOD)
-        .limit(1)
-        .execute()
+    def _fetch_price_id():
+        return (
+            sb.table("plan_billing_periods")
+            .select("stripe_price_id")
+            .eq("plan_id", FOUNDING_PLAN_ID)
+            .eq("billing_period", FOUNDING_BILLING_PERIOD)
+            .limit(1)
+            .execute()
+        )
+
+    bp_result = await _run_with_budget(
+        asyncio.to_thread(_fetch_price_id),
+        budget=5.0,
+        phase="route",
+        source="founding.checkout",
     )
     stripe_price_id = (bp_result.data[0] or {}).get("stripe_price_id") if bp_result.data else None
     if not stripe_price_id:
@@ -179,7 +190,15 @@ async def founding_checkout(
         "user_agent": request.headers.get("user-agent", "")[:500],
     }
 
-    lead_insert = sb.table("founding_leads").insert(lead_row).execute()
+    def _insert_lead():
+        return sb.table("founding_leads").insert(lead_row).execute()
+
+    lead_insert = await _run_with_budget(
+        asyncio.to_thread(_insert_lead),
+        budget=5.0,
+        phase="route",
+        source="founding.checkout.insert_lead",
+    )
     lead_record = (lead_insert.data or [{}])[0]
     lead_id = lead_record.get("id")
     if not lead_id:
@@ -225,9 +244,22 @@ async def founding_checkout(
         )
 
     try:
-        sb.table("founding_leads").update({
-            "checkout_session_id": session.id,
-        }).eq("id", lead_id).execute()
+        _session_id = session.id
+
+        def _update_session_id():
+            return (
+                sb.table("founding_leads")
+                .update({"checkout_session_id": _session_id})
+                .eq("id", lead_id)
+                .execute()
+            )
+
+        await _run_with_budget(
+            asyncio.to_thread(_update_session_id),
+            budget=5.0,
+            phase="route",
+            source="founding.checkout.update_session_id",
+        )
     except Exception as e:
         logger.warning(f"founding: failed to persist session_id — lead_id={lead_id} err={e}")
 

--- a/backend/routes/indice_municipal.py
+++ b/backend/routes/indice_municipal.py
@@ -7,8 +7,11 @@ Público. Cache: InMemory 1h TTL.
 CORS: Access-Control-Allow-Origin: * (link bait embeddável).
 """
 
+import asyncio
 import logging
 import re
+
+from pipeline.budget import _run_with_budget
 import time
 import unicodedata
 from typing import Optional
@@ -255,15 +258,24 @@ async def get_municipio(
     try:
         from supabase_client import get_supabase
         sb = get_supabase()
-        resp = (
-            sb.table("indice_municipal")
-            .select("*")
-            .eq("uf", uf)
-            .eq("periodo", periodo)
-            .ilike("municipio_nome", f"%{municipio_part.replace('-', '%')}%")
-            .order("score_total", desc=True)
-            .limit(1)
-            .execute()
+
+        def _sync_query():
+            return (
+                sb.table("indice_municipal")
+                .select("*")
+                .eq("uf", uf)
+                .eq("periodo", periodo)
+                .ilike("municipio_nome", f"%{municipio_part.replace('-', '%')}%")
+                .order("score_total", desc=True)
+                .limit(1)
+                .execute()
+            )
+
+        resp = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=5.0,
+            phase="route",
+            source="indice_municipal.get_indice_municipio",
         )
         rows = resp.data or []
     except Exception as e:

--- a/backend/routes/lead_capture.py
+++ b/backend/routes/lead_capture.py
@@ -3,8 +3,11 @@
 Public (no auth) endpoint that stores email + context for lead nurturing.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
+
+from pipeline.budget import _run_with_budget
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -35,17 +38,23 @@ async def capture_lead(req: LeadCaptureRequest):
     try:
         from supabase_client import get_supabase
         sb = get_supabase()
+        lead_row = {
+            "email": req.email.lower().strip(),
+            "source": req.source,
+            "setor": req.setor,
+            "uf": req.uf.upper() if req.uf else None,
+            "captured_at": req.captured_at or datetime.now(timezone.utc).isoformat(),
+        }
 
-        sb.table("leads").upsert(
-            {
-                "email": req.email.lower().strip(),
-                "source": req.source,
-                "setor": req.setor,
-                "uf": req.uf.upper() if req.uf else None,
-                "captured_at": req.captured_at or datetime.now(timezone.utc).isoformat(),
-            },
-            on_conflict="email,source",
-        ).execute()
+        def _sync_upsert():
+            return sb.table("leads").upsert(lead_row, on_conflict="email,source").execute()
+
+        await _run_with_budget(
+            asyncio.to_thread(_sync_upsert),
+            budget=5.0,
+            phase="route",
+            source="lead_capture.capture_lead",
+        )
     except Exception as e:
         # Fail-open: don't block UX if DB is down
         logger.warning("Failed to store lead: %s", e)

--- a/backend/routes/plans.py
+++ b/backend/routes/plans.py
@@ -10,8 +10,11 @@ This endpoint provides comprehensive plan information including:
 Data source: `plans` table in database (via SYS-M04 infrastructure)
 """
 
+import asyncio
 import logging
 from typing import List, Dict, Any
+
+from pipeline.budget import _run_with_budget
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -77,14 +80,22 @@ async def get_plans_with_capabilities(db=Depends(get_db)):
 
     try:
         # Fetch all active plans from database
-        result = (
-            db.table("plans")
-            .select(
-                "id, name, description, price_brl, duration_days, max_searches, is_active"
+        def _sync_query():
+            return (
+                db.table("plans")
+                .select(
+                    "id, name, description, price_brl, duration_days, max_searches, is_active"
+                )
+                .eq("is_active", True)
+                .order("price_brl")
+                .execute()
             )
-            .eq("is_active", True)
-            .order("price_brl")
-            .execute()
+
+        result = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=5.0,
+            phase="route",
+            source="plans.get_plans_with_capabilities",
         )
 
         if not result.data:

--- a/backend/routes/referral.py
+++ b/backend/routes/referral.py
@@ -8,9 +8,12 @@ Endpoints:
                              is being referred via a code.
 """
 
+import asyncio
 import logging
 import secrets
 import string
+
+from pipeline.budget import _run_with_budget
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -155,12 +158,20 @@ async def get_referral_code(user: dict = Depends(require_auth)):
     user_id = user["id"]
 
     # Check if a code already exists before we decide to send welcome email
-    pre_existing = (
-        sb.table("referrals")
-        .select("code")
-        .eq("referrer_user_id", user_id)
-        .limit(1)
-        .execute()
+    def _check_existing():
+        return (
+            sb.table("referrals")
+            .select("code")
+            .eq("referrer_user_id", user_id)
+            .limit(1)
+            .execute()
+        )
+
+    pre_existing = await _run_with_budget(
+        asyncio.to_thread(_check_existing),
+        budget=5.0,
+        phase="route",
+        source="referral.get_referral_code",
     )
     had_code = bool(getattr(pre_existing, "data", None))
 
@@ -198,11 +209,19 @@ async def get_referral_stats(user: dict = Depends(require_auth)):
         raise HTTPException(status_code=500, detail="Erro ao obter estatísticas.")
 
     try:
-        rows = (
-            sb.table("referrals")
-            .select("status")
-            .eq("referrer_user_id", user_id)
-            .execute()
+        def _fetch_stats():
+            return (
+                sb.table("referrals")
+                .select("status")
+                .eq("referrer_user_id", user_id)
+                .execute()
+            )
+
+        rows = await _run_with_budget(
+            asyncio.to_thread(_fetch_stats),
+            budget=5.0,
+            phase="route",
+            source="referral.get_referral_stats",
         )
         data = getattr(rows, "data", []) or []
     except Exception:
@@ -247,12 +266,20 @@ async def redeem_referral(
         raise HTTPException(status_code=403, detail="Identidade inválida.")
 
     try:
-        match = (
-            sb.table("referrals")
-            .select("id, referrer_user_id, status, referred_user_id")
-            .eq("code", code)
-            .limit(1)
-            .execute()
+        def _lookup_code():
+            return (
+                sb.table("referrals")
+                .select("id, referrer_user_id, status, referred_user_id")
+                .eq("code", code)
+                .limit(1)
+                .execute()
+            )
+
+        match = await _run_with_budget(
+            asyncio.to_thread(_lookup_code),
+            budget=5.0,
+            phase="route",
+            source="referral.redeem_referral",
         )
     except Exception:
         logger.exception("Referral lookup failed for code redeem")
@@ -272,12 +299,23 @@ async def redeem_referral(
         return ReferralRedeemResponse(status="already_redeemed")
 
     try:
-        sb.table("referrals").update(
-            {
-                "referred_user_id": body.referred_user_id,
-                "status": "signed_up",
-            }
-        ).eq("id", row["id"]).execute()
+        _row_id = row["id"]
+        _referred_uid = body.referred_user_id
+
+        def _update_status():
+            return (
+                sb.table("referrals")
+                .update({"referred_user_id": _referred_uid, "status": "signed_up"})
+                .eq("id", _row_id)
+                .execute()
+            )
+
+        await _run_with_budget(
+            asyncio.to_thread(_update_status),
+            budget=5.0,
+            phase="route",
+            source="referral.redeem_referral.update",
+        )
     except Exception:
         logger.exception("Failed to mark referral as signed_up")
         raise HTTPException(status_code=500, detail="Erro ao registrar indicação.")

--- a/backend/routes/relatorio.py
+++ b/backend/routes/relatorio.py
@@ -10,8 +10,11 @@ Email delivery is best-effort — if Resend fails, the lead is still captured
 and `email_queued=False` is returned so the frontend can surface a retry hint.
 """
 
+import asyncio
 import hashlib
 import logging
+
+from pipeline.budget import _run_with_budget
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Request
@@ -97,9 +100,15 @@ async def request_relatorio(payload: RelatorioRequest, request: Request):
     }
 
     try:
-        supabase.table("report_leads").upsert(
-            row, on_conflict="email,source"
-        ).execute()
+        def _sync_upsert():
+            return supabase.table("report_leads").upsert(row, on_conflict="email,source").execute()
+
+        await _run_with_budget(
+            asyncio.to_thread(_sync_upsert),
+            budget=5.0,
+            phase="route",
+            source="relatorio.request_relatorio",
+        )
     except Exception:
         logger.exception(
             "report_lead_db_error email_domain=%s", _email_domain(payload.email)

--- a/backend/routes/seo_admin.py
+++ b/backend/routes/seo_admin.py
@@ -1,9 +1,13 @@
 """S14: SEO metrics API for admin dashboard."""
 
+import asyncio
+import logging
+from typing import Optional
+
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
-from typing import Optional
-import logging
+
+from pipeline.budget import _run_with_budget
 
 from auth import require_auth
 from admin import require_admin
@@ -40,12 +44,15 @@ async def get_seo_metrics(
         from supabase_client import get_supabase
 
         supabase = get_supabase()
-        response = (
-            supabase.table("seo_metrics")
-            .select("*")
-            .order("date", desc=True)
-            .limit(days)
-            .execute()
+
+        def _sync_query():
+            return supabase.table("seo_metrics").select("*").order("date", desc=True).limit(days).execute()
+
+        response = await _run_with_budget(
+            asyncio.to_thread(_sync_query),
+            budget=5.0,
+            phase="route",
+            source="seo_admin.get_seo_metrics",
         )
         rows = response.data or []
 

--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -12,6 +12,8 @@ Layers de implementacao (/sitemap/cnpjs):
 
 import asyncio
 import logging
+
+from pipeline.budget import _run_with_budget
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -114,9 +116,11 @@ async def sitemap_cnpjs(response: Response):
         return SitemapCnpjsResponse(**cached)
 
     try:
-        data = await asyncio.wait_for(
+        data = await _run_with_budget(
             asyncio.to_thread(_fetch_top_cnpjs),
-            timeout=_BUDGET_S,
+            budget=_BUDGET_S,
+            phase="route",
+            source="sitemap_cnpjs.sitemap_cnpjs",
         )
         _set_cached("cnpjs", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
@@ -276,9 +280,11 @@ async def sitemap_fornecedores_cnpj(response: Response):
         return SitemapFornecedoresCnpjResponse(**cached)
 
     try:
-        data = await asyncio.wait_for(
+        data = await _run_with_budget(
             asyncio.to_thread(_fetch_top_fornecedores_cnpjs),
-            timeout=_BUDGET_S,
+            budget=_BUDGET_S,
+            phase="route",
+            source="sitemap_cnpjs.sitemap_fornecedores_cnpj",
         )
         _set_fornecedores_cached("fornecedores_cnpj", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:

--- a/backend/routes/sitemap_licitacoes_do_dia.py
+++ b/backend/routes/sitemap_licitacoes_do_dia.py
@@ -11,6 +11,8 @@ TTL 1h (dia corrente muda durante o dia).
 
 import asyncio
 import logging
+
+from pipeline.budget import _run_with_budget
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -80,9 +82,11 @@ async def sitemap_licitacoes_do_dia_indexable(response: Response):
         return SitemapLicitacoesDoDiaResponse(**cached)
 
     try:
-        data = await asyncio.wait_for(
+        data = await _run_with_budget(
             asyncio.to_thread(_fetch_indexable_dates),
-            timeout=_BUDGET_S,
+            budget=_BUDGET_S,
+            phase="route",
+            source="sitemap_licitacoes_do_dia.sitemap_licitacoes_do_dia_indexable",
         )
         _set_cached("dates", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:

--- a/backend/routes/sitemap_orgaos.py
+++ b/backend/routes/sitemap_orgaos.py
@@ -11,6 +11,8 @@ Implementation layers:
 
 import asyncio
 import logging
+
+from pipeline.budget import _run_with_budget
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -74,9 +76,11 @@ async def sitemap_orgaos(response: Response):
         return SitemapOrgaosResponse(**cached)
 
     try:
-        data = await asyncio.wait_for(
+        data = await _run_with_budget(
             asyncio.to_thread(_fetch_top_orgaos),
-            timeout=_BUDGET_S,
+            budget=_BUDGET_S,
+            phase="route",
+            source="sitemap_orgaos.sitemap_orgaos",
         )
         _set_cached("orgaos", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
@@ -220,9 +224,11 @@ async def sitemap_contratos_orgao_indexable(response: Response):
         del _contratos_orgao_cache[key]
 
     try:
-        data = await asyncio.wait_for(
+        data = await _run_with_budget(
             asyncio.to_thread(_fetch_contratos_orgao_indexable),
-            timeout=_BUDGET_S,
+            budget=_BUDGET_S,
+            phase="route",
+            source="sitemap_orgaos.sitemap_contratos_orgao_indexable",
         )
         _contratos_orgao_cache[key] = (data, time.time(), _CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:


### PR DESCRIPTION
## Context

Issue #600 — follow-up to the Stage 2-8 outage fix (PR #579). The original RES-BE-015 sweep covered 11 long-tail SEO routes. The audit script's `--all-routes` flag revealed 19 additional violations in 12 route files outside that scope. These are the same `bare_execute` and `wait_for_to_thread` antipatterns that caused the 2026-04-27 to 2026-04-30 outage cycle.

## Changes

- **sitemap_cnpjs.py** (2×): `wait_for_to_thread` → `_run_with_budget`
- **sitemap_orgaos.py** (2×): `wait_for_to_thread` → `_run_with_budget`
- **sitemap_licitacoes_do_dia.py** (1×): `wait_for_to_thread` → `_run_with_budget`
- **export.py** (1×): `wait_for_to_thread` → `_run_with_budget` (budget=10.0, PDF gen)
- **comparador.py** (1×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **indice_municipal.py** (1×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **lead_capture.py** (1×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **plans.py** (1×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **relatorio.py** (1×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **seo_admin.py** (1×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **referral.py** (4×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **founding.py** (3×): bare `execute()` → `_run_with_budget` + `asyncio.to_thread`
- **`.github/workflows/audit-execute-without-budget.yml`**: expanded from 11-file scope to `--all-routes` (67 files)

## Testing Plan

- [x] `python backend/scripts/audit_execute_without_budget.py --all-routes` → `OK: zero violations across 67 files`
- [x] `pytest -k "referral or founding or comparador or lead_capture or plans or relatorio or seo_admin or sitemap or export" --ignore=backend/tests/fuzz` → 205 passed, 0 failures
- [ ] CI Backend Tests workflow passing

## Risks & Rollback

**Risk:** Minimal. `_run_with_budget` wraps `asyncio.wait_for` with the same timeout semantics; all `except asyncio.TimeoutError` / `except Exception` handlers remain intact. The only behavioral difference is Prometheus counter emission on timeout.

**Rollback:** Revert commit `910ac17e`. No schema changes, no env var changes required.

## Closes

Closes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced performance and resource allocation for database operations across multiple backend endpoints, including search, PDF export, lead management, pricing, referrals, reports, and sitemap generation features.

* **Chores**
  * Extended audit workflow coverage to encompass all route files for comprehensive quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->