### PR TITLE
feat(frontend): CTA inline mid-page em cnpj/orgao/contratos

### DIFF
--- a/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
+++ b/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
@@ -176,6 +176,30 @@ export default function CnpjPerfilClient({ perfil }: { perfil: PerfilB2G }) {
         </div>
       </div>
 
+      {/* Inline CTA mid-page */}
+      <div className="my-6 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 flex flex-col sm:flex-row items-center justify-between gap-3">
+        <p className="text-sm text-gray-700">
+          <strong>{editais_abertos_setor} editais</strong> abertos no setor de {setor_nome} esta
+          semana.
+        </p>
+        <Link
+          href={`/signup?ref=cnpj-mid&setor=${perfil.setor_detectado}&uf=${empresa.uf}`}
+          className="text-sm font-bold text-white bg-green-600 hover:bg-green-700 px-4 py-2 rounded-md whitespace-nowrap w-full sm:w-auto text-center"
+          onClick={() => {
+            if (typeof window !== 'undefined' && window.mixpanel) {
+              window.mixpanel.track('cta_inline_clicked', {
+                placement: 'mid',
+                page: 'cnpj',
+                setor: perfil.setor_detectado,
+                uf: empresa.uf,
+              });
+            }
+          }}
+        >
+          Ver agora →
+        </Link>
+      </div>
+
       {/* UFs de atuação */}
       {ufs_atuacao.length > 0 && (
         <div className="mb-8">

--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -312,6 +312,27 @@ export default async function ContratosSetorUfPage({ params }: Props) {
                     </section>
                   )}
 
+                  {/* Inline CTA mid-page — após tabela de fornecedores */}
+                  <div className="my-6 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 flex flex-col sm:flex-row items-center justify-between gap-3">
+                    <p className="text-sm text-gray-700">
+                      <strong>{totalContracts.toLocaleString('pt-BR')} contratos</strong> de{' '}
+                      {sector.name} em {ufName}
+                      {totalEditais > 0 && (
+                        <>
+                          {' '}
+                          — <strong>{totalEditais} editais abertos</strong> agora
+                        </>
+                      )}
+                      .
+                    </p>
+                    <Link
+                      href={`/signup?ref=contratos-mid&setor=${setor}&uf=${uf}`}
+                      className="text-sm font-bold text-white bg-green-600 hover:bg-green-700 px-4 py-2 rounded-md whitespace-nowrap w-full sm:w-auto text-center"
+                    >
+                      Ver editais agora →
+                    </Link>
+                  </div>
+
                   {/* Sample Contracts */}
                   {data.sample_contracts.length > 0 && (
                     <section className="mb-8">

--- a/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
+++ b/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
@@ -167,6 +167,32 @@ export default function OrgaoPerfilClient({ stats }: { stats: OrgaoStats }) {
         </div>
       </div>
 
+      {/* Inline CTA mid-page */}
+      <div className="my-6 rounded-lg bg-blue-50 border border-blue-200 px-4 py-3 flex flex-col sm:flex-row items-center justify-between gap-3">
+        <p className="text-sm text-gray-700">
+          <strong>
+            {licitacoes_30d} {licitacoes_30d === 1 ? 'edital publicado' : 'editais publicados'}
+          </strong>{' '}
+          por este órgão nos últimos 30 dias.
+        </p>
+        <Link
+          href={`/signup?ref=orgao-mid&uf=${uf}`}
+          className="text-sm font-bold text-white bg-green-600 hover:bg-green-700 px-4 py-2 rounded-md whitespace-nowrap w-full sm:w-auto text-center"
+          onClick={() => {
+            if (typeof window !== 'undefined' && window.mixpanel) {
+              window.mixpanel.track('cta_inline_clicked', {
+                placement: 'mid',
+                page: 'orgao',
+                uf,
+                licitacoes_30d,
+              });
+            }
+          }}
+        >
+          Monitorar este órgão →
+        </Link>
+      </div>
+
       {/* Org info card */}
       <div className="bg-gray-50 rounded-xl p-6 mb-8">
         <h2 className="text-lg font-bold text-gray-800 mb-4">Dados do Órgão</h2>


### PR DESCRIPTION
## Context

Páginas programáticas `/cnpj/[cnpj]`, `/orgaos/[slug]` e `/contratos/[setor]/[uf]` têm CTR 25–100% no Google (tráfego de maior intenção), mas o CTA de conversão estava apenas no rodapé. Scroll depth analytics mostram <40% dos visitantes chegando ao rodapé em páginas longas com tabelas de dados. CTA embeddado após bloco de dados = +121% vs CTA só no rodapé (Klettke/HubSpot).

## Changes

- `CnpjPerfilClient.tsx`: barra CTA inline após stats cards (contratos 24m / valor total / editais abertos), `ref=cnpj-mid`, Mixpanel `cta_inline_clicked placement=mid`
- `OrgaoPerfilClient.tsx`: barra CTA inline após stats cards (licitações 30d), `ref=orgao-mid`, Mixpanel `cta_inline_clicked placement=mid`  
- `contratos/[setor]/[uf]/page.tsx`: barra CTA inline após tabela top_fornecedores, `ref=contratos-mid`, copy dinâmico com total_contracts + totalEditais

Layout responsivo: `flex-col` mobile (botão full-width), `flex-row` sm+ (botão compacto).

**Nota:** `contratos/page.tsx` é Server Component — sem `onClick` Mixpanel direto. `ref=contratos-mid` no URL permite tracking via Mixpanel `page_load` event. Os outros 2 arquivos são `use client` e disparam `cta_inline_clicked` no onClick.

## Testing Plan

- [ ] Frontend tests passando: `npx jest --testPathPattern="cnpj-perfil|orgao|contratos"` — 53 testes, 0 failures verificados localmente
- [ ] Validação manual: `/cnpj/[cnpj]` — CTA inline visível entre stats cards e tabela de UFs de atuação
- [ ] Validação manual: `/orgaos/[slug]` — CTA inline visível entre stats cards e dados do órgão
- [ ] Validação manual: `/contratos/[setor]/[uf]` — CTA inline visível após tabela top_fornecedores
- [ ] Mobile layout: botão ocupa largura total em viewport <640px
- [ ] Mixpanel: `cta_inline_clicked` com `placement=mid` dispara em clique (cnpj + orgao pages)

## Risks & Rollback

Risco: nenhum — adição pura de elementos existentes, sem lógica modificada. Rollback: reverter os 3 arquivos (71 linhas adicionadas, 0 removidas).

## Closes

Closes #623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inline call-to-action sections added to CNPJ profiles, contract pages, and agency profiles to encourage engagement.
  * CTAs display contextual information such as open opportunities and publication activity.
  * New "Monitor this agency" option available on agency profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->