### PR TITLE
fix(data): DATA-CNAE-002 CNAE mapping with non-fatal startup guard (#710)

### DIFF
--- a/backend/startup/lifespan.py
+++ b/backend/startup/lifespan.py
@@ -6,6 +6,7 @@ import os
 import signal
 import time
 from contextlib import asynccontextmanager
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -103,6 +104,71 @@ async def _mark_inflight_sessions_timed_out() -> None:
         logger.error("CRIT-002 AC15: Timeout marking in-flight sessions (5s limit)")
     except Exception as e:
         logger.error(f"CRIT-002 AC15: Failed to mark in-flight sessions: {e}")
+
+
+async def _warmup_cnae_mapping() -> None:
+    """DATA-CNAE-002: Merge ``public.cnae_setores`` rows over the hardcoded
+    CNAE→setor baseline.
+
+    Non-fatal startup guard: any failure (DB unreachable, table missing,
+    PostgREST cache stale, permission denied) logs a WARNING and returns.
+    Lifespan continues with the hardcoded baseline (Gap-8 status quo) —
+    NEVER aborts startup.
+
+    Pattern mirrors :func:`_check_cache_schema` and the Supabase probe
+    further down in this module: every external call wrapped in try/except,
+    bounded by ``asyncio.wait_for`` so a slow query can't wedge startup.
+
+    Why this is the fix for the PR #679 → PR #702 revert:
+      * No daemon thread / Redis pubsub listener (#702 suspect #1)
+      * No ARQ cron registration (#702 suspect #2)
+      * Bare ``except Exception`` swallows PostgREST 404 / cache lag
+        (#702 suspect #3)
+      * Merge (not replace) on the in-memory dict so a failed warmup
+        leaves the hardcoded baseline intact for ``map_cnae_to_setor``.
+    """
+    timeout_s = float(os.getenv("CNAE_WARMUP_TIMEOUT_S", "5.0"))
+    try:
+        from utils import cnae_mapping
+
+        async def _do_load() -> Optional[dict]:
+            return await asyncio.to_thread(cnae_mapping.load_cnae_from_db)
+
+        rows = await asyncio.wait_for(_do_load(), timeout=timeout_s)
+        if rows is None:
+            logger.warning(
+                "DATA-CNAE-002: CNAE warmup returned None (DB load failed) — "
+                "continuing with hardcoded baseline (%d entries)",
+                len(cnae_mapping.CNAE_TO_SETOR),
+            )
+            return
+        if not rows:
+            logger.info(
+                "DATA-CNAE-002: cnae_setores table empty — using hardcoded "
+                "baseline (%d entries)",
+                len(cnae_mapping.CNAE_TO_SETOR),
+            )
+            return
+        before = len(cnae_mapping.CNAE_TO_SETOR)
+        cnae_mapping.CNAE_TO_SETOR.update(rows)
+        after = len(cnae_mapping.CNAE_TO_SETOR)
+        logger.info(
+            "DATA-CNAE-002: CNAE mapping warmed up — %d DB rows merged "
+            "(%d → %d entries total)",
+            len(rows), before, after,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "DATA-CNAE-002: CNAE warmup timed out after %.1fs — "
+            "using hardcoded fallback (non-fatal)",
+            timeout_s,
+        )
+    except Exception as exc:
+        logger.warning(
+            "DATA-CNAE-002: CNAE warmup failed (%s: %s) — "
+            "using hardcoded fallback (non-fatal)",
+            type(exc).__name__, exc,
+        )
 
 
 _SATURATION_INTERVAL = 30
@@ -349,6 +415,11 @@ async def lifespan(app_instance: FastAPI):
         from redis_pool import is_redis_available
         _redis_status = "OK" if await is_redis_available() else "unavailable"
     logger.info("STARTUP GATE: Redis %s — setting ready=true", _redis_status)
+
+    # DATA-CNAE-002: Merge cnae_setores rows over hardcoded baseline.
+    # Non-fatal: any DB failure logs WARNING + falls back to hardcoded map.
+    # See _warmup_cnae_mapping for rationale (PR #679 → PR #702 revert).
+    await _warmup_cnae_mapping()
 
     _state.startup_time = time.monotonic()
 

--- a/backend/tests/test_lifespan_cnae.py
+++ b/backend/tests/test_lifespan_cnae.py
@@ -1,0 +1,210 @@
+"""DATA-CNAE-002 (#710) — non-fatal CNAE warmup guard tests.
+
+Pins the contract that the CNAE warmup never aborts startup:
+    * DB raises -> warmup logs warning, returns; CNAE_TO_SETOR unchanged.
+    * DB returns rows -> CNAE_TO_SETOR merges them (hardcoded keys preserved).
+    * DB returns empty -> CNAE_TO_SETOR unchanged, no error.
+    * DB times out -> warmup logs warning, returns; CNAE_TO_SETOR unchanged.
+
+Failure of any of these tests indicates a regression of the PR #679 →
+PR #702 revert: a CNAE-warmup error propagating out of `lifespan` would
+fail the Railway healthcheck and roll back the deploy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_warmup_cnae_db_raises_does_not_abort_startup(caplog):
+    """AC1/AC3: Supabase exception during warmup must NOT raise.
+
+    Mirrors the PR #702 revert reason: any failure in CNAE warmup must
+    log a WARNING and let lifespan continue with the hardcoded baseline.
+    """
+    from utils import cnae_mapping
+    from startup.lifespan import _warmup_cnae_mapping
+
+    baseline_keys = set(cnae_mapping.CNAE_TO_SETOR.keys())
+    baseline_engenharia = cnae_mapping.CNAE_TO_SETOR.get("4120")
+
+    mock_sb = MagicMock()
+    # Simulate PostgREST PGRST205 (table missing in cache) — must not raise.
+    mock_sb.table.return_value.select.return_value.execute.side_effect = \
+        RuntimeError("PGRST205: schema cache stale")
+
+    with (
+        patch("supabase_client.get_supabase", return_value=mock_sb),
+        caplog.at_level("WARNING"),
+    ):
+        # Must complete without raising
+        await _warmup_cnae_mapping()
+
+    # Hardcoded baseline must be untouched
+    assert set(cnae_mapping.CNAE_TO_SETOR.keys()) == baseline_keys
+    assert cnae_mapping.CNAE_TO_SETOR.get("4120") == baseline_engenharia
+
+    # A WARNING-level operator signal must have been emitted on the
+    # DATA-CNAE-002 channel — wording is intentionally loose so refactors
+    # don't break the contract (only the level + ticket prefix matter).
+    warning_messages = [
+        rec.message for rec in caplog.records if rec.levelname == "WARNING"
+    ]
+    assert any(
+        "DATA-CNAE-002" in msg for msg in warning_messages
+    ), f"Expected DATA-CNAE-002 WARNING, got: {warning_messages}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_warmup_cnae_db_rows_merge_over_baseline():
+    """AC1: Successful DB load merges rows into CNAE_TO_SETOR.
+
+    DB rows override hardcoded values for the same key; new keys are added;
+    untouched hardcoded keys remain. Critical that this is a MERGE (.update)
+    not a REPLACE (= rows) — losing the hardcoded baseline would regress
+    callers that depend on legacy CNAEs not yet seeded into the DB.
+    """
+    from utils import cnae_mapping
+    from startup.lifespan import _warmup_cnae_mapping
+
+    baseline_keys = set(cnae_mapping.CNAE_TO_SETOR.keys())
+    # Pick a hardcoded key the DB will override
+    overridden_key = "4120"
+    assert overridden_key in baseline_keys, "test fixture assumes 4120 is hardcoded"
+
+    new_rows = [
+        {"codigo_cnae": overridden_key, "setor": "engenharia_civil_test_override"},
+        {"codigo_cnae": "9999", "setor": "test_new_sector"},
+    ]
+    mock_response = MagicMock()
+    mock_response.data = new_rows
+
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.select.return_value.execute.return_value = mock_response
+
+    original_4120 = cnae_mapping.CNAE_TO_SETOR.get(overridden_key)
+    try:
+        with patch("supabase_client.get_supabase", return_value=mock_sb):
+            await _warmup_cnae_mapping()
+
+        # Override applied
+        assert cnae_mapping.CNAE_TO_SETOR[overridden_key] == "engenharia_civil_test_override"
+        # New key added
+        assert cnae_mapping.CNAE_TO_SETOR["9999"] == "test_new_sector"
+        # Untouched hardcoded keys preserved (sample one not in new_rows)
+        assert "4781" in cnae_mapping.CNAE_TO_SETOR
+        assert cnae_mapping.CNAE_TO_SETOR["4781"] == "vestuario"
+    finally:
+        # Restore baseline so subsequent tests in this file see hardcoded values
+        cnae_mapping.CNAE_TO_SETOR[overridden_key] = original_4120
+        cnae_mapping.CNAE_TO_SETOR.pop("9999", None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_warmup_cnae_empty_table_keeps_baseline(caplog):
+    """AC1: Empty DB result preserves hardcoded baseline (no warning, info-level)."""
+    from utils import cnae_mapping
+    from startup.lifespan import _warmup_cnae_mapping
+
+    baseline_size = len(cnae_mapping.CNAE_TO_SETOR)
+
+    mock_response = MagicMock()
+    mock_response.data = []
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.select.return_value.execute.return_value = mock_response
+
+    with (
+        patch("supabase_client.get_supabase", return_value=mock_sb),
+        caplog.at_level("INFO"),
+    ):
+        await _warmup_cnae_mapping()
+
+    assert len(cnae_mapping.CNAE_TO_SETOR) == baseline_size
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+async def test_warmup_cnae_timeout_does_not_abort_startup(caplog):
+    """AC1/AC3: A slow DB query times out without aborting startup.
+
+    Pins the asyncio.wait_for guard — if Supabase hangs, we surrender
+    after CNAE_WARMUP_TIMEOUT_S and continue with the hardcoded baseline.
+    """
+    from utils import cnae_mapping
+    from startup.lifespan import _warmup_cnae_mapping
+
+    baseline_size = len(cnae_mapping.CNAE_TO_SETOR)
+
+    def _slow_load():
+        # Block long enough to trip the wait_for timeout we set below.
+        import time as _t
+        _t.sleep(2)
+        return {}
+
+    with (
+        patch("utils.cnae_mapping.load_cnae_from_db", side_effect=_slow_load),
+        patch.dict("os.environ", {"CNAE_WARMUP_TIMEOUT_S": "0.1"}),
+        caplog.at_level("WARNING"),
+    ):
+        await _warmup_cnae_mapping()
+
+    assert len(cnae_mapping.CNAE_TO_SETOR) == baseline_size
+    assert any(
+        "DATA-CNAE-002" in rec.message
+        and ("timed out" in rec.message.lower() or "fallback" in rec.message.lower())
+        for rec in caplog.records
+    ), f"Expected DATA-CNAE-002 timeout warning, got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# AC3: /health/ready stays 200 when CNAE warmup fails
+# ---------------------------------------------------------------------------
+
+class TestHealthReadyAfterCnaeWarmupFailure:
+    """AC3: When the CNAE warmup raises, lifespan still completes and
+    /health/ready returns 200 once Redis + Supabase are up.
+
+    This pins the end-to-end contract from the issue: "the underlying
+    DB error must NOT crash the readiness check". Since warmup runs
+    inside lifespan startup (not on the request path), this is implicit
+    — but we exercise the route here to cover the regression that
+    triggered the PR #679 revert.
+    """
+
+    def test_ready_200_when_cnae_warmup_would_have_raised(self):
+        import time
+        from fastapi.testclient import TestClient
+
+        # Force any future warmup invocation to raise — proves that even
+        # if the guard regresses, the route layer is independent.
+        with (
+            patch("startup.state.startup_time", time.monotonic()),
+            patch(
+                "utils.cnae_mapping.load_cnae_from_db",
+                side_effect=RuntimeError("simulated DB outage"),
+            ),
+        ):
+            mock_redis = AsyncMock()
+            mock_redis.ping = AsyncMock(return_value=True)
+            mock_sb = MagicMock()
+            mock_sb.table.return_value.select.return_value.limit.return_value = MagicMock()
+            mock_resp = MagicMock()
+            mock_resp.data = [{"id": "x"}]
+            with (
+                patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis),
+                patch("supabase_client.sb_execute_direct", new_callable=AsyncMock, return_value=mock_resp),
+                patch("supabase_client.get_supabase", return_value=mock_sb),
+            ):
+                from main import app
+                client = TestClient(app, raise_server_exceptions=False)
+                response = client.get("/health/ready")
+                assert response.status_code == 200, response.json()
+                data = response.json()
+                assert data["ready"] is True

--- a/backend/utils/cnae_mapping.py
+++ b/backend/utils/cnae_mapping.py
@@ -3,11 +3,45 @@ CNAE to SmartLic sector mapping.
 
 Maps Brazilian CNAE (Classificação Nacional de Atividades Econômicas)
 codes to SmartLic sector IDs used by the search pipeline.
+
+Lookup architecture (DATA-CNAE-002 — re-implementation after PR #679 revert):
+    L1: ``CNAE_TO_SETOR`` — module-level dict, hardcoded baseline + DB merge.
+        Updated in-place by :func:`load_cnae_from_db` (called from
+        ``startup.lifespan``). Never replaced — DB rows merge over the
+        hardcoded baseline so unmapped keys still resolve via the legacy
+        snapshot even if the DB is unreachable.
+    L2: ``public.cnae_setores`` table (Supabase) — optional override.
+        If the table is empty, missing, or unreachable, lookups answer
+        from the hardcoded baseline (Gap-8 status quo).
+
+Why no listener / no ARQ cron / no TTL cache (DATA-CNAE-002 vs #679):
+    PR #679 was reverted (#702) because its lazily-spawned daemon thread
+    (Redis pubsub listener with its own event loop) blocked the Railway
+    healthcheck on cold start. This re-implementation deliberately omits:
+      * the Redis pubsub listener (PR #702 suspect cause #1)
+      * the ARQ cron registration `start_cnae_coverage_task` (suspect #2)
+      * the admin CRUD surface (would require PostgREST cache propagation
+        — suspect #3)
+    Instead, the warmup is a one-shot synchronous-style merge during
+    ``lifespan`` startup, wrapped in a non-fatal try/except guard.
 """
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 # CNAE→sector mappings
 # Format: CNAE 4-digit prefix → sector_id
+#
+# This dict is the source of truth for `map_cnae_to_setor`. It is populated
+# at import time with the hardcoded baseline (below) and may be MERGED with
+# rows from `public.cnae_setores` during startup via :func:`load_cnae_from_db`.
+# DB rows override the hardcoded baseline; missing keys fall through to the
+# baseline so the function never raises on cold start or DB outage.
 CNAE_TO_SETOR: dict[str, str] = {
     # Engenharia / Construção Civil
     "4120": "engenharia",    # Construção de edifícios
@@ -130,3 +164,50 @@ def map_cnae_to_setor(cnae: str) -> str:
 def get_setor_name(setor_id: str) -> str:
     """Get human-readable sector name."""
     return SETOR_NAMES.get(setor_id, setor_id.replace("_", " ").title())
+
+
+def load_cnae_from_db() -> Optional[dict[str, str]]:
+    """Load CNAE→setor overrides from ``public.cnae_setores``.
+
+    Called once at startup from ``startup.lifespan`` (DATA-CNAE-002).
+    Returns a fresh dict on success (possibly empty if the table exists
+    but has no rows) or ``None`` on any failure — caller is expected to
+    log a warning and proceed with the hardcoded baseline.
+
+    Failure modes that MUST NOT raise:
+      * Supabase unreachable (network / DNS)
+      * Table missing (PostgREST PGRST205 — schema cache stale)
+      * Permission denied (RLS misconfigured)
+      * Malformed rows
+    All collapse to ``None`` — a non-fatal signal to the caller.
+    """
+    try:
+        from supabase_client import get_supabase  # local import: keep tests fast
+    except Exception as exc:  # pragma: no cover — import-time failure
+        logger.debug("cnae_mapping: supabase_client import failed: %s", exc)
+        return None
+
+    try:
+        sb = get_supabase()
+        result = (
+            sb.table("cnae_setores")
+            .select("codigo_cnae,setor")
+            .execute()
+        )
+    except Exception as exc:
+        logger.debug(
+            "cnae_mapping: DB load failed (%s) — caller should fall back",
+            exc,
+        )
+        return None
+
+    rows = getattr(result, "data", None) or []
+    out: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        codigo = row.get("codigo_cnae")
+        setor = row.get("setor")
+        if isinstance(codigo, str) and isinstance(setor, str) and codigo and setor:
+            out[codigo] = setor
+    return out

--- a/supabase/migrations/20260505113807_cnae_setores_table.down.sql
+++ b/supabase/migrations/20260505113807_cnae_setores_table.down.sql
@@ -1,0 +1,5 @@
+-- Rollback for DATA-CNAE-002 (#710): drop the cnae_setores table.
+-- Safe at any time — the backend falls back to the hardcoded CNAE_TO_SETOR
+-- baseline when this table is missing.
+DROP POLICY IF EXISTS "cnae_setores_read_authenticated" ON public.cnae_setores;
+DROP TABLE IF EXISTS public.cnae_setores;

--- a/supabase/migrations/20260505113807_cnae_setores_table.sql
+++ b/supabase/migrations/20260505113807_cnae_setores_table.sql
@@ -1,0 +1,46 @@
+-- DATA-CNAE-002 (#710) — CNAE→setor mapping table
+--
+-- Re-implementation of DATA-CNAE-001 (#679) after revert via #702.
+-- The original PR's daemon-thread Redis pubsub listener wedged the
+-- Railway healthcheck on cold start. This migration creates ONLY the
+-- minimal table; warmup happens in `startup/lifespan._warmup_cnae_mapping`
+-- with a non-fatal try/except guard. If the table is empty, missing,
+-- or unreachable, lookups still answer from the hardcoded baseline in
+-- `backend/utils/cnae_mapping.py::CNAE_TO_SETOR`.
+--
+-- Schema kept deliberately small — no audit log, no RLS-managed admin
+-- CRUD, no Redis invalidation channel. Future stories can extend safely
+-- once startup is proven stable.
+
+CREATE TABLE IF NOT EXISTS public.cnae_setores (
+    codigo_cnae text PRIMARY KEY,
+    setor       text NOT NULL,
+    descricao   text,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.cnae_setores IS
+    'DATA-CNAE-002 (#710): CNAE→setor mapping override. Hardcoded baseline '
+    'in backend/utils/cnae_mapping.py is merged with rows from this table '
+    'at startup; if this table is empty/missing/unreachable, the baseline '
+    'answers all lookups (Gap-8 status quo).';
+COMMENT ON COLUMN public.cnae_setores.codigo_cnae IS
+    '4-digit IBGE CNAE prefix (e.g. "4781"). Matches the prefix extraction '
+    'in utils/cnae_mapping.py::map_cnae_to_setor.';
+COMMENT ON COLUMN public.cnae_setores.setor IS
+    'SmartLic sector id (e.g. "engenharia"). Must match an id in '
+    'backend/sectors_data.yaml or DEFAULT_FALLBACK_SETOR ("geral").';
+
+-- RLS: read-only for authenticated; writes via service_role only.
+ALTER TABLE public.cnae_setores ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "cnae_setores_read_authenticated" ON public.cnae_setores;
+CREATE POLICY "cnae_setores_read_authenticated"
+    ON public.cnae_setores
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+-- service_role bypasses RLS by default in Supabase; no explicit policy
+-- is required for INSERT/UPDATE/DELETE. The backend's startup warmup
+-- runs as service_role via supabase_client.get_supabase().


### PR DESCRIPTION
## Context

PR #679 (DATA-CNAE-001) was reverted via PR #702 because the backend crashed at the Railway healthcheck on cold start. This PR re-implements the minimal subset with a non-fatal startup guard.

### AC0 — Empirical root cause

**Source:** `gh pr view 702` + `git show 3687c9ba4` (the reverted #679 implementation).

PR #702 documented three suspect causes:
1. **`backend/utils/cnae_mapping.py:331` Redis pubsub listener daemon thread** — lazily spawned on first `map_cnae_to_setor()` call, ran a `loop.run_until_complete(_subscribe())` inside `threading.Thread(daemon=True)` with no failure boundary. Most likely culprit.
2. **`start_cnae_coverage_task` ARQ cron registration** — added to `backend/jobs/cron/scheduler.py` at import time.
3. **`/v1/admin/cnae-mapping` routes referenced PostgREST symbols** that hadn't propagated through the schema cache after the new migrations applied.

Railway logs are unavailable from this worktree; the git-based root cause is sufficient — the listener thread design is visible in `git show 3687c9ba4:backend/utils/cnae_mapping.py` (lines 331-403).

### Design decisions to avoid the original crash

| Design point | PR #679 (reverted) | PR #710 (this PR) |
|---|---|---|
| Cache invalidation | Redis pubsub daemon thread | None (merge-only at startup) |
| Background jobs | `cnae_coverage` ARQ cron | None |
| Admin CRUD | 8 routes + audit log | None |
| In-memory dict | Replaced with TTL cache | Hardcoded baseline merged in-place |
| Failure mode | Listener crash propagates | Bare `try/except Exception` in lifespan |
| Migrations | 3 (table + audit + seed) | 1 (table only, no seed) |

## Changes

* `supabase/migrations/20260505113807_cnae_setores_table.sql` (+ down):
  minimal `cnae_setores(codigo_cnae text PRIMARY KEY, setor text NOT NULL, descricao text, created_at timestamptz DEFAULT now())`. RLS enabled (read for authenticated, writes via service_role only). **No seed** — empty table is the expected initial state.
* `backend/utils/cnae_mapping.py`: keep `CNAE_TO_SETOR` as the module-level dict source of truth (callers in `routes/onboarding.py` and `routes/empresa_publica.py` continue to import it unchanged). Add `load_cnae_from_db()` returning rows or `None` on failure.
* `backend/startup/lifespan.py`: add `_warmup_cnae_mapping()` invoked once during startup after the Supabase probe. Wraps the load in `asyncio.wait_for(asyncio.to_thread(...), timeout=CNAE_WARMUP_TIMEOUT_S=5s)`. Any failure (timeout, exception, `None` result) logs `WARNING` and continues with the hardcoded baseline. On success, **merges** rows into `CNAE_TO_SETOR` — never replaces — so the baseline still answers for unmapped keys.
* `backend/tests/test_lifespan_cnae.py`: 5 tests pinning the contract.

## Testing Plan

- [x] `pytest backend/tests/test_lifespan_cnae.py` — 5 passed (DB raises / merges / empty / timeout / `/health/ready` stays 200 when warmup raises)
- [x] `pytest backend/tests/test_cnae_mapping.py tests/test_health_ready.py tests/test_health_canary.py` — 66 passed (no regression)
- [ ] CI gates: backend-tests, frontend-tests, audit-execute-without-budget, migration-gate (down.sql pairing)
- [ ] On staging/prod after deploy: confirm `STARTUP GATE: Redis ... — setting ready=true` is followed by either `DATA-CNAE-002: CNAE mapping warmed up — N DB rows merged` (table seeded) or `DATA-CNAE-002: cnae_setores table empty — using hardcoded baseline` (initial deploy, expected). NEVER abort startup.

## Risks & Rollback

| Risk | Mitigation |
|---|---|
| Slow Supabase wedges startup | `asyncio.wait_for(timeout=5s)` env-overridable via `CNAE_WARMUP_TIMEOUT_S` |
| `cnae_setores` table missing in some envs | Bare `except Exception` swallows PostgREST 404 + logs WARNING |
| RLS misconfigured | Same — bare except + warning |
| DB rows override hardcoded values incorrectly | Merge (`.update`) preserves hardcoded keys; revert by `DELETE FROM cnae_setores WHERE codigo_cnae = '...'` (no admin route — manual SQL) |
| Need to disable warmup entirely | Set `CNAE_WARMUP_TIMEOUT_S=0` (forces immediate timeout → fallback) |

**Rollback:** `git revert <merge>` + `supabase db push` will run the down.sql to drop the table. The hardcoded baseline keeps answering throughout.

## Closes

#710

🤖 Generated with [Claude Code](https://claude.com/claude-code)