### PR TITLE
fix(pseo): default SITEMAP_VARIANT='legacy' — robots.txt apontava sitemap 404 (#656)

### DIFF
--- a/frontend/__tests__/app/robots.test.ts
+++ b/frontend/__tests__/app/robots.test.ts
@@ -2,7 +2,7 @@
  * SEO-PROG-007 AC7: Unit tests for `app/robots.ts` route handler.
  *
  * Covers:
- *  - Default production: full Allow/Disallow + Google-Extended + 7 AI blocks + sitemap_index + host
+ *  - Default production: full Allow/Disallow + Google-Extended + 7 AI blocks + sitemap.xml (legacy default) + host
  *  - ENV=preview / ENV=staging: block-all (no sitemap, no host canonical mention)
  *  - SITEMAP_USE_INDEX_VARIANT toggle (legacy | index)
  *  - AC6 path-exact: /alertas-publicos/* allowed, /api/sitemap-* allowed, /admin/seo blocked
@@ -101,9 +101,9 @@ describe('app/robots.ts — production defaults', () => {
     expect(r.rules).toHaveLength(9);
   });
 
-  it('declares sitemap_index URL by default (SITEMAP_USE_INDEX_VARIANT unset)', () => {
+  it('declares /sitemap.xml by default (SITEMAP_USE_INDEX_VARIANT unset — #656 fix)', () => {
     const r = loadRobots();
-    expect(r.sitemap).toBe(`${CANONICAL}/sitemap_index.xml`);
+    expect(r.sitemap).toBe(`${CANONICAL}/sitemap.xml`);
   });
 
   it('declares host canonical', () => {
@@ -198,9 +198,9 @@ describe('app/robots.ts — SITEMAP_USE_INDEX_VARIANT flag (AC3)', () => {
     expect(r.sitemap).toBe(`${CANONICAL}/sitemap_index.xml`);
   });
 
-  it('unset (default) points to /sitemap_index.xml', () => {
+  it('unset (default) points to /sitemap.xml (#656: legacy is safe default until sitemap_index.xml ships)', () => {
     const r = loadRobots();
-    expect(r.sitemap).toBe(`${CANONICAL}/sitemap_index.xml`);
+    expect(r.sitemap).toBe(`${CANONICAL}/sitemap.xml`);
   });
 });
 

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -21,8 +21,8 @@ const BASE_URL = process.env.NEXT_PUBLIC_CANONICAL_URL || 'https://smartlic.tech
 // Falls through to production rules if NEXT_PUBLIC_ENVIRONMENT is unset (safe default).
 // Wired in Railway via NEXT_PUBLIC_ENVIRONMENT=production|preview|staging|development.
 const ENV = process.env.NEXT_PUBLIC_ENVIRONMENT || 'production';
-// 'index' (default, post SEO-PROG-006) | 'legacy' (rollback flag)
-const SITEMAP_VARIANT = process.env.SITEMAP_USE_INDEX_VARIANT || 'index';
+// 'legacy' (default → /sitemap.xml) | 'index' (opt-in → /sitemap_index.xml, when that route ships)
+const SITEMAP_VARIANT = process.env.SITEMAP_USE_INDEX_VARIANT || 'legacy';
 
 const SITEMAP_URL =
   SITEMAP_VARIANT === 'legacy'


### PR DESCRIPTION
## Context

`robots.ts` (SEO-PROG-007) usava `|| 'index'` como default para `SITEMAP_USE_INDEX_VARIANT`, gerando `Sitemap: https://smartlic.tech/sitemap_index.xml` — rota que **não existe** no app Next.js.

Resultado: todos os crawlers (Google, Bing) recebiam URL de sitemap quebrada (404), perdendo referência para 10k+ URLs pSEO. `public/robots.txt` (estático, fallback) apontava corretamente para `/sitemap.xml`, mas `app/robots.ts` tem precedência e sobrescreve.

## Changes

- `frontend/app/robots.ts` L25: `|| 'index'` → `|| 'legacy'` (aponta para `/sitemap.xml` que existe)
- `frontend/app/robots.ts` L24: comentário atualizado para refletir o comportamento correto
- `frontend/__tests__/app/robots.test.ts`: 2 assertions do default atualizadas (`sitemap_index.xml` → `sitemap.xml`)

## Testing Plan

- [x] 40/40 unit tests passando (`npx jest --testPathPattern="__tests__/app/robots"`)
- [x] Testes de variant explícito (`legacy` e `index`) inalterados — flag ainda funciona
- [x] Testes AC6 path-exact inalterados — nenhuma regressão em allow/disallow rules
- [x] `curl https://smartlic.tech/robots.txt | grep Sitemap` pós-deploy deve retornar `/sitemap.xml`

## Risks & Rollback

**Risco mínimo:** 1-line change. Se `SITEMAP_USE_INDEX_VARIANT=index` estiver setado em Railway, comportamento não muda. Se não estiver setado (atual), passa de 404 para URL válida.

**Rollback:** setar `SITEMAP_USE_INDEX_VARIANT=index` em Railway env sem deploy para reverter comportamento (hot rollback sem PR).

## Closes

Closes #656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default sitemap endpoint in robots configuration to `/sitemap.xml`.

* **Tests**
  * Updated test expectations for default sitemap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->