### PR TITLE
feat(analytics): CONV-INST-001 — enrich page_load with traffic_source + landing flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to SmartLic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **CONV-INST-001**: Analytics `page_load` enriquecido com `traffic_source` (organic_search | paid_search | referral | direct | utm_campaign), `is_landing_page` e `entry_pathname` super-property. Helper puro `frontend/lib/analytics-traffic-source.ts` isolado e testado com 169 testes unitários. Gated por LGPD consent. Additive-only — nenhuma propriedade existente removida.
+
 ## [0.5.4] - 2026-04-18 - CACHE WARMING DEPRECATION
 
 ### Removed — BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to SmartLic will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-- **CONV-INST-001**: Analytics `page_load` enriquecido com `traffic_source` (organic_search | paid_search | referral | direct | utm_campaign), `is_landing_page` e `entry_pathname` super-property. Helper puro `frontend/lib/analytics-traffic-source.ts` isolado e testado com 169 testes unitários. Gated por LGPD consent. Additive-only — nenhuma propriedade existente removida.
-
 ## [0.5.4] - 2026-04-18 - CACHE WARMING DEPRECATION
 
 ### Removed — BREAKING

--- a/frontend/__tests__/components/AnalyticsProvider.test.tsx
+++ b/frontend/__tests__/components/AnalyticsProvider.test.tsx
@@ -8,6 +8,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { AnalyticsProvider } from '@/app/components/AnalyticsProvider';
 import mixpanel from 'mixpanel-browser';
 import * as Sentry from '@sentry/nextjs';
+import { usePathname } from 'next/navigation';
 
 // Mock dependencies
 jest.mock('mixpanel-browser');
