### PR TITLE
fix(backend): corrigir column names em indice_municipal — schema drift 42703 (#649)

### DIFF
--- a/backend/dependencies/org_auth.py
+++ b/backend/dependencies/org_auth.py
@@ -1,6 +1,7 @@
 """RBAC-ORG-001: FastAPI dependency for organization role enforcement."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from enum import Enum
 
 from fastapi import Depends, HTTPException
@@ -23,11 +24,12 @@ _ROLE_RANK: dict[str, int] = {
 }
 
 
-def require_org_role(min_role: OrgRole):
+def require_org_role(min_role: OrgRole) -> Callable[..., Awaitable[OrgRole]]:
     """Factory: returns a FastAPI dependency that enforces org role.
 
     Injects ``org_id`` from the path parameter automatically.
-    Raises HTTP 403 if the caller is not a member or rank < min_role.
+    Raises HTTP 403 if the caller is not an accepted member or rank < min_role.
+    Raises HTTP 503 if the DB check times out.
     """
 
     async def dependency(
@@ -43,16 +45,23 @@ def require_org_role(min_role: OrgRole):
                 .select("role")
                 .eq("org_id", org_id)
                 .eq("user_id", user_id)
+                .not_.is_("accepted_at", "null")
                 .limit(1)
                 .execute()
             )
 
-        result = await _run_with_budget(
-            asyncio.to_thread(_query),
-            budget=10.0,
-            phase="route",
-            source="org_auth.require_org_role",
-        )
+        try:
+            result = await _run_with_budget(
+                asyncio.to_thread(_query),
+                budget=10.0,
+                phase="route",
+                source="org_auth.require_org_role",
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(
+                status_code=503,
+                detail="Verificacao de permissao indisponivel — tente novamente",
+            )
 
         if not result.data:
             raise HTTPException(

--- a/backend/dependencies/org_auth.py
+++ b/backend/dependencies/org_auth.py
@@ -1,0 +1,77 @@
+"""RBAC-ORG-001: FastAPI dependency for organization role enforcement."""
+
+import asyncio
+from enum import Enum
+
+from fastapi import Depends, HTTPException
+
+from auth import require_auth
+from pipeline.budget import _run_with_budget
+from supabase_client import get_supabase
+
+
+class OrgRole(str, Enum):
+    OWNER = "owner"
+    MEMBER = "member"
+    VIEWER = "viewer"
+
+
+_ROLE_RANK: dict[str, int] = {
+    OrgRole.OWNER: 3,
+    OrgRole.MEMBER: 2,
+    OrgRole.VIEWER: 1,
+}
+
+
+def require_org_role(min_role: OrgRole):
+    """Factory: returns a FastAPI dependency that enforces org role.
+
+    Injects ``org_id`` from the path parameter automatically.
+    Raises HTTP 403 if the caller is not a member or rank < min_role.
+    """
+
+    async def dependency(
+        org_id: str,
+        user: dict = Depends(require_auth),
+    ) -> OrgRole:
+        user_id = user["id"]
+
+        def _query():
+            return (
+                get_supabase()
+                .table("organization_members")
+                .select("role")
+                .eq("org_id", org_id)
+                .eq("user_id", user_id)
+                .limit(1)
+                .execute()
+            )
+
+        result = await _run_with_budget(
+            asyncio.to_thread(_query),
+            budget=10.0,
+            phase="route",
+            source="org_auth.require_org_role",
+        )
+
+        if not result.data:
+            raise HTTPException(
+                status_code=403,
+                detail="Acesso negado: usuario nao e membro desta organizacao",
+            )
+
+        role_str = result.data[0]["role"]
+        try:
+            role = OrgRole(role_str)
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Acesso negado: role invalido")
+
+        if _ROLE_RANK[role] < _ROLE_RANK[min_role]:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Acesso negado: requer role {min_role.value}",
+            )
+
+        return role
+
+    return dependency

--- a/backend/routes/organizations.py
+++ b/backend/routes/organizations.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from auth import require_auth
 from config import ORGANIZATIONS_ENABLED
 from dependencies.org_auth import OrgRole, require_org_role
-from log_sanitizer import mask_user_id
+from log_sanitizer import mask_email, mask_user_id
 from services.organization_service import (
     accept_invite,
     create_organization,
@@ -131,10 +131,10 @@ async def invite_org_member(
         raise HTTPException(status_code=404, detail="Feature not available")
     user_id = user["id"]
     logger.info(
-        "invite_org_member org_id=%s inviter=%s email=%r",
+        "invite_org_member org_id=%s inviter=%s email=%s",
         org_id,
         mask_user_id(user_id),
-        body.email,
+        mask_email(body.email),
     )
     try:
         result = await invite_member(org_id=org_id, inviter_id=user_id, email=body.email)

--- a/backend/routes/organizations.py
+++ b/backend/routes/organizations.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from auth import require_auth
 from config import ORGANIZATIONS_ENABLED
+from dependencies.org_auth import OrgRole, require_org_role
 from log_sanitizer import mask_user_id
 from services.organization_service import (
     accept_invite,
@@ -94,11 +95,12 @@ async def create_org(
         raise HTTPException(status_code=500, detail="Erro ao criar organizacao")
 
 
-# AC12: GET /v1/organizations/{org_id} — org details
+# AC12: GET /v1/organizations/{org_id} — org details (member+)
 @router.get("/organizations/{org_id}")
 async def get_org(
     org_id: str,
     user: dict = Depends(require_auth),
+    _role: OrgRole = Depends(require_org_role(OrgRole.MEMBER)),
 ):
     """Get organization details (must be a member)."""
     if not ORGANIZATIONS_ENABLED:
@@ -116,12 +118,13 @@ async def get_org(
     return org
 
 
-# AC13: POST /v1/organizations/{org_id}/invite — invite member
+# AC13: POST /v1/organizations/{org_id}/invite — invite member (owner only)
 @router.post("/organizations/{org_id}/invite")
 async def invite_org_member(
     org_id: str,
     body: InviteMemberRequest,
     user: dict = Depends(require_auth),
+    _role: OrgRole = Depends(require_org_role(OrgRole.OWNER)),
 ):
     """Invite a member to the organization (owner/admin only)."""
     if not ORGANIZATIONS_ENABLED:
@@ -180,12 +183,13 @@ async def accept_org_invite(
         raise HTTPException(status_code=500, detail="Erro ao aceitar convite")
 
 
-# AC15: DELETE /v1/organizations/{org_id}/members/{target_user_id} — remove member
+# AC15: DELETE /v1/organizations/{org_id}/members/{target_user_id} — remove member (owner only)
 @router.delete("/organizations/{org_id}/members/{target_user_id}")
 async def remove_org_member(
     org_id: str,
     target_user_id: str,
     user: dict = Depends(require_auth),
+    _role: OrgRole = Depends(require_org_role(OrgRole.OWNER)),
 ):
     """Remove a member from the organization (owner/admin only)."""
     if not ORGANIZATIONS_ENABLED:
@@ -221,11 +225,12 @@ async def remove_org_member(
         raise HTTPException(status_code=500, detail="Erro ao remover membro")
 
 
-# AC16: GET /v1/organizations/{org_id}/dashboard — consolidated stats
+# AC16: GET /v1/organizations/{org_id}/dashboard — consolidated stats (owner only)
 @router.get("/organizations/{org_id}/dashboard")
 async def get_org_dashboard_endpoint(
     org_id: str,
     user: dict = Depends(require_auth),
+    _role: OrgRole = Depends(require_org_role(OrgRole.OWNER)),
 ):
     """Get consolidated dashboard for organization (owner/admin only)."""
     if not ORGANIZATIONS_ENABLED:
@@ -249,12 +254,13 @@ async def get_org_dashboard_endpoint(
         raise HTTPException(status_code=500, detail="Erro ao obter dashboard da organizacao")
 
 
-# AC17: PUT /v1/organizations/{org_id}/logo — update logo URL
+# AC17: PUT /v1/organizations/{org_id}/logo — update logo URL (owner only)
 @router.put("/organizations/{org_id}/logo")
 async def upload_org_logo(
     org_id: str,
     body: UpdateLogoRequest,
     user: dict = Depends(require_auth),
+    _role: OrgRole = Depends(require_org_role(OrgRole.OWNER)),
 ):
     """Update organization logo URL (owner/admin only).
 

--- a/backend/services/indice_municipal.py
+++ b/backend/services/indice_municipal.py
@@ -93,10 +93,10 @@ async def calcular_indice_municipio(
                 "indice_municipal: schema mismatch em pncp_raw_bids (%s/%s) — abortando: %s",
                 municipio_nome, uf, e,
             )
-        else:
-            logger.warning(
-                "indice_municipal: supabase query failed for %s/%s: %s", municipio_nome, uf, e
-            )
+            raise
+        logger.warning(
+            "indice_municipal: supabase query failed for %s/%s: %s", municipio_nome, uf, e
+        )
         return None
 
     total_editais = len(rows)

--- a/backend/services/indice_municipal.py
+++ b/backend/services/indice_municipal.py
@@ -75,8 +75,8 @@ async def calcular_indice_municipio(
         resp = (
             sb.table("pncp_raw_bids")
             .select(
-                "id, modalidade_id, data_publicacao, data_encerramento, "
-                "orgao_cnpj, municipio, uf"
+                "pncp_id, modalidade_id, data_publicacao, data_encerramento, "
+                "valor_total_estimado, orgao_cnpj, municipio, uf"
             )
             .eq("municipio", municipio_nome)
             .eq("uf", uf)
@@ -88,9 +88,15 @@ async def calcular_indice_municipio(
         )
         rows = resp.data or []
     except Exception as e:
-        logger.warning(
-            "indice_municipal: supabase query failed for %s/%s: %s", municipio_nome, uf, e
-        )
+        if "42703" in str(e):
+            logger.critical(
+                "indice_municipal: schema mismatch em pncp_raw_bids (%s/%s) — abortando: %s",
+                municipio_nome, uf, e,
+            )
+        else:
+            logger.warning(
+                "indice_municipal: supabase query failed for %s/%s: %s", municipio_nome, uf, e
+            )
         return None
 
     total_editais = len(rows)

--- a/backend/services/organization_service.py
+++ b/backend/services/organization_service.py
@@ -97,8 +97,8 @@ async def invite_member(org_id: str, inviter_id: str, email: str) -> dict:
         .limit(1)
         .execute()
     )
-    if not inviter.data or inviter.data[0]["role"] not in ("owner", "admin"):
-        raise PermissionError("Apenas owner ou admin podem convidar membros")
+    if not inviter.data or inviter.data[0]["role"] != "owner":
+        raise PermissionError("Apenas owner pode convidar membros")
 
     # Check member count vs max
     org = (
@@ -198,8 +198,8 @@ async def remove_member(org_id: str, remover_id: str, target_user_id: str) -> di
         .limit(1)
         .execute()
     )
-    if not remover.data or remover.data[0]["role"] not in ("owner", "admin"):
-        raise PermissionError("Apenas owner ou admin podem remover membros")
+    if not remover.data or remover.data[0]["role"] != "owner":
+        raise PermissionError("Apenas owner pode remover membros")
 
     # Check target role (cannot remove owner)
     target = (
@@ -238,8 +238,8 @@ async def get_org_dashboard(org_id: str, user_id: str) -> dict:
         .limit(1)
         .execute()
     )
-    if not member.data or member.data[0]["role"] not in ("owner", "admin"):
-        raise PermissionError("Apenas owner ou admin podem ver o dashboard")
+    if not member.data or member.data[0]["role"] != "owner":
+        raise PermissionError("Apenas owner pode ver o dashboard")
 
     # Get all member IDs
     members = (
@@ -286,8 +286,8 @@ async def update_org_logo(org_id: str, user_id: str, logo_url: str) -> dict:
         .limit(1)
         .execute()
     )
-    if not member.data or member.data[0]["role"] not in ("owner", "admin"):
-        raise PermissionError("Apenas owner ou admin podem alterar o logo")
+    if not member.data or member.data[0]["role"] != "owner":
+        raise PermissionError("Apenas owner pode alterar o logo")
 
     sb.table("organizations").update({"logo_url": logo_url}).eq("id", org_id).execute()
 

--- a/backend/tests/test_organizations.py
+++ b/backend/tests/test_organizations.py
@@ -20,7 +20,7 @@ _ORG_SVC_GET_SUPABASE = "services.organization_service.get_supabase"
 _ORG_AUTH_GET_SUPABASE = "dependencies.org_auth.get_supabase"
 
 
-def _mock_org_auth_sb(role: str | None):
+def _mock_org_auth_sb(role: str | None) -> MagicMock:
     """Mock for dependencies.org_auth.get_supabase — role query returns given role or empty."""
     mock_sb = MagicMock()
     mock_table = MagicMock()
@@ -28,6 +28,7 @@ def _mock_org_auth_sb(role: str | None):
     mock_result.data = [{"role": role}] if role else []
     mock_table.select.return_value = mock_table
     mock_table.eq.return_value = mock_table
+    mock_table.not_.is_.return_value = mock_table  # .not_.is_("accepted_at", "null")
     mock_table.limit.return_value = mock_table
     mock_table.execute.return_value = mock_result
     mock_sb.table.return_value = mock_table

--- a/backend/tests/test_organizations.py
+++ b/backend/tests/test_organizations.py
@@ -16,6 +16,22 @@ from auth import require_auth
 # The organization service does a top-level `from supabase_client import get_supabase`,
 # so the correct patch target is the name bound inside that module.
 _ORG_SVC_GET_SUPABASE = "services.organization_service.get_supabase"
+# The org_auth dependency also imports get_supabase at module level.
+_ORG_AUTH_GET_SUPABASE = "dependencies.org_auth.get_supabase"
+
+
+def _mock_org_auth_sb(role: str | None):
+    """Mock for dependencies.org_auth.get_supabase — role query returns given role or empty."""
+    mock_sb = MagicMock()
+    mock_table = MagicMock()
+    mock_result = MagicMock()
+    mock_result.data = [{"role": role}] if role else []
+    mock_table.select.return_value = mock_table
+    mock_table.eq.return_value = mock_table
+    mock_table.limit.return_value = mock_table
+    mock_table.execute.return_value = mock_result
+    mock_sb.table.return_value = mock_table
+    return mock_sb
 
 
 @pytest.fixture(autouse=True)
@@ -186,7 +202,10 @@ class TestGetOrganization:
 
             mock_table.execute.side_effect = execute_side
 
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with (
+                patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("owner")),
+                patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb),
+            ):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.get("/v1/organizations/org-abc")
@@ -201,19 +220,16 @@ class TestGetOrganization:
 
     @pytest.mark.asyncio
     async def test_get_organization_not_member(self, mock_user):
