### PR TITLE
chore(ci): merge-conflict-check workflow — git merge-tree guard

### DIFF
--- a/.github/workflows/merge-conflict-check.yml
+++ b/.github/workflows/merge-conflict-check.yml
@@ -1,0 +1,33 @@
+name: Merge Conflict Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  conflict-check:
+    name: Check Real Merge Conflicts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Detect line-level conflicts
+        run: |
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          echo "Merge base: $MERGE_BASE"
+          echo "PR HEAD:    $(git rev-parse HEAD)"
+          echo "origin/main: $(git rev-parse origin/main)"
+
+          # git merge-tree exits 1 and prints conflict markers if real conflicts exist
+          if git merge-tree --write-tree "$MERGE_BASE" HEAD origin/main > /tmp/merge-result 2>&1; then
+            echo "✅ No line-level conflicts detected."
+          else
+            echo "❌ Real merge conflicts detected:"
+            cat /tmp/merge-result
+            exit 1
+          fi

--- a/.github/workflows/merge-conflict-check.yml
+++ b/.github/workflows/merge-conflict-check.yml
@@ -18,13 +18,12 @@ jobs:
 
       - name: Detect line-level conflicts
         run: |
-          MERGE_BASE=$(git merge-base HEAD origin/main)
-          echo "Merge base: $MERGE_BASE"
-          echo "PR HEAD:    $(git rev-parse HEAD)"
+          echo "PR HEAD:     $(git rev-parse HEAD)"
           echo "origin/main: $(git rev-parse origin/main)"
+          echo "Merge base:  $(git merge-base HEAD origin/main)"
 
-          # git merge-tree exits 1 and prints conflict markers if real conflicts exist
-          if git merge-tree --write-tree "$MERGE_BASE" HEAD origin/main > /tmp/merge-result 2>&1; then
+          # --write-tree takes 2 branches, auto-finds merge-base, exits 1 on conflicts
+          if git merge-tree --write-tree HEAD origin/main > /tmp/merge-result 2>&1; then
             echo "✅ No line-level conflicts detected."
           else
             echo "❌ Real merge conflicts detected:"


### PR DESCRIPTION
## Context

`strict:true` branch protection forces CI re-run on every PR whenever any other PR merges to main — even with zero file overlap. With sequential Dependabot batches this creates 15min×N serial queue.

## Changes

- `.github/workflows/merge-conflict-check.yml` — new required check using `git merge-tree --write-tree` to detect real line-level conflicts between the PR branch and `origin/main`

## How it works

```
MERGE_BASE=$(git merge-base HEAD origin/main)
git merge-tree --write-tree "$MERGE_BASE" HEAD origin/main
# exits 1 only if actual conflict markers (<<<<<<) exist
```

PRs with no file overlap → always passes regardless of how far behind main.
PRs with real conflicts → blocked at the check, not at merge.

## Post-merge steps (automated)

After this PR merges:
1. Add "Check Real Merge Conflicts" as required check via branch protection API
2. Disable `strict:true` — replaced by this guard

## Testing Plan

- [x] Workflow syntax valid (YAML linted)
- [ ] CI run on this PR confirms check passes (no conflicts with main)
- [ ] After merge: verify `strict=false` + new required check active

## Risks & Rollback

Low risk — additive only. Rollback = delete workflow file + re-enable strict via API.
No backend/frontend code touched.

## Closes

N/A — infra improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated merge-conflict detection on pull requests targeting the main branch.
  * Pull requests with line-level conflicts will now be flagged and the check will fail, with conflict details reported to aid resolution.
  * This prevents merging PRs with unresolved line conflicts and streamlines integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->