@@ -72,6 +73,9 @@ describe('AnalyticsProvider Component', () => {
     // Default: no UTM params stored, direct traffic
     getStoredUTMParams.mockReturnValue({});
     deriveTrafficSource.mockReturnValue('direct');
+
+    // Restore usePathname implementation (reset by resetMocks:true in jest.config.js)
+    (usePathname as jest.Mock).mockReturnValue('/test-page');
   });
 
   afterEach(() => {

--- a/frontend/__tests__/components/AnalyticsProvider.test.tsx
+++ b/frontend/__tests__/components/AnalyticsProvider.test.tsx
@@ -26,6 +26,11 @@ jest.mock('../../app/components/CookieConsentBanner', () => ({
 
 jest.mock('../../hooks/useAnalytics', () => ({
   captureUTMParams: jest.fn(),
+  getStoredUTMParams: jest.fn(() => ({})),
+}));
+
+jest.mock('../../lib/analytics-traffic-source', () => ({
+  deriveTrafficSource: jest.fn(() => 'direct'),
 }));
 
 jest.mock('../../app/components/AuthProvider', () => ({
@@ -46,7 +51,8 @@ jest.mock('../../hooks/useClarity', () => ({
 
 const mockMixpanel = mixpanel as jest.Mocked<typeof mixpanel>;
 const { getCookieConsent } = require('../../app/components/CookieConsentBanner');
-const { captureUTMParams } = require('../../hooks/useAnalytics');
+const { captureUTMParams, getStoredUTMParams } = require('../../hooks/useAnalytics');
+const { deriveTrafficSource } = require('../../lib/analytics-traffic-source');
 
 describe('AnalyticsProvider Component', () => {
   const originalEnv = process.env;
@@ -55,12 +61,17 @@ describe('AnalyticsProvider Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    sessionStorage.clear();
     process.env = { ...originalEnv };
     process.env.NEXT_PUBLIC_MIXPANEL_TOKEN = 'test-token-123';
     process.env.NODE_ENV = 'test';
 
     // Mock Sentry.getClient to return null initially
     (Sentry.getClient as jest.Mock).mockReturnValue(null);
+
+    // Default: no UTM params stored, direct traffic
+    getStoredUTMParams.mockReturnValue({});
+    deriveTrafficSource.mockReturnValue('direct');
   });
 
   afterEach(() => {
@@ -411,6 +422,155 @@ describe('AnalyticsProvider Component', () => {
           debug: true,
         }));
       });
+    });
+  });
+
+  describe('CONV-INST-001: traffic_source enrichment', () => {
+    // AC7 scenario 1: organic_search referrer
+    it('AC7-1: page_load includes traffic_source=organic_search for Google referrer', async () => {
+      getCookieConsent.mockReturnValue({ analytics: true });
+      getStoredUTMParams.mockReturnValue({});
+      deriveTrafficSource.mockReturnValue('organic_search');
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockMixpanel.track).toHaveBeenCalledWith(
+          'page_load',
+          expect.objectContaining({ traffic_source: 'organic_search' })
+        );
+      });
+    });
+
+    // AC7 scenario 2: utm_campaign
+    it('AC7-2: page_load includes traffic_source=utm_campaign when UTM params present', async () => {
+      getCookieConsent.mockReturnValue({ analytics: true });
+      getStoredUTMParams.mockReturnValue({ utm_source: 'blog', utm_medium: 'cta', utm_campaign: 'trial' });
+      deriveTrafficSource.mockReturnValue('utm_campaign');
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockMixpanel.track).toHaveBeenCalledWith(
+          'page_load',
+          expect.objectContaining({
+            traffic_source: 'utm_campaign',
+            utm_source: 'blog',
+            utm_campaign: 'trial',
+          })
+        );
+      });
+    });
+
+    // AC7 scenario 3: first navigation → is_landing_page: true
+    it('AC7-3: first navigation sets is_landing_page=true and registers entry_pathname', async () => {
+      getCookieConsent.mockReturnValue({ analytics: true });
+      // sessionStorage is clear from beforeEach
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockMixpanel.track).toHaveBeenCalledWith(
+          'page_load',
+          expect.objectContaining({ is_landing_page: true })
+        );
+      });
+
+      expect(mockMixpanel.register).toHaveBeenCalledWith(
+        expect.objectContaining({ entry_pathname: expect.any(String) })
+      );
+    });
+
+    // AC7 scenario 4: second navigation → is_landing_page: false
+    it('AC7-4: second navigation sets is_landing_page=false and does NOT call register with entry_pathname again', async () => {
+      getCookieConsent.mockReturnValue({ analytics: true });
+      // Simulate first path already recorded
+      sessionStorage.setItem('smartlic_first_path_recorded', '1');
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockMixpanel.track).toHaveBeenCalledWith(
+          'page_load',
+          expect.objectContaining({ is_landing_page: false })
+        );
+      });
+
+      // register should NOT have been called with entry_pathname on second navigation
+      const registerCallsWithEntryPath = (mockMixpanel.register as jest.Mock).mock.calls.filter(
+        (args: unknown[]) => args[0] && typeof args[0] === 'object' && 'entry_pathname' in (args[0] as object)
+      );
+      expect(registerCallsWithEntryPath).toHaveLength(0);
+    });
+
+    it('page_load includes direct traffic_source when no referrer and no UTM', async () => {
+      getCookieConsent.mockReturnValue({ analytics: true });
+      getStoredUTMParams.mockReturnValue({});
+      deriveTrafficSource.mockReturnValue('direct');
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockMixpanel.track).toHaveBeenCalledWith(
+          'page_load',
+          expect.objectContaining({ traffic_source: 'direct' })
+        );
+      });
+    });
+
+    it('utm_source/utm_campaign not included when UTM params absent', async () => {
+      getCookieConsent.mockReturnValue({ analytics: true });
+      getStoredUTMParams.mockReturnValue({});
+      deriveTrafficSource.mockReturnValue('direct');
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      await waitFor(() => {
+        expect(mockMixpanel.track).toHaveBeenCalledWith('page_load', expect.any(Object));
+      });
+
+      const trackArgs = (mockMixpanel.track as jest.Mock).mock.calls.find(
+        (c: unknown[]) => c[0] === 'page_load'
+      );
+      expect(trackArgs![1]).not.toHaveProperty('utm_source');
+      expect(trackArgs![1]).not.toHaveProperty('utm_campaign');
+    });
+
+    it('does not track when consent not granted', () => {
+      getCookieConsent.mockReturnValue({ analytics: false });
+
+      render(
+        <AnalyticsProvider>
+          <div>Test Content</div>
+        </AnalyticsProvider>
+      );
+
+      expect(mockMixpanel.track).not.toHaveBeenCalled();
+      expect(mockMixpanel.register).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/__tests__/lib/analytics-traffic-source.test.ts
+++ b/frontend/__tests__/lib/analytics-traffic-source.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for analytics-traffic-source helpers
+ *
+ * Covers CONV-INST-001 AC7: 4 required scenarios + edge cases.
+ */
+
+import {
+  isSearchEngine,
+  deriveTrafficSource,
+  extractUtmFields,
+  SEARCH_ENGINE_DOMAINS,
+} from '../../lib/analytics-traffic-source';
+
+describe('isSearchEngine', () => {
+  it('returns false for empty string', () => {
+    expect(isSearchEngine('')).toBe(false);
+  });
+
+  it('returns false for invalid URL', () => {
+    expect(isSearchEngine('not-a-url')).toBe(false);
+  });
+
+  it('returns true for exact google.com', () => {
+    expect(isSearchEngine('https://google.com/search?q=test')).toBe(true);
+  });
+
+  it('returns true for www.google.com subdomain', () => {
+    expect(isSearchEngine('https://www.google.com/search?q=pncp')).toBe(true);
+  });
+
+  it('returns true for news.google.com subdomain', () => {
+    expect(isSearchEngine('https://news.google.com/stories')).toBe(true);
+  });
+
+  it('returns true for bing.com', () => {
+    expect(isSearchEngine('https://www.bing.com/search?q=licitacao')).toBe(true);
+  });
+
+  it('returns true for duckduckgo.com', () => {
+    expect(isSearchEngine('https://duckduckgo.com/?q=pregao')).toBe(true);
+  });
+
+  it('returns true for yahoo.com', () => {
+    expect(isSearchEngine('https://search.yahoo.com/search?p=test')).toBe(true);
+  });
+
+  it('returns false for non-search referrer', () => {
+    expect(isSearchEngine('https://twitter.com/user')).toBe(false);
+  });
+
+  it('returns false for site that contains search engine name but is not one', () => {
+    // hostname "notgoogle.com" should not match ".google.com" suffix
+    expect(isSearchEngine('https://notgoogle.com/page')).toBe(false);
+  });
+
+  it('covers all SEARCH_ENGINE_DOMAINS constants', () => {
+    for (const domain of SEARCH_ENGINE_DOMAINS) {
+      expect(isSearchEngine(`https://www.${domain}/search`)).toBe(true);
+    }
+  });
+});
+
+describe('deriveTrafficSource', () => {
+  // AC7 scenario 1: organic_search
+  it('AC7-1: Google referrer with no UTM → organic_search', () => {
+    const result = deriveTrafficSource(
+      'https://www.google.com/search?q=pncp',
+      {}
+    );
+    expect(result).toBe('organic_search');
+  });
+
+  // AC7 scenario 2: utm_campaign
+  it('AC7-2: UTM params present (no medium) → utm_campaign', () => {
+    const result = deriveTrafficSource('', {
+      utm_source: 'blog',
+      utm_medium: 'cta',
+    });
+    expect(result).toBe('utm_campaign');
+  });
+
+  it('paid_search wins over utm_campaign when utm_medium=cpc', () => {
+    const result = deriveTrafficSource('', {
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'trial',
+    });
+    expect(result).toBe('paid_search');
+  });
+
+  it('paid_search when utm_medium=paid (case-insensitive)', () => {
+    const result = deriveTrafficSource('', {
+      utm_source: 'google',
+      utm_medium: 'PAID',
+    });
+    expect(result).toBe('paid_search');
+  });
+
+  it('utm_campaign for any other utm_medium value', () => {
+    const result = deriveTrafficSource('', {
+      utm_source: 'newsletter',
+      utm_medium: 'email',
+    });
+    expect(result).toBe('utm_campaign');
+  });
+
+  it('referral for non-search referrer with no UTM', () => {
+    const result = deriveTrafficSource('https://linkedin.com/post/123', {});
+    expect(result).toBe('referral');
+  });
+
+  it('direct when no referrer and no UTM', () => {
+    const result = deriveTrafficSource('', {});
+    expect(result).toBe('direct');
+  });
+
+  it('organic_search NOT returned when UTM params also present with search engine referrer', () => {
+    // UTM takes precedence over organic_search (utm_campaign rule wins)
+    const result = deriveTrafficSource('https://www.google.com/search?q=test', {
+      utm_source: 'google',
+      utm_medium: 'organic',
+    });
+    expect(result).toBe('utm_campaign');
+  });
+});
+
+describe('extractUtmFields', () => {
+  it('extracts utm fields from URLSearchParams', () => {
+    const params = new URLSearchParams(
+      'utm_source=google&utm_medium=cpc&utm_campaign=trial&foo=bar'
+    );
+    const result = extractUtmFields(params);
+    expect(result).toEqual({
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'trial',
+    });
+    expect(result).not.toHaveProperty('foo');
+  });
+
+  it('extracts utm fields from plain object', () => {
+    const params = {
+      utm_source: 'newsletter',
+      utm_content: 'header-cta',
+      other_param: 'ignored',
+    };
+    const result = extractUtmFields(params);
+    expect(result).toEqual({
+      utm_source: 'newsletter',
+      utm_content: 'header-cta',
+    });
+    expect(result).not.toHaveProperty('other_param');
+  });
+
+  it('returns empty object when no utm fields present', () => {
+    const params = new URLSearchParams('page=1&sort=asc');
+    expect(extractUtmFields(params)).toEqual({});
+  });
+
+  it('returns empty object for empty plain object', () => {
+    expect(extractUtmFields({})).toEqual({});
+  });
+
+  it('does not include keys with empty/falsy values from plain object', () => {
+    const params = { utm_source: '', utm_medium: 'email' };
+    const result = extractUtmFields(params);
+    expect(result).toEqual({ utm_medium: 'email' });
+  });
+});

--- a/frontend/app/components/AnalyticsProvider.tsx
+++ b/frontend/app/components/AnalyticsProvider.tsx
@@ -5,7 +5,8 @@ import mixpanel from 'mixpanel-browser';
 import * as Sentry from '@sentry/nextjs';
 import { usePathname } from 'next/navigation';
 import { getCookieConsent, type CookieConsent } from './CookieConsentBanner';
-import { captureUTMParams } from '../../hooks/useAnalytics';
+import { captureUTMParams, getStoredUTMParams } from '../../hooks/useAnalytics';
+import { deriveTrafficSource } from '../../lib/analytics-traffic-source';
 import { useClarity } from '../../hooks/useClarity';
 import { useAuth } from './AuthProvider';
 import { useUserProfile } from '../../hooks/useUserProfile';
@@ -88,15 +89,40 @@ export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
       // STORY-219 AC24-AC27: Capture UTM params on first load
       captureUTMParams();
 
+      // CONV-INST-001: Derive traffic_source + set entry_pathname super-property
+      const utmParams = getStoredUTMParams();
+      const trafficSource = deriveTrafficSource(document.referrer, utmParams);
+
+      // Register entry_pathname as super-property on first navigation of session
+      const FIRST_PATH_KEY = 'smartlic_first_path_recorded';
+      const isFirstPath = !sessionStorage.getItem(FIRST_PATH_KEY);
+      if (isFirstPath) {
+        sessionStorage.setItem(FIRST_PATH_KEY, '1');
+        try {
+          mixpanel.register({ entry_pathname: pathname });
+        } catch {
+          // ignore
+        }
+      }
+
       // Track page_load
       try {
-        mixpanel.track('page_load', {
+        const pageLoadProps: Record<string, unknown> = {
           path: pathname,
           timestamp: new Date().toISOString(),
           environment: process.env.NODE_ENV || 'development',
           referrer: document.referrer || 'direct',
           user_agent: navigator.userAgent,
-        });
+          // CONV-INST-001 AC1: enriched fields
+          traffic_source: trafficSource,
+          is_landing_page: isFirstPath,
+        };
+
+        // Include raw utm_source and utm_campaign when present (AC1)
+        if (utmParams['utm_source']) pageLoadProps['utm_source'] = utmParams['utm_source'];
+        if (utmParams['utm_campaign']) pageLoadProps['utm_campaign'] = utmParams['utm_campaign'];
+
+        mixpanel.track('page_load', pageLoadProps);
       } catch {
         // ignore
       }

--- a/frontend/lib/analytics-traffic-source.ts
+++ b/frontend/lib/analytics-traffic-source.ts
@@ -1,0 +1,104 @@
+/**
+ * Analytics Traffic Source Derivation
+ *
+ * Pure helper module for deriving traffic_source from referrer + UTM params.
+ * Used by AnalyticsProvider to enrich page_load events.
+ *
+ * Implements CONV-INST-001 AC1.
+ */
+
+export const SEARCH_ENGINE_DOMAINS = [
+  'google.com',
+  'bing.com',
+  'duckduckgo.com',
+  'yahoo.com',
+] as const;
+
+export type TrafficSource =
+  | 'organic_search'
+  | 'paid_search'
+  | 'referral'
+  | 'direct'
+  | 'utm_campaign';
+
+/**
+ * Check if a referrer hostname belongs to a known search engine.
+ * Uses hostname suffix matching to handle subdomains (e.g. www.google.com, news.google.com).
+ */
+export function isSearchEngine(referrer: string): boolean {
+  if (!referrer) return false;
+  try {
+    const hostname = new URL(referrer).hostname;
+    return SEARCH_ENGINE_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive traffic_source from referrer and UTM params.
+ *
+ * Priority order (first match wins):
+ * 1. paid_search  — utm_medium is 'cpc' or 'paid'
+ * 2. utm_campaign — any utm_* param present
+ * 3. organic_search — referrer is a search engine AND no UTM
+ * 4. referral — referrer non-empty, not search engine, no UTM
+ * 5. direct — default (no referrer, no UTM)
+ *
+ * @param referrer  - value of document.referrer (empty string if direct)
+ * @param utmParams - UTM params captured from URL (via getStoredUTMParams or URLSearchParams)
+ */
+export function deriveTrafficSource(
+  referrer: string,
+  utmParams: Record<string, string>
+): TrafficSource {
+  const hasUtm = Object.keys(utmParams).length > 0;
+  const utmMedium = utmParams['utm_medium']?.toLowerCase() ?? '';
+
+  // 1. Paid search: explicit paid medium
+  if (hasUtm && (utmMedium === 'cpc' || utmMedium === 'paid')) {
+    return 'paid_search';
+  }
+
+  // 2. UTM campaign: any UTM param present (catches all other UTM traffic)
+  if (hasUtm) {
+    return 'utm_campaign';
+  }
+
+  // 3. Organic search: search engine referrer, no UTM
+  if (referrer && isSearchEngine(referrer)) {
+    return 'organic_search';
+  }
+
+  // 4. Referral: non-search referrer, no UTM
+  if (referrer) {
+    return 'referral';
+  }
+
+  // 5. Direct: no referrer, no UTM
+  return 'direct';
+}
+
+/**
+ * Extract UTM params from a URLSearchParams or plain object.
+ * Returns a subset with only keys matching utm_*.
+ */
+export function extractUtmFields(params: URLSearchParams | Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+
+  if (params instanceof URLSearchParams) {
+    for (const key of UTM_KEYS) {
+      const val = params.get(key);
+      if (val) result[key] = val;
+    }
+  } else {
+    for (const key of UTM_KEYS) {
+      if (params[key]) result[key] = params[key];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Context

Páginas pSEO recebem 126 clicks/mês via GSC mas **zero conversões rastreáveis** — não sabemos de qual canal (organic_search, referral, direct) vêm os visitantes que chegam ao `/signup`. O evento `page_load` existente não tinha `traffic_source` nem `is_landing_page`.

## Changes

- `frontend/lib/analytics-traffic-source.ts` — helper puro `deriveTrafficSource(referrer, utmParams)` com suporte a `organic_search | paid_search | referral | direct | utm_campaign`
- `frontend/app/components/AnalyticsProvider.tsx` — enrich `page_load` com `traffic_source`, `is_landing_page` (sessionStorage gate), `entry_pathname` super property
- `frontend/__tests__/lib/analytics-traffic-source.test.ts` — 169 linhas cobrindo 4 traffic sources + edge cases
- `frontend/__tests__/components/AnalyticsProvider.test.tsx` — extend testes existentes: referrer google → organic_search, UTM → utm_campaign, primeira nav → is_landing_page:true

## Testing Plan

- [x] Unit tests `analytics-traffic-source.ts`: 4 cenários (organic/paid/referral/direct) + edge cases (subdomains, invalid URL)
- [x] Integration tests `AnalyticsProvider.test.tsx`: referrer → traffic_source derivation, sessionStorage → is_landing_page, entry_pathname super property
- [x] Backward compat: campos adicionais apenas — `page_load` continua disparando com campos atuais
- [x] LGPD gate: toda lógica dentro de `getCookieConsent().analytics === true`
- [x] `resetMocks:true` fix: `usePathname` mock restaurado em `beforeEach` para estabilidade de testes

## Risks & Rollback

Risco baixo: mudança additive-only no evento existente `page_load`. Nenhuma propriedade removida. `sessionStorage` gracefully handles SSR (typeof window check). Rollback: reverter 2 commits ou remover os 3 novos campos do payload.

## Closes

Closes #714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enriched page_load analytics with traffic-source classification (organic, paid, referral, direct, UTM-driven), conditional UTM fields, landing-page detection (entry path recorded on first visit) and consent-aware tracking (no events when consent denied).

* **Tests**
  * Added thorough tests covering traffic-source derivation, UTM extraction, landing-page behavior, and consent gating.

* **Documentation**
  * Changelog entry documenting the analytics enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->