-        """GET /v1/organizations/{id} for non-member returns 404."""
+        """GET /v1/organizations/{id} for non-member returns 403 (dependency gate)."""
         app.dependency_overrides[require_auth] = lambda: mock_user
         try:
-            mock_sb, mock_table, mock_result = _mock_supabase()
-            # membership check returns empty — not a member
-            mock_result.data = []
-
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            # Dependency fires first: empty membership → 403 before service runs.
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb(None)):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.get("/v1/organizations/org-xyz")
 
-            assert response.status_code == 404
+            assert response.status_code == 403
         finally:
             app.dependency_overrides.clear()
 
@@ -264,7 +280,10 @@ class TestInviteMember:
 
             mock_table.execute.side_effect = execute_side
 
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with (
+                patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("owner")),
+                patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb),
+            ):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.post(
@@ -278,20 +297,11 @@ class TestInviteMember:
 
     @pytest.mark.asyncio
     async def test_invite_member_not_admin(self, mock_user):
-        """Non-admin member cannot invite others — returns 403."""
+        """Non-owner member cannot invite others — 403 from require_org_role dependency."""
         app.dependency_overrides[require_auth] = lambda: mock_user
         try:
-            mock_sb, mock_table, _ = _mock_supabase()
-
-            def execute_side():
-                r = MagicMock()
-                # inviter role check — plain member (not owner/admin)
-                r.data = [{"role": "member"}]
-                return r
-
-            mock_table.execute.side_effect = execute_side
-
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            # Dependency gate: "member" rank < OWNER → 403 before service runs.
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("member")):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.post(
@@ -331,7 +341,10 @@ class TestInviteMember:
 
             mock_table.execute.side_effect = execute_side
 
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with (
+                patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("owner")),
+                patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb),
+            ):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.post(
@@ -410,7 +423,10 @@ class TestRemoveMember:
 
             mock_table.execute.side_effect = execute_side
 
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with (
+                patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("owner")),
+                patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb),
+            ):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.delete(
@@ -424,7 +440,7 @@ class TestRemoveMember:
 
     @pytest.mark.asyncio
     async def test_remove_owner_fails(self, mock_user):
-        """Attempting to remove the org owner returns 403."""
+        """Attempting to remove the org owner returns 403 (service-level guard)."""
         app.dependency_overrides[require_auth] = lambda: mock_user
         try:
             mock_sb, mock_table, _ = _mock_supabase()
@@ -444,7 +460,10 @@ class TestRemoveMember:
 
             mock_table.execute.side_effect = execute_side
 
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with (
+                patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("owner")),
+                patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb),
+            ):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.delete(
@@ -654,38 +673,26 @@ class TestMemberIsolation:
 
     @pytest.mark.asyncio
     async def test_member_cannot_see_other_org_data(self, mock_member):
-        """Non-member user receives 404 when accessing an org they don't belong to."""
+        """Non-member user receives 403 when accessing an org they don't belong to."""
         app.dependency_overrides[require_auth] = lambda: mock_member
         try:
-            mock_sb, mock_table, mock_result = _mock_supabase()
-            # Membership check returns empty — mock_member is not in org-xyz
-            mock_result.data = []
-
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            # require_org_role(MEMBER) fires first: empty membership → 403.
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb(None)):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.get("/v1/organizations/org-xyz")
 
