### PR TITLE
feat(seo): inline trial CTA + Mixpanel em /cnpj e /orgaos (#652)

### DIFF
--- a/frontend/__tests__/InlineTrialCTA.test.tsx
+++ b/frontend/__tests__/InlineTrialCTA.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for InlineTrialCTA component (#652).
+ *
+ * Inline (NOT sticky) CTA that lives on programmatic SEO pages
+ * (/cnpj/[cnpj], /orgaos/[slug]) to capture trial signups.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InlineTrialCTA from '../app/components/InlineTrialCTA';
+
+describe('InlineTrialCTA', () => {
+  const originalMixpanel = (window as unknown as { mixpanel?: unknown }).mixpanel;
+
+  afterEach(() => {
+    (window as unknown as { mixpanel?: unknown }).mixpanel = originalMixpanel;
+  });
+
+  it('renders the literal copy from issue #652', () => {
+    render(<InlineTrialCTA page="cnpj" source="cnpj-page" />);
+    expect(
+      screen.getByText('Monitore contratos deste órgão — Teste grátis 14 dias'),
+    ).toBeInTheDocument();
+  });
+
+  it('builds /signup link with source=cnpj-page and orgao=<cnpj>', () => {
+    render(
+      <InlineTrialCTA
+        page="cnpj"
+        source="cnpj-page"
+        extraParam={{ name: 'orgao', value: '01914765000108' }}
+      />,
+    );
+    const link = screen.getByRole('link', { name: /Começar trial grátis/ });
+    expect(link).toHaveAttribute(
+      'href',
+      '/signup?source=cnpj-page&orgao=01914765000108',
+    );
+  });
+
+  it('builds /signup link with source=orgao-page and slug=<slug>', () => {
+    render(
+      <InlineTrialCTA
+        page="orgao"
+        source="orgao-page"
+        extraParam={{ name: 'slug', value: 'prefeitura-de-floripa' }}
+      />,
+    );
+    const link = screen.getByRole('link', { name: /Começar trial grátis/ });
+    expect(link).toHaveAttribute(
+      'href',
+      '/signup?source=orgao-page&slug=prefeitura-de-floripa',
+    );
+  });
+
+  it('omits extra param when not provided', () => {
+    render(<InlineTrialCTA page="cnpj" source="cnpj-page" />);
+    const link = screen.getByRole('link', { name: /Começar trial grátis/ });
+    expect(link).toHaveAttribute('href', '/signup?source=cnpj-page');
+  });
+
+  it('fires Mixpanel cta_click with page+position on click (cnpj)', () => {
+    const trackSpy = jest.fn();
+    (window as unknown as { mixpanel: { track: jest.Mock } }).mixpanel = {
+      track: trackSpy,
+    };
+
+    render(
+      <InlineTrialCTA
+        page="cnpj"
+        source="cnpj-page"
+        extraParam={{ name: 'orgao', value: '01914765000108' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: /Começar trial grátis/ }));
+
+    expect(trackSpy).toHaveBeenCalledWith('cta_click', {
+      page: 'cnpj',
+      position: 'inline',
+    });
+  });
+
+  it('fires Mixpanel cta_click with page+position on click (orgao)', () => {
+    const trackSpy = jest.fn();
+    (window as unknown as { mixpanel: { track: jest.Mock } }).mixpanel = {
+      track: trackSpy,
+    };
+
+    render(
+      <InlineTrialCTA
+        page="orgao"
+        source="orgao-page"
+        extraParam={{ name: 'slug', value: 'foo' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: /Começar trial grátis/ }));
+
+    expect(trackSpy).toHaveBeenCalledWith('cta_click', {
+      page: 'orgao',
+      position: 'inline',
+    });
+  });
+
+  it('does not throw when window.mixpanel is undefined', () => {
+    delete (window as unknown as { mixpanel?: unknown }).mixpanel;
+    render(<InlineTrialCTA page="cnpj" source="cnpj-page" />);
+    expect(() =>
+      fireEvent.click(screen.getByRole('link', { name: /Começar trial grátis/ })),
+    ).not.toThrow();
+  });
+});

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import CnpjPerfilClient from './CnpjPerfilClient';
+import InlineTrialCTA from '../../components/InlineTrialCTA';
 import { LeadCapture } from '@/components/LeadCapture';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
@@ -185,6 +186,13 @@ export default async function CnpjPerfilPage({
       />
 
       <CnpjPerfilClient perfil={perfil} />
+
+      {/* #652: Inline trial CTA after contratos section */}
+      <InlineTrialCTA
+        page="cnpj"
+        source="cnpj-page"
+        extraParam={{ name: 'orgao', value: cnpj }}
+      />
 
       {/* A2: Contextual lead capture with detected sector + UF */}
       <div className="mt-10">

--- a/frontend/app/components/InlineTrialCTA.tsx
+++ b/frontend/app/components/InlineTrialCTA.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+
+interface Props {
+  /** Mixpanel `page` property (e.g. 'cnpj', 'orgao') */
+  page: 'cnpj' | 'orgao';
+  /**
+   * Tracked source on the signup URL (e.g. 'cnpj-page', 'orgao-page').
+   * Becomes `?source=<source>` and is the primary attribution vector for /signup.
+   */
+  source: string;
+  /**
+   * Optional extra query param appended after `source`.
+   * For `/cnpj/[cnpj]` use `{ orgao: cnpj }`; for `/orgaos/[slug]` use `{ slug }`.
+   */
+  extraParam?: { name: string; value: string };
+}
+
+/**
+ * Inline trial CTA used on programmatic SEO pages (/cnpj/[cnpj], /orgaos/[slug])
+ * to convert high-intent CNPJ/órgão lookups into trial signups (#652).
+ *
+ * Complementary, NOT a paywall — content above remains fully accessible.
+ */
+export default function InlineTrialCTA({ page, source, extraParam }: Props) {
+  const params = new URLSearchParams({ source });
+  if (extraParam) {
+    params.set(extraParam.name, extraParam.value);
+  }
+  const href = `/signup?${params.toString()}`;
+
+  const handleClick = () => {
+    if (typeof window !== 'undefined' && window.mixpanel) {
+      window.mixpanel.track('cta_click', { page, position: 'inline' });
+    }
+  };
+
+  return (
+    <section
+      aria-label="Trial gratuito SmartLic"
+      className="my-10 rounded-xl border border-blue-200 bg-blue-50 p-6 text-center sm:p-8"
+    >
+      <h2 className="text-xl font-bold text-gray-900 sm:text-2xl">
+        Monitore contratos deste órgão — Teste grátis 14 dias
+      </h2>
+      <p className="mx-auto mt-2 max-w-xl text-sm text-gray-600 sm:text-base">
+        Receba alertas de novos editais, classificação por setor com IA e análise
+        de viabilidade. Sem cartão de crédito.
+      </p>
+      <Link
+        href={href}
+        onClick={handleClick}
+        className="mt-5 inline-block rounded-xl bg-green-600 px-8 py-3 text-center font-bold text-white shadow-lg transition-colors hover:bg-green-700 sm:w-auto"
+      >
+        Começar trial grátis →
+      </Link>
+    </section>
+  );
+}

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import OrgaoPerfilClient from './OrgaoPerfilClient';
+import InlineTrialCTA from '../../components/InlineTrialCTA';
 import { LeadCapture } from '@/components/LeadCapture';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
@@ -191,6 +192,13 @@ export default async function OrgaoPerfilPage({
       />
 
       <OrgaoPerfilClient stats={stats} />
+
+      {/* #652: Inline trial CTA after licitações list */}
+      <InlineTrialCTA
+        page="orgao"
+        source="orgao-page"
+        extraParam={{ name: 'slug', value: slug }}
+      />
 
       <div className="mt-10">
         <LeadCapture


### PR DESCRIPTION
## Context

70% do tráfego orgânico atual são lookups de CNPJ específico (ex: `/cnpj/01914765000108`). GSC mostra CTR 50–100% nas páginas `/orgaos/*` e `/cnpj/*` quando aparecem (alta intenção), mas zero conversão detectada — não há CTA in-page apontando para o trial. Visitante CNPJ-lookup é exatamente o ICP B2B do SmartLic e está perdendo o caminho para signup.

Precedente: PR #626 adicionou um **mobile sticky CTA** em 7 páginas pSEO. Esta PR complementa #626 com um **inline CTA card** desktop + mobile, posicionado depois do conteúdo principal (contratos/licitações) — onde o visitante já consumiu valor e está pronto para a próxima ação.

## Changes

- **`frontend/app/components/InlineTrialCTA.tsx`** (novo) — Client Component compartilhado com copy literal de #652: "Monitore contratos deste órgão — Teste grátis 14 dias". Recebe `page`, `source` e `extraParam` opcional.
- **`frontend/app/cnpj/[cnpj]/page.tsx`** — Renderiza `<InlineTrialCTA page="cnpj" source="cnpj-page" extraParam={{ name: 'orgao', value: cnpj }} />` depois de `<CnpjPerfilClient>` e antes do `<LeadCapture>`. Link: `/signup?source=cnpj-page&orgao=<cnpj>`.
- **`frontend/app/orgaos/[slug]/page.tsx`** — Mesmo padrão com `source="orgao-page"` + `slug`. Link: `/signup?source=orgao-page&slug=<slug>`.
- **`frontend/__tests__/InlineTrialCTA.test.tsx`** (novo) — 7 testes cobrindo copy verbatim, composição do link, payload Mixpanel (`cta_click`, `{ page, position: 'inline' }`) e guard para `window.mixpanel` ausente.

Acceptance Criteria (de #652):

- [x] Banner/card CTA em `/cnpj/[cnpj]` após seção de contratos
- [x] CTA inline em `/orgaos/[slug]` após lista de licitações
- [x] CTA linka para `/signup?source=cnpj-page&orgao=<cnpj>` (e equivalente para órgãos)
- [x] Mixpanel `track('cta_click', { page: 'cnpj' | 'orgao', position: 'inline' })`
- [x] Não bloqueia conteúdo — CTA é complementar

Decisões deliberadas:

- CTAs existentes em `CnpjPerfilClient.tsx` e `OrgaoPerfilClient.tsx` (com `?ref=cnpj`, `?ref=orgao`) **NÃO foram alteradas**. Eles disparam eventos diferentes (`cnpj_lookup`, `orgao_lookup`, `cta_inline_clicked`). A nova CTA usa `?source=...` + evento `cta_click` para attribution distinta.
- Mixpanel via `window.mixpanel.track(...)` — mesmo padrão usado em `StickyTrialCTA.tsx` e nas CTAs existentes nesses dois client components. O tipo `Window['mixpanel']` já está declarado em `frontend/types/external.d.ts`.
- Component compartilhado em `app/components/` (vs path sugerido `cnpj/[cnpj]/InlineTrialCTA.tsx`) porque é usado em duas rotas — task autoriza "(optional) shared helper".

## Testing Plan

- [x] `tsc --noEmit` passa sem erros
- [x] `jest --testPathPattern="InlineTrialCTA|cnpj-perfil|orgaos"` — 23/23 passando (7 novos + 16 existentes relacionados)
- [ ] Smoke manual pós-deploy: visitar `https://smartlic.tech/cnpj/01914765000108` e `https://smartlic.tech/orgaos/<slug>` — confirmar card visível abaixo da tabela; clicar e verificar query params em `/signup` e evento `cta_click` no Mixpanel

`npm run lint` (= `next lint`) não é executável no Next.js 16 (CLI removida); o repo também não roda lint em CI nem expõe `eslint` em `node_modules/.bin`. Type safety validada via `tsc --noEmit -p tsconfig.json` (exit 0).

## Risks & Rollback

- **Risco baixo.** Componente puramente aditivo, isolado em rotas pSEO públicas. Server Components (`page.tsx`) seguem renderizando como antes; o novo nó é um Client Component irmão de `CnpjPerfilClient`/`OrgaoPerfilClient`.
- **Sem backend, sem migrations, sem env vars.** Sem dependências novas.
- **Rollback:** revert da PR retorna o estado prévio sem efeito colateral. Não há feature flag necessária — o componente não toca conteúdo existente.
- **SSG/SEO:** ambas as páginas mantêm `revalidate = 86400` (24h ISR) e os JSON-LD existentes; copy do CTA é estática e renderizada no HTML, indexável.

## Closes

Closes #652