### PR TITLE
fix(pseo): /indice-municipal thin content + revalidate + link interno (#659)

### DIFF
--- a/frontend/app/indice-municipal/[municipio-uf]/page.tsx
+++ b/frontend/app/indice-municipal/[municipio-uf]/page.tsx
@@ -1,12 +1,15 @@
 /**
  * STORY-435 AC2: Página de município — /indice-municipal/[municipio-uf]
  *
- * SSG com revalidate 1h. Schema.org: Article.
+ * ISR revalidate 24h. Schema.org: Article.
  * Slug format: "sao-paulo-sp" (nome-slug + "-" + uf 2 chars)
  */
 
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+export const revalidate = 86400;
 
 interface PageProps {
   params: Promise<{ 'municipio-uf': string }>;
@@ -36,7 +39,7 @@ async function fetchMunicipio(slug: string, periodo: string) {
   try {
     const res = await fetch(
       `${backendUrl}/v1/indice-municipal/${slug}?periodo=${periodo}`,
-      { next: { revalidate: 3600 }, signal: AbortSignal.timeout(10000) }
+      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) }
     );
     if (!res.ok) return null;
     return await res.json();
@@ -79,7 +82,7 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
         },
       ] : [],
     },
-    robots: { index: true },
+    robots: data ? { index: true } : { index: false, follow: true },
   };
 }
 
@@ -92,6 +95,8 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
   const municipioTitulo = deslugify(municipioSlug);
 
   const data = await fetchMunicipio(slug, periodo);
+
+  if (!data) notFound();
 
   const score = data?.score_total != null ? Number(data.score_total) : null;
   const scoreColor =
@@ -177,107 +182,87 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
           Período: {periodo} · Fonte: PNCP via SmartLic
         </p>
 