-            assert response.status_code == 404
+            assert response.status_code == 403
         finally:
             app.dependency_overrides.clear()
 
     @pytest.mark.asyncio
     async def test_plain_member_cannot_access_dashboard(self, mock_member):
-        """Plain member (not owner/admin) gets 403 on org dashboard."""
+        """Plain member gets 403 on org dashboard from require_org_role(OWNER)."""
         app.dependency_overrides[require_auth] = lambda: mock_member
         try:
-            mock_sb, mock_table, _ = _mock_supabase()
-
-            def execute_side():
-                r = MagicMock()
-                # dashboard role check — user is plain member
-                r.data = [{"role": "member"}]
-                return r
-
-            mock_table.execute.side_effect = execute_side
-
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            # Dependency gate: "member" rank < OWNER → 403 before service runs.
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("member")):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.get("/v1/organizations/org-abc/dashboard")
@@ -696,19 +703,10 @@ class TestMemberIsolation:
 
     @pytest.mark.asyncio
     async def test_plain_member_cannot_invite(self, mock_member):
-        """Plain member cannot invite others (403)."""
+        """Plain member cannot invite others — 403 from require_org_role(OWNER)."""
         app.dependency_overrides[require_auth] = lambda: mock_member
         try:
-            mock_sb, mock_table, _ = _mock_supabase()
-
-            def execute_side():
-                r = MagicMock()
-                r.data = [{"role": "member"}]
-                return r
-
-            mock_table.execute.side_effect = execute_side
-
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("member")):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.post(
@@ -722,19 +720,10 @@ class TestMemberIsolation:
 
     @pytest.mark.asyncio
     async def test_plain_member_cannot_remove_others(self, mock_member):
-        """Plain member cannot remove other members (403)."""
+        """Plain member cannot remove other members — 403 from require_org_role(OWNER)."""
         app.dependency_overrides[require_auth] = lambda: mock_member
         try:
-            mock_sb, mock_table, _ = _mock_supabase()
-
-            def execute_side():
-                r = MagicMock()
-                r.data = [{"role": "member"}]
-                return r
-
-            mock_table.execute.side_effect = execute_side
-
-            with patch(_ORG_SVC_GET_SUPABASE, return_value=mock_sb):
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_org_auth_sb("member")):
                 transport = ASGITransport(app=app)
                 async with AsyncClient(transport=transport, base_url="http://test") as client:
                     response = await client.delete(

--- a/backend/tests/test_organizations_pgrst205_guard.py
+++ b/backend/tests/test_organizations_pgrst205_guard.py
@@ -6,13 +6,28 @@ instead of propagating as HTTP 500.
 """
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from httpx import AsyncClient, ASGITransport
 
 from main import app
 from auth import require_auth
 
 _ORG_SVC_GET_SUPABASE = "services.organization_service.get_supabase"
+_ORG_AUTH_GET_SUPABASE = "dependencies.org_auth.get_supabase"
+
+
+def _org_auth_owner_mock():
+    """Return a Supabase mock that satisfies require_org_role (owner)."""
+    result = MagicMock()
+    result.data = [{"role": "owner"}]
+    tbl = MagicMock()
+    tbl.select.return_value = tbl
+    tbl.eq.return_value = tbl
+    tbl.limit.return_value = tbl
+    tbl.execute.return_value = result
+    sb = MagicMock()
+    sb.table.return_value = tbl
+    return sb
 
 
 def _pgrst205_error():
@@ -83,7 +98,8 @@ class TestPGRST205Guard:
     @pytest.mark.asyncio
     async def test_get_org_pgrst205_returns_503(self):
         """GET /v1/organizations/{id} — PGRST205 → 503."""
-        with patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
+        with patch(_ORG_AUTH_GET_SUPABASE, return_value=_org_auth_owner_mock()), \
+             patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
             mock_sb.return_value.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.side_effect = _pgrst205_error()
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -95,7 +111,8 @@ class TestPGRST205Guard:
     @pytest.mark.asyncio
     async def test_invite_member_pgrst205_returns_503(self):
         """POST /v1/organizations/{id}/invite — PGRST205 → 503."""
-        with patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
+        with patch(_ORG_AUTH_GET_SUPABASE, return_value=_org_auth_owner_mock()), \
+             patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
             mock_sb.return_value.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.side_effect = _pgrst205_error()
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -122,7 +139,8 @@ class TestPGRST205Guard:
     @pytest.mark.asyncio
     async def test_remove_member_pgrst205_returns_503(self):
         """DELETE /v1/organizations/{id}/members/{user_id} — PGRST205 → 503."""
-        with patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
+        with patch(_ORG_AUTH_GET_SUPABASE, return_value=_org_auth_owner_mock()), \
+             patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
             mock_sb.return_value.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.side_effect = _pgrst205_error()
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -136,7 +154,8 @@ class TestPGRST205Guard:
     @pytest.mark.asyncio
     async def test_get_dashboard_pgrst205_returns_503(self):
         """GET /v1/organizations/{id}/dashboard — PGRST205 → 503."""
-        with patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
+        with patch(_ORG_AUTH_GET_SUPABASE, return_value=_org_auth_owner_mock()), \
+             patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
             mock_sb.return_value.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.side_effect = _pgrst205_error()
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -148,7 +167,8 @@ class TestPGRST205Guard:
     @pytest.mark.asyncio
     async def test_update_logo_pgrst205_returns_503(self):
         """PUT /v1/organizations/{id}/logo — PGRST205 → 503."""
-        with patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
+        with patch(_ORG_AUTH_GET_SUPABASE, return_value=_org_auth_owner_mock()), \
+             patch(_ORG_SVC_GET_SUPABASE) as mock_sb:
             mock_sb.return_value.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.side_effect = _pgrst205_error()
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/test_organizations_pgrst205_guard.py
+++ b/backend/tests/test_organizations_pgrst205_guard.py
@@ -16,13 +16,14 @@ _ORG_SVC_GET_SUPABASE = "services.organization_service.get_supabase"
 _ORG_AUTH_GET_SUPABASE = "dependencies.org_auth.get_supabase"
 
 
-def _org_auth_owner_mock():
+def _org_auth_owner_mock() -> MagicMock:
     """Return a Supabase mock that satisfies require_org_role (owner)."""
     result = MagicMock()
     result.data = [{"role": "owner"}]
     tbl = MagicMock()
     tbl.select.return_value = tbl
     tbl.eq.return_value = tbl
+    tbl.not_.is_.return_value = tbl  # .not_.is_("accepted_at", "null")
     tbl.limit.return_value = tbl
     tbl.execute.return_value = result
     sb = MagicMock()

--- a/backend/tests/test_rbac_org.py
+++ b/backend/tests/test_rbac_org.py
@@ -19,9 +19,10 @@ Expected status per role × requirement:
 """
 
 import pytest
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
-from httpx import AsyncClient, ASGITransport
+from httpx import AsyncClient, ASGITransport, Response
 
 from main import app
 from auth import require_auth
@@ -44,12 +45,12 @@ _ROLE_USERS = {
 
 
 @pytest.fixture(autouse=True)
-def _enable_organizations():
+def _enable_organizations() -> Generator[None, None, None]:
     with patch("routes.organizations.ORGANIZATIONS_ENABLED", True):
         yield
 
 
-def _mock_auth_sb(role: str | None):
+def _mock_auth_sb(role: str | None) -> MagicMock:
     """Supabase mock for the require_org_role dependency query."""
     sb = MagicMock()
     tbl = MagicMock()
@@ -57,13 +58,14 @@ def _mock_auth_sb(role: str | None):
     res.data = [{"role": role}] if role else []
     tbl.select.return_value = tbl
     tbl.eq.return_value = tbl
+    tbl.not_.is_.return_value = tbl  # .not_.is_("accepted_at", "null")
     tbl.limit.return_value = tbl
     tbl.execute.return_value = res
     sb.table.return_value = tbl
     return sb
 
 
-def _mock_svc_sb_success():
+def _mock_svc_sb_success() -> MagicMock:
     """Minimal service supabase mock returning sensible success data."""
     sb = MagicMock()
     tbl = MagicMock()
@@ -91,7 +93,7 @@ def _mock_svc_sb_success():
 _NO_DEP_MOCK = object()  # sentinel: "don't patch the org-auth dep supabase"
 
 
-async def _call(method: str, path: str, role_user: dict, dep_role=_NO_DEP_MOCK, **kwargs):
+async def _call(method: str, path: str, role_user: dict, dep_role: object = _NO_DEP_MOCK, **kwargs) -> Response:
     """Execute one HTTP request with auth + optional org-role dep mock.
 
     dep_role=_NO_DEP_MOCK — don't mock (auth-only endpoints, no require_org_role)
@@ -160,8 +162,7 @@ class TestRbacCreateOrg:
         with patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb):
             resp = await _call("post", "/v1/organizations", _ROLE_USERS[role], json={"name": "Test Org"})
 
-        # Auth passes → service runs → 201 (not 401/403 auth error)
-        assert resp.status_code in (201, 400, 500)  # not 401/403
+        assert resp.status_code == 201
 
 
 # ── Endpoint 3: GET /organizations/{id} — min_role=MEMBER ────────────────────
@@ -305,8 +306,7 @@ class TestRbacAcceptInvite:
         with patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb):
             resp = await _call("post", f"/v1/organizations/{ORG_ID}/accept", _ROLE_USERS[role])
 
-        # Auth passes → service runs (200 or 400 depending on invite state)
-        assert resp.status_code in (200, 400)
+        assert resp.status_code == 200
 
 
 # ── Endpoint 6: DELETE /organizations/{id}/members/{uid} — min_role=OWNER ────

--- a/backend/tests/test_rbac_org.py
+++ b/backend/tests/test_rbac_org.py
@@ -1,0 +1,472 @@
+"""RBAC-ORG-001: 3 roles × 8 endpoints = 24 RBAC test cases.
+
+Matrix:
+  Roles: owner (rank 3), member (rank 2), viewer (rank 1)
+  Endpoints:
+    1. GET  /v1/organizations/me                        — auth-only
+    2. POST /v1/organizations                           — auth-only
+    3. GET  /v1/organizations/{id}                      — min_role=MEMBER
+    4. POST /v1/organizations/{id}/invite               — min_role=OWNER
+    5. POST /v1/organizations/{id}/accept               — auth-only
+    6. DELETE /v1/organizations/{id}/members/{uid}      — min_role=OWNER
+    7. GET  /v1/organizations/{id}/dashboard            — min_role=OWNER
+    8. PUT  /v1/organizations/{id}/logo                 — min_role=OWNER
+
+Expected status per role × requirement:
+  auth-only: all roles → pass (2xx)
+  min=MEMBER: owner→pass, member→pass, viewer→403
+  min=OWNER:  owner→pass, member→403,  viewer→403
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from httpx import AsyncClient, ASGITransport
+
+from main import app
+from auth import require_auth
+
+_ORG_AUTH_GET_SUPABASE = "dependencies.org_auth.get_supabase"
+_ORG_SVC_GET_SUPABASE = "services.organization_service.get_supabase"
+
+ORG_ID = "org-test-001"
+TARGET_UID = "user-target-001"
+
+_USER_OWNER = {"id": "user-owner", "email": "owner@rbac.test", "role": "authenticated", "aal": "aal1"}
+_USER_MEMBER = {"id": "user-member", "email": "member@rbac.test", "role": "authenticated", "aal": "aal1"}
+_USER_VIEWER = {"id": "user-viewer", "email": "viewer@rbac.test", "role": "authenticated", "aal": "aal1"}
+
+_ROLE_USERS = {
+    "owner": _USER_OWNER,
+    "member": _USER_MEMBER,
+    "viewer": _USER_VIEWER,
+}
+
+
+@pytest.fixture(autouse=True)
+def _enable_organizations():
+    with patch("routes.organizations.ORGANIZATIONS_ENABLED", True):
+        yield
+
+
+def _mock_auth_sb(role: str | None):
+    """Supabase mock for the require_org_role dependency query."""
+    sb = MagicMock()
+    tbl = MagicMock()
+    res = MagicMock()
+    res.data = [{"role": role}] if role else []
+    tbl.select.return_value = tbl
+    tbl.eq.return_value = tbl
+    tbl.limit.return_value = tbl
+    tbl.execute.return_value = res
+    sb.table.return_value = tbl
+    return sb
+
+
+def _mock_svc_sb_success():
+    """Minimal service supabase mock returning sensible success data."""
+    sb = MagicMock()
+    tbl = MagicMock()
+    res = MagicMock()
+    res.data = [{"id": "row-1", "role": "owner"}]
+    res.count = 1
+    tbl.select.return_value = tbl
+    tbl.insert.return_value = tbl
+    tbl.update.return_value = tbl
+    tbl.delete.return_value = tbl
+    tbl.eq.return_value = tbl
+    tbl.in_.return_value = tbl
+    tbl.single.return_value = tbl
+    tbl.limit.return_value = tbl
+    tbl.order.return_value = tbl
+    tbl.not_.return_value = tbl
+    tbl.is_.return_value = tbl
+    tbl.execute.return_value = res
+    sb.table.return_value = tbl
+    return sb
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+_NO_DEP_MOCK = object()  # sentinel: "don't patch the org-auth dep supabase"
+
+
+async def _call(method: str, path: str, role_user: dict, dep_role=_NO_DEP_MOCK, **kwargs):
+    """Execute one HTTP request with auth + optional org-role dep mock.
+
+    dep_role=_NO_DEP_MOCK — don't mock (auth-only endpoints, no require_org_role)
+    dep_role=None          — mock with empty data (user not in org → 403)
+    dep_role="owner"|...   — mock with that role
+    """
+    app.dependency_overrides[require_auth] = lambda: role_user
+    try:
+        if dep_role is not _NO_DEP_MOCK:
+            with patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb(dep_role)):
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as c:
+                    resp = await getattr(c, method)(path, **kwargs)
+        else:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as c:
+                resp = await getattr(c, method)(path, **kwargs)
+        return resp
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Endpoint 1: GET /organizations/me — auth-only ─────────────────────────────
+
+
+class TestRbacGetMyOrg:
+    """Endpoint 1 (auth-only): all roles see 200."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["owner", "member", "viewer"])
+    async def test_get_my_org_all_roles_pass(self, role: str):
+        svc_sb = _mock_svc_sb_success()
+        svc_sb.table.return_value.execute.return_value.data = []  # no org → {"organization": null}
+
+        with patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb):
+            resp = await _call("get", "/v1/organizations/me", _ROLE_USERS[role])
+
+        assert resp.status_code == 200
+
+
+# ── Endpoint 2: POST /organizations — auth-only ───────────────────────────────
+
+
+class TestRbacCreateOrg:
+    """Endpoint 2 (auth-only): all roles can attempt create (result depends on service)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["owner", "member", "viewer"])
+    async def test_create_org_all_roles_pass_auth(self, role: str):
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            if call_count[0] == 1:
+                r.data = [{"id": "org-new", "name": "Test Org", "owner_id": "u1", "max_members": 5, "plan_type": "consultoria"}]
+            else:
+                r.data = [{"id": "mem-1"}]
+            return r
+
+        svc_sb, svc_tbl, _ = _mock_svc_sb_success(), MagicMock(), None
+        svc_tbl.insert.return_value = svc_tbl
+        svc_tbl.execute.side_effect = execute_side
+        svc_sb.table.return_value = svc_tbl
+
+        with patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb):
+            resp = await _call("post", "/v1/organizations", _ROLE_USERS[role], json={"name": "Test Org"})
+
+        # Auth passes → service runs → 201 (not 401/403 auth error)
+        assert resp.status_code in (201, 400, 500)  # not 401/403
+
+
+# ── Endpoint 3: GET /organizations/{id} — min_role=MEMBER ────────────────────
+
+
+class TestRbacGetOrg:
+    """Endpoint 3: owner→200, member→200, viewer→403."""
+
+    @pytest.mark.asyncio
+    async def test_get_org_owner_passes(self):
+        svc_sb = _mock_svc_sb_success()
+        org_data = {"id": ORG_ID, "name": "Org", "owner_id": "u1", "max_members": 5, "plan_type": "consultoria"}
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            if call_count[0] == 1:
+                r.data = [{"role": "owner"}]
+            elif call_count[0] == 2:
+                r.data = org_data
+            else:
+                r.data = [{"user_id": "u1", "role": "owner", "invited_at": None, "accepted_at": "2026-01-01"}]
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with (
+            patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb("owner")),
+            patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb),
+        ):
+            resp = await _call("get", f"/v1/organizations/{ORG_ID}", _USER_OWNER, dep_role="owner")
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_org_member_passes(self):
+        svc_sb = _mock_svc_sb_success()
+        org_data = {"id": ORG_ID, "name": "Org", "owner_id": "u1", "max_members": 5, "plan_type": "consultoria"}
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            if call_count[0] == 1:
+                r.data = [{"role": "member"}]
+            elif call_count[0] == 2:
+                r.data = org_data
+            else:
+                r.data = []
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with (
+            patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb("member")),
+            patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb),
+        ):
+            resp = await _call("get", f"/v1/organizations/{ORG_ID}", _USER_MEMBER, dep_role="member")
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_get_org_viewer_blocked(self):
+        """viewer rank < MEMBER → 403 from require_org_role."""
+        resp = await _call("get", f"/v1/organizations/{ORG_ID}", _USER_VIEWER, dep_role="viewer")
+        assert resp.status_code == 403
+
+
+# ── Endpoint 4: POST /organizations/{id}/invite — min_role=OWNER ─────────────
+
+
+class TestRbacInvite:
+    """Endpoint 4: owner→200, member→403, viewer→403."""
+
+    @pytest.mark.asyncio
+    async def test_invite_owner_passes(self):
+        svc_sb = _mock_svc_sb_success()
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            r.data = [{"role": "owner"}] if call_count[0] == 1 else [{"id": "x"}]
+            r.data = {"max_members": 5} if call_count[0] == 2 else r.data
+            r.count = 1
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with (
+            patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb("owner")),
+            patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb),
+        ):
+            resp = await _call(
+                "post", f"/v1/organizations/{ORG_ID}/invite", _USER_OWNER,
+                dep_role="owner", json={"email": "new@test.com"},
+            )
+
+        # 200 or 400 (user-not-found) — either way, auth/rbac passed
+        assert resp.status_code in (200, 400)
+
+    @pytest.mark.asyncio
+    async def test_invite_member_blocked(self):
+        resp = await _call(
+            "post", f"/v1/organizations/{ORG_ID}/invite", _USER_MEMBER,
+            dep_role="member", json={"email": "x@test.com"},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_invite_viewer_blocked(self):
+        resp = await _call(
+            "post", f"/v1/organizations/{ORG_ID}/invite", _USER_VIEWER,
+            dep_role="viewer", json={"email": "x@test.com"},
+        )
+        assert resp.status_code == 403
+
+
+# ── Endpoint 5: POST /organizations/{id}/accept — auth-only ──────────────────
+
+
+class TestRbacAcceptInvite:
+    """Endpoint 5 (auth-only): all roles can accept."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["owner", "member", "viewer"])
+    async def test_accept_invite_all_roles_pass_auth(self, role: str):
+        svc_sb = _mock_svc_sb_success()
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            # pending invite — not yet accepted
+            r.data = [{"id": "inv-1", "accepted_at": None}] if call_count[0] == 1 else [{}]
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb):
+            resp = await _call("post", f"/v1/organizations/{ORG_ID}/accept", _ROLE_USERS[role])
+
+        # Auth passes → service runs (200 or 400 depending on invite state)
+        assert resp.status_code in (200, 400)
+
+
+# ── Endpoint 6: DELETE /organizations/{id}/members/{uid} — min_role=OWNER ────
+
+
+class TestRbacRemoveMember:
+    """Endpoint 6: owner→200, member→403, viewer→403."""
+
+    @pytest.mark.asyncio
+    async def test_remove_member_owner_passes(self):
+        svc_sb = _mock_svc_sb_success()
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            if call_count[0] == 1:
+                r.data = [{"role": "owner"}]
+            elif call_count[0] == 2:
+                r.data = [{"id": "mem-t", "role": "member"}]
+            else:
+                r.data = [{"id": "mem-t"}]
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with (
+            patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb("owner")),
+            patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb),
+        ):
+            resp = await _call(
+                "delete", f"/v1/organizations/{ORG_ID}/members/{TARGET_UID}",
+                _USER_OWNER, dep_role="owner",
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_remove_member_member_blocked(self):
+        resp = await _call(
+            "delete", f"/v1/organizations/{ORG_ID}/members/{TARGET_UID}",
+            _USER_MEMBER, dep_role="member",
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_remove_member_viewer_blocked(self):
+        resp = await _call(
+            "delete", f"/v1/organizations/{ORG_ID}/members/{TARGET_UID}",
+            _USER_VIEWER, dep_role="viewer",
+        )
+        assert resp.status_code == 403
+
+
+# ── Endpoint 7: GET /organizations/{id}/dashboard — min_role=OWNER ───────────
+
+
+class TestRbacDashboard:
+    """Endpoint 7: owner→200, member→403, viewer→403."""
+
+    @pytest.mark.asyncio
+    async def test_dashboard_owner_passes(self):
+        svc_sb = _mock_svc_sb_success()
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            if call_count[0] == 1:
+                r.data = [{"role": "owner"}]
+            elif call_count[0] == 2:
+                r.data = [{"user_id": "u1"}]
+            else:
+                r.data = [{"total_results": 5, "total_value": 100.0}]
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with (
+            patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb("owner")),
+            patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb),
+        ):
+            resp = await _call("get", f"/v1/organizations/{ORG_ID}/dashboard", _USER_OWNER, dep_role="owner")
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_dashboard_member_blocked(self):
+        resp = await _call("get", f"/v1/organizations/{ORG_ID}/dashboard", _USER_MEMBER, dep_role="member")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_dashboard_viewer_blocked(self):
+        resp = await _call("get", f"/v1/organizations/{ORG_ID}/dashboard", _USER_VIEWER, dep_role="viewer")
+        assert resp.status_code == 403
+
+
+# ── Endpoint 8: PUT /organizations/{id}/logo — min_role=OWNER ────────────────
+
+
+class TestRbacLogo:
+    """Endpoint 8: owner→200, member→403, viewer→403."""
+
+    @pytest.mark.asyncio
+    async def test_logo_owner_passes(self):
+        svc_sb = _mock_svc_sb_success()
+        call_count = [0]
+
+        def execute_side():
+            call_count[0] += 1
+            r = MagicMock()
+            r.data = [{"role": "owner"}] if call_count[0] == 1 else [{}]
+            return r
+
+        svc_sb.table.return_value.execute.side_effect = execute_side
+
+        with (
+            patch(_ORG_AUTH_GET_SUPABASE, return_value=_mock_auth_sb("owner")),
+            patch(_ORG_SVC_GET_SUPABASE, return_value=svc_sb),
+        ):
+            resp = await _call(
+                "put", f"/v1/organizations/{ORG_ID}/logo", _USER_OWNER,
+                dep_role="owner", json={"logo_url": "https://example.com/logo.png"},
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_logo_member_blocked(self):
+        resp = await _call(
+            "put", f"/v1/organizations/{ORG_ID}/logo", _USER_MEMBER,
+            dep_role="member", json={"logo_url": "https://example.com/logo.png"},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_logo_viewer_blocked(self):
+        resp = await _call(
+            "put", f"/v1/organizations/{ORG_ID}/logo", _USER_VIEWER,
+            dep_role="viewer", json={"logo_url": "https://example.com/logo.png"},
+        )
+        assert resp.status_code == 403
+
+
+# ── Edge: non-member (not in org at all) ─────────────────────────────────────
+
+
+class TestRbacNonMemberEdge:
+    """Edge case: user not in org at all → 403 on any role-gated endpoint."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method,path,body", [
+        ("get",    f"/v1/organizations/{ORG_ID}",                       None),
+        ("post",   f"/v1/organizations/{ORG_ID}/invite",                {"email": "x@x.com"}),
+        ("delete", f"/v1/organizations/{ORG_ID}/members/{TARGET_UID}",  None),
+        ("get",    f"/v1/organizations/{ORG_ID}/dashboard",             None),
+        ("put",    f"/v1/organizations/{ORG_ID}/logo",                  {"logo_url": "http://x.com/l.png"}),
+    ])
+    async def test_non_member_blocked_on_role_gated_endpoints(self, method: str, path: str, body):
+        kwargs = {"json": body} if body else {}
+        # dep_role=None → _mock_auth_sb(None) → data=[] → 403
+        resp = await _call(method, path, _USER_OWNER, dep_role=None, **kwargs)
+        assert resp.status_code == 403

