### PR TITLE
test(pseo): testes de dedup CNPJ em contratos_publicos e sitemap_cnpjs

### DIFF
--- a/backend/tests/test_contratos_publicos.py
+++ b/backend/tests/test_contratos_publicos.py
@@ -188,3 +188,138 @@ class TestFornecedoresStats:
         assert resp.json()["total_suppliers"] == 20
 
         _fornecedores_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Dedup: same CNPJ appearing multiple times in pncp_supplier_contracts
+# ---------------------------------------------------------------------------
+
+class TestContratosDedup:
+    """Verify that endpoints aggregate per-CNPJ correctly when DB has multiple
+    rows for the same supplier/orgao (multiple contracts per entity)."""
+
+    def _mock_chain(self, mock_sb, rows):
+        mock_resp = MagicMock()
+        mock_resp.data = rows
+        (
+            mock_sb.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .order.return_value
+            .limit.return_value
+            .execute.return_value
+        ) = mock_resp
+
+    @patch("routes.contratos_publicos.get_supabase", create=True)
+    def test_contratos_stats_no_duplicate_fornecedores(self, mock_get_sb, client):
+        """Same ni_fornecedor in multiple rows → single aggregated entry in top_fornecedores."""
+        mock_sb = MagicMock()
+        self._mock_chain(mock_sb, [
+            # Supplier A with 3 contracts (keyword match: uniforme)
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "10000.0", "data_assinatura": "2026-03-01",
+             "objeto_contrato": "Fornecimento de uniformes"},
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "20000.0", "data_assinatura": "2026-02-01",
+             "objeto_contrato": "Fornecimento de fardamentos"},
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "30000.0", "data_assinatura": "2026-01-01",
+             "objeto_contrato": "Fornecimento de uniformes escolares"},
+            # Supplier B with 1 contract
+            {"ni_fornecedor": "22222222000222", "nome_fornecedor": "Fornecedor B",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "5000.0", "data_assinatura": "2026-03-10",
+             "objeto_contrato": "Aquisicao de uniformes especiais"},
+        ])
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb):
+            from routes.contratos_publicos import _contratos_cache
+            _contratos_cache.clear()
+            resp = client.get("/v1/contratos/vestuario/sp/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        cnpjs_in_top = [f["cnpj"] for f in data["top_fornecedores"]]
+        # No duplicate CNPJs in top_fornecedores
+        assert len(cnpjs_in_top) == len(set(cnpjs_in_top)), "Duplicate supplier CNPJ in top_fornecedores"
+        # Supplier A aggregated: 3 contracts, value = 60000
+        forn_a = next((f for f in data["top_fornecedores"] if f["cnpj"] == "11111111000111"), None)
+        assert forn_a is not None
+        assert forn_a["total_contratos"] == 3
+        assert abs(forn_a["valor_total"] - 60000.0) < 0.01
+
+    @patch("routes.contratos_publicos.get_supabase", create=True)
+    def test_contratos_stats_no_duplicate_orgaos(self, mock_get_sb, client):
+        """Same orgao_cnpj in multiple rows → single aggregated entry in top_orgaos."""
+        mock_sb = MagicMock()
+        self._mock_chain(mock_sb, [
+            # Orgao X with 2 contracts (keyword match: uniforme)
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "88888888000888", "orgao_nome": "Orgao X",
+             "valor_global": "15000.0", "data_assinatura": "2026-03-01",
+             "objeto_contrato": "Aquisicao de uniformes"},
+            {"ni_fornecedor": "22222222000222", "nome_fornecedor": "Fornecedor B",
+             "orgao_cnpj": "88888888000888", "orgao_nome": "Orgao X",
+             "valor_global": "25000.0", "data_assinatura": "2026-02-01",
+             "objeto_contrato": "Compra de fardamentos"},
+            # Orgao Y with 1 contract
+            {"ni_fornecedor": "33333333000333", "nome_fornecedor": "Fornecedor C",
+             "orgao_cnpj": "77777777000777", "orgao_nome": "Orgao Y",
+             "valor_global": "8000.0", "data_assinatura": "2026-03-05",
+             "objeto_contrato": "Fornecimento de calcados e uniformes"},
+        ])
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb):
+            from routes.contratos_publicos import _contratos_cache
+            _contratos_cache.clear()
+            resp = client.get("/v1/contratos/vestuario/sp/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        cnpjs_in_top = [o["cnpj"] for o in data["top_orgaos"]]
+        # No duplicate CNPJs in top_orgaos
+        assert len(cnpjs_in_top) == len(set(cnpjs_in_top)), "Duplicate orgao CNPJ in top_orgaos"
+        # Orgao X aggregated: 2 contracts from different suppliers
+        orgao_x = next((o for o in data["top_orgaos"] if o["cnpj"] == "88888888000888"), None)
+        assert orgao_x is not None
+        assert orgao_x["total_contratos"] == 2
+        assert abs(orgao_x["valor_total"] - 40000.0) < 0.01
+
+    @patch("routes.contratos_publicos.get_supabase", create=True)
+    def test_fornecedores_stats_no_duplicate_suppliers(self, mock_get_sb, client):
+        """Same ni_fornecedor in multiple rows → single entry in supplier_ranking."""
+        mock_sb = MagicMock()
+        self._mock_chain(mock_sb, [
+            # Supplier A with 3 contracts (all use "uniformes" — reliable vestuario keyword)
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "10000.0", "data_assinatura": "2026-03-01",
+             "objeto_contrato": "Compra de uniformes tipo 1"},
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "10000.0", "data_assinatura": "2026-02-01",
+             "objeto_contrato": "Compra de uniformes tipo 2"},
+            {"ni_fornecedor": "11111111000111", "nome_fornecedor": "Fornecedor A",
+             "orgao_cnpj": "99999999000999", "orgao_nome": "Orgao Z",
+             "valor_global": "10000.0", "data_assinatura": "2026-01-01",
+             "objeto_contrato": "Compra de uniformes tipo 3"},
+        ])
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb):
+            from routes.contratos_publicos import _fornecedores_cache
+            _fornecedores_cache.clear()
+            resp = client.get("/v1/fornecedores/vestuario/sp/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        cnpjs_in_ranking = [s["cnpj"] for s in data["supplier_ranking"]]
+        # No duplicate CNPJs in supplier_ranking
+        assert len(cnpjs_in_ranking) == len(set(cnpjs_in_ranking)), "Duplicate CNPJ in supplier_ranking"
+        # Single supplier aggregated (all 3 contracts matched keyword filter)
+        assert len(cnpjs_in_ranking) == 1
+        assert data["supplier_ranking"][0]["cnpj"] == "11111111000111"
+        assert data["supplier_ranking"][0]["total_contratos"] == 3

--- a/backend/tests/test_sitemap_cnpjs.py
+++ b/backend/tests/test_sitemap_cnpjs.py
@@ -201,3 +201,103 @@ class TestSitemapCnpjs:
         resp = client.get("/v1/sitemap/cnpjs")
         data = resp.json()
         assert data["total"] <= 5000
+
+
+# ---------------------------------------------------------------------------
+# Tests for /v1/sitemap/fornecedores-cnpj
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _clear_fornecedores_cache():
+    from routes.sitemap_cnpjs import _fornecedores_sitemap_cache
+    _fornecedores_sitemap_cache.clear()
+    yield
+    _fornecedores_sitemap_cache.clear()
+
+
+class TestSitemapFornecedoresCnpj:
+    """Tests for /v1/sitemap/fornecedores-cnpj."""
+
+    @patch("supabase_client.get_supabase")
+    def test_dedup_same_cnpj_multiple_contracts(self, mock_get_sb, client, _clear_fornecedores_cache):
+        """Same ni_fornecedor in multiple rows → single entry in response (no duplicates)."""
+        rows = [
+            {"ni_fornecedor": "11111111111111"},
+            {"ni_fornecedor": "11111111111111"},
+            {"ni_fornecedor": "11111111111111"},
+            {"ni_fornecedor": "22222222222222"},
+        ]
+        mock_get_sb.return_value = _mock_supabase_with_data(rows)
+
+        resp = client.get("/v1/sitemap/fornecedores-cnpj")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert len(data["cnpjs"]) == 2
+        assert len(set(data["cnpjs"])) == 2, "Response contains duplicate CNPJs"
+
+    @patch("supabase_client.get_supabase")
+    def test_sorted_by_contract_count(self, mock_get_sb, client, _clear_fornecedores_cache):
+        """CNPJs sorted descending by contract count."""
+        rows = [
+            {"ni_fornecedor": "11111111111111"},
+            {"ni_fornecedor": "22222222222222"},
+            {"ni_fornecedor": "22222222222222"},
+            {"ni_fornecedor": "22222222222222"},
+            {"ni_fornecedor": "33333333333333"},
+            {"ni_fornecedor": "33333333333333"},
+        ]
+        mock_get_sb.return_value = _mock_supabase_with_data(rows)
+
+        resp = client.get("/v1/sitemap/fornecedores-cnpj")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 3
+        assert data["cnpjs"][0] == "22222222222222"  # 3 contracts
+        assert data["cnpjs"][1] == "33333333333333"  # 2 contracts
+        assert data["cnpjs"][2] == "11111111111111"  # 1 contract
+
+    @patch("supabase_client.get_supabase")
+    def test_filters_invalid_cnpjs(self, mock_get_sb, client, _clear_fornecedores_cache):
+        """Skips non-14-digit and non-numeric ni_fornecedor values."""
+        rows = [
+            {"ni_fornecedor": ""},
+            {"ni_fornecedor": None},
+            {"ni_fornecedor": "123"},
+            {"ni_fornecedor": "ABCDEFGHIJKLMN"},
+            {"ni_fornecedor": "44444444444444"},
+            {"ni_fornecedor": "44444444444444"},
+        ]
+        mock_get_sb.return_value = _mock_supabase_with_data(rows)
+
+        resp = client.get("/v1/sitemap/fornecedores-cnpj")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["cnpjs"] == ["44444444444444"]
+
+    @patch("supabase_client.get_supabase")
+    def test_max_5000_fornecedores(self, mock_get_sb, client, _clear_fornecedores_cache):
+        """Respects _MAX_FORNECEDORES_CNPJS cap."""
+        rows = []
+        for i in range(6000):
+            cnpj = f"{i:014d}"
+            rows.extend([{"ni_fornecedor": cnpj}] * 2)
+        mock_get_sb.return_value = _mock_supabase_with_data(rows)
+
+        resp = client.get("/v1/sitemap/fornecedores-cnpj")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] <= 5000
+        assert len(data["cnpjs"]) <= 5000
+
+    @patch("supabase_client.get_supabase")
+    def test_graceful_failure(self, mock_get_sb, client, _clear_fornecedores_cache):
+        """Returns empty response on Supabase error."""
+        mock_get_sb.side_effect = Exception("connection failed")
+
+        resp = client.get("/v1/sitemap/fornecedores-cnpj")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cnpjs"] == []
+        assert data["total"] == 0


