### PR TITLE
feat(intel): migration + RPC cnpj_supplier_intel for Raio-X (#628)

### DIFF
--- a/supabase/migrations/20260505113800_intel_reports_schema.down.sql
+++ b/supabase/migrations/20260505113800_intel_reports_schema.down.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- DOWN: intel_reports_schema — reverses 20260505113800_intel_reports_schema.sql
+-- Date: 2026-05-05
+-- Issue: #628
+-- Author: @data-engineer
+-- ============================================================================
+-- Context:
+--   Reverse criação de `intel_report_purchases` (tabela + RLS + índices).
+--   IMPORTANTE: aplicar este down também desfaz qualquer compra registrada —
+--   só rodar em recovery após confirmar que não há linhas, ou após backup.
+--
+--   Este down NÃO toca em `cnpj_supplier_intel` / `count_cnpj_contracts`
+--   (RPCs vivem em migration separada com seu próprio .down.sql).
+-- ============================================================================
+
+-- DROP em ordem oposta da up; CASCADE remove policies + índices automaticamente.
+-- IF EXISTS garante idempotência.
+
+DROP POLICY IF EXISTS "irp_owner_select"   ON public.intel_report_purchases;
+DROP POLICY IF EXISTS "irp_service_insert" ON public.intel_report_purchases;
+DROP POLICY IF EXISTS "irp_service_update" ON public.intel_report_purchases;
+DROP POLICY IF EXISTS "irp_service_select" ON public.intel_report_purchases;
+
+DROP INDEX IF EXISTS public.idx_irp_user_id;
+DROP INDEX IF EXISTS public.idx_irp_stripe_pi;
+DROP INDEX IF EXISTS public.idx_irp_status;
+
+DROP TABLE IF EXISTS public.intel_report_purchases CASCADE;

--- a/supabase/migrations/20260505113800_intel_reports_schema.sql
+++ b/supabase/migrations/20260505113800_intel_reports_schema.sql
@@ -1,0 +1,103 @@
+-- ============================================================================
+-- UP: intel_reports_schema — INTEL-REPORT-001 "Raio-X do Concorrente"
+-- Date: 2026-05-05
+-- Issue: #628
+-- Author: @data-engineer
+-- ============================================================================
+-- Context:
+--   Primeiro produto one-time purchase da plataforma (R$197). Esta migration
+--   cria a tabela `intel_report_purchases` que rastreia o ciclo de vida de
+--   compras de relatórios PDF: pending → generating → ready (ou failed/refunded).
+--   PDFs expiram após 30 dias (signed URL).
+--
+--   RPCs `cnpj_supplier_intel` e `count_cnpj_contracts` são adicionadas em
+--   migration separada (20260505113900_cnpj_supplier_intel_rpc.sql) para
+--   permitir rollback granular do schema vs lógica de agregação.
+-- ============================================================================
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Tabela: intel_report_purchases
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.intel_report_purchases (
+    id                          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                     UUID         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    product_type                TEXT         NOT NULL,
+    entity_key                  TEXT         NOT NULL,                       -- e.g. CNPJ for raio-x
+    stripe_payment_intent_id    TEXT         UNIQUE,                          -- Stripe pi_xxx
+    status                      TEXT         NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending','generating','ready','failed','refunded')),
+    pdf_url                     TEXT,                                         -- signed URL (Supabase Storage)
+    created_at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    expires_at                  TIMESTAMPTZ  NOT NULL DEFAULT (NOW() + INTERVAL '30 days')
+);
+
+COMMENT ON TABLE  public.intel_report_purchases IS
+    'INTEL-REPORT-001 — One-time PDF report purchases (R$197 raio-x do concorrente). 30d signed URL expiry.';
+COMMENT ON COLUMN public.intel_report_purchases.product_type IS
+    'Tipo de relatório (ex.: cnpj_raio_x). Permite expansão futura sem schema change.';
+COMMENT ON COLUMN public.intel_report_purchases.entity_key IS
+    'Chave da entidade analisada — para cnpj_raio_x é o CNPJ (digits-only).';
+COMMENT ON COLUMN public.intel_report_purchases.stripe_payment_intent_id IS
+    'Idempotency key contra Stripe webhook. UNIQUE evita double-fulfillment.';
+COMMENT ON COLUMN public.intel_report_purchases.status IS
+    'Lifecycle: pending → generating → ready | failed | refunded.';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Índices
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- Lookup principal: relatórios de um usuário (página "Meus Relatórios")
+CREATE INDEX IF NOT EXISTS idx_irp_user_id
+    ON public.intel_report_purchases (user_id, created_at DESC);
+
+-- Webhook Stripe lookup por payment_intent (já é UNIQUE, mas índice explícito
+-- para clareza e plan stability)
+CREATE INDEX IF NOT EXISTS idx_irp_stripe_pi
+    ON public.intel_report_purchases (stripe_payment_intent_id);
+
+-- Worker que polla relatórios em estado 'generating' (job de PDF generation)
+CREATE INDEX IF NOT EXISTS idx_irp_status
+    ON public.intel_report_purchases (status, created_at DESC);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- RLS: SELECT restrito a auth.uid() = user_id; writes apenas via service_role.
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.intel_report_purchases ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "irp_owner_select"     ON public.intel_report_purchases;
+DROP POLICY IF EXISTS "irp_service_insert"   ON public.intel_report_purchases;
+DROP POLICY IF EXISTS "irp_service_update"   ON public.intel_report_purchases;
+DROP POLICY IF EXISTS "irp_service_select"   ON public.intel_report_purchases;
+
+-- Authenticated users see only their own purchases
+CREATE POLICY "irp_owner_select" ON public.intel_report_purchases
+    FOR SELECT
+    TO authenticated
+    USING (auth.uid() = user_id);
+
+-- service_role precisa SELECT/INSERT/UPDATE para webhook + worker
+CREATE POLICY "irp_service_select" ON public.intel_report_purchases
+    FOR SELECT
+    TO service_role
+    USING (true);
+
+CREATE POLICY "irp_service_insert" ON public.intel_report_purchases
+    FOR INSERT
+    TO service_role
+    WITH CHECK (true);
+
+CREATE POLICY "irp_service_update" ON public.intel_report_purchases
+    FOR UPDATE
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- Note: anon e authenticated NÃO recebem INSERT/UPDATE — apenas service_role.
+-- DELETE não é exposto a ninguém (relatórios são histórico financeiro,
+-- preservados; refunded é status, não delete).
+
+COMMIT;

--- a/supabase/migrations/20260505113900_cnpj_supplier_intel_rpc.down.sql
+++ b/supabase/migrations/20260505113900_cnpj_supplier_intel_rpc.down.sql
@@ -1,0 +1,16 @@
+-- ============================================================================
+-- DOWN: cnpj_supplier_intel_rpc — reverses 20260505113900_cnpj_supplier_intel_rpc.sql
+-- Date: 2026-05-05
+-- Issue: #628
+-- Author: @data-engineer
+-- ============================================================================
+-- Context:
+--   DROP RPCs `cnpj_supplier_intel(text, integer)` e `count_cnpj_contracts(text)`.
+--   Operação puramente DDL (sem dados); idempotente via IF EXISTS.
+--
+--   IMPORTANTE: este down NÃO toca em `intel_report_purchases` — a tabela
+--   reverte via 20260505113800_intel_reports_schema.down.sql (rollback granular).
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.cnpj_supplier_intel(TEXT, INTEGER);
+DROP FUNCTION IF EXISTS public.count_cnpj_contracts(TEXT);

--- a/supabase/migrations/20260505113900_cnpj_supplier_intel_rpc.sql
+++ b/supabase/migrations/20260505113900_cnpj_supplier_intel_rpc.sql
@@ -1,0 +1,306 @@
+-- ============================================================================
+-- UP: cnpj_supplier_intel_rpc — RPCs de agregação para Raio-X do Concorrente
+-- Date: 2026-05-05
+-- Issue: #628
+-- Author: @data-engineer
+-- ============================================================================
+-- Context:
+--   Pipeline INTEL-REPORT-001 (R$197): DataLake → RPC → LLM → PDF → Stripe → email.
+--   Esta migration entrega o passo 2 (RPC). Todas as agregações operam sobre
+--   `pncp_supplier_contracts` (~2M+ rows; index `idx_psc_ni_fornecedor` existente).
+--
+--   Duas RPCs:
+--     1. `count_cnpj_contracts(p_cnpj)` — pre-check rápido para gate de checkout
+--        (bloquear compra se < 5 contratos, evitar refund por falta de dados).
+--     2. `cnpj_supplier_intel(p_cnpj, p_window_months default 36)` — payload
+--        completo (JSONB) consumido pelo backend para gerar PDF via ReportLab.
+--
+--   SECURITY DEFINER + `SET search_path = public, pg_temp` é mandatory por
+--   memory `feedback_secdef_search_path_trap` (SEC-SECDEF-001/002 audit).
+--   GRANT só a service_role — payload sensível (analytics agregadas) só é
+--   liberado pós-pagamento confirmado pelo backend.
+-- ============================================================================
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- RPC 1: count_cnpj_contracts(p_cnpj text) RETURNS INT
+-- Pre-check usado no checkout. Lightweight: COUNT com index idx_psc_ni_fornecedor.
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.count_cnpj_contracts(p_cnpj TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_count INTEGER;
+    v_clean TEXT;
+BEGIN
+    -- Normalize: digits only, defensive
+    v_clean := regexp_replace(COALESCE(p_cnpj, ''), '[^0-9]', '', 'g');
+    IF length(v_clean) <> 14 THEN
+        RETURN 0;
+    END IF;
+
+    -- Cap statement timeout dentro da função (consistente com service_role
+    -- statement_timeout=15s setado em outra migration; defesa em profundidade).
+    SET LOCAL statement_timeout = '15s';
+
+    SELECT COUNT(*)::INTEGER
+      INTO v_count
+      FROM public.pncp_supplier_contracts
+     WHERE ni_fornecedor = v_clean
+       AND is_active = TRUE;
+
+    RETURN COALESCE(v_count, 0);
+END;
+$$;
+
+COMMENT ON FUNCTION public.count_cnpj_contracts(TEXT) IS
+    'INTEL-REPORT-001 — Pre-check de quantidade de contratos para CNPJ. Backend bloqueia checkout se < 5.';
+
+REVOKE ALL ON FUNCTION public.count_cnpj_contracts(TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.count_cnpj_contracts(TEXT) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.count_cnpj_contracts(TEXT) TO service_role;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- RPC 2: cnpj_supplier_intel(p_cnpj text, p_window_months int DEFAULT 36)
+-- Retorna JSONB com agregações completas. Janela padrão 36 meses.
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.cnpj_supplier_intel(
+    p_cnpj           TEXT,
+    p_window_months  INTEGER DEFAULT 36
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_clean         TEXT;
+    v_window_start  DATE;
+    v_result        JSONB;
+
+    v_total_count       BIGINT;
+    v_total_value       NUMERIC;
+    v_avg_ticket        NUMERIC;
+    v_data_primeiro     DATE;
+    v_data_ultimo       DATE;
+
+    v_top_orgaos        JSONB;
+    v_top_objetos       JSONB;
+    v_distribuicao_uf   JSONB;
+    v_distribuicao_esfera JSONB;
+    v_serie_temporal    JSONB;
+    v_raw_contracts     JSONB;
+BEGIN
+    -- Defesa em profundidade: timeout local de 15s.
+    -- Casa com service_role statement_timeout=15s + Railway 120s proxy.
+    SET LOCAL statement_timeout = '15s';
+
+    -- Validate inputs
+    v_clean := regexp_replace(COALESCE(p_cnpj, ''), '[^0-9]', '', 'g');
+    IF length(v_clean) <> 14 THEN
+        RAISE EXCEPTION 'invalid cnpj: must be 14 digits after normalization';
+    END IF;
+
+    IF p_window_months IS NULL OR p_window_months < 1 OR p_window_months > 240 THEN
+        RAISE EXCEPTION 'invalid window: p_window_months must be between 1 and 240';
+    END IF;
+
+    v_window_start := (CURRENT_DATE - (p_window_months || ' months')::INTERVAL)::DATE;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Headline metrics (single pass)
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT
+        COUNT(*)::BIGINT,
+        COALESCE(SUM(valor_global), 0)::NUMERIC,
+        COALESCE(AVG(valor_global), 0)::NUMERIC,
+        MIN(data_assinatura),
+        MAX(data_assinatura)
+      INTO
+        v_total_count,
+        v_total_value,
+        v_avg_ticket,
+        v_data_primeiro,
+        v_data_ultimo
+      FROM public.pncp_supplier_contracts
+     WHERE ni_fornecedor = v_clean
+       AND is_active = TRUE
+       AND data_assinatura >= v_window_start;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Top 10 órgãos compradores (por valor, com count + valor_total)
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT COALESCE(
+             jsonb_agg(entry ORDER BY (entry->>'valor_total')::NUMERIC DESC, (entry->>'count')::BIGINT DESC),
+             '[]'::JSONB
+           )
+      INTO v_top_orgaos
+      FROM (
+        SELECT jsonb_build_object(
+                   'orgao_cnpj',  orgao_cnpj,
+                   'orgao_nome',  orgao_nome,
+                   'count',       count,
+                   'valor_total', valor_total
+               ) AS entry
+          FROM (
+            SELECT orgao_cnpj,
+                   MAX(orgao_nome)             AS orgao_nome,
+                   COUNT(*)::BIGINT            AS count,
+                   COALESCE(SUM(valor_global), 0)::NUMERIC AS valor_total
+              FROM public.pncp_supplier_contracts
+             WHERE ni_fornecedor = v_clean
+               AND is_active = TRUE
+               AND data_assinatura >= v_window_start
+               AND orgao_cnpj IS NOT NULL
+             GROUP BY orgao_cnpj
+             ORDER BY valor_total DESC, count DESC
+             LIMIT 10
+          ) t
+      ) sub;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Top 10 objetos (agrupados pelos primeiros 80 chars do objeto_contrato,
+    -- por frequência)
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT COALESCE(
+             jsonb_agg(entry ORDER BY (entry->>'count')::BIGINT DESC, (entry->>'valor_total')::NUMERIC DESC),
+             '[]'::JSONB
+           )
+      INTO v_top_objetos
+      FROM (
+        SELECT jsonb_build_object(
+                   'objeto_resumo', objeto_resumo,
+                   'count',         count,
+                   'valor_total',   valor_total
+               ) AS entry
+          FROM (
+            SELECT LEFT(COALESCE(NULLIF(TRIM(objeto_contrato), ''), '(sem objeto)'), 80) AS objeto_resumo,
+                   COUNT(*)::BIGINT                AS count,
+                   COALESCE(SUM(valor_global), 0)::NUMERIC AS valor_total
+              FROM public.pncp_supplier_contracts
+             WHERE ni_fornecedor = v_clean
+               AND is_active = TRUE
+               AND data_assinatura >= v_window_start
+             GROUP BY LEFT(COALESCE(NULLIF(TRIM(objeto_contrato), ''), '(sem objeto)'), 80)
+             ORDER BY count DESC, valor_total DESC
+             LIMIT 10
+          ) t
+      ) sub;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Distribuição por UF
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT COALESCE(jsonb_agg(entry ORDER BY (entry->>'valor_total')::NUMERIC DESC), '[]'::JSONB)
+      INTO v_distribuicao_uf
+      FROM (
+        SELECT jsonb_build_object(
+                   'uf',          COALESCE(uf, '??'),
+                   'count',       COUNT(*)::BIGINT,
+                   'valor_total', COALESCE(SUM(valor_global), 0)::NUMERIC
+               ) AS entry
+          FROM public.pncp_supplier_contracts
+         WHERE ni_fornecedor = v_clean
+           AND is_active = TRUE
+           AND data_assinatura >= v_window_start
+         GROUP BY COALESCE(uf, '??')
+      ) t;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Distribuição por esfera (F/E/M/D)
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT COALESCE(jsonb_object_agg(esfera_label, payload), '{}'::JSONB)
+      INTO v_distribuicao_esfera
+      FROM (
+        SELECT COALESCE(esfera, '?')               AS esfera_label,
+               jsonb_build_object(
+                   'count',       COUNT(*)::BIGINT,
+                   'valor_total', COALESCE(SUM(valor_global), 0)::NUMERIC
+               )                                    AS payload
+          FROM public.pncp_supplier_contracts
+         WHERE ni_fornecedor = v_clean
+           AND is_active = TRUE
+           AND data_assinatura >= v_window_start
+         GROUP BY COALESCE(esfera, '?')
+      ) t;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Série temporal (por mês, dentro da janela)
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT COALESCE(jsonb_agg(entry ORDER BY entry->>'mes'), '[]'::JSONB)
+      INTO v_serie_temporal
+      FROM (
+        SELECT jsonb_build_object(
+                   'mes',         to_char(date_trunc('month', data_assinatura), 'YYYY-MM'),
+                   'count',       COUNT(*)::BIGINT,
+                   'valor_total', COALESCE(SUM(valor_global), 0)::NUMERIC
+               ) AS entry
+          FROM public.pncp_supplier_contracts
+         WHERE ni_fornecedor = v_clean
+           AND is_active = TRUE
+           AND data_assinatura >= v_window_start
+           AND data_assinatura IS NOT NULL
+         GROUP BY date_trunc('month', data_assinatura)
+      ) t;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Últimos 50 contratos (raw para narrativa do PDF)
+    -- ──────────────────────────────────────────────────────────────────────
+    SELECT COALESCE(jsonb_agg(entry ORDER BY entry->>'data_assinatura' DESC NULLS LAST), '[]'::JSONB)
+      INTO v_raw_contracts
+      FROM (
+        SELECT jsonb_build_object(
+                   'numero_controle_pncp', numero_controle_pncp,
+                   'orgao_nome',           orgao_nome,
+                   'uf',                   uf,
+                   'municipio',            municipio,
+                   'valor_global',         valor_global,
+                   'data_assinatura',      data_assinatura,
+                   'objeto_contrato',      objeto_contrato
+               ) AS entry
+          FROM public.pncp_supplier_contracts
+         WHERE ni_fornecedor = v_clean
+           AND is_active = TRUE
+           AND data_assinatura >= v_window_start
+         ORDER BY data_assinatura DESC NULLS LAST
+         LIMIT 50
+      ) t;
+
+    -- ──────────────────────────────────────────────────────────────────────
+    -- Assemble final payload
+    -- ──────────────────────────────────────────────────────────────────────
+    v_result := jsonb_build_object(
+        'cnpj',                   v_clean,
+        'window_months',          p_window_months,
+        'window_start',           v_window_start,
+        'total_contracts',        v_total_count,
+        'total_value',            v_total_value,
+        'avg_ticket',             v_avg_ticket,
+        'data_primeiro_contrato', v_data_primeiro,
+        'data_ultimo_contrato',   v_data_ultimo,
+        'top_orgaos',             v_top_orgaos,
+        'top_objetos',            v_top_objetos,
+        'distribuicao_uf',        v_distribuicao_uf,
+        'distribuicao_esfera',    v_distribuicao_esfera,
+        'serie_temporal',         v_serie_temporal,
+        'raw_contracts',          v_raw_contracts,
+        'generated_at',           NOW()
+    );
+
+    RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.cnpj_supplier_intel(TEXT, INTEGER) IS
+    'INTEL-REPORT-001 — Agregações sobre pncp_supplier_contracts para gerar PDF Raio-X do Concorrente. SECURITY DEFINER, service_role only.';
+
+REVOKE ALL ON FUNCTION public.cnpj_supplier_intel(TEXT, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.cnpj_supplier_intel(TEXT, INTEGER) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.cnpj_supplier_intel(TEXT, INTEGER) TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## Context

Camada de dados (passo 1 do pipeline) do produto **INTEL-REPORT-001 "Raio-X do Concorrente"** — primeiro one-time purchase da plataforma (R$197). Pipeline completo: DataLake -> RPC -> LLM -> PDF -> Stripe -> email. PDF de 8-12 páginas analisando histórico completo de um CNPJ fornecedor em contratos públicos.

Source table de agregação: `pncp_supplier_contracts` (~2M+ rows; index `idx_psc_ni_fornecedor` já existente em `20260409100000_pncp_supplier_contracts.sql`).

## Changes

**Schema (`20260505113800_intel_reports_schema.sql` + `.down.sql`)**
- Tabela `public.intel_report_purchases`:
  - PK `id uuid DEFAULT gen_random_uuid()`
  - FK `user_id` -> `auth.users(id) ON DELETE CASCADE`
  - `product_type`, `entity_key` (CNPJ para raio-x)
  - `stripe_payment_intent_id` UNIQUE (idempotência webhook)
  - `status` CHECK IN (`pending`, `generating`, `ready`, `failed`, `refunded`) DEFAULT `pending`
  - `pdf_url`, `created_at`, `expires_at = now() + 30 days`
- Indexes: `idx_irp_user_id (user_id, created_at DESC)`, `idx_irp_stripe_pi`, `idx_irp_status (status, created_at DESC)`
- RLS habilitado: `irp_owner_select` (authenticated, `auth.uid() = user_id`), `irp_service_select|insert|update` (service_role only). Anon e authenticated não recebem write.

**RPCs (`20260505113900_cnpj_supplier_intel_rpc.sql` + `.down.sql`)**
- `count_cnpj_contracts(p_cnpj text) RETURNS integer` — pre-check rápido para gate de checkout (bloquear compra se < 5 contratos).
- `cnpj_supplier_intel(p_cnpj text, p_window_months integer DEFAULT 36) RETURNS jsonb` — agregações sobre `pncp_supplier_contracts` (filtrado por `ni_fornecedor` + janela + `is_active`):
  - `total_contracts`, `total_value`, `avg_ticket`
  - `data_primeiro_contrato`, `data_ultimo_contrato`
  - `top_orgaos` (top 10 órgãos compradores por valor, com count + valor_total)
  - `top_objetos` (top 10 por frequência, agrupados por primeiros 80 chars de `objeto_contrato`)
  - `distribuicao_uf` (count + valor por UF)
  - `distribuicao_esfera` (F/E/M/D breakdown)
  - `serie_temporal` (count + valor por mês, dentro da janela)
  - `raw_contracts` (últimos 50 com `numero_controle_pncp`, `orgao_nome`, `uf`, `municipio`, `valor_global`, `data_assinatura`, `objeto_contrato`)
- Ambas as RPCs:
  - `SECURITY DEFINER` + `SET search_path = public, pg_temp` (mandatory por SEC-SECDEF-001/002 audit; memory `feedback_secdef_search_path_trap`).
  - `SET LOCAL statement_timeout = '15s'` no início do corpo (consistente com service_role policy e waterfall Railway 120s).
  - `REVOKE ALL FROM anon, authenticated`; `GRANT EXECUTE TO service_role` only — payload de inteligência só liberado pós-pagamento confirmado pelo backend.
- Validação de input: CNPJ normalizado para 14 dígitos; janela 1..240 meses; raise on invalid.

**Coluna mapping** (verificada em `20260409100000_pncp_supplier_contracts.sql`):
- `ni_fornecedor` (NOT `cnpj_fornecedor`) para filtro do supplier.
- `uf` (NOT `unidade_uf`).
- Demais columns conforme issue: `valor_global`, `data_assinatura`, `objeto_contrato`, `orgao_cnpj`, `orgao_nome`, `municipio`, `esfera`, `is_active`, `numero_controle_pncp`.

## Testing Plan

- [ ] CI `migration-gate.yml` — paired `.down.sql` presente para ambos os ups (STORY-6.2).
- [ ] CI `migration-check.yml` — não introduz drift relativo a outras migrations pendentes.
- [ ] Após merge: `supabase db push --include-all` aplica via deploy.yml. Sentry alerta se falhar (degraded deploy).
- [ ] Smoke pós-deploy:
  - `select count(*) from public.intel_report_purchases;` retorna 0 (nova tabela).
  - `select * from public.cnpj_supplier_intel('00000000000000', 36);` retorna shape esperado com zeros / arrays vazios (CNPJ inexistente).
  - `select public.count_cnpj_contracts('00000000000000');` retorna 0.
  - `select public.count_cnpj_contracts('00360305000104');` (CNPJ real do DataLake — Banco do Brasil) retorna count > 0.
- [ ] Validar p95 < 500ms localmente com 3 CNPJs de alto volume (issue AC) — bloqueado nesta PR (acesso prod limitado), executar como follow-up assim que branch promovida a staging.
- [ ] Próxima PR: backend route `POST /v1/intel-reports/checkout` + `POST /webhooks/stripe` handler para criar linha em `intel_report_purchases` e disparar geração assíncrona.

## Risks & Rollback

- **Risco baixo**: pure DDL — sem DML. Tabela nova; RPCs novas (não tocam em RPCs existentes).
- **SEC-SECDEF-001/002 compliance**: ambas as funções já entram com `SET search_path = public, pg_temp`. Auditoria pós-deploy via `tests/test_debt03_rpc_security_audit.py` deve passar (assert do migration de audit já força 0 SECDEF non-compliant).
- **Rollback granular**:
  - Reverter apenas RPCs (sem perder schema): aplicar `20260505113900_cnpj_supplier_intel_rpc.down.sql`.
  - Reverter schema completo (atenção: cascade derruba qualquer FK futura): aplicar `20260505113800_intel_reports_schema.down.sql` em ordem inversa.
- **Stripe idempotência**: `stripe_payment_intent_id UNIQUE` previne double-fulfillment se webhook entregar 2x.

## Closes #628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Intel PDF report purchase tracking system with integrated Stripe payment support, user-specific order management, multi-stage status tracking, and secure PDF delivery with configurable expiration
  * Added supplier intelligence analytics functions enabling comprehensive contract analysis with aggregated performance metrics, rankings by buying organization and contract type, geographic distribution breakdown, and monthly historical trends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->