### PR TITLE
feat(seo): rewrite title/meta-desc de /licitacoes/ e /cnpj/* (#651)

### DIFF
--- a/frontend/__tests__/licitacoes/sector-pages.test.tsx
+++ b/frontend/__tests__/licitacoes/sector-pages.test.tsx
@@ -311,7 +311,7 @@ describe('Meta tags structure (AC9, AC11)', () => {
   it('title follows pattern for each sector', () => {
     SECTORS.forEach((s) => {
       const title = `Editais de ${s.name} 2026 — Para sua Empresa | SmartLic`;
-      expect(title.length).toBeLessThan(100);
+      expect(title.length).toBeLessThanOrEqual(91);
       expect(title).toContain(s.name);
     });
   });

--- a/frontend/__tests__/licitacoes/sector-pages.test.tsx
+++ b/frontend/__tests__/licitacoes/sector-pages.test.tsx
@@ -310,7 +310,7 @@ describe('JSON-LD schema (AC10)', () => {
 describe('Meta tags structure (AC9, AC11)', () => {
   it('title follows pattern for each sector', () => {
     SECTORS.forEach((s) => {
-      const title = `Licitações de ${s.name} — Oportunidades Abertas`;
+      const title = `Editais de ${s.name} 2026 — Para sua Empresa | SmartLic`;
       expect(title.length).toBeLessThan(100);
       expect(title).toContain(s.name);
     });
@@ -318,7 +318,7 @@ describe('Meta tags structure (AC9, AC11)', () => {
 
   it('description follows pattern for each sector', () => {
     SECTORS.forEach((s) => {
-      const desc = `Encontre licitações abertas de ${s.name}. Analise com IA e score de viabilidade. 14 dias grátis.`;
+      const desc = `Encontre editais abertos de ${s.name}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`;
       expect(desc.length).toBeLessThan(200);
     });
   });

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -85,7 +85,7 @@ export async function generateMetadata({
 
   return {
     title: `${empresa.razao_social} — Histórico de Contratos Públicos`,
-    description: `${empresa.razao_social} tem ${total_contratos_24m} contratos com o governo nos últimos 24 meses. Total: ${valorFormatado}. Score B2G: ${score}.`,
+    description: `Contratos públicos, licitações e editais do CNPJ ${cnpj} (${empresa.razao_social}). ${total_contratos_24m} contratos | ${valorFormatado} captados. Monitore via SmartLic.`,
     alternates: {
       canonical: `https://smartlic.tech/cnpj/${cnpj}`,
     },

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -57,14 +57,14 @@ export async function generateMetadata({
   return {
     robots: { index: true },
     title: `Editais de ${sector.name} 2026 — Para sua Empresa | SmartLic`,
-    description: `Encontre ${totalOpen > 0 ? totalOpen : ""} editais abertos de ${sector.name} em ${topUfs}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`,
+    description: `Encontre ${totalOpen > 0 ? `${totalOpen} ` : ""}editais abertos de ${sector.name} em ${topUfs}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`,
     alternates: {
       canonical: canonicalUrl,
     },
     // AC11: Open Graph
     openGraph: {
       title: `Editais de ${sector.name} 2026 — Para sua Empresa | SmartLic`,
-      description: `Encontre editais abertos de ${sector.name}. Analise com IA e score de viabilidade. Teste grátis 14 dias.`,
+      description: `Encontre editais abertos de ${sector.name}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`,
       url: canonicalUrl,
       type: "website",
       locale: "pt_BR",

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -56,15 +56,15 @@ export async function generateMetadata({
   // AC9: Meta tags
   return {
     robots: { index: true },
-    title: `Licitações de ${sector.name} — ${totalOpen > 0 ? `${totalOpen} Oportunidades Abertas` : "Oportunidades Abertas"}`,
-    description: `Encontre ${totalOpen > 0 ? totalOpen : ""} licitações abertas de ${sector.name} em ${topUfs}. Analise com IA e score de viabilidade. 14 dias grátis.`,
+    title: `Editais de ${sector.name} 2026 — Para sua Empresa | SmartLic`,
+    description: `Encontre ${totalOpen > 0 ? totalOpen : ""} editais abertos de ${sector.name} em ${topUfs}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`,
     alternates: {
       canonical: canonicalUrl,
     },
     // AC11: Open Graph
     openGraph: {
-      title: `Licitações de ${sector.name} — Oportunidades Abertas | SmartLic`,
-      description: `Encontre licitações abertas de ${sector.name}. Analise a viabilidade com IA. 14 dias grátis.`,
+      title: `Editais de ${sector.name} 2026 — Para sua Empresa | SmartLic`,
+      description: `Encontre editais abertos de ${sector.name}. Analise com IA e score de viabilidade. Teste grátis 14 dias.`,
       url: canonicalUrl,
       type: "website",
       locale: "pt_BR",

--- a/frontend/app/licitacoes/page.tsx
+++ b/frontend/app/licitacoes/page.tsx
@@ -7,16 +7,16 @@ import { SECTORS, fetchSectorStats, formatBRL } from "@/lib/sectors";
  */
 
 export const metadata: Metadata = {
-  title: "Licitações por Setor — Oportunidades Abertas",
+  title: "Licitações Públicas 2026 — Editais Abertos por Setor | SmartLic",
   description:
-    "Encontre licitações abertas em 15 setores: TI, Saúde, Engenharia, Alimentos e mais. Dados reais do PNCP atualizados diariamente.",
+    "Encontre licitações públicas abertas em 2026: TI, Saúde, Engenharia, Alimentos e mais. Análise com IA e score de viabilidade. Teste grátis 14 dias.",
   alternates: {
     canonical: "https://smartlic.tech/licitacoes",
   },
   openGraph: {
-    title: "Licitações por Setor — Oportunidades Abertas | SmartLic",
+    title: "Licitações Públicas 2026 — Editais por Setor | SmartLic",
     description:
-      "Encontre licitações abertas em 15 setores. Dados reais do PNCP atualizados diariamente. 14 dias grátis.",
+      "Encontre licitações públicas abertas em 2026. Análise com IA, score de viabilidade. 14 dias grátis.",
     url: "https://smartlic.tech/licitacoes",
     type: "website",
     locale: "pt_BR",


### PR DESCRIPTION
## Context

GSC mostra 460/497 queries com impressões mas **zero cliques** (CTR 1.49% vs benchmark B2B 5-8%). Páginas em pos 3-5 com snippets genéricos não comunicam value prop.

Issue #651 — sprint ativo On-Page CTA & Copy (60% → 70% após este PR).

## Changes

- **`/licitacoes/page.tsx`**: title `Licitações Públicas 2026 — Editais Abertos por Setor | SmartLic` — captura query "licitações públicas para o ano de 2026" (94 impressões, pos 4.69, CTR 0)
- **`/licitacoes/[setor]/page.tsx`**: title benefit-first `Editais de [setor] 2026 — Para sua Empresa | SmartLic` (todos ≤91 chars); description inclui "Teste grátis 14 dias"
- **`/cnpj/[cnpj]/page.tsx`**: description inclui CNPJ explícito + value prop "Monitore via SmartLic" para visitantes B2B em lookup de CNPJ
- **`__tests__/licitacoes/sector-pages.test.tsx`**: padrão de título atualizado para novo formato benefit-first

## Testing Plan

- [x] 36 testes `sector-pages.test.tsx` passando (0 failures)
- [x] 160 testes `mkt-003-licitacoes.test.tsx` passando (0 failures)
- [x] Todos os títulos de setores verificados ≤ 91 chars (abaixo do limite de 100 do teste)
- [ ] Medir CTR antes/depois via GSC (janela 14 dias — AC4 — monitoramento manual)

## Risks & Rollback

Risco baixo: mudanças puras de copy em metadata. Nenhuma lógica de negócio afetada. Rollback: `git revert 7b7f25d61`.

## Closes

Closes #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for sector page meta tag structure

* **Refactor**
  * Updated page titles and descriptions for improved SEO alignment across sector, CNPJ, and main licensing pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->