-        {!data && (
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
-            <p className="text-yellow-800 font-medium">Dados não disponíveis</p>
-            <p className="text-yellow-700 text-sm mt-1">
-              {municipioTitulo} não possui editais suficientes no PNCP para este período (mínimo
-              10).
-            </p>
-            <Link
-              href="/indice-municipal"
-              className="text-blue-600 hover:underline mt-3 block text-sm"
-            >
-              ← Ver ranking completo
-            </Link>
+        {/* Score principal */}
+        <div className="bg-white border rounded-xl p-6 mb-6 flex items-center gap-6 shadow-sm">
+          <div className="text-center">
+            <div className={`text-5xl font-bold ${scoreColor}`}>
+              {score?.toFixed(1)}
+            </div>
+            <div className="text-xs text-gray-400 mt-1">de 100 pontos</div>
           </div>
-        )}
-
-        {data && (
-          <>
-            {/* Score principal */}
-            <div className="bg-white border rounded-xl p-6 mb-6 flex items-center gap-6 shadow-sm">
-              <div className="text-center">
-                <div className={`text-5xl font-bold ${scoreColor}`}>
-                  {score?.toFixed(1)}
-                </div>
-                <div className="text-xs text-gray-400 mt-1">de 100 pontos</div>
-              </div>
-              <div className="flex-1">
-                {data.ranking_nacional && (
-                  <p className="text-sm text-gray-700">
-                    <span className="font-medium">Ranking nacional:</span>{' '}
-                    {data.ranking_nacional}º lugar
-                  </p>
-                )}
-                {data.ranking_uf && (
-                  <p className="text-sm text-gray-700">
-                    <span className="font-medium">Ranking em {uf}:</span>{' '}
-                    {data.ranking_uf}º lugar
-                  </p>
-                )}
-                <p className="text-sm text-gray-700">
-                  <span className="font-medium">Total de editais:</span>{' '}
-                  {new Intl.NumberFormat('pt-BR').format(data.total_editais)}
-                </p>
-              </div>
-            </div>
-
-            {/* 5 dimensões */}
-            <h2 className="text-lg font-semibold text-gray-800 mb-3">Dimensões do índice</h2>
-            <div className="space-y-3 mb-8">
-              {dimensoes.map((dim) => (
-                <div key={dim.nome} className="bg-white border rounded-lg p-4 shadow-sm">
-                  <div className="flex justify-between items-center mb-1">
-                    <span className="text-sm font-medium text-gray-700">{dim.nome}</span>
-                    <span
-                      className={`text-sm font-bold ${
-                        dim.score >= 14
-                          ? 'text-green-600'
-                          : dim.score >= 8
-                            ? 'text-yellow-600'
-                            : 'text-red-600'
-                      }`}
-                    >
-                      {dim.score.toFixed(1)}/20
-                    </span>
-                  </div>
-                  <div className="w-full bg-gray-100 rounded-full h-2">
-                    {/* eslint-disable-next-line local-rules/no-inline-styles -- DYNAMIC: width is computed from dimension score relative to maximum */}
-                    <div
-                      className={`h-2 rounded-full ${
-                        dim.score >= 14
-                          ? 'bg-green-500'
-                          : dim.score >= 8
-                            ? 'bg-yellow-500'
-                            : 'bg-red-500'
-                      }`}
-                      style={{ width: `${(dim.score / 20) * 100}%` }}
-                    />
-                  </div>
-                  <p className="text-xs text-gray-400 mt-1">{dim.desc}</p>
-                </div>
-              ))}
-            </div>
-
-            {/* CTA */}
-            <div className="bg-blue-50 border border-blue-200 rounded-xl p-6 text-center">
-              <h3 className="text-base font-semibold text-blue-900 mb-1">
-                Acompanhe as licitações de {municipioTitulo}
-              </h3>
-              <p className="text-sm text-blue-700 mb-3">
-                Receba alertas de novos editais e analise oportunidades em tempo real.
+          <div className="flex-1">
+            {data.ranking_nacional && (
+              <p className="text-sm text-gray-700">
+                <span className="font-medium">Ranking nacional:</span>{' '}
+                {data.ranking_nacional}º lugar
               </p>
-              <Link
-                href={`/signup?ref=indice-municipal&uf=${uf}&municipio=${municipioSlug}`}
-                className="inline-block bg-blue-600 text-white text-sm font-medium px-5 py-2 rounded-lg hover:bg-blue-700 transition-colors"
-              >
-                Ver editais abertos em {municipioTitulo} →
-              </Link>
-              <p className="text-xs text-blue-600 mt-2">14 dias grátis, sem cartão de crédito.</p>
+            )}
+            {data.ranking_uf && (
+              <p className="text-sm text-gray-700">
+                <span className="font-medium">Ranking em {uf}:</span>{' '}
+                {data.ranking_uf}º lugar
+              </p>
+            )}
+            <p className="text-sm text-gray-700">
+              <span className="font-medium">Total de editais:</span>{' '}
+              {new Intl.NumberFormat('pt-BR').format(data.total_editais)}
+            </p>
+          </div>
+        </div>
+
+        {/* 5 dimensões */}
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">Dimensões do índice</h2>
+        <div className="space-y-3 mb-8">
+          {dimensoes.map((dim) => (
+            <div key={dim.nome} className="bg-white border rounded-lg p-4 shadow-sm">
+              <div className="flex justify-between items-center mb-1">
+                <span className="text-sm font-medium text-gray-700">{dim.nome}</span>
+                <span
+                  className={`text-sm font-bold ${
+                    dim.score >= 14
+                      ? 'text-green-600'
+                      : dim.score >= 8
+                        ? 'text-yellow-600'
+                        : 'text-red-600'
+                  }`}
+                >
+                  {dim.score.toFixed(1)}/20
+                </span>
+              </div>
+              <div className="w-full bg-gray-100 rounded-full h-2">
+                {/* eslint-disable-next-line local-rules/no-inline-styles -- DYNAMIC: width is computed from dimension score relative to maximum */}
+                <div
+                  className={`h-2 rounded-full ${
+                    dim.score >= 14
+                      ? 'bg-green-500'
+                      : dim.score >= 8
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                  }`}
+                  style={{ width: `${(dim.score / 20) * 100}%` }}
+                />
+              </div>
+              <p className="text-xs text-gray-400 mt-1">{dim.desc}</p>
             </div>
-          </>
-        )}
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div className="bg-blue-50 border border-blue-200 rounded-xl p-6 text-center">
+          <h3 className="text-base font-semibold text-blue-900 mb-1">
+            Acompanhe as licitações de {municipioTitulo}
+          </h3>
+          <p className="text-sm text-blue-700 mb-3">
+            Receba alertas de novos editais e analise oportunidades em tempo real.
+          </p>
+          <Link
+            href={`/signup?ref=indice-municipal&uf=${uf}&municipio=${municipioSlug}`}
+            className="inline-block bg-blue-600 text-white text-sm font-medium px-5 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Ver editais abertos em {municipioTitulo} →
+          </Link>
+          <p className="text-xs text-blue-600 mt-2">14 dias grátis, sem cartão de crédito.</p>
+        </div>
 
         <div className="mt-8 text-xs text-gray-400 border-t pt-4">
           Dados derivados do PNCP (Portal Nacional de Contratações Públicas). Licença{' '}
@@ -292,6 +277,9 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
           — cite: SmartLic Índice Municipal.
           <Link href="/indice-municipal" className="ml-4 hover:underline">
             ← Voltar ao ranking
+          </Link>
+          <Link href={`/municipios/${slug}`} className="ml-4 hover:underline">
+            Ver licitações abertas →
           </Link>
         </div>
       </main>

--- a/frontend/app/indice-municipal/[municipio-uf]/page.tsx
+++ b/frontend/app/indice-municipal/[municipio-uf]/page.tsx
@@ -36,16 +36,13 @@ function deslugify(slug: string): string {
 
 async function fetchMunicipio(slug: string, periodo: string) {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
-  try {
-    const res = await fetch(
-      `${backendUrl}/v1/indice-municipal/${slug}?periodo=${periodo}`,
-      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) }
-    );
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+  const res = await fetch(
+    `${backendUrl}/v1/indice-municipal/${slug}?periodo=${periodo}`,
+    { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) }
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`fetchMunicipio failed: ${res.status}`);
+  return res.json();
 }
 
 export async function generateMetadata({ params, searchParams }: PageProps): Promise<Metadata> {
@@ -56,7 +53,12 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
   const municipioSlug = extractMunicipioSlug(slug);
   const municipioTitulo = deslugify(municipioSlug);
 
-  const data = await fetchMunicipio(slug, periodo);
+  let data = null;
+  let genuineNotFound = false;
+  try {
+    data = await fetchMunicipio(slug, periodo);
+    if (data === null) genuineNotFound = true;
+  } catch { /* transient backend error: keep page indexable */ }
   const score = data?.score_total != null ? Number(data.score_total) : null;
   const scoreText = score != null ? ` Score ${score.toFixed(1)} de 100.` : '';
 
@@ -82,7 +84,7 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
         },
       ] : [],
     },
