### PR TITLE
feat(seo): /observatorio/[slug] breadcrumb visual + JSON-LD + canonical (#658)

### DIFF
--- a/frontend/__tests__/app/observatorio-slug-breadcrumb.test.tsx
+++ b/frontend/__tests__/app/observatorio-slug-breadcrumb.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Issue #658: /observatorio/[slug] breadcrumb visual + JSON-LD BreadcrumbList +
+ * canonical on noindex branch.
+ *
+ * Asserts:
+ * - generateMetadata: noindex branch (missing payload) emits explicit canonical
+ *   to its own URL (não herda root).
+ * - Page render: <nav aria-label="Breadcrumb"> presente.
+ * - Page render: JSON-LD script com "@type": "BreadcrumbList" e 3 ListItems.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+// Mock client component to avoid Recharts/SSR deps in test render
+jest.mock('@/app/observatorio/[slug]/ObservatorioRelatorioClient', () => {
+  const Mock = () => <div data-testid="observatorio-client" />;
+  Mock.displayName = 'ObservatorioRelatorioClientMock';
+  return { __esModule: true, default: Mock };
+});
+
+jest.mock('@sentry/nextjs', () => ({
+  captureMessage: jest.fn(),
+}));
+
+const mockRelatorio = {
+  mes: 3,
+  ano: 2026,
+  mes_nome: 'março',
+  periodo: 'Editais publicados de 1 a 31 de março de 2026',
+  total_editais: 12543,
+  valor_total: 1580000000,
+  valor_medio: 125000,
+  top_ufs: [],
+  modalidades: [],
+  tendencia_semanal: [],
+  setores_em_alta: [],
+  gerado_em: '2026-04-01T10:00:00Z',
+  fonte: 'SmartLic Observatório — dados PNCP',
+  license: 'Creative Commons BY 4.0',
+};
+
+global.fetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => mockRelatorio,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateMetadata — canonical em branch noindex (Issue #658)
+// ---------------------------------------------------------------------------
+
+describe('generateMetadata — canonical no branch noindex (Issue #658)', () => {
+  it('payload vazio gera canonical explícito para a própria URL', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ...mockRelatorio, total_editais: 0 }),
+    });
+    const { generateMetadata } = await import('@/app/observatorio/[slug]/page');
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: 'raio-x-marco-2026' }),
+    });
+    expect(meta.alternates?.canonical).toBe(
+      'https://smartlic.tech/observatorio/raio-x-marco-2026',
+    );
+    // Continua noindex mas follow=true (canonical+noindex é sinal Google válido).
+    const robots = meta.robots as { index?: boolean; follow?: boolean } | undefined;
+    expect(robots?.index).toBe(false);
+    expect(robots?.follow).toBe(true);
+  });
+
+  it('fetch retorna null → canonical explícito mantido', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false });
+    const { generateMetadata } = await import('@/app/observatorio/[slug]/page');
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: 'raio-x-abril-2026' }),
+    });
+    expect(meta.alternates?.canonical).toBe(
+      'https://smartlic.tech/observatorio/raio-x-abril-2026',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Page render — visual breadcrumb + JSON-LD BreadcrumbList (Issue #658)
+// ---------------------------------------------------------------------------
+
+describe('RelatorioPage render — breadcrumb visual + JSON-LD (Issue #658)', () => {
+  it('renderiza <nav aria-label="Breadcrumb"> e JSON-LD BreadcrumbList com 3 ListItem', async () => {
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+    // Server component returns a Promise<JSX>
+    const element = await Page({
+      params: Promise.resolve({ slug: 'raio-x-marco-2026' }),
+    });
+    const { container } = render(element as React.ReactElement);
+
+    // Visual nav
+    const nav = container.querySelector('nav[aria-label="Breadcrumb"]');
+    expect(nav).not.toBeNull();
+    const items = nav!.querySelectorAll('li');
+    expect(items.length).toBe(3);
+    // current page tem aria-current
+    expect(nav!.querySelector('[aria-current="page"]')).not.toBeNull();
+
+    // JSON-LD BreadcrumbList
+    const scripts = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    const breadcrumbScript = scripts.find((s) =>
+      (s.textContent || '').includes('"@type":"BreadcrumbList"'),
+    );
+    expect(breadcrumbScript).toBeDefined();
+    const parsed = JSON.parse(breadcrumbScript!.textContent || '{}');
+    expect(parsed['@type']).toBe('BreadcrumbList');
+    expect(parsed.itemListElement).toHaveLength(3);
+    expect(parsed.itemListElement[0].name).toBe('Home');
+    expect(parsed.itemListElement[0].item).toBe('https://smartlic.tech/');
+    expect(parsed.itemListElement[1].name).toBe('Observatório');
+    expect(parsed.itemListElement[1].item).toBe(
+      'https://smartlic.tech/observatorio',
+    );
+    expect(parsed.itemListElement[2].item).toBe(
+      'https://smartlic.tech/observatorio/raio-x-marco-2026',
+    );
+    expect(parsed.itemListElement[2].position).toBe(3);
+  });
+});

--- a/frontend/app/observatorio/[slug]/page.tsx
+++ b/frontend/app/observatorio/[slug]/page.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Metadata } from 'next';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import * as Sentry from '@sentry/nextjs';
 import ObservatorioRelatorioClient from './ObservatorioRelatorioClient';
@@ -72,11 +73,13 @@ export async function generateMetadata({
 
   // STORY-431 AC13: missing or empty payload → noindex metadata so an
   // accidentally-cached blank page never lands in Google's index.
+  // Issue #658: explicit canonical to own URL (não herdar root do layout.tsx).
   if (!relatorio || !relatorio.total_editais) {
     return {
       title: `Raio-X das Licitações — ${mesDisplay} ${ano}`,
       description: `Análise mensal das licitações públicas brasileiras em ${mesDisplay.toLowerCase()} de ${ano}.`,
-      robots: { index: false, follow: false },
+      alternates: { canonical: `https://smartlic.tech/observatorio/${slug}` },
+      robots: { index: false, follow: true },
     };
   }
 
@@ -161,6 +164,25 @@ export default async function RelatorioPage({
       }
     : null;
 
+  // Issue #658: BreadcrumbList JSON-LD + visual nav breadcrumb.
+  // Pattern: contratos/[setor]/[uf]/page.tsx (JSON-LD) + alertas-publicos/[setor]/[uf]/page.tsx (visual).
+  const breadcrumbs = [
+    { name: 'Home', url: '/' },
+    { name: 'Observatório', url: '/observatorio' },
+    { name: `Raio-X — ${mesDisplay} ${ano}`, url: `/observatorio/${slug}` },
+  ];
+
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbs.map((item, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: item.name,
+      item: `https://smartlic.tech${item.url}`,
+    })),
+  };
+
   return (
     <>
       {datasetSchema && (
@@ -169,6 +191,25 @@ export default async function RelatorioPage({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetSchema) }}
         />
       )}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      {/* Issue #658: visual breadcrumb (matches alertas-publicos pattern). */}
+      <nav aria-label="Breadcrumb" className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 text-sm text-gray-500">
+        <ol className="flex flex-wrap items-center gap-1">
+          {breadcrumbs.map((item, i) => (
+            <li key={item.url + i} className="flex items-center gap-1">
+              {i > 0 && <span className="text-gray-400">/</span>}
+              {i < breadcrumbs.length - 1 ? (
+                <Link href={item.url} className="hover:text-blue-600">{item.name}</Link>
+              ) : (
+                <span aria-current="page" className="text-gray-900 font-medium">{item.name}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
       <ObservatorioRelatorioClient
         relatorio={relatorio}
         slug={slug}

--- a/frontend/app/observatorio/[slug]/page.tsx
+++ b/frontend/app/observatorio/[slug]/page.tsx
@@ -164,6 +164,9 @@ export default async function RelatorioPage({
       }
     : null;
 
+  // Escape `<` to prevent early script-tag termination if backend strings contain `</script>`.
+  const toSafeJsonLd = (value: unknown) => JSON.stringify(value).replace(/</g, '\\u003c');
+
   // Issue #658: BreadcrumbList JSON-LD + visual nav breadcrumb.
   // Pattern: contratos/[setor]/[uf]/page.tsx (JSON-LD) + alertas-publicos/[setor]/[uf]/page.tsx (visual).
   const breadcrumbs = [
@@ -188,12 +191,12 @@ export default async function RelatorioPage({
       {datasetSchema && (
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetSchema) }}
+          dangerouslySetInnerHTML={{ __html: toSafeJsonLd(datasetSchema) }}
         />
       )}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+        dangerouslySetInnerHTML={{ __html: toSafeJsonLd(breadcrumbSchema) }}
       />
       {/* Issue #658: visual breadcrumb (matches alertas-publicos pattern). */}
       <nav aria-label="Breadcrumb" className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 text-sm text-gray-500">


### PR DESCRIPTION
## Context
Laudo pSEO 2026-05-03 Eixo 4 (Score 78%): /observatorio/[slug] é a única rota pSEO sem breadcrumb visual nem BreadcrumbList JSON-LD. Adicionalmente, branch noindex herdava canonical = root.

## Changes
- Visual breadcrumb nav (Home > Observatório > current) — pattern alertas-publicos
- JSON-LD BreadcrumbList — pattern contratos/[setor]/[uf]
- Canonical explícito mesmo em noindex (própria URL, não root)

## Testing Plan
- [x] Snapshot test asserta nav + JSON-LD presentes
- [x] Lint clean
- [x] Match com reference patterns (alertas-publicos + contratos)

## Risks & Rollback
Low risk — additive structured data + visual nav. Revert single commit.

## Closes
Closes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visible breadcrumb navigation on Observatory pages and embedded BreadcrumbList JSON-LD for improved navigation and SEO.

* **Improvements**
  * Explicit canonical URLs for Observatory pages when primary data is missing; robots set to index: false, follow: true in that case.
  * Safer JSON-LD rendering to prevent markup injection.

* **Tests**
  * Added automated tests validating metadata, breadcrumb UI, and JSON-LD output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->