--- a/docs/stories/2026-04/RBAC-ORG-001-enforce-org-role-dependency.story.md
+++ b/docs/stories/2026-04/RBAC-ORG-001-enforce-org-role-dependency.story.md
@@ -3,7 +3,7 @@
 **Priority:** P1
 **Effort:** S-M (2-3 dias)
 **Squad:** @dev + @architect
-**Status:** Ready
+**Status:** InProgress
 **Epic:** [EPIC-TD-2026Q2](EPIC-TD-2026Q2/) ou [EPIC-RES-BE-2026-Q2](EPIC-RES-BE-2026-Q2.md)
 **Sprint:** Sprint 2 (após user input)
 **Dependências bloqueadoras:** GV-014 Ready conditional (consultoria-client-readonly) · ADR enum decision (USER)
@@ -35,53 +35,47 @@ Hierarchy: owner > member > viewer. Detalhes em ADR `docs/adr/org-rbac.md` (cria
 
 ### AC1: Enum confirmation + migration (se needed)
 
-- [ ] Confirmar `organization_members.role` enum atual via psql
-- [ ] Se diferente de Q1: `ALTER TYPE org_role_enum` migration + paired down.sql
+- [x] Confirmar `organization_members.role` enum atual via psql
+- [x] DB usa TEXT CHECK constraint (não PG enum). `ALTER TYPE org_role_enum` não aplicável.
+  - Old CHECK: `('owner', 'admin', 'member')` — Migration `20260501000000` swaps `admin`→`viewer`.
+  - Zero admin rows em prod na data de implementação (2026-05-01).
+  - `supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql` + paired `.down.sql`
 
 ### AC2: FastAPI dependency `require_org_role`
 
-- [ ] `backend/dependencies/org_auth.py` (novo):
-  ```python
-  from enum import Enum
-  class OrgRole(str, Enum):
-      OWNER = "owner"
-      MEMBER = "member"
-      VIEWER = "viewer"
-  
-  async def require_org_role(min_role: OrgRole):
-      async def dependency(
-          org_id: UUID,
-          user_id: UUID = Depends(require_auth),
-          sb = Depends(get_supabase),
-      ) -> OrgRole:
-          # SELECT role FROM organization_members WHERE org_id=$1 AND user_id=$2
-          # If role rank < min_role rank → HTTP 403
-          ...
-      return dependency
-  ```
-- [ ] Hierarchy: owner > member > viewer
+- [x] `backend/dependencies/org_auth.py` criado com `OrgRole` enum + factory `require_org_role`
+- [x] Hierarchy: owner (3) > member (2) > viewer (1) via `_ROLE_RANK` dict
+- [x] Uses `_run_with_budget(asyncio.to_thread(_query), budget=10s)` (RES-BE-016 pattern)
+- [x] 403 para não-membro (empty data) e para rank insuficiente
 
 ### AC3: Apply em 8 endpoints
 
-- [ ] `POST /v1/organizations` — create (no role required, owner self-assigned)
-- [ ] `POST /v1/organizations/{id}/invite` — `require_org_role(OrgRole.OWNER)`
-- [ ] `POST /v1/organizations/{id}/accept` — invitee (auth-only, no role check)
-- [ ] `PATCH /v1/organizations/{id}` — `require_org_role(OrgRole.OWNER)`
-- [ ] `DELETE /v1/organizations/{id}` — `require_org_role(OrgRole.OWNER)`
-- [ ] `GET /v1/organizations/{id}/members` — `require_org_role(OrgRole.MEMBER)`
-- [ ] `POST /v1/organizations/{id}/leave` — self (auth-only)
-- [ ] `PATCH /v1/organizations/{id}/members/{member_id}` (role update) — `require_org_role(OrgRole.OWNER)`
+**NOTA @po:** 5 endpoints da AC3 original (PATCH /{id}, DELETE /{id}, GET /{id}/members,
+POST /{id}/leave, PATCH /{id}/members/{id}) não existem em `routes/organizations.py`.
+Implementação aplicada nos 8 endpoints EXISTENTES. AC3 precisa ser corrigida por @po.
+
+- [x] `GET /v1/organizations/me` — auth-only (sem role check)
+- [x] `POST /v1/organizations` — auth-only (owner self-assigned)
+- [x] `GET /v1/organizations/{id}` — `require_org_role(OrgRole.MEMBER)`
+- [x] `POST /v1/organizations/{id}/invite` — `require_org_role(OrgRole.OWNER)`
+- [x] `POST /v1/organizations/{id}/accept` — auth-only (invitee)
+- [x] `DELETE /v1/organizations/{id}/members/{uid}` — `require_org_role(OrgRole.OWNER)`
+- [x] `GET /v1/organizations/{id}/dashboard` — `require_org_role(OrgRole.OWNER)`
+- [x] `PUT /v1/organizations/{id}/logo` — `require_org_role(OrgRole.OWNER)`
 
 ### AC4: Tests cross-product
 
-- [ ] `test_rbac_org.py`: 3 roles × 8 endpoints = 24 cases
-- [ ] Each case: setup user with role X, call endpoint Y, assert status (200 if allowed, 403 if not)
-- [ ] Edge: user not in org → 403/404
+- [x] `backend/tests/test_rbac_org.py`: 29 cases (24 matrix + 5 non-member edge)
+- [x] Each case: mock auth + mock dep supabase with role X, assert status
+- [x] Edge: user not in org → 403 (5 endpoints × 1 non-member case)
+- [x] `backend/tests/test_organizations.py`: 11 existing tests updated for new dep mock
 
 ### AC5: Frontend handle 403
 
-- [ ] `frontend/app/organizations/page.tsx` (se existir) graceful 403 message
-- [ ] Hide UI buttons baseado em role (avoid 403 surprises)
+- [x] `frontend/hooks/useOrganization.ts`: 403 → mensagem "Acesso negado: sua função não permite..."
+- [x] `frontend/app/conta/equipe/page.tsx`: `isOwnerOrAdmin` = `role === "owner"` (botões invite/remove ocultos)
+- [x] Types atualizados: `"owner" | "member" | "viewer"` (removido `"admin"`)
+- [x] `ROLE_LABELS/COLORS` atualizados com `viewer`
 
 ---
 
@@ -101,11 +95,26 @@ Hierarchy: owner > member > viewer. Detalhes em ADR `docs/adr/org-rbac.md` (cria
 
 ---
 
+## File List
+
+| File | Action | Notes |
+|------|--------|-------|
+| `backend/dependencies/org_auth.py` | NEW | OrgRole enum + require_org_role factory |
+| `backend/routes/organizations.py` | MOD | Imports + 5 endpoints get require_org_role Depends |
+| `backend/services/organization_service.py` | MOD | 4× `not in ("owner", "admin")` → `!= "owner"` |
+| `supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql` | NEW | CHECK admin→viewer + RLS update |
+| `supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql` | NEW | Rollback migration |
+| `backend/tests/test_rbac_org.py` | NEW | 29 RBAC test cases |
+| `backend/tests/test_organizations.py` | MOD | 11 tests updated for new dep mock |
+| `frontend/hooks/useOrganization.ts` | MOD | Role types + 403 graceful message |
+| `frontend/app/conta/equipe/page.tsx` | MOD | Role types, ROLE_LABELS/COLORS, isOwnerOrAdmin→owner |
+
 ## Dev Notes
 
 - `routes/organizations.py` (Module 13 Reversa code-analysis)
 - `auth.py:require_auth` pattern de dependency injection
 - RLS policies em `organization_members` mantêm 2ª camada defense (mesmo se dependency falha, RLS bloqueia)
+- AC3 mismatch: story lista 5 endpoints inexistentes — scope aplicado aos 8 existentes; @po deve corrigir AC3
 
 ---
 
@@ -163,3 +172,4 @@ Status: Blocked → Ready (com gate em Phase 0 conforme RES-BE-005 padrão).
 |---|---|---|---|
 | 2026-04-28 | 1.0 | Story criada — recria fictícia state.json sm_handoff. Bloqueada user input Q1-Q5. Origem: `_reversa_sdd/sm-briefing-refactor.md` + sm-briefing.md sec.2.3 + review-report.md Gap-1. | @sm (River) |
 | 2026-04-28 | 1.1 | User input Q1-Q4 respondidas: enum owner/member/viewer, owner=invite+update+delete+role-change, default=inviter define, leave=qualquer role exceto único owner. ADR `docs/adr/org-rbac.md` criado. PO validation: GO (9/10) com Phase 0 enum verify Required Fix. Status: Blocked → Ready. | @po (Pax) |
+| 2026-05-01 | 1.2 | Implementação @dev. Phase 0 confirmado: TEXT CHECK (não PG enum), zero admin rows. Migration 20260501000000 criada. `backend/dependencies/org_auth.py` + dependency aplicada em 5 endpoints. Service admin→owner. 29 testes novos + 11 existentes atualizados. Frontend types + 403 graceful. AC3 mismatch documentado (5 endpoints inexistentes). Status: Ready → InProgress. | @dev (Dex) |

--- a/frontend/app/conta/equipe/page.tsx
+++ b/frontend/app/conta/equipe/page.tsx
@@ -245,7 +245,7 @@ export default function EquipePage() {
   const myMember = org.members.find(
     (m) => m.email.toLowerCase() === myEmail.toLowerCase(),
   );
-  const isOwnerOrAdmin = myMember?.role === "owner";
+  const isOwner = myMember?.role === "owner";
 
   return (
     <>
@@ -276,7 +276,7 @@ export default function EquipePage() {
             </div>
 
             {/* Invite button — only for owner/admin, only if slots available */}
-            {isOwnerOrAdmin && (
+            {isOwner && (
               <button
                 onClick={() => setShowInviteModal(true)}
                 disabled={!canInvite}
@@ -392,7 +392,7 @@ export default function EquipePage() {
                 </div>
 
                 {/* Remove controls — only owner/admin can remove, never remove owner, never remove self */}
-                {isOwnerOrAdmin && !isOwner && !isMe && (
+                {isOwner && !isOwner && !isMe && (
                   <div className="flex items-center gap-2 flex-shrink-0">
                     {isConfirmingRemove ? (
                       <>

--- a/frontend/app/conta/equipe/page.tsx
+++ b/frontend/app/conta/equipe/page.tsx
@@ -15,7 +15,7 @@ interface OrgMember {
   user_id: string | null;
   email: string;
   name: string | null;
-  role: "owner" | "admin" | "member";
+  role: "owner" | "member" | "viewer";
   status: "accepted" | "pending";
   joined_at: string | null;
   invited_at: string;
@@ -32,21 +32,21 @@ interface Organization {
 interface OrgRef {
   id: string;
   name: string;
-  role: "owner" | "admin" | "member";
+  role: "owner" | "member" | "viewer";
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 const ROLE_LABELS: Record<string, string> = {
   owner: "Proprietário",
-  admin: "Admin",
   member: "Membro",
+  viewer: "Visualizador",
 };
 
 const ROLE_COLORS: Record<string, string> = {
   owner: "bg-[var(--brand-blue-subtle)] text-[var(--brand-blue)]",
-  admin: "bg-[var(--success-subtle)] text-[var(--success)]",
   member: "bg-[var(--surface-1)] text-[var(--ink-secondary)]",
+  viewer: "bg-[var(--warning-subtle)] text-[var(--warning)]",
 };
 
 function formatDate(iso: string): string {
@@ -245,7 +245,7 @@ export default function EquipePage() {
   const myMember = org.members.find(
     (m) => m.email.toLowerCase() === myEmail.toLowerCase(),
   );
-  const isOwnerOrAdmin = myMember?.role === "owner" || myMember?.role === "admin";
+  const isOwnerOrAdmin = myMember?.role === "owner";
 
   return (
     <>

--- a/frontend/hooks/useOrganization.ts
+++ b/frontend/hooks/useOrganization.ts
@@ -16,7 +16,7 @@ export interface OrgMember {
   user_id: string | null;
   email: string;
   name: string | null;
-  role: "owner" | "admin" | "member";
+  role: "owner" | "member" | "viewer";
   status: "accepted" | "pending";
   joined_at: string | null;
   invited_at: string;
@@ -52,6 +52,12 @@ const fetchOrgWithAuth = async (token: string): Promise<Organization | null> => 
   });
 
   if (!detailRes.ok) {
+    if (detailRes.status === 403) {
+      throw new FetchError(
+        "Acesso negado: sua função não permite ver os detalhes da organização.",
+        403
+      );
+    }
     const data = await detailRes.json().catch(() => ({}));
     throw new FetchError(
       data.message || "Erro ao carregar detalhes da organização",

--- a/supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql
+++ b/supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql
@@ -17,6 +17,7 @@ COMMENT ON COLUMN public.organization_members.role
 -- Restore original RLS policies
 DROP POLICY IF EXISTS "Org members can view organization"     ON public.organizations;
 DROP POLICY IF EXISTS "Org owner can view all members"        ON public.organization_members;
+DROP POLICY IF EXISTS "Org members can view all members"      ON public.organization_members;
 DROP POLICY IF EXISTS "Org owner can insert members"          ON public.organization_members;
 DROP POLICY IF EXISTS "Org owner can delete members"          ON public.organization_members;
 

--- a/supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql
+++ b/supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql
@@ -1,5 +1,9 @@
 -- RBAC-ORG-001 rollback: restore 'admin' role and original RLS policies.
 
+-- Convert 'viewer' rows to 'member' before re-adding old constraint
+-- (old constraint does not allow 'viewer').
+UPDATE public.organization_members SET role = 'member' WHERE role = 'viewer';
+
 ALTER TABLE public.organization_members
   DROP CONSTRAINT IF EXISTS organization_members_role_check;
 

--- a/supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql
+++ b/supabase/migrations/20260501000000_rbac_org_001_role_viewer.down.sql
@@ -1,0 +1,70 @@
+-- RBAC-ORG-001 rollback: restore 'admin' role and original RLS policies.
+
+ALTER TABLE public.organization_members
+  DROP CONSTRAINT IF EXISTS organization_members_role_check;
+
+ALTER TABLE public.organization_members
+  ADD CONSTRAINT organization_members_role_check
+  CHECK (role IN ('owner', 'admin', 'member'));
+
+COMMENT ON COLUMN public.organization_members.role
+  IS 'Role within the org: owner (full control), admin (manage members), member (read-only team access)';
+
+-- Restore original RLS policies
+DROP POLICY IF EXISTS "Org members can view organization"     ON public.organizations;
+DROP POLICY IF EXISTS "Org owner can view all members"        ON public.organization_members;
+DROP POLICY IF EXISTS "Org owner can insert members"          ON public.organization_members;
+DROP POLICY IF EXISTS "Org owner can delete members"          ON public.organization_members;
+
+CREATE POLICY "Org admins can view organization"
+  ON public.organizations FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id = public.organizations.id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('owner', 'admin')
+        AND om.accepted_at IS NOT NULL
+    )
+  );
+
+CREATE POLICY "Org owner/admin can view all members"
+  ON public.organization_members FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id = public.organization_members.org_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('owner', 'admin')
+        AND om.accepted_at IS NOT NULL
+    )
+  );
+
+CREATE POLICY "Org owner/admin can insert members"
+  ON public.organization_members FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id = public.organization_members.org_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('owner', 'admin')
+        AND om.accepted_at IS NOT NULL
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.organizations o
+      WHERE o.id = public.organization_members.org_id AND o.owner_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Org owner/admin can delete members"
+  ON public.organization_members FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id = public.organization_members.org_id
+        AND om.user_id = auth.uid()
+        AND om.role IN ('owner', 'admin')
+        AND om.accepted_at IS NOT NULL
+    )
+    OR auth.uid() = user_id
+  );

--- a/supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql
+++ b/supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql
@@ -39,8 +39,9 @@ CREATE POLICY "Org members can view organization"
 
 -- organization_members table — view policy
 DROP POLICY IF EXISTS "Org owner/admin can view all members" ON public.organization_members;
+DROP POLICY IF EXISTS "Org owner can view all members" ON public.organization_members;
 
-CREATE POLICY "Org owner can view all members"
+CREATE POLICY "Org members can view all members"
   ON public.organization_members
   FOR SELECT
   USING (
@@ -48,7 +49,6 @@ CREATE POLICY "Org owner can view all members"
       SELECT 1 FROM public.organization_members om
       WHERE om.org_id  = public.organization_members.org_id
         AND om.user_id = auth.uid()
-        AND om.role    = 'owner'
         AND om.accepted_at IS NOT NULL
     )
   );

--- a/supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql
+++ b/supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql
@@ -1,10 +1,12 @@
 -- RBAC-ORG-001: Replace 'admin' role with 'viewer' in organization_members.
 -- Hierarchy: owner (3) > member (2) > viewer (1).
--- Table was empty at migration time (no admin rows to migrate).
 
 -- ============================================================================
 -- 1. CHECK constraint: swap 'admin' for 'viewer'
 -- ============================================================================
+
+-- Convert any legacy 'admin' rows before tightening constraint.
+UPDATE public.organization_members SET role = 'viewer' WHERE role = 'admin';
 
 ALTER TABLE public.organization_members
   DROP CONSTRAINT IF EXISTS organization_members_role_check;
@@ -58,19 +60,14 @@ CREATE POLICY "Org owner can insert members"
   ON public.organization_members
   FOR INSERT
   WITH CHECK (
-    EXISTS (
+    -- Callers may only insert non-owner roles (backend service_role handles owner bootstrap)
+    public.organization_members.role <> 'owner'
+    AND EXISTS (
       SELECT 1 FROM public.organization_members om
       WHERE om.org_id  = public.organization_members.org_id
         AND om.user_id = auth.uid()
         AND om.role    = 'owner'
         AND om.accepted_at IS NOT NULL
-    )
-    OR
-    -- Allow owner to add the first member row (bootstrap: owner adds themselves)
-    EXISTS (
-      SELECT 1 FROM public.organizations o
-      WHERE o.id       = public.organization_members.org_id
-        AND o.owner_id = auth.uid()
     )
   );
 

--- a/supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql
+++ b/supabase/migrations/20260501000000_rbac_org_001_role_viewer.sql
@@ -1,0 +1,99 @@
+-- RBAC-ORG-001: Replace 'admin' role with 'viewer' in organization_members.
+-- Hierarchy: owner (3) > member (2) > viewer (1).
+-- Table was empty at migration time (no admin rows to migrate).
+
+-- ============================================================================
+-- 1. CHECK constraint: swap 'admin' for 'viewer'
+-- ============================================================================
+
+ALTER TABLE public.organization_members
+  DROP CONSTRAINT IF EXISTS organization_members_role_check;
+
+ALTER TABLE public.organization_members
+  ADD CONSTRAINT organization_members_role_check
+  CHECK (role IN ('owner', 'member', 'viewer'));
+
+COMMENT ON COLUMN public.organization_members.role
+  IS 'Role within org: owner (full control, rank 3), member (team access, rank 2), viewer (read-only, rank 1)';
+
+-- ============================================================================
+-- 2. RLS policies: replace 'admin' references with 'owner' (only owners manage)
+-- ============================================================================
+
+-- organizations table
+DROP POLICY IF EXISTS "Org admins can view organization" ON public.organizations;
+
+CREATE POLICY "Org members can view organization"
+  ON public.organizations
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id  = public.organizations.id
+        AND om.user_id = auth.uid()
+        AND om.accepted_at IS NOT NULL
+    )
+  );
+
+-- organization_members table — view policy
+DROP POLICY IF EXISTS "Org owner/admin can view all members" ON public.organization_members;
+
+CREATE POLICY "Org owner can view all members"
+  ON public.organization_members
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id  = public.organization_members.org_id
+        AND om.user_id = auth.uid()
+        AND om.role    = 'owner'
+        AND om.accepted_at IS NOT NULL
+    )
+  );
+
+-- organization_members table — insert policy
+DROP POLICY IF EXISTS "Org owner/admin can insert members" ON public.organization_members;
+
+CREATE POLICY "Org owner can insert members"
+  ON public.organization_members
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id  = public.organization_members.org_id
+        AND om.user_id = auth.uid()
+        AND om.role    = 'owner'
+        AND om.accepted_at IS NOT NULL
+    )
+    OR
+    -- Allow owner to add the first member row (bootstrap: owner adds themselves)
+    EXISTS (
+      SELECT 1 FROM public.organizations o
+      WHERE o.id       = public.organization_members.org_id
+        AND o.owner_id = auth.uid()
+    )
+  );
+
+-- organization_members table — delete policy
+DROP POLICY IF EXISTS "Org owner/admin can delete members" ON public.organization_members;
+
+CREATE POLICY "Org owner can delete members"
+  ON public.organization_members
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.organization_members om
+      WHERE om.org_id  = public.organization_members.org_id
+        AND om.user_id = auth.uid()
+        AND om.role    = 'owner'
+        AND om.accepted_at IS NOT NULL
+    )
+    OR
+    -- Users can remove themselves (leave org)
+    auth.uid() = user_id
+  );
+
+DO $$
+BEGIN
+  RAISE NOTICE 'RBAC-ORG-001: role CHECK updated (admin → viewer), RLS policies updated';
+END $$;


### PR DESCRIPTION
## Summary

- `services/indice_municipal.py` usava 5 column names inexistentes em `pncp_raw_bids`
- Cada deploy gerava 199 warnings `column pncp_raw_bids.id does not exist` (PostgreSQL 42703)
- Storm de queries falhando saturava event loop uvicorn
- Inclui RBAC-ORG-001: `require_org_role` dependency + migracao role `admin->viewer`

**Colunas corrigidas:** id->pncp_id, data_publicacao_pncp->data_publicacao, valor_estimado->valor_total_estimado, cnpj_contratado->orgao_cnpj

**RBAC-ORG-001:** OrgRole enum + require_org_role dependency, RLS members view fix, 42703 re-raise, isOwnerOrAdmin->isOwner

## Testing Plan

- [ ] Deploy Railway sem warnings 42703 nos logs
- [ ] /health/live retorna 200 continuamente
- [ ] GET /v1/organizations/{id} retorna 200 para member
- [ ] POST /v1/organizations/{id}/invite retorna 403 para member
- [ ] Migration aplicada sem erros no CI

## Closes

Closes #596
Closes #649

Generated with Claude Code