### PR TITLE
fix(auth): handle_new_user search_path wedge — signup unblock P0

### DIFF
--- a/.github/workflows/handle-new-user-guard.yml
+++ b/.github/workflows/handle-new-user-guard.yml
@@ -33,7 +33,13 @@ jobs:
           MATCHES=$(echo "$CHANGED" | xargs grep -l "handle_new_user" 2>/dev/null || true)
           if [ -n "$MATCHES" ]; then
             echo "found=true" >> $GITHUB_OUTPUT
-            echo "files=$MATCHES" >> $GITHUB_OUTPUT
+            # Multiline-safe heredoc delimiter (multiple matched files split by \n
+            # break a plain `key=value` write to $GITHUB_OUTPUT)
+            {
+              echo "files<<MATCHES_EOF"
+              echo "$MATCHES"
+              echo "MATCHES_EOF"
+            } >> $GITHUB_OUTPUT
           else
             echo "found=false" >> $GITHUB_OUTPUT
           fi

--- a/supabase/migrations/20260504140600_fix_signup_trigger_search_path.down.sql
+++ b/supabase/migrations/20260504140600_fix_signup_trigger_search_path.down.sql
@@ -1,0 +1,50 @@
+-- Rollback: restore pre-fix versions (search_path inherited, no exception handler).
+-- WARNING: rollback re-introduces signup wedge bug. Only use if fix causes regression.
+
+CREATE OR REPLACE FUNCTION public.create_default_alert_preferences()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $func$
+BEGIN
+  INSERT INTO alert_preferences (user_id)
+  VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $func$
+DECLARE
+  _phone text;
+BEGIN
+  _phone := regexp_replace(COALESCE(NEW.raw_user_meta_data->>'phone_whatsapp', ''), '[^0-9]', '', 'g');
+  IF length(_phone) > 11 AND left(_phone, 2) = '55' THEN _phone := substring(_phone from 3); END IF;
+  IF left(_phone, 1) = '0' THEN _phone := substring(_phone from 2); END IF;
+  IF length(_phone) NOT IN (10, 11) THEN _phone := NULL; END IF;
+
+  INSERT INTO public.profiles (
+    id, email, full_name, company, sector,
+    phone_whatsapp, whatsapp_consent, plan_type,
+    avatar_url, context_data, trial_expires_at
+  )
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', ''),
+    COALESCE(NEW.raw_user_meta_data->>'company', ''),
+    COALESCE(NEW.raw_user_meta_data->>'sector', ''),
+    _phone,
+    COALESCE((NEW.raw_user_meta_data->>'whatsapp_consent')::boolean, FALSE),
+    'free_trial',
+    NEW.raw_user_meta_data->>'avatar_url',
+    '{}'::jsonb,
+    NOW() + INTERVAL '14 days'
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$func$;

--- a/supabase/migrations/20260504140600_fix_signup_trigger_search_path.sql
+++ b/supabase/migrations/20260504140600_fix_signup_trigger_search_path.sql
@@ -1,0 +1,70 @@
+-- Fix signup wedge: handle_new_user + create_default_alert_preferences
+-- Root cause: SECURITY DEFINER without SET search_path inherits caller's
+-- search_path. supabase_auth_admin (GoTrue role) has search_path=auth, so
+-- nested trigger create_default_alert_preferences references unqualified
+-- `alert_preferences` and fails with 42P01 (relation does not exist),
+-- aborting auth.users INSERT and surfacing as "Database error saving new user".
+--
+-- Fix (defense-in-depth):
+--   1. SET search_path = public, pg_temp on both functions
+--   2. SECURITY DEFINER on create_default_alert_preferences
+--   3. EXCEPTION handler in handle_new_user so partial failures don't abort signup
+--
+-- Repro: signup wedge since 2026-04-10 (24 days, 0 new users).
+-- Validated post-fix: signup 200 OK, profile+alert_preferences cascade populated.
+
+CREATE OR REPLACE FUNCTION public.create_default_alert_preferences()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+BEGIN
+  INSERT INTO public.alert_preferences (user_id)
+  VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  _phone text;
+BEGIN
+  _phone := regexp_replace(COALESCE(NEW.raw_user_meta_data->>'phone_whatsapp', ''), '[^0-9]', '', 'g');
+  IF length(_phone) > 11 AND left(_phone, 2) = '55' THEN _phone := substring(_phone from 3); END IF;
+  IF left(_phone, 1) = '0' THEN _phone := substring(_phone from 2); END IF;
+  IF length(_phone) NOT IN (10, 11) THEN _phone := NULL; END IF;
+
+  BEGIN
+    INSERT INTO public.profiles (
+      id, email, full_name, company, sector,
+      phone_whatsapp, whatsapp_consent, plan_type,
+      avatar_url, context_data, trial_expires_at
+    )
+    VALUES (
+      NEW.id,
+      NEW.email,
+      COALESCE(NEW.raw_user_meta_data->>'full_name', ''),
+      COALESCE(NEW.raw_user_meta_data->>'company', ''),
+      COALESCE(NEW.raw_user_meta_data->>'sector', ''),
+      _phone,
+      COALESCE((NEW.raw_user_meta_data->>'whatsapp_consent')::boolean, FALSE),
+      'free_trial',
+      NEW.raw_user_meta_data->>'avatar_url',
+      '{}'::jsonb,
+      NOW() + INTERVAL '14 days'
+    )
+    ON CONFLICT (id) DO NOTHING;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'handle_new_user failed user=%: % (%)', NEW.id, SQLERRM, SQLSTATE;
+  END;
+
+  RETURN NEW;
+END;
+$func$;