### PR DESCRIPTION
## Context

Issue #663 — pSEO Health Sprint. Queries sem DISTINCT em `contratos_publicos.py` (linhas 191-199 e 273) poderiam causar CNPJs duplicados nos sitemaps se `pncp_supplier_contracts` tivesse múltiplos registros por entidade. A investigação confirmou que o dedup já é feito via `defaultdict` keying (Python-level) nos endpoints de dados, e via `counts: dict[str, int]` nos endpoints de sitemap — mas não havia testes cobrindo esse comportamento.

## Changes

- `backend/tests/test_contratos_publicos.py`: Adiciona `TestContratosDedup` com 3 testes:
  - `test_contratos_stats_no_duplicate_fornecedores` — mesmo `ni_fornecedor` em múltiplas linhas → entrada única e agregada em `top_fornecedores`
  - `test_contratos_stats_no_duplicate_orgaos` — mesmo `orgao_cnpj` em múltiplas linhas → entrada única e agregada em `top_orgaos`
  - `test_fornecedores_stats_no_duplicate_suppliers` — mesmo `ni_fornecedor` → entrada única em `supplier_ranking`

- `backend/tests/test_sitemap_cnpjs.py`: Adiciona `TestSitemapFornecedoresCnpj` com 5 testes cobrindo `/v1/sitemap/fornecedores-cnpj` (endpoint sem cobertura prévia):
  - Dedup quando mesmo CNPJ aparece múltiplas vezes
  - Ordenação por volume de contratos
  - Filtro de CNPJs inválidos (non-14-digit, None, vazio)
  - Cap de 5000 CNPJs
  - Graceful failure em erro Supabase

## Testing Plan

- [x] 27 testes passando localmente (`pytest tests/test_contratos_publicos.py tests/test_sitemap_cnpjs.py -v`)
- [x] 0 regressões nos testes existentes
- [x] Todos novos testes escritos com `asyncio.to_thread` + mock correto via `supabase_client.get_supabase`
- [x] Cache limpo antes e depois de cada teste (`_fornecedores_sitemap_cache`)

## Risks & Rollback

Apenas testes — zero risco em produção. Sem alterações em código de produção.

## Closes

Closes #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for supplier and organization deduplication in contract statistics endpoints.
  * Added test suite for sitemap endpoint with validation for contract rankings, data filtering, and result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->