### PR TITLE
fix(pseo): /indice-municipal/[municipio-uf] thin content + revalidate ausente (#659)

### DIFF
--- a/frontend/app/indice-municipal/[municipio-uf]/page.tsx
+++ b/frontend/app/indice-municipal/[municipio-uf]/page.tsx
@@ -7,6 +7,9 @@
 
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+export const revalidate = 86400;
 
 interface PageProps {
   params: Promise<{ 'municipio-uf': string }>;
@@ -79,7 +82,7 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
         },
       ] : [],
     },
-    robots: { index: true },
+    robots: data ? { index: true } : { index: false, follow: false },
   };
 }
 
@@ -92,6 +95,7 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
   const municipioTitulo = deslugify(municipioSlug);
 
   const data = await fetchMunicipio(slug, periodo);
+  if (!data) notFound();
 
   const score = data?.score_total != null ? Number(data.score_total) : null;
   const scoreColor =
@@ -177,24 +181,7 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
           Período: {periodo} · Fonte: PNCP via SmartLic
         </p>
 
-        {!data && (
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
-            <p className="text-yellow-800 font-medium">Dados não disponíveis</p>
-            <p className="text-yellow-700 text-sm mt-1">
-              {municipioTitulo} não possui editais suficientes no PNCP para este período (mínimo
-              10).
-            </p>
-            <Link
-              href="/indice-municipal"
-              className="text-blue-600 hover:underline mt-3 block text-sm"
-            >
-              ← Ver ranking completo
-            </Link>
-          </div>
-        )}
-
-        {data && (
-          <>
+        <>
             {/* Score principal */}
             <div className="bg-white border rounded-xl p-6 mb-6 flex items-center gap-6 shadow-sm">
               <div className="text-center">
@@ -276,8 +263,7 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
               </Link>
               <p className="text-xs text-blue-600 mt-2">14 dias grátis, sem cartão de crédito.</p>
             </div>
-          </>
-        )}
+        </>
 
         <div className="mt-8 text-xs text-gray-400 border-t pt-4">
           Dados derivados do PNCP (Portal Nacional de Contratações Públicas). Licença{' '}
@@ -292,6 +278,9 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
           — cite: SmartLic Índice Municipal.
           <Link href="/indice-municipal" className="ml-4 hover:underline">
             ← Voltar ao ranking
+          </Link>
+          <Link href={`/municipios/${slug}`} className="ml-4 hover:underline">
+            Ver perfil completo de {municipioTitulo}
           </Link>
         </div>
       </main>


### PR DESCRIPTION
## Context
pSEO Health Sprint — issue #659. Página `/indice-municipal/[municipio-uf]` indexava thin content (200 OK com "dados não disponíveis") e não declarava `export const revalidate`, usando semântica fraca de fetch cache.

## Changes
- `export const revalidate = 86400` adicionado (alinha com `/cnpj`, `/orgaos`, `/municipios`)
- `notFound()` chamado quando backend retorna null — substitui 200 thin content por 404 adequado
- `robots: { index: false, follow: false }` em `generateMetadata` quando data ausente (belt-and-suspenders)
- Link para `/municipios/${slug}` adicionado no footer (internal linking graph)
- Bloco JSX dead code `{!data && ...}` removido (unreachable após `notFound()`)

## Testing Plan
- [x] 11 testes unitários passando (`__tests__/indice-municipal.test.tsx`)
- [x] Somente 1 arquivo alterado: `frontend/app/indice-municipal/[municipio-uf]/page.tsx`
- Validação manual: `GET /indice-municipal/municipio-inexistente-xx` deve retornar 404

## Risks & Rollback
- Risco baixo: apenas frontend, sem backend
- Rollback: reverter `if (!data) notFound()` para restaurar comportamento anterior

## Closes
Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing municipality data with proper 404 responses instead of inline error messages
  * Enhanced SEO with dynamic robot meta tags based on data availability

* **New Features**
  * Updated footer navigation to direct users to the complete municipality profile

<!-- end of auto-generated comment: release notes by coderabbit.ai -->