### PR DESCRIPTION
## Summary

Causa raiz: `handle_new_user` `SECURITY DEFINER` sem `SET search_path` herda search_path do caller (`supabase_auth_admin` = `auth`). Trigger nested `create_default_alert_preferences` referencia `alert_preferences` UNQUALIFIED + NÃO era SECDEF → procura em `auth.alert_preferences` → 42P01 `relation does not exist` → aborta `auth.users` INSERT → GoTrue retorna 500 `"Database error saving new user"`.

## Context

- **Wedge ativo desde 2026-04-10** (24 dias, 0 novos signups). Confirma vacuum aquisição n=2/30d documentado em memory baseline 2026-04-24.
- User report 2026-05-04: _"Oi, tentei me cadastrar no smartlic.tech, erro: Database error saving new user"_.
- Reproduzido empiricamente via Management API:
  ```sql
  SET LOCAL search_path = auth;
  INSERT INTO auth.users (...);
  -- ERROR 42P01: relation "alert_preferences" does not exist
  ```
- Severity P0 — bloqueia 100% funil aquisição.

## Fix (defense-in-depth)

1. **`SET search_path = public, pg_temp`** em ambas funções (security best practice 2026 — Supabase docs RU_EwB).
2. **`SECURITY DEFINER`** em `create_default_alert_preferences` (era `false`).
3. **`EXCEPTION WHEN OTHERS`** handler em `handle_new_user` — partial failures (alert_preferences ou outros downstream triggers) `RAISE WARNING` mas não abortam signup.

Pre-applied via Management API hotfix antes deste PR para unblock prod imediatamente. PR commita migration ao repo para idempotência via `supabase db push` na próxima deploy + auditoria.

## Testing Plan

- [x] Hotfix aplicado prod via Management API (2026-05-04 ~14:05 UTC)
- [x] curl POST `/auth/v1/signup` → 200 OK + access_token retornado
- [x] `profile_rows=1` + `alert_rows=1` (cascade populated)
- [x] `plan_type='free_trial'` + `trial_expires_at = NOW() + 14d`
- [x] Test users (`conselho-*@test.smartlic.tech`, `searchpath-debug-*@test.smartlic.tech`) limpos
- [x] `.down.sql` rollback paired (STORY-6.2)
- [ ] CI: Backend Tests + Frontend Tests pass
- [ ] Pós-merge: monitor `auth.users.created_at` 1h — esperar primeiro signup orgânico real

## Closes

P0 incident — signup wedge revenue-blocking. Validar com user reporter quando deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a signup wedge so new users can complete registration reliably.
  * Improved error handling during account creation so registration succeeds even if secondary setup steps fail.

* **Chores**
  * Small CI/workflow output formatting improvement for change-detection steps.

* **Revert**
  * Rollback option restored prior signup trigger behavior (includes warning it may reintroduce the original wedge).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->