### PR TITLE
feat(seo): mobile sticky trial CTA across 7 pSEO pages (#626)

### DIFF
--- a/frontend/__tests__/StickyTrialCTA.test.tsx
+++ b/frontend/__tests__/StickyTrialCTA.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tests for StickyTrialCTA component (#626)
+ * Mobile sticky trial CTA — visible after >600px scroll, hidden on desktop via sm:hidden.
+ */
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import StickyTrialCTA from '../app/components/StickyTrialCTA';
+
+describe('StickyTrialCTA', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+  });
+
+  it('renders nothing when scrollY <= 600', () => {
+    render(<StickyTrialCTA refParam="sticky-test" />);
+    expect(screen.queryByText(/Testar 14 dias grátis/)).toBeNull();
+  });
+
+  it('renders the CTA link after scrolling beyond 600px', () => {
+    render(<StickyTrialCTA refParam="sticky-test" />);
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { value: 700, writable: true, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    const link = screen.getByRole('link', { name: /Testar 14 dias grátis/ });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/signup?ref=sticky-test');
+  });
+
+  it('uses sm:hidden so the bar is mobile-only', () => {
+    const { container } = render(<StickyTrialCTA refParam="sticky-test" />);
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { value: 700, writable: true, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    const bar = container.querySelector('.fixed');
+    expect(bar).not.toBeNull();
+    expect(bar?.className).toContain('sm:hidden');
+  });
+
+  it('honors a custom label prop', () => {
+    render(<StickyTrialCTA refParam="sticky-test" label="Começar grátis" />);
+
+    act(() => {
+      Object.defineProperty(window, 'scrollY', { value: 700, writable: true, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(screen.getByRole('link', { name: /Começar grátis/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/app/alertas-publicos/[setor]/[uf]/page.tsx
+++ b/frontend/app/alertas-publicos/[setor]/[uf]/page.tsx
@@ -13,6 +13,7 @@ import {
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
+import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 
 
 export const revalidate = 86400; // 24h ISR — alinhado com blog/contratos; reduz wave de re-validation que satura backend WC=1 (incident 2026-04-29)
@@ -119,6 +120,7 @@ export default async function AlertasPage({ params }: Props) {
   return (
     <>
       <LandingNavbar />
+      <StickyTrialCTA refParam="sticky-alertas" />
       <main className="min-h-screen bg-surface-0">
         {/* JSON-LD */}
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />

--- a/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
+++ b/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 
 interface Contrato {
   orgao: string;
@@ -108,6 +109,7 @@ export default function CnpjPerfilClient({ perfil }: { perfil: PerfilB2G }) {
 
   return (
     <div className="not-prose">
+      <StickyTrialCTA refParam="sticky-cnpj" />
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-3">{headline}</h1>

--- a/frontend/app/components/StickyTrialCTA.tsx
+++ b/frontend/app/components/StickyTrialCTA.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface Props {
+  refParam: string;
+  label?: string;
+}
+
+export default function StickyTrialCTA({ refParam, label = 'Testar 14 dias grátis' }: Props) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > 600);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  if (!show) return null;
+
+  const handleClick = () => {
+    if (typeof window !== 'undefined' && window.mixpanel) {
+      window.mixpanel.track('sticky_cta_clicked', { ref: refParam });
+    }
+  };
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 z-40 sm:hidden bg-white border-t border-gray-200 px-4 py-3 shadow-lg">
+      <Link
+        href={`/signup?ref=${refParam}`}
+        onClick={handleClick}
+        className="block w-full bg-green-600 hover:bg-green-700 text-white text-center font-bold py-3 rounded-lg"
+      >
+        {label} →
+      </Link>
+      <p className="text-center text-xs text-gray-500 mt-1">Sem cartão de crédito</p>
+    </div>
+  );
+}

--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -13,6 +13,7 @@ import { formatBRL } from '@/lib/sectors';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
+import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 
 export const revalidate = 14400; // 4h ISR (reduzido de 24h para melhorar freshness dos dados)
 
@@ -195,6 +196,7 @@ export default async function ContratosSetorUfPage({ params }: Props) {
   return (
     <>
       <LandingNavbar />
+      <StickyTrialCTA refParam="sticky-contratos" />
       <main className="min-h-screen bg-gray-50 pt-20 pb-16">
         {jsonLd.map((ld, i) => (
           <script

--- a/frontend/app/indice-municipal/[municipio-uf]/page.tsx
+++ b/frontend/app/indice-municipal/[municipio-uf]/page.tsx
@@ -8,6 +8,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 
 export const revalidate = 86400;
 
@@ -180,6 +181,7 @@ export default async function MunicipioPage({ params, searchParams }: PageProps)
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
       />
 
+      <StickyTrialCTA refParam="sticky-indice" />
       <main className="max-w-3xl mx-auto px-4 py-10">
         <nav className="text-sm text-gray-500 mb-6">
           <Link href="/indice-municipal" className="hover:underline">

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -15,6 +15,7 @@ import { getSectorFaqs } from "@/data/sector-faqs";
 import { getFreshnessLabel } from "@/lib/seo";
 import { MicroDemo } from "@/components/seo/MicroDemo";
 import { MicroDemoSchema } from "@/components/seo/MicroDemoSchema";
+import StickyTrialCTA from "@/app/components/StickyTrialCTA";
 
 /**
  * STORY-324 AC5: SSG with ISR 6h for sector landing pages.
@@ -103,7 +104,9 @@ export default async function SectorPage({
   const relatedSectors = getRelatedSectors(setor);
 
   return (
-    <main id="main-content" className="min-h-screen bg-white dark:bg-gray-950">
+    <>
+      <StickyTrialCTA refParam="sticky-licitacoes" />
+      <main id="main-content" className="min-h-screen bg-white dark:bg-gray-950">
       {/* AC6: Hero */}
       <section className="bg-gradient-to-br from-brand-blue to-blue-700 text-white py-16 px-4">
         <div className="max-w-5xl mx-auto text-center">
@@ -491,6 +494,7 @@ export default async function SectorPage({
         }}
       />
     </main>
+    </>
   );
 }
 

--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
+import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 
 // Sprint 4 Parte 13: páginas de municípios com licitações abertas
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -187,6 +188,7 @@ export default async function MunicipioSlugPage({ params }: Props) {
   return (
     <>
       <LandingNavbar />
+      <StickyTrialCTA refParam="sticky-municipio" />
       <main className="min-h-screen bg-gray-50 pt-20 pb-16">
         {jsonLd.map((ld, i) => (
           <script

--- a/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
+++ b/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 
 interface LicitacaoRecente {
   objeto_compra: string;
@@ -126,6 +127,7 @@ export default function OrgaoPerfilClient({ stats }: { stats: OrgaoStats }) {
 
   return (
     <div className="not-prose">
+      <StickyTrialCTA refParam="sticky-orgao" />
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-3">{headline}</h1>


### PR DESCRIPTION
## Context
60% do tráfego orgânico é mobile e nenhuma página programática tem sticky CTA. Mobile sticky bottom = +11% conversão (Klettke/DigitalApplied A/B). Pre-revenue, runway-zero — é deixar conversão na mesa.

## Changes
- Novo `frontend/app/components/StickyTrialCTA.tsx` — `'use client'`, scroll-triggered >600px, `sm:hidden`
- Integração em 7 páginas pSEO com refParam único: cnpj, orgao, municipio, indice, contratos, licitacoes, alertas
- Mixpanel `sticky_cta_clicked` event via `window.mixpanel` (padrão já estabelecido em CnpjPerfilClient/OrgaoPerfilClient — typing já existente em `frontend/types/external.d.ts`)
- Test: render assertions vazio<600px / visível>600px / sm:hidden present / custom label

## Testing Plan
- [x] RTL test render gating (4 tests, all pass — `npm test -- StickyTrialCTA`)
- [x] TypeScript check clean (full project tsc --noEmit, no errors)
- [x] Verifiquei desktop (≥640px) sem regressão (sm:hidden)
- [ ] Lighthouse mobile spot-check após deploy (informacional)

## Risks & Rollback
Low risk — additive; sm:hidden garante zero impacto desktop. Componente é opt-in por página (mount explícito). Rollback: `git revert` único commit.

## Closes
Closes #626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sticky trial call-to-action banner that appears after users scroll on key landing pages, providing quick access to sign up for a free trial
  * Includes analytics tracking for trial CTA interactions

* **Tests**
  * Added test coverage for sticky trial CTA component visibility and interaction behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->