### PR TITLE
feat(sec): TOTP MFA enroll + verify endpoints (#639)

### DIFF
--- a/backend/routes/mfa.py
+++ b/backend/routes/mfa.py
@@ -5,6 +5,10 @@ STORY-317: TOTP MFA with recovery codes.
 - POST /v1/mfa/recovery-codes — Generate recovery codes after MFA enrollment
 - POST /v1/mfa/verify-recovery — Verify a recovery code (brute force protected)
 - POST /v1/mfa/regenerate-recovery — Regenerate recovery codes (requires aal2)
+
+Issue #639: Primary TOTP enrollment + verification (B2G compliance).
+- POST /v1/mfa/enroll — Enrol a TOTP factor; returns QR + secret + backup codes
+- POST /v1/mfa/verify-totp — Verify TOTP code, complete enrollment, elevate to aal2
 """
 
 import asyncio
@@ -13,11 +17,18 @@ import secrets
 from datetime import datetime, timezone, timedelta
 
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from auth import require_auth
 from authorization import check_user_roles
+from log_sanitizer import mask_ip_address, mask_user_id
+from rate_limiter import require_rate_limit
+from schemas.user import (
+    MFAEnrollResponse,
+    MFAVerifyRequest,
+    MFAVerifyResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -289,6 +300,310 @@ async def verify_recovery_code(
         success=False,
         remaining_codes=0,
         message=f"Código inválido ou já utilizado. Tentativas restantes: {remaining_attempts}",
+    )
+
+
+# ─── Issue #639 — Primary TOTP enrollment + verification ──────────────────────
+
+# Rate limit: max 5 attempts per 15 minutes on /verify-totp (brute-force guard)
+_VERIFY_TOTP_MAX_ATTEMPTS = 5
+_VERIFY_TOTP_WINDOW_SECONDS = 900  # 15 minutes
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract caller IP, respecting X-Forwarded-For (Railway proxy)."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+def _get_user_access_token(request: Request) -> str:
+    """Extract the Bearer token from the Authorization header.
+
+    Required for user-scoped auth.mfa.* operations against Supabase GoTrue.
+    Returns empty string when missing — caller should handle gracefully
+    (typically only reached in unit tests where Supabase is mocked).
+    """
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        return auth_header[7:].strip()
+    return ""
+
+
+def _get_user_supabase_for_auth(access_token: str):
+    """Build a user-scoped Supabase client with the user's session bound.
+
+    `auth.mfa.enroll/challenge/verify` operate via GoTrue (not PostgREST),
+    so we must call ``set_session`` after constructing the client.
+    """
+    from supabase_client import get_user_supabase
+
+    client = get_user_supabase(access_token)
+    try:
+        # set_session requires a refresh_token argument; we don't have it
+        # server-side, so pass an empty string. GoTrue accepts the access
+        # token alone for the brief duration of this request.
+        client.auth.set_session(access_token=access_token, refresh_token="")
+    except Exception as e:  # noqa: BLE001
+        logger.debug(
+            "MFA: set_session raised %s (continuing — auth.mfa.* will pick up "
+            "the Authorization header set by get_user_supabase)",
+            type(e).__name__,
+        )
+    return client
+
+
+def _extract_totp_payload(enroll_resp) -> tuple[str, str, str]:
+    """Normalise the supabase-py enroll response into (factor_id, qr_uri, secret).
+
+    The SDK returns either a dataclass-style object (``.id``, ``.totp.uri``) or
+    a dict depending on version. We handle both shapes defensively.
+    """
+    def _attr_or_key(obj, key, default=None):
+        if obj is None:
+            return default
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    factor_id = _attr_or_key(enroll_resp, "id", "")
+    totp = _attr_or_key(enroll_resp, "totp")
+    qr_uri = _attr_or_key(totp, "uri", "") or _attr_or_key(totp, "qr_code", "")
+    secret = _attr_or_key(totp, "secret", "")
+
+    return str(factor_id or ""), str(qr_uri or ""), str(secret or "")
+
+
+def _extract_factor_id_from_challenge(challenge_resp) -> str:
+    """Extract challenge id from supabase-py challenge response (object or dict)."""
+    if challenge_resp is None:
+        return ""
+    if isinstance(challenge_resp, dict):
+        return str(challenge_resp.get("id", ""))
+    return str(getattr(challenge_resp, "id", ""))
+
+
+async def _persist_backup_codes(user_id: str) -> list[str]:
+    """Generate + persist a fresh batch of recovery codes (reuses existing infra).
+
+    Replaces any existing codes (matches /recovery-codes endpoint semantics).
+    Returns the plaintext codes — they MUST be shown to the user once and
+    never logged.
+    """
+    sb = await _get_supabase()
+
+    await asyncio.to_thread(
+        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id).execute
+    )
+
+    plaintext_codes = _generate_recovery_codes()
+    rows = [{"user_id": user_id, "code_hash": _hash_code(code)} for code in plaintext_codes]
+    await asyncio.to_thread(
+        sb.table("mfa_recovery_codes").insert(rows).execute
+    )
+
+    return plaintext_codes
+
+
+def _log_mfa_event(
+    user_id: str,
+    event: str,
+    success: bool,
+    ip: str,
+    extra: str = "",
+) -> None:
+    """Structured log for MFA enroll/verify attempts (Issue #639 AC).
+
+    PII is masked via log_sanitizer (mask_user_id, mask_ip_address).
+    """
+    logger.info(
+        "mfa_event user_id=%s event=%s success=%s ip=%s%s",
+        mask_user_id(user_id),
+        event,
+        success,
+        mask_ip_address(ip),
+        f" {extra}" if extra else "",
+    )
+
+
+@router.post("/enroll", response_model=MFAEnrollResponse)
+async def enroll_totp(
+    request: Request,
+    user: dict = Depends(require_auth),
+):
+    """Issue #639 AC1: Enrol a TOTP MFA factor for the current user.
+
+    Returns the QR code URI (otpauth://...), the base32 secret, and 10 fresh
+    one-time backup codes. The user adds the URI/secret to an authenticator
+    app and then calls /verify-totp with a generated code to complete enrolment.
+
+    Backup codes are returned ONCE — the client must persist them.
+    """
+    user_id = user["id"]
+    ip = _get_client_ip(request)
+    access_token = _get_user_access_token(request)
+
+    if not access_token:
+        _log_mfa_event(user_id, "mfa_enroll", success=False, ip=ip, extra="reason=missing_token")
+        raise HTTPException(status_code=401, detail="Token de autenticação ausente.")
+
+    try:
+        sb_user = _get_user_supabase_for_auth(access_token)
+        enroll_resp = await asyncio.to_thread(
+            lambda: sb_user.auth.mfa.enroll({
+                "factor_type": "totp",
+                "friendly_name": "SmartLic",
+            })
+        )
+    except Exception as e:  # noqa: BLE001 — Supabase SDK raises various types
+        _log_mfa_event(
+            user_id, "mfa_enroll", success=False, ip=ip,
+            extra=f"reason=supabase_error type={type(e).__name__}",
+        )
+        logger.warning("MFA enrol failed for user %s: %s", mask_user_id(user_id), type(e).__name__)
+        raise HTTPException(
+            status_code=502,
+            detail="Não foi possível iniciar o cadastro de MFA. Tente novamente em instantes.",
+        )
+
+    factor_id, qr_uri, secret = _extract_totp_payload(enroll_resp)
+    if not factor_id or not qr_uri or not secret:
+        _log_mfa_event(
+            user_id, "mfa_enroll", success=False, ip=ip, extra="reason=incomplete_response",
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Resposta de cadastro MFA incompleta. Tente novamente.",
+        )
+
+    # Generate and persist backup codes (reuses existing recovery-codes infra).
+    try:
+        backup_codes = await _persist_backup_codes(user_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "MFA enrol: failed to persist backup codes for user %s: %s",
+            mask_user_id(user_id),
+            type(e).__name__,
+        )
+        # Non-fatal: enrolment can proceed; user can call /v1/mfa/recovery-codes later.
+        backup_codes = []
+
+    _log_mfa_event(user_id, "mfa_enroll", success=True, ip=ip, extra=f"factor_id={factor_id[:8]}")
+
+    return MFAEnrollResponse(
+        factor_id=factor_id,
+        qr_code_uri=qr_uri,
+        secret=secret,
+        backup_codes=backup_codes,
+    )
+
+
+@router.post(
+    "/verify-totp",
+    response_model=MFAVerifyResponse,
+    dependencies=[Depends(require_rate_limit(_VERIFY_TOTP_MAX_ATTEMPTS, _VERIFY_TOTP_WINDOW_SECONDS))],
+)
+async def verify_totp(
+    body: MFAVerifyRequest,
+    request: Request,
+    user: dict = Depends(require_auth),
+):
+    """Issue #639 AC2: Verify a TOTP code to complete enrolment + elevate to aal2.
+
+    Looks up the user's most recent unverified factor, creates a Supabase
+    challenge, then verifies the supplied code. On success the Supabase
+    session is elevated to aal2 (subsequent requests carry that claim in
+    the JWT, gating /admin and other sensitive routes).
+
+    Rate limit: 5 attempts / 15 min via require_rate_limit (token bucket).
+    """
+    user_id = user["id"]
+    ip = _get_client_ip(request)
+    access_token = _get_user_access_token(request)
+
+    if not access_token:
+        _log_mfa_event(user_id, "mfa_verify", success=False, ip=ip, extra="reason=missing_token")
+        raise HTTPException(status_code=401, detail="Token de autenticação ausente.")
+
+    # Find the user's most recent unverified factor (the one they just enrolled).
+    sb = await _get_supabase()
+    try:
+        result = await asyncio.to_thread(
+            sb.table("mfa_factors")
+            .select("id, status, created_at")
+            .eq("user_id", user_id)
+            .eq("factor_type", "totp")
+            .order("created_at", desc=True)
+            .execute
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "MFA verify: failed to read factors for user %s: %s",
+            mask_user_id(user_id),
+            type(e).__name__,
+        )
+        raise HTTPException(status_code=502, detail="Erro ao consultar fator MFA.")
+
+    factors = result.data or []
+    # Prefer the most-recent unverified factor; fall back to verified for re-challenge.
+    pending = next((f for f in factors if f.get("status") == "unverified"), None)
+    target = pending or (factors[0] if factors else None)
+
+    if not target:
+        _log_mfa_event(
+            user_id, "mfa_verify", success=False, ip=ip, extra="reason=no_factor",
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Nenhum fator MFA encontrado. Cadastre um TOTP primeiro via /v1/mfa/enroll.",
+        )
+
+    factor_id = target["id"]
+
+    try:
+        sb_user = _get_user_supabase_for_auth(access_token)
+        challenge_resp = await asyncio.to_thread(
+            lambda: sb_user.auth.mfa.challenge({"factor_id": factor_id})
+        )
+        challenge_id = _extract_factor_id_from_challenge(challenge_resp)
+        if not challenge_id:
+            raise RuntimeError("empty challenge_id from Supabase")
+
+        await asyncio.to_thread(
+            lambda: sb_user.auth.mfa.verify({
+                "factor_id": factor_id,
+                "challenge_id": challenge_id,
+                "code": body.totp_code,
+            })
+        )
+    except Exception as e:  # noqa: BLE001
+        _log_mfa_event(
+            user_id,
+            "mfa_verify",
+            success=False,
+            ip=ip,
+            extra=f"reason=verify_failed type={type(e).__name__}",
+        )
+        logger.warning(
+            "MFA verify failed for user %s: %s",
+            mask_user_id(user_id),
+            type(e).__name__,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Código TOTP inválido ou expirado. Verifique o relógio do dispositivo e tente novamente.",
+        )
+
+    _log_mfa_event(user_id, "mfa_verify", success=True, ip=ip, extra=f"factor_id={factor_id[:8]}")
+
+    return MFAVerifyResponse(
+        success=True,
+        aal_level="aal2",
+        factor_id=factor_id,
+        message="Verificação concluída. Sua sessão agora está em AAL2.",
     )
 
 

--- a/backend/routes/mfa.py
+++ b/backend/routes/mfa.py
@@ -15,6 +15,7 @@ import asyncio
 import logging
 import secrets
 from datetime import datetime, timezone, timedelta
+from typing import Literal
 
 import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -421,29 +422,55 @@ async def _persist_backup_codes(user_id: str) -> list[str]:
     return plaintext_codes
 
 
+# Closed-set log reasons. CodeQL's `py/clear-text-logging-sensitive-data`
+# taint tracker will not allow a sensitive variable (e.g. the TOTP `secret`
+# returned by Supabase enrol) to flow into a Literal-typed parameter, which
+# is why we expose only this allowlist instead of a free-form ``extra: str``.
+LogReason = Literal[
+    "missing_token",
+    "supabase_error",
+    "incomplete_response",
+    "no_factor",
+    "challenge_failed",
+    "verify_failed",
+    "ok",
+]
+
+
 def _log_mfa_event(
     user_id: str,
     event: str,
     success: bool,
     ip: str,
-    extra: str = "",
+    reason: LogReason | None = None,
+    error_type: str | None = None,
 ) -> None:
     """Structured log for MFA enroll/verify attempts (Issue #639 AC).
 
     PII is masked via log_sanitizer (mask_user_id, mask_ip_address). All
     user-derived values are additionally passed through ``_safe_log_value``
-    to strip CRLF/control chars and prevent log-injection
-    (CodeQL py/log-injection / py/clear-text-logging-sensitive-data).
+    to strip CRLF/control chars.
+
+    Parameters are deliberately allowlisted to a closed set so that CodeQL's
+    `py/clear-text-logging-sensitive-data` taint tracker cannot reach this
+    log sink from any sensitive source (TOTP secret, recovery codes, raw
+    exception messages, etc.). ``error_type`` is only ever fed
+    ``type(e).__name__`` — a bounded class identifier — never a message or
+    traceback. Free-form ``extra`` is intentionally NOT supported.
     """
-    safe_extra = _safe_log_value(extra)
-    logger.info(
-        "mfa_event user_id=%s event=%s success=%s ip=%s%s",
-        _safe_log_value(mask_user_id(user_id)),
-        _safe_log_value(event),
-        success,
-        _safe_log_value(mask_ip_address(ip)),
-        f" {safe_extra}" if safe_extra else "",
-    )
+    parts = [
+        f"user_id={_safe_log_value(mask_user_id(user_id))}",
+        f"event={_safe_log_value(event)}",
+        f"success={success}",
+        f"ip={_safe_log_value(mask_ip_address(ip))}",
+    ]
+    if reason:
+        # ``reason`` is constrained by ``LogReason`` Literal — no taint flow possible.
+        parts.append(f"reason={reason}")
+    if error_type:
+        # ``type(e).__name__`` is a bounded class identifier; defensive truncate anyway.
+        parts.append(f"error_type={_safe_log_value(error_type)}")
+    logger.info("mfa_event %s", " ".join(parts))
 
 
 @router.post("/enroll", response_model=MFAEnrollResponse)
@@ -464,7 +491,7 @@ async def enroll_totp(
     access_token = _get_user_access_token(request)
 
     if not access_token:
-        _log_mfa_event(user_id, "mfa_enroll", success=False, ip=ip, extra="reason=missing_token")
+        _log_mfa_event(user_id, "mfa_enroll", success=False, ip=ip, reason="missing_token")
         raise HTTPException(status_code=401, detail="Token de autenticação ausente.")
 
     try:
@@ -478,7 +505,7 @@ async def enroll_totp(
     except Exception as e:  # noqa: BLE001 — Supabase SDK raises various types
         _log_mfa_event(
             user_id, "mfa_enroll", success=False, ip=ip,
-            extra=f"reason=supabase_error type={type(e).__name__}",
+            reason="supabase_error", error_type=type(e).__name__,
         )
         logger.warning(
             "MFA enrol failed for user %s: %s",
@@ -493,7 +520,7 @@ async def enroll_totp(
     factor_id, qr_uri, secret = _extract_totp_payload(enroll_resp)
     if not factor_id or not qr_uri or not secret:
         _log_mfa_event(
-            user_id, "mfa_enroll", success=False, ip=ip, extra="reason=incomplete_response",
+            user_id, "mfa_enroll", success=False, ip=ip, reason="incomplete_response",
         )
         raise HTTPException(
             status_code=502,
@@ -512,7 +539,10 @@ async def enroll_totp(
         # Non-fatal: enrolment can proceed; user can call /v1/mfa/recovery-codes later.
         backup_codes = []
 
-    _log_mfa_event(user_id, "mfa_enroll", success=True, ip=ip, extra=f"factor_id={factor_id[:8]}")
+    # NOTE: factor_id deliberately excluded from log payload — success=True is the audit
+    # signal; including factor_id would require relaxing the LogReason allowlist and
+    # widen the CodeQL py/clear-text-logging-sensitive-data attack surface.
+    _log_mfa_event(user_id, "mfa_enroll", success=True, ip=ip, reason="ok")
 
     return MFAEnrollResponse(
         factor_id=factor_id,
@@ -546,7 +576,7 @@ async def verify_totp(
     access_token = _get_user_access_token(request)
 
     if not access_token:
-        _log_mfa_event(user_id, "mfa_verify", success=False, ip=ip, extra="reason=missing_token")
+        _log_mfa_event(user_id, "mfa_verify", success=False, ip=ip, reason="missing_token")
         raise HTTPException(status_code=401, detail="Token de autenticação ausente.")
 
     # Find the user's most recent unverified factor (the one they just enrolled).
@@ -575,7 +605,7 @@ async def verify_totp(
 
     if not target:
         _log_mfa_event(
-            user_id, "mfa_verify", success=False, ip=ip, extra="reason=no_factor",
+            user_id, "mfa_verify", success=False, ip=ip, reason="no_factor",
         )
         raise HTTPException(
             status_code=400,
@@ -606,7 +636,8 @@ async def verify_totp(
             "mfa_verify",
             success=False,
             ip=ip,
-            extra=f"reason=verify_failed type={type(e).__name__}",
+            reason="verify_failed",
+            error_type=type(e).__name__,
         )
         logger.warning(
             "MFA verify failed for user %s: %s",
@@ -618,7 +649,8 @@ async def verify_totp(
             detail="Código TOTP inválido ou expirado. Verifique o relógio do dispositivo e tente novamente.",
         )
 
-    _log_mfa_event(user_id, "mfa_verify", success=True, ip=ip, extra=f"factor_id={factor_id[:8]}")
+    # factor_id deliberately excluded — see enroll branch.
+    _log_mfa_event(user_id, "mfa_verify", success=True, ip=ip, reason="ok")
 
     return MFAVerifyResponse(
         success=True,

--- a/backend/routes/mfa.py
+++ b/backend/routes/mfa.py
@@ -40,6 +40,19 @@ RECOVERY_CODE_LENGTH = 8  # 8 hex chars = 4 bytes = 2^32 possibilities
 MAX_FAILED_ATTEMPTS_PER_HOUR = 3
 
 
+def _safe_log_value(value: object, max_len: int = 200) -> str:
+    """Strip CRLF/control chars and truncate before logging.
+
+    Defends against log-injection (CodeQL py/log-injection) when interpolating
+    user-controlled or user-derived values (user_id, factor_id, exception types)
+    into log statements. Output is always a plain str — never raw secrets.
+    """
+    if value is None:
+        return ""
+    text = str(value).replace("\r", "").replace("\n", "")
+    return text[:max_len]
+
+
 # ─── Schemas ───────────────────────────────────────────────────────────────────
 
 class MfaStatusResponse(BaseModel):
@@ -417,15 +430,19 @@ def _log_mfa_event(
 ) -> None:
     """Structured log for MFA enroll/verify attempts (Issue #639 AC).
 
-    PII is masked via log_sanitizer (mask_user_id, mask_ip_address).
+    PII is masked via log_sanitizer (mask_user_id, mask_ip_address). All
+    user-derived values are additionally passed through ``_safe_log_value``
+    to strip CRLF/control chars and prevent log-injection
+    (CodeQL py/log-injection / py/clear-text-logging-sensitive-data).
     """
+    safe_extra = _safe_log_value(extra)
     logger.info(
         "mfa_event user_id=%s event=%s success=%s ip=%s%s",
-        mask_user_id(user_id),
-        event,
+        _safe_log_value(mask_user_id(user_id)),
+        _safe_log_value(event),
         success,
-        mask_ip_address(ip),
-        f" {extra}" if extra else "",
+        _safe_log_value(mask_ip_address(ip)),
+        f" {safe_extra}" if safe_extra else "",
     )
 
 
@@ -463,7 +480,11 @@ async def enroll_totp(
             user_id, "mfa_enroll", success=False, ip=ip,
             extra=f"reason=supabase_error type={type(e).__name__}",
         )
-        logger.warning("MFA enrol failed for user %s: %s", mask_user_id(user_id), type(e).__name__)
+        logger.warning(
+            "MFA enrol failed for user %s: %s",
+            _safe_log_value(mask_user_id(user_id)),
+            _safe_log_value(type(e).__name__),
+        )
         raise HTTPException(
             status_code=502,
             detail="Não foi possível iniciar o cadastro de MFA. Tente novamente em instantes.",
@@ -485,8 +506,8 @@ async def enroll_totp(
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "MFA enrol: failed to persist backup codes for user %s: %s",
-            mask_user_id(user_id),
-            type(e).__name__,
+            _safe_log_value(mask_user_id(user_id)),
+            _safe_log_value(type(e).__name__),
         )
         # Non-fatal: enrolment can proceed; user can call /v1/mfa/recovery-codes later.
         backup_codes = []
@@ -542,8 +563,8 @@ async def verify_totp(
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "MFA verify: failed to read factors for user %s: %s",
-            mask_user_id(user_id),
-            type(e).__name__,
+            _safe_log_value(mask_user_id(user_id)),
+            _safe_log_value(type(e).__name__),
         )
         raise HTTPException(status_code=502, detail="Erro ao consultar fator MFA.")
 
@@ -589,8 +610,8 @@ async def verify_totp(
         )
         logger.warning(
             "MFA verify failed for user %s: %s",
-            mask_user_id(user_id),
-            type(e).__name__,
+            _safe_log_value(mask_user_id(user_id)),
+            _safe_log_value(type(e).__name__),
         )
         raise HTTPException(
             status_code=400,

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -361,3 +361,65 @@ class SignupResponse(BaseModel):
         default=True,
         description="Whether Supabase requires email confirmation before login",
     )
+
+
+# ─── MFA Schemas (Issue #639 — TOTP enroll + verify) ──────────────────────────
+
+class MFAEnrollResponse(BaseModel):
+    """Response body for POST /v1/mfa/enroll (Issue #639).
+
+    Contains the data needed for the user to add the TOTP factor to an
+    authenticator app (Google Authenticator, Authy, 1Password, etc.) and
+    one-time backup codes for recovery if the device is lost.
+    """
+
+    factor_id: str = Field(..., description="Supabase mfa_factors.id (UUID)")
+    qr_code_uri: str = Field(
+        ...,
+        description=(
+            "otpauth:// URI per RFC 6238. Encode as QR code on the client. "
+            "Most TOTP apps support pasting the URI directly."
+        ),
+    )
+    secret: str = Field(
+        ...,
+        description=(
+            "Base32-encoded TOTP shared secret. Provided so the user can "
+            "manually enter it when the QR code cannot be scanned."
+        ),
+    )
+    backup_codes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "10 one-time recovery codes (XXXX-XXXX format). Shown ONCE — "
+            "user must save them. Used as MFA bypass via /v1/mfa/verify-recovery."
+        ),
+    )
+
+
+class MFAVerifyRequest(BaseModel):
+    """Request body for POST /v1/mfa/verify-totp (Issue #639)."""
+
+    totp_code: str = Field(
+        ...,
+        min_length=6,
+        max_length=10,
+        description="6-digit TOTP code from authenticator app (RFC 6238)",
+    )
+
+    @field_validator("totp_code")
+    @classmethod
+    def _strip_and_validate_digits(cls, v: str) -> str:
+        cleaned = v.strip().replace(" ", "").replace("-", "")
+        if not cleaned.isdigit():
+            raise ValueError("totp_code must contain only digits")
+        return cleaned
+
+
+class MFAVerifyResponse(BaseModel):
+    """Response body for POST /v1/mfa/verify-totp (Issue #639)."""
+
+    success: bool = Field(..., description="True when the code matched and AAL was elevated to aal2")
+    aal_level: str = Field(default="aal2", description="Authenticator Assurance Level after verification")
+    factor_id: str = Field(..., description="ID of the verified factor")
+    message: str = Field(default="", description="Human-readable status message")

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -6035,6 +6035,91 @@
         "title": "LicitacoesIndexableResponse",
         "type": "object"
       },
+      "MFAEnrollResponse": {
+        "description": "Response body for POST /v1/mfa/enroll (Issue #639).\n\nContains the data needed for the user to add the TOTP factor to an\nauthenticator app (Google Authenticator, Authy, 1Password, etc.) and\none-time backup codes for recovery if the device is lost.",
+        "properties": {
+          "backup_codes": {
+            "description": "10 one-time recovery codes (XXXX-XXXX format). Shown ONCE \u2014 user must save them. Used as MFA bypass via /v1/mfa/verify-recovery.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Backup Codes",
+            "type": "array"
+          },
+          "factor_id": {
+            "description": "Supabase mfa_factors.id (UUID)",
+            "title": "Factor Id",
+            "type": "string"
+          },
+          "qr_code_uri": {
+            "description": "otpauth:// URI per RFC 6238. Encode as QR code on the client. Most TOTP apps support pasting the URI directly.",
+            "title": "Qr Code Uri",
+            "type": "string"
+          },
+          "secret": {
+            "description": "Base32-encoded TOTP shared secret. Provided so the user can manually enter it when the QR code cannot be scanned.",
+            "title": "Secret",
+            "type": "string"
+          }
+        },
+        "required": [
+          "factor_id",
+          "qr_code_uri",
+          "secret"
+        ],
+        "title": "MFAEnrollResponse",
+        "type": "object"
+      },
+      "MFAVerifyRequest": {
+        "description": "Request body for POST /v1/mfa/verify-totp (Issue #639).",
+        "properties": {
+          "totp_code": {
+            "description": "6-digit TOTP code from authenticator app (RFC 6238)",
+            "maxLength": 10,
+            "minLength": 6,
+            "title": "Totp Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "totp_code"
+        ],
+        "title": "MFAVerifyRequest",
+        "type": "object"
+      },
+      "MFAVerifyResponse": {
+        "description": "Response body for POST /v1/mfa/verify-totp (Issue #639).",
+        "properties": {
+          "aal_level": {
+            "default": "aal2",
+            "description": "Authenticator Assurance Level after verification",
+            "title": "Aal Level",
+            "type": "string"
+          },
+          "factor_id": {
+            "description": "ID of the verified factor",
+            "title": "Factor Id",
+            "type": "string"
+          },
+          "message": {
+            "default": "",
+            "description": "Human-readable status message",
+            "title": "Message",
+            "type": "string"
+          },
+          "success": {
+            "description": "True when the code matched and AAL was elevated to aal2",
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "factor_id"
+        ],
+        "title": "MFAVerifyResponse",
+        "type": "object"
+      },
       "MemorySnapshot": {
         "description": "Response for GET /admin/memory-snapshot (SEN-BE-010 AC0).",
         "properties": {
@@ -17032,6 +17117,33 @@
         ]
       }
     },
+    "/v1/mfa/enroll": {
+      "post": {
+        "description": "Issue #639 AC1: Enrol a TOTP MFA factor for the current user.\n\nReturns the QR code URI (otpauth://...), the base32 secret, and 10 fresh\none-time backup codes. The user adds the URI/secret to an authenticator\napp and then calls /verify-totp with a generated code to complete enrolment.\n\nBackup codes are returned ONCE \u2014 the client must persist them.",
+        "operationId": "enroll_totp_v1_mfa_enroll_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MFAEnrollResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Enroll Totp",
+        "tags": [
+          "MFA"
+        ]
+      }
+    },
     "/v1/mfa/recovery-codes": {
       "post": {
         "description": "AC5: Generate 10 recovery codes after MFA enrollment.\n\nThis should be called immediately after successful MFA enrollment.\nStores bcrypt-hashed codes in the database, returns plaintext once.",
@@ -17155,6 +17267,53 @@
           }
         ],
         "summary": "Verify Recovery Code",
+        "tags": [
+          "MFA"
+        ]
+      }
+    },
+    "/v1/mfa/verify-totp": {
+      "post": {
+        "description": "Issue #639 AC2: Verify a TOTP code to complete enrolment + elevate to aal2.\n\nLooks up the user's most recent unverified factor, creates a Supabase\nchallenge, then verifies the supplied code. On success the Supabase\nsession is elevated to aal2 (subsequent requests carry that claim in\nthe JWT, gating /admin and other sensitive routes).\n\nRate limit: 5 attempts / 15 min via require_rate_limit (token bucket).",
+        "operationId": "verify_totp_v1_mfa_verify_totp_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MFAVerifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MFAVerifyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Verify Totp",
         "tags": [
           "MFA"
         ]

--- a/backend/tests/test_mfa.py
+++ b/backend/tests/test_mfa.py
@@ -495,3 +495,286 @@ class TestMfaEdgeCases:
         data = res.json()
         assert data["mfa_enabled"] is False
         assert data["factors"] == []
+
+
+# ─── Issue #639 — TOTP Enroll + Verify Endpoints ──────────────────────────────
+
+@pytest.fixture
+def client_with_token():
+    """Test client that injects a Bearer token so /enroll + /verify-totp can
+    extract the access token from the Authorization header."""
+    from main import app
+    from auth import require_auth
+    app.dependency_overrides[require_auth] = lambda: {
+        "id": "test-user-id-123",
+        "email": "test@example.com",
+        "role": "authenticated",
+        "aal": "aal1",
+    }
+    tc = TestClient(app, headers={"Authorization": "Bearer fake-test-jwt-token"})
+    yield tc
+    app.dependency_overrides.clear()
+
+
+class TestEnrollTotpEndpoint:
+    """Tests for POST /v1/mfa/enroll (Issue #639 AC1)."""
+
+    @patch("routes.mfa._persist_backup_codes", new_callable=AsyncMock,
+           return_value=["AAAA-BBBB", "CCCC-DDDD"])
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    def test_enroll_happy_path(self, mock_user_sb, mock_codes, client_with_token):
+        """Successful enrolment returns factor_id, qr_code_uri, secret, and codes."""
+        # Build a mock supabase-py enroll response shaped as a dict
+        enroll_resp = {
+            "id": "factor-uuid-123",
+            "type": "totp",
+            "totp": {
+                "qr_code": "<svg>...</svg>",
+                "secret": "JBSWY3DPEHPK3PXP",
+                "uri": "otpauth://totp/SmartLic:test@example.com?secret=JBSWY3DPEHPK3PXP&issuer=SmartLic",
+            },
+        }
+        sb_user = MagicMock()
+        sb_user.auth.mfa.enroll.return_value = enroll_resp
+        mock_user_sb.return_value = sb_user
+
+        res = client_with_token.post("/v1/mfa/enroll")
+        assert res.status_code == 200, res.text
+        data = res.json()
+        assert data["factor_id"] == "factor-uuid-123"
+        assert data["qr_code_uri"].startswith("otpauth://totp/")
+        assert data["secret"] == "JBSWY3DPEHPK3PXP"
+        assert data["backup_codes"] == ["AAAA-BBBB", "CCCC-DDDD"]
+        # Verify enroll was called with totp + friendly_name
+        call_args = sb_user.auth.mfa.enroll.call_args[0][0]
+        assert call_args["factor_type"] == "totp"
+        assert call_args["friendly_name"] == "SmartLic"
+
+    def test_enroll_rejects_missing_token(self):
+        """No Authorization header → 401."""
+        from main import app
+        from auth import require_auth
+        app.dependency_overrides[require_auth] = lambda: {
+            "id": "test-user-id-123", "email": "x@x.com", "role": "authenticated", "aal": "aal1"
+        }
+        try:
+            tc = TestClient(app)  # no Authorization header
+            res = tc.post("/v1/mfa/enroll")
+            assert res.status_code == 401
+        finally:
+            app.dependency_overrides.clear()
+
+    @patch("routes.mfa._persist_backup_codes", new_callable=AsyncMock, return_value=[])
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    def test_enroll_supabase_failure_returns_502(self, mock_user_sb, mock_codes, client_with_token):
+        """Supabase SDK error → 502."""
+        sb_user = MagicMock()
+        sb_user.auth.mfa.enroll.side_effect = Exception("supabase down")
+        mock_user_sb.return_value = sb_user
+
+        res = client_with_token.post("/v1/mfa/enroll")
+        assert res.status_code == 502
+        assert "MFA" in res.json()["detail"] or "Não foi possível" in res.json()["detail"]
+
+    @patch("routes.mfa._persist_backup_codes", new_callable=AsyncMock, return_value=[])
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    def test_enroll_incomplete_response_returns_502(self, mock_user_sb, mock_codes, client_with_token):
+        """Empty totp payload → 502."""
+        sb_user = MagicMock()
+        sb_user.auth.mfa.enroll.return_value = {"id": "abc", "totp": {}}
+        mock_user_sb.return_value = sb_user
+
+        res = client_with_token.post("/v1/mfa/enroll")
+        assert res.status_code == 502
+
+    @patch("routes.mfa._persist_backup_codes", new_callable=AsyncMock,
+           side_effect=Exception("db down"))
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    def test_enroll_continues_when_backup_codes_fail(self, mock_user_sb, mock_codes, client_with_token):
+        """Backup-code persistence failure is non-fatal — return enrol with empty codes."""
+        sb_user = MagicMock()
+        sb_user.auth.mfa.enroll.return_value = {
+            "id": "factor-1", "totp": {"uri": "otpauth://totp/x", "secret": "JBSW"}
+        }
+        mock_user_sb.return_value = sb_user
+
+        res = client_with_token.post("/v1/mfa/enroll")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["backup_codes"] == []
+
+
+class TestVerifyTotpEndpoint:
+    """Tests for POST /v1/mfa/verify-totp (Issue #639 AC2 + AC4 brute-force)."""
+
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    @patch("routes.mfa._get_supabase")
+    def test_verify_happy_path(self, mock_sb, mock_user_sb, client_with_token):
+        """Valid code → 200 + aal2."""
+        # Factors lookup
+        mock_sb_instance = MagicMock()
+        mock_factors = MagicMock()
+        mock_factors.data = [{"id": "factor-1", "status": "unverified", "created_at": "2026-01-01"}]
+        (
+            mock_sb_instance.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .order.return_value
+            .execute.return_value
+        ) = mock_factors
+        mock_sb.return_value = mock_sb_instance
+
+        # User-scoped client (challenge + verify)
+        sb_user = MagicMock()
+        sb_user.auth.mfa.challenge.return_value = {"id": "challenge-1"}
+        sb_user.auth.mfa.verify.return_value = MagicMock()
+        mock_user_sb.return_value = sb_user
+
+        res = client_with_token.post("/v1/mfa/verify-totp", json={"totp_code": "123456"})
+        assert res.status_code == 200, res.text
+        data = res.json()
+        assert data["success"] is True
+        assert data["aal_level"] == "aal2"
+        assert data["factor_id"] == "factor-1"
+        # Verify call args
+        verify_args = sb_user.auth.mfa.verify.call_args[0][0]
+        assert verify_args["factor_id"] == "factor-1"
+        assert verify_args["challenge_id"] == "challenge-1"
+        assert verify_args["code"] == "123456"
+
+    @patch("routes.mfa._get_supabase")
+    def test_verify_no_factor_returns_400(self, mock_sb, client_with_token):
+        """No enrolled factor → 400."""
+        mock_sb_instance = MagicMock()
+        mock_factors = MagicMock()
+        mock_factors.data = []
+        (
+            mock_sb_instance.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .order.return_value
+            .execute.return_value
+        ) = mock_factors
+        mock_sb.return_value = mock_sb_instance
+
+        res = client_with_token.post("/v1/mfa/verify-totp", json={"totp_code": "654321"})
+        assert res.status_code == 400
+        assert "Cadastre" in res.json()["detail"] or "fator" in res.json()["detail"].lower()
+
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    @patch("routes.mfa._get_supabase")
+    def test_verify_wrong_code_returns_400(self, mock_sb, mock_user_sb, client_with_token):
+        """Bad TOTP code → Supabase verify raises → 400."""
+        mock_sb_instance = MagicMock()
+        mock_factors = MagicMock()
+        mock_factors.data = [{"id": "factor-1", "status": "unverified", "created_at": "2026-01-01"}]
+        (
+            mock_sb_instance.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .order.return_value
+            .execute.return_value
+        ) = mock_factors
+        mock_sb.return_value = mock_sb_instance
+
+        sb_user = MagicMock()
+        sb_user.auth.mfa.challenge.return_value = {"id": "challenge-1"}
+        sb_user.auth.mfa.verify.side_effect = Exception("invalid_code")
+        mock_user_sb.return_value = sb_user
+
+        res = client_with_token.post("/v1/mfa/verify-totp", json={"totp_code": "000000"})
+        assert res.status_code == 400
+        assert "TOTP" in res.json()["detail"] or "inválido" in res.json()["detail"].lower()
+
+    def test_verify_validates_digits_only(self, client_with_token):
+        """Non-numeric totp_code → 422 from Pydantic validator."""
+        res = client_with_token.post("/v1/mfa/verify-totp", json={"totp_code": "abcdef"})
+        assert res.status_code == 422
+
+    @patch("routes.mfa._get_user_supabase_for_auth")
+    @patch("routes.mfa._get_supabase")
+    @patch("config.get_feature_flag", return_value=True)
+    def test_verify_brute_force_returns_429(self, mock_flag, mock_sb, mock_user_sb, client_with_token):
+        """Issue #639 AC4: 6th attempt within 15min → 429.
+
+        require_rate_limit(5, 900) is wired in via Depends; on the 6th call
+        within the window the FlexibleRateLimiter must throttle.
+        """
+        # Allow factor lookup + challenge to succeed for the first 5 calls
+        mock_sb_instance = MagicMock()
+        mock_factors = MagicMock()
+        mock_factors.data = [{"id": "factor-1", "status": "unverified", "created_at": "2026-01-01"}]
+        (
+            mock_sb_instance.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .order.return_value
+            .execute.return_value
+        ) = mock_factors
+        mock_sb.return_value = mock_sb_instance
+
+        sb_user = MagicMock()
+        sb_user.auth.mfa.challenge.return_value = {"id": "challenge-1"}
+        sb_user.auth.mfa.verify.side_effect = Exception("invalid_code")
+        mock_user_sb.return_value = sb_user
+
+        # Reset the in-memory rate limiter so this test is hermetic
+        from rate_limiter import _flexible_limiter
+        _flexible_limiter._memory_store.clear()
+
+        # 5 attempts allowed (each returns 400 because code is wrong)
+        for i in range(5):
+            res = client_with_token.post("/v1/mfa/verify-totp", json={"totp_code": "000000"})
+            assert res.status_code == 400, f"attempt {i + 1} returned {res.status_code}"
+
+        # 6th attempt → 429 from rate limiter
+        res = client_with_token.post("/v1/mfa/verify-totp", json={"totp_code": "000000"})
+        assert res.status_code == 429
+        assert "Retry-After" in res.headers
+
+
+class TestMfaStatusAdminEnforcement:
+    """Issue #639 AC3: /status reports mfa_required=True for admin/master."""
+
+    @patch("routes.mfa.check_user_roles", new_callable=AsyncMock, return_value=(True, True))
+    @patch("routes.mfa._get_supabase")
+    def test_admin_user_mfa_required_true(self, mock_sb, mock_roles, client):
+        mock_result = MagicMock()
+        mock_result.data = []
+        mock_sb_instance = MagicMock()
+        mock_sb_instance.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_result
+        mock_sb.return_value = mock_sb_instance
+
+        res = client.get("/v1/mfa/status")
+        assert res.status_code == 200
+        assert res.json()["mfa_required"] is True
+
+    @patch("routes.mfa.check_user_roles", new_callable=AsyncMock, return_value=(False, True))
+    @patch("routes.mfa._get_supabase")
+    def test_master_user_mfa_required_true(self, mock_sb, mock_roles, client):
+        mock_result = MagicMock()
+        mock_result.data = []
+        mock_sb_instance = MagicMock()
+        mock_sb_instance.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_result
+        mock_sb.return_value = mock_sb_instance
+
+        res = client.get("/v1/mfa/status")
+        assert res.status_code == 200
+        assert res.json()["mfa_required"] is True
+
+    @patch("routes.mfa.check_user_roles", new_callable=AsyncMock, return_value=(False, False))
+    @patch("routes.mfa._get_supabase")
+    def test_regular_user_mfa_required_false(self, mock_sb, mock_roles, client):
+        mock_result = MagicMock()
+        mock_result.data = []
+        mock_sb_instance = MagicMock()
+        mock_sb_instance.table.return_value.select.return_value.eq.return_value.execute.return_value = mock_result
+        mock_sb.return_value = mock_sb_instance
+
+        res = client.get("/v1/mfa/status")
+        assert res.status_code == 200
+        assert res.json()["mfa_required"] is False

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -3124,6 +3124,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/mfa/enroll": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enroll Totp
+         * @description Issue #639 AC1: Enrol a TOTP MFA factor for the current user.
+         *
+         *     Returns the QR code URI (otpauth://...), the base32 secret, and 10 fresh
+         *     one-time backup codes. The user adds the URI/secret to an authenticator
+         *     app and then calls /verify-totp with a generated code to complete enrolment.
+         *
+         *     Backup codes are returned ONCE — the client must persist them.
+         */
+        post: operations["enroll_totp_v1_mfa_enroll_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/mfa/recovery-codes": {
         parameters: {
             query?: never;
@@ -3209,6 +3235,33 @@ export interface paths {
          *     On success: marks code as used, returns remaining count.
          */
         post: operations["verify_recovery_code_v1_mfa_verify_recovery_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/mfa/verify-totp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Verify Totp
+         * @description Issue #639 AC2: Verify a TOTP code to complete enrolment + elevate to aal2.
+         *
+         *     Looks up the user's most recent unverified factor, creates a Supabase
+         *     challenge, then verifies the supplied code. On success the Supabase
+         *     session is elevated to aal2 (subsequent requests carry that claim in
+         *     the JWT, gating /admin and other sensitive routes).
+         *
+         *     Rate limit: 5 attempts / 15 min via require_rate_limit (token bucket).
+         */
+        post: operations["verify_totp_v1_mfa_verify_totp_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -7478,6 +7531,75 @@ export interface components {
             total: number;
             /** Updated At */
             updated_at: string;
+        };
+        /**
+         * MFAEnrollResponse
+         * @description Response body for POST /v1/mfa/enroll (Issue #639).
+         *
+         *     Contains the data needed for the user to add the TOTP factor to an
+         *     authenticator app (Google Authenticator, Authy, 1Password, etc.) and
+         *     one-time backup codes for recovery if the device is lost.
+         */
+        MFAEnrollResponse: {
+            /**
+             * Backup Codes
+             * @description 10 one-time recovery codes (XXXX-XXXX format). Shown ONCE — user must save them. Used as MFA bypass via /v1/mfa/verify-recovery.
+             */
+            backup_codes?: string[];
+            /**
+             * Factor Id
+             * @description Supabase mfa_factors.id (UUID)
+             */
+            factor_id: string;
+            /**
+             * Qr Code Uri
+             * @description otpauth:// URI per RFC 6238. Encode as QR code on the client. Most TOTP apps support pasting the URI directly.
+             */
+            qr_code_uri: string;
+            /**
+             * Secret
+             * @description Base32-encoded TOTP shared secret. Provided so the user can manually enter it when the QR code cannot be scanned.
+             */
+            secret: string;
+        };
+        /**
+         * MFAVerifyRequest
+         * @description Request body for POST /v1/mfa/verify-totp (Issue #639).
+         */
+        MFAVerifyRequest: {
+            /**
+             * Totp Code
+             * @description 6-digit TOTP code from authenticator app (RFC 6238)
+             */
+            totp_code: string;
+        };
+        /**
+         * MFAVerifyResponse
+         * @description Response body for POST /v1/mfa/verify-totp (Issue #639).
+         */
+        MFAVerifyResponse: {
+            /**
+             * Aal Level
+             * @description Authenticator Assurance Level after verification
+             * @default aal2
+             */
+            aal_level: string;
+            /**
+             * Factor Id
+             * @description ID of the verified factor
+             */
+            factor_id: string;
+            /**
+             * Message
+             * @description Human-readable status message
+             * @default
+             */
+            message: string;
+            /**
+             * Success
+             * @description True when the code matched and AAL was elevated to aal2
+             */
+            success: boolean;
         };
         /**
          * MemorySnapshot
@@ -13703,6 +13825,26 @@ export interface operations {
             };
         };
     };
+    enroll_totp_v1_mfa_enroll_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MFAEnrollResponse"];
+                };
+            };
+        };
+    };
     generate_recovery_codes_v1_mfa_recovery_codes_post: {
         parameters: {
             query?: never;
@@ -13783,6 +13925,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VerifyRecoveryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    verify_totp_v1_mfa_verify_totp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MFAVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MFAVerifyResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Context
B2G compliance gating — empresas fornecedoras de orgaos publicos exigem MFA. Stack ja tinha `/status`, `/recovery-codes`, `/verify-recovery`, `/regenerate-recovery`. Faltavam os endpoints **primarios** de enrollment TOTP que conectam a infra Supabase MFA — bloqueando a configuracao real para usuarios admin/master.

## Summary
- POST `/v1/mfa/enroll` -> `{factor_id, qr_code_uri, secret, backup_codes}` via Supabase `auth.mfa.enroll` (RFC 6238 TOTP). Reutiliza `_generate_recovery_codes` existente para backup codes (bcrypt-hashed, store em `mfa_recovery_codes`)
- POST `/v1/mfa/verify-totp` body `{totp_code}` -> AAL2 elevation via `auth.mfa.challenge` + `auth.mfa.verify`. Procura o factor mais recente unverified do usuario (state machine pendente -> verified)
- GET `/v1/mfa/status`: `mfa_required` ja era `True` para `is_admin OR is_master` desde STORY-317 (mantido — auditoria confirma compliance)
- Rate limit `5 attempts / 15 min` em `/verify-totp` via `Depends(require_rate_limit(5, 900))` (brute-force guard, key por user_id ou IP)
- Schemas Pydantic novos em `backend/schemas/user.py`: `MFAEnrollResponse`, `MFAVerifyRequest` (digit-only validator), `MFAVerifyResponse`
- Logs estruturados sanitizados com `log_sanitizer.mask_user_id` + `mask_ip_address` (PII safe): `{user_id, event, success, ip, ...}`

## Implementation Notes
- `auth.mfa.*` operam via GoTrue (nao PostgREST), entao usamos um cliente user-scoped (`get_user_supabase` + `auth.set_session`) com o Bearer token extraido do header — cliente service-role nao funcionaria para enrollment (operaria sem usuario alvo)
- Resposta do SDK supabase-py 2.28 normalizada via `_extract_totp_payload` (suporta dict + dataclass shape) — defensiva contra variacoes de versao
- Falha em persistir backup codes e **non-fatal** (enrolment continua, usuario chama `/recovery-codes` depois)
- Sem nova dependencia adicionada (`secrets`, `bcrypt`, `Supabase SDK` ja em `requirements.txt`)

## Testing Plan
- [x] pytest tests/test_mfa.py: **45 passed** (was 32; +13 novos)
  - Happy path enroll (factor_id, qr_uri, secret, backup_codes retornados)
  - Enroll: missing token -> 401
  - Enroll: Supabase exception -> 502
  - Enroll: response incompleto -> 502
  - Enroll: backup codes failure non-fatal
  - Verify happy path: 200 + aal2 + factor_id correto
  - Verify: no factor enrolled -> 400
  - Verify: wrong code -> 400 (Supabase verify raises)
  - Verify: non-numeric totp_code -> 422 (Pydantic validator)
  - Verify: 6th attempt -> 429 (rate limit AC)
  - Status: admin -> mfa_required=True
  - Status: master -> mfa_required=True
  - Status: regular user -> mfa_required=False
- [x] ruff check pass (`routes/mfa.py tests/test_mfa.py schemas/user.py`)
- [ ] Manual pos-deploy: enroll real TOTP em authenticator app + verify via Playwright (admin user `tiago.sasaki@gmail.com`)

## Risks & Rollback
**Aditivo, sem migration**. 2 endpoints novos; `/status` mantem comportamento. Risco isolado no fluxo enroll/verify — usuarios sem TOTP atual nao sao afetados. Rollback = revert PR.

Backup codes hashing usa bcrypt existente (nao SHA-256 novo) — **reuso da infra `mfa_recovery_codes`**.

## Closes
Closes #639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TOTP MFA enrollment (QR/otpauth URI, shared secret) with regenerated hashed backup/recovery codes; enrollment still succeeds if backup-code persistence fails.
  * TOTP verification elevates session AAL to aal2 on success and returns the verified factor ID.
  * Input validation for TOTP codes (whitespace/dash stripped, digits-only).
  * Brute-force protection: 5 attempts per 15 minutes with Retry-After.

* **Tests**
  * Integration coverage for enroll, verify, status, rate-limiting, input validation, and supporting fixture.

* **Chores**
  * Added MFA request/response types to client API schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->