### PR TITLE
feat(seo): /licitacoes/[setor] breadcrumb visual (#662)

### DIFF
--- a/frontend/__tests__/licitacoes-setor-breadcrumb.test.tsx
+++ b/frontend/__tests__/licitacoes-setor-breadcrumb.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Issue #662: Visual breadcrumb on /licitacoes/[setor].
+ *
+ * Asserts:
+ * - <nav aria-label="Breadcrumb"> renders with 3 items
+ * - aria-current="page" on last item
+ * - Last item resolves to sector.name
+ */
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return ({ children, href, ...props }: { children: React.ReactNode; href: string; [k: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(),
+}));
+
+// Mock data dependencies
+jest.mock('@/lib/sectors', () => ({
+  getSectorBySlug: jest.fn(),
+  getAllSectorSlugs: jest.fn(() => ['saude']),
+  getRelatedSectors: jest.fn(() => []),
+  fetchSectorStats: jest.fn(),
+  formatBRL: jest.fn((v: number) => `R$ ${v}`),
+  SECTORS: [],
+}));
+jest.mock('@/data/sector-faqs', () => ({ getSectorFaqs: jest.fn(() => []) }));
+jest.mock('@/lib/seo', () => ({ getFreshnessLabel: jest.fn(() => 'Hoje') }));
+jest.mock('@/components/seo/MicroDemo', () => ({ MicroDemo: () => null }));
+jest.mock('@/components/seo/MicroDemoSchema', () => ({ MicroDemoSchema: () => null }));
+jest.mock('@/lib/programmatic', () => ({ UF_NAMES: { SP: 'São Paulo' } }));
+
+const { getSectorBySlug, fetchSectorStats, getRelatedSectors } = require('@/lib/sectors');
+const { getSectorFaqs } = require('@/data/sector-faqs');
+import SectorPage from '@/app/licitacoes/[setor]/page';
+
+const MOCK_SECTOR = {
+  id: 'saude',
+  name: 'Saúde',
+  slug: 'saude',
+  description: 'Setor de saúde pública',
+};
+
+describe('/licitacoes/[setor] visual breadcrumb (#662)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSectorBySlug.mockReturnValue(MOCK_SECTOR);
+    getSectorFaqs.mockReturnValue([]);
+    getRelatedSectors.mockReturnValue([]);
+    fetchSectorStats.mockResolvedValue({
+      total_open: 10,
+      total_value: 1_000_000,
+      avg_value: 100_000,
+      top_ufs: [{ name: 'SP', count: 5 }],
+      sample_items: [],
+      last_updated: '2026-05-04T12:00:00Z',
+    });
+  });
+
+  it('renders <nav aria-label="Breadcrumb"> with exactly 3 visible items', async () => {
+    const ui = await SectorPage({ params: Promise.resolve({ setor: 'saude' }) });
+    render(ui as React.ReactElement);
+
+    const nav = screen.getByRole('navigation', { name: /breadcrumb/i });
+    expect(nav).toBeInTheDocument();
+
+    // ol > li[content] (skip aria-hidden separators)
+    const items = within(nav)
+      .getAllByRole('listitem')
+      .filter((li) => li.getAttribute('aria-hidden') !== 'true');
+    expect(items).toHaveLength(3);
+
+    expect(within(items[0]).getByRole('link', { name: /início/i })).toHaveAttribute('href', '/');
+    expect(within(items[1]).getByRole('link', { name: /licitações/i })).toHaveAttribute('href', '/licitacoes');
+    expect(items[2]).toHaveTextContent('Saúde');
+  });
+
+  it('marks last item with aria-current="page"', async () => {
+    const ui = await SectorPage({ params: Promise.resolve({ setor: 'saude' }) });
+    render(ui as React.ReactElement);
+
+    const current = screen.getByText('Saúde', { selector: '[aria-current="page"]' });
+    expect(current).toBeInTheDocument();
+    expect(current.tagName.toLowerCase()).toBe('li');
+  });
+});

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -107,6 +107,20 @@ export default async function SectorPage({
       {/* AC6: Hero */}
       <section className="bg-gradient-to-br from-brand-blue to-blue-700 text-white py-16 px-4">
         <div className="max-w-5xl mx-auto text-center">
+          {/* Issue #662: Visual breadcrumb (matches JSON-LD BreadcrumbList below) */}
+          <nav aria-label="Breadcrumb" className="text-sm text-white/60 mb-4 text-left">
+            <ol className="flex flex-wrap items-center gap-x-1">
+              <li>
+                <Link href="/" className="hover:text-white/80">Início</Link>
+              </li>
+              <li aria-hidden="true"> › </li>
+              <li>
+                <Link href="/licitacoes" className="hover:text-white/80">Licitações</Link>
+              </li>
+              <li aria-hidden="true"> › </li>
+              <li aria-current="page" className="text-white/80">{sector.name}</li>
+            </ol>
+          </nav>
           <h1 className="text-3xl md:text-5xl font-bold mb-4">
             Licitações de {sector.name}
             {stats && stats.total_open > 0 && (


### PR DESCRIPTION
## Context
Laudo pSEO 2026-05-03 Eixo 4 (Score 78%): /licitacoes/[setor] já tem JSON-LD BreadcrumbList (linha ~498) mas falta nav visual. Outras rotas pSEO têm; aqui é gap.

## Changes
- Visual `<nav aria-label="Breadcrumb">` (Início > Licitações > {setor.name})
- Estilo consistente com alertas-publicos (text-sm white/60 over hero gradient)
- JSON-LD na linha ~498 intacto (não duplicado)

## Testing Plan
- [x] Snapshot test (`__tests__/licitacoes-setor-breadcrumb.test.tsx`) asserta nav + 3 items + aria-current
- [x] Existing licitacoes test suite still passing (235 passed, 0 failures)
- [x] JSON-LD não duplicado

## Risks & Rollback
Low risk — additive visual + accessibility. Revert single commit.

## Closes
Closes #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added breadcrumb navigation to procurement sector pages, displaying the full navigation path (Home › Procurement › Sector Name) to improve user navigation and contextual awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->