### PR TITLE
feat(copy): BlogInlineCTA — verbosity cap + 1st-person CTA (#621)

### DIFF
--- a/frontend/app/blog/components/BlogInlineCTA.tsx
+++ b/frontend/app/blog/components/BlogInlineCTA.tsx
@@ -15,6 +15,13 @@ interface BlogInlineCTAProps {
   ctaMessage?: string;
 }
 
+/**
+ * Blog inline CTA banner.
+ *
+ * Copy rules:
+ * - ctaMessage ≤ 12 words (ideally ≤ 8)
+ * - ctaText ≤ 4 words
+ */
 export default function BlogInlineCTA({
   slug,
   campaign = 'b2g',
@@ -36,7 +43,7 @@ export default function BlogInlineCTA({
         href={href}
         className="inline-block bg-brand-navy hover:bg-brand-blue-hover text-white font-semibold px-4 py-2 rounded-button text-sm transition-all hover:scale-[1.02] active:scale-[0.98] whitespace-nowrap"
       >
-        {ctaText || 'Comece Agora'}
+        {ctaText || 'Testar 14 dias grátis'}
       </Link>
     </div>
   );

--- a/frontend/app/blog/content/como-escolher-plataforma-ia-licitacoes.tsx
+++ b/frontend/app/blog/content/como-escolher-plataforma-ia-licitacoes.tsx
@@ -288,7 +288,7 @@ export default function ComoEscolherPlataformaIaLicitacoes() {
       <BlogInlineCTA
         slug="como-escolher-plataforma-ia-licitacoes"
         campaign="guias"
-        ctaMessage="Aplique os 7 critérios na prática: 14 dias grátis para avaliar cobertura, precisão e viabilidade no seu setor."
+        ctaMessage="Aplique os 7 critérios no SmartLic — 14 dias grátis."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/ia-licitacoes-limitacoes-o-que-nao-faz.tsx
+++ b/frontend/app/blog/content/ia-licitacoes-limitacoes-o-que-nao-faz.tsx
@@ -187,7 +187,7 @@ export default function IaLicitacoesLimitacoesOQueNaoFaz() {
       <BlogInlineCTA
         slug="ia-licitacoes-limitacoes-o-que-nao-faz"
         campaign="guias"
-        ctaMessage="Veja o que a IA faz bem: 14 dias grátis para testar a triagem e viabilidade automática no seu setor."
+        ctaMessage="Teste triagem e viabilidade automática — 14 dias grátis."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/ia-licitacoes-pequenas-empresas-mei-epp.tsx
+++ b/frontend/app/blog/content/ia-licitacoes-pequenas-empresas-mei-epp.tsx
@@ -223,7 +223,7 @@ export default function IaLicitacoesPequenasEmpresasMeiEpp() {
       <BlogInlineCTA
         slug="ia-licitacoes-pequenas-empresas-mei-epp"
         campaign="b2g"
-        ctaMessage="Monitore editais exclusivos para ME/EPP no seu setor — 14 dias grátis, sem cartão."
+        ctaMessage="Monitore editais ME/EPP no seu setor — 14 dias grátis."
         ctaText="Testar Grátis"
       />
 

--- a/frontend/app/blog/content/ia-licitacoes-por-setor-saude-ti-engenharia.tsx
+++ b/frontend/app/blog/content/ia-licitacoes-por-setor-saude-ti-engenharia.tsx
@@ -273,7 +273,7 @@ export default function IaLicitacoesPorSetorSaudeTiEngenharia() {
       <BlogInlineCTA
         slug="ia-licitacoes-por-setor-saude-ti-engenharia"
         campaign="guias"
-        ctaMessage="Monitore editais do seu setor com classificação por IA — 14 dias grátis, sem cartão."
+        ctaMessage="Editais do seu setor classificados por IA — 14 dias grátis."
         ctaText="Testar Grátis"
       />
 

--- a/frontend/app/blog/content/ia-nova-lei-licitacoes-14133-fornecedores.tsx
+++ b/frontend/app/blog/content/ia-nova-lei-licitacoes-14133-fornecedores.tsx
@@ -211,7 +211,7 @@ export default function IaNovaLeiLicitacoes14133Fornecedores() {
       <BlogInlineCTA
         slug="ia-nova-lei-licitacoes-14133-fornecedores"
         campaign="guias"
-        ctaMessage="Veja como a IA filtra editais da nova lei: 14 dias grátis, sem cartão."
+        ctaMessage="IA filtra editais da Lei 14.133 — 14 dias grátis."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/ia-triagem-editais-filtrar-licitacoes.tsx
+++ b/frontend/app/blog/content/ia-triagem-editais-filtrar-licitacoes.tsx
@@ -319,7 +319,7 @@ export default function IaTriagemEditaisFiltrarLicitacoes() {
       <BlogInlineCTA
         slug="ia-triagem-editais-filtrar-licitacoes"
         campaign="b2g"
-        ctaMessage="Veja como o SmartLic aplica as 3 camadas de triagem no seu setor — trial gratuito por 14 dias, sem cartão de crédito."
+        ctaMessage="Triagem em 3 camadas no SmartLic — 14 dias grátis."
         ctaText="Começar triagem automática"
       />
 

--- a/frontend/app/blog/content/melhores-plataformas-licitacao-2026-ranking.tsx
+++ b/frontend/app/blog/content/melhores-plataformas-licitacao-2026-ranking.tsx
@@ -246,7 +246,7 @@ export default function MelhoresPlataformasLicitacao2026Ranking() {
       <BlogInlineCTA
         slug="melhores-plataformas-licitacao-2026-ranking"
         campaign="guias"
-        ctaMessage="Teste a plataforma com IA de classificação setorial — 14 dias grátis, sem cartão de crédito."
+        ctaMessage="Plataforma com IA de classificação setorial — 14 dias grátis."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/precisao-ia-licitacoes-taxa-acerto.tsx
+++ b/frontend/app/blog/content/precisao-ia-licitacoes-taxa-acerto.tsx
@@ -374,7 +374,7 @@ export default function PrecisaoIaLicitacoesTaxaAcerto() {
       <BlogInlineCTA
         slug="precisao-ia-licitacoes-taxa-acerto"
         campaign="guias"
-        ctaMessage="Veja como a classificação do SmartLic funciona no seu setor com precisão validada — 14 dias grátis, sem cartão de crédito."
+        ctaMessage="Classificação SmartLic com precisão validada — 14 dias grátis."
         ctaText="Testar agora gratuitamente"
       />
 

--- a/frontend/app/blog/content/roi-ia-licitacoes-calculadora-retorno.tsx
+++ b/frontend/app/blog/content/roi-ia-licitacoes-calculadora-retorno.tsx
@@ -244,7 +244,7 @@ export default function RoiIaLicitacoesCalculadoraRetorno() {
       <BlogInlineCTA
         slug="roi-ia-licitacoes-calculadora-retorno"
         campaign="b2g"
-        ctaMessage="Calcule o ROI da sua operação na prática: 14 dias grátis para ver quantos editais relevantes estão passando pela sua triagem atual."
+        ctaMessage="Calcule o ROI no SmartLic — 14 dias grátis."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/smartlic-vs-effecti-comparacao-2026.tsx
+++ b/frontend/app/blog/content/smartlic-vs-effecti-comparacao-2026.tsx
@@ -239,7 +239,7 @@ export default function SmartlicVsEffectiComparacao2026() {
       <BlogInlineCTA
         slug="smartlic-vs-effecti-comparacao-2026"
         campaign="guias"
-        ctaMessage="Veja a diferença na prática: teste o SmartLic por 14 dias, sem cartão de crédito."
+        ctaMessage="Teste o SmartLic por 14 dias — sem cartão."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/smartlic-vs-licitanet-comparacao.tsx
+++ b/frontend/app/blog/content/smartlic-vs-licitanet-comparacao.tsx
@@ -256,7 +256,7 @@ export default function SmartlicVsLicitanetComparacao() {
       <BlogInlineCTA
         slug="smartlic-vs-licitanet-comparacao"
         campaign="guias"
-        ctaMessage="Veja a diferença na prática: teste a classificação por IA do SmartLic por 14 dias, sem cartão."
+        ctaMessage="Teste a classificação por IA do SmartLic — 14 dias grátis."
         ctaText="Começar Trial Gratuito"
       />
 

--- a/frontend/app/blog/content/smartlic-vs-planilha-excel-quando-automatizar.tsx
+++ b/frontend/app/blog/content/smartlic-vs-planilha-excel-quando-automatizar.tsx
@@ -182,7 +182,7 @@ export default function SmartlicVsPlanilhaExcelQuandoAutomatizar() {
       <BlogInlineCTA
         slug="smartlic-vs-planilha-excel-quando-automatizar"
         campaign="guias"
-        ctaMessage="Compare na prática: teste o SmartLic por 14 dias e veja quanto tempo você economiza versus sua planilha atual."
+        ctaMessage="Compare SmartLic vs planilha — 14 dias grátis."
         ctaText="Testar Agora — Sem Cartão"
       />
 


### PR DESCRIPTION
## Context
Blog CTA messages with 17+ words exceed cognitive friction threshold. `"Comece Agora"` (2nd-person imperative) less effective than infinitive 1st-person.

## Changes
- Default `ctaText`: `"Comece Agora"` → `"Testar 14 dias grátis"`
- JSDoc enforces: `ctaMessage ≤ 12 palavras`, `ctaText ≤ 4`
- Rewrote long ctaMessage in 12 blog content files (max 22 words → 10 words)

## Testing Plan
- [x] grep verifies no ctaMessage > 12 words (max now 10)
- [ ] CI: jest + eslint (worktree node_modules absent — runs in CI)
- [ ] Manual: snapshot tests refreshed if drift

## Risks & Rollback
Low risk — pure copy/strings, no JSX/logic changes. Revert single commit.

## Closes
Closes #621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation and copy-length guidelines to the call-to-action component for consistent messaging practices.

* **Updates**
  * Streamlined and unified call-to-action messages across blog articles for improved consistency.
  * Updated default call-to-action text to "Try 14 days free," emphasizing trial access.
  * Refined promotional messaging across content to focus on core product features and the free trial offer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->