-    robots: data ? { index: true } : { index: false, follow: true },
+    robots: genuineNotFound ? { index: false, follow: false } : { index: true },
   };
 }
 


### PR DESCRIPTION
## Context
pSEO Health Sprint — issue #659. Página `/indice-municipal/[municipio-uf]` indexava thin content (200 OK com "dados não disponíveis") e não declarava `export const revalidate`, usando semântica fraca de fetch cache.

## Changes
- `export const revalidate = 86400` adicionado (alinha com `/cnpj`, `/orgaos`, `/municipios`)
- `fetchMunicipio` diferencia **404 genuíno** (município não existe) de **erro transiente** (backend 500/503/timeout)
  - 404 → retorna `null` → `notFound()` (correto)
  - não-404 → lança erro → ISR serve versão stale (preserva indexabilidade durante outages)
- `generateMetadata` usa flag `genuineNotFound` para `robots: noindex` apenas em 404 real — evita deindexação falsa durante saturação do backend (Stage 4-8)
- Link para `/municipios/${slug}` adicionado no footer (internal linking graph)
- Bloco JSX dead code `{!data && ...}` removido (unreachable após `notFound()`)

## Testing Plan
- [x] 11 testes unitários passando (`__tests__/indice-municipal.test.tsx`)
- [x] Somente 1 arquivo alterado: `frontend/app/indice-municipal/[municipio-uf]/page.tsx`
- Validação manual: `GET /indice-municipal/municipio-inexistente-xx` deve retornar 404
- Backend 500 durante outage: página permanece indexável, ISR serve versão em cache

## Risks & Rollback
- Risco baixo: apenas frontend, sem backend
- Rollback: reverter `if (!data) notFound()` para restaurar comportamento anterior

## Closes
Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased page cache duration to reduce revalidation frequency.

* **Bug Fixes**
  * Improved error handling so missing municipality returns 404; transient backend errors surface correctly.
  * Page now renders primary score/dimensions/CTA sections assuming data exists.
  * Metadata now prevents indexing for genuinely missing pages.
  * Fixed footer link routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->