### PR TITLE
feat(copy): TrialConversionScreen — 1st-person CTA + data-driven footer (#625)

### DIFF
--- a/frontend/__tests__/trial-components.test.tsx
+++ b/frontend/__tests__/trial-components.test.tsx
@@ -115,7 +115,7 @@ describe('TrialConversionScreen', () => {
 
     render(<TrialConversionScreen trialValue={mockTrialValue} onClose={jest.fn()} />);
 
-    const ctaButton = screen.getByRole('button', { name: /Continuar com SmartLic Pro/i });
+    const ctaButton = screen.getByRole('button', { name: /Manter meu acesso/i });
     fireEvent.click(ctaButton);
 
     // Should attempt fetch then fallback to router.push

--- a/frontend/app/components/TrialConversionScreen.tsx
+++ b/frontend/app/components/TrialConversionScreen.tsx
@@ -301,13 +301,17 @@ export function TrialConversionScreen({ trialValue, onClose, loading }: TrialCon
         >
           {checkoutLoading
             ? "Redirecionando para pagamento..."
-            : `Continuar com SmartLic Pro — ${formatCurrency(dynamicPrices[billingPeriod].monthly)}/mês`}
+            : hasData
+              ? `Manter meu acesso — ${formatCurrency(dynamicPrices[billingPeriod].monthly)}/mês`
+              : `Começar com SmartLic Pro — ${formatCurrency(dynamicPrices[billingPeriod].monthly)}/mês`}
         </button>
 
         {/* Confidence Footer */}
         <div className="mt-6 text-center space-y-2">
           <p className="text-sm text-ink-secondary">
-            Seu concorrente pode estar usando SmartLic agora. Continue tendo vantagem.
+            {hasData && trialValue!.total_value > 0
+              ? `Você já analisou ${formatCurrency(trialValue!.total_value)} em oportunidades nos últimos 14 dias. Sem o Pro, esse fluxo para hoje.`
+              : "14 dias bastaram para mapear seu mercado. O Pro mantém o radar ligado."}
           </p>
           <p className="text-xs text-ink-muted">
             Cancele quando quiser. Sem contrato de fidelidade.


### PR DESCRIPTION
## Context
Botão `"Continuar com SmartLic Pro"` é burocrático-passivo. Copy de rodapé `"Seu concorrente pode estar usando SmartLic agora"` é FOMO genérico — não usa dados reais do usuário já presentes na tela.

## Changes
- Botão 1ª pessoa: `"Manter meu acesso — R$ {price}/mês"` (hasData) / `"Começar com SmartLic Pro"` (fallback)
- Footer cita `formatCurrency(trialValue.total_value)` quando >0
- FocusTrap, Escape handler, analytics event names — todos inalterados

## Testing Plan
- [x] Snapshot tests atualizados
- [x] Lint clean
- [x] Behavior tests (focus trap, escape) intactos

## Risks & Rollback
Low risk — copy only. Revert single commit.

## Closes
Closes #625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trial conversion screen messaging is now personalized based on your trial activity
  * Button label and footer message adapt based on whether you have prior trial data
  * Context-aware confirmation messaging displays your trial period activity when applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->