### PR TITLE
test(selenium): support MFA admin login

### DIFF
--- a/tests/selenium/README.md
+++ b/tests/selenium/README.md
@@ -1,0 +1,16 @@
+# Selenium tests
+
+## Authenticated tests
+
+Authenticated Selenium tests use `logged_in_driver` and require:
+
+- `ADMIN_PASSWORD`: password for `ADMIN_EMAIL`.
+- `ADMIN_TOTP_SECRET`: base32 TOTP seed from the authenticator app when the account has MFA enabled.
+
+Optional variables:
+
+- `ADMIN_EMAIL`: defaults to `tiago.sasaki@gmail.com`.
+- `BASE_URL`: defaults to `https://smartlic.tech`.
+- `HEADLESS`: defaults to `true`.
+
+`ADMIN_TOTP_SECRET` must be provided through the local environment or CI secrets. Never commit the secret value.

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -1,8 +1,13 @@
 import os
+import time
 import pytest
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
 
 from insight_collector import InsightCollector, get_collector
@@ -10,7 +15,24 @@ from insight_collector import InsightCollector, get_collector
 BASE_URL = os.getenv("BASE_URL", "https://smartlic.tech")
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "tiago.sasaki@gmail.com")
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "")
+ADMIN_TOTP_SECRET = os.getenv("ADMIN_TOTP_SECRET", "")
 HEADLESS = os.getenv("HEADLESS", "true").lower() == "true"
+
+MFA_SCREEN = (
+    By.XPATH,
+    "//*[contains(normalize-space(.), 'Verificação em dois fatores') "
+    "or contains(normalize-space(.), 'dois fatores')]",
+)
+MFA_CODE_INPUT = (
+    By.CSS_SELECTOR,
+    "input[autocomplete='one-time-code'], "
+    "input[inputmode='numeric'], "
+    "input[name*='code' i], "
+    "input[id*='code' i], "
+    "input[type='tel'], "
+    "input[type='text']",
+)
+MFA_SUBMIT_BUTTON = (By.CSS_SELECTOR, "button[type='submit']")
 
 
 @pytest.fixture(scope="session")
@@ -47,15 +69,69 @@ def driver():
     drv.quit()
 
 
+def _mfa_screen_visible(driver) -> bool:
+    return any(element.is_displayed() for element in driver.find_elements(*MFA_SCREEN))
+
+
+def _complete_mfa_if_required(driver, base_url: str, timeout: int = 30) -> bool:
+    login_url = f"{base_url}/login"
+    try:
+        WebDriverWait(driver, timeout).until(
+            lambda d: not d.current_url.startswith(login_url) or _mfa_screen_visible(d)
+        )
+    except TimeoutException:
+        if not _mfa_screen_visible(driver):
+            raise
+
+    if not _mfa_screen_visible(driver):
+        return False
+
+    if not ADMIN_TOTP_SECRET:
+        pytest.skip(
+            "ADMIN_TOTP_SECRET não configurado — obrigatório para testes autenticados com MFA"
+        )
+
+    import pyotp
+
+    totp_code = pyotp.TOTP(ADMIN_TOTP_SECRET.replace(" ", "")).now()
+    code_input = WebDriverWait(driver, 10).until(
+        EC.element_to_be_clickable(MFA_CODE_INPUT)
+    )
+    code_input.clear()
+    code_input.send_keys(totp_code)
+    driver.find_element(*MFA_SUBMIT_BUTTON).click()
+
+    WebDriverWait(driver, timeout).until(
+        lambda d: not d.current_url.startswith(login_url)
+    )
+    return True
+
+
 @pytest.fixture(scope="session")
 def logged_in_driver(driver, base_url, collector):
     """Driver com sessão de admin autenticada. Faz login uma única vez."""
     if not ADMIN_PASSWORD:
         pytest.skip("ADMIN_PASSWORD não configurado — pule testes autenticados")
     from pages.login_page import LoginPage
+
     page = LoginPage(driver, base_url)
-    login_time = page.login(ADMIN_EMAIL, ADMIN_PASSWORD)
+    page.navigate_to()
+    t0 = time.time()
+
+    email_el = page.wait_for_clickable(*LoginPage.EMAIL_INPUT)
+    email_el.clear()
+    email_el.send_keys(ADMIN_EMAIL)
+
+    pwd_el = driver.find_element(*LoginPage.PASSWORD_INPUT)
+    pwd_el.clear()
+    pwd_el.send_keys(ADMIN_PASSWORD)
+
+    page.js_click(driver.find_element(*LoginPage.SUBMIT_BUTTON))
+    mfa_completed = _complete_mfa_if_required(driver, base_url)
+
+    login_time = time.time() - t0
     collector.metric("login_success_seconds", login_time)
+    collector.metric("login_mfa_completed", mfa_completed)
     return driver
 
 

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -29,8 +29,7 @@ MFA_CODE_INPUT = (
     "input[inputmode='numeric'], "
     "input[name*='code' i], "
     "input[id*='code' i], "
-    "input[type='tel'], "
-    "input[type='text']",
+    "input[type='tel']",
 )
 MFA_SUBMIT_BUTTON = (By.CSS_SELECTOR, "button[type='submit']")
 
@@ -70,10 +69,16 @@ def driver():
 
 
 def _mfa_screen_visible(driver) -> bool:
+    """Return True if the MFA verification screen is currently displayed."""
     return any(element.is_displayed() for element in driver.find_elements(*MFA_SCREEN))
 
 
 def _complete_mfa_if_required(driver, base_url: str, timeout: int = 30) -> bool:
+    """Complete TOTP MFA flow if the MFA screen appears after password submission.
+
+    Returns True if MFA was completed, False if MFA screen was not shown.
+    Skips the test (via pytest.skip) if MFA is required but ADMIN_TOTP_SECRET is absent.
+    """
     login_url = f"{base_url}/login"
     try:
         WebDriverWait(driver, timeout).until(
@@ -93,7 +98,12 @@ def _complete_mfa_if_required(driver, base_url: str, timeout: int = 30) -> bool:
 
     import pyotp
 
-    totp_code = pyotp.TOTP(ADMIN_TOTP_SECRET.replace(" ", "")).now()
+    totp = pyotp.TOTP(ADMIN_TOTP_SECRET.replace(" ", ""))
+    # Wait out the current window if fewer than 5 seconds remain to avoid expiry on submit.
+    remaining = 30 - (time.time() % 30)
+    if remaining < 5:
+        time.sleep(remaining + 1)
+    totp_code = totp.now()
     code_input = WebDriverWait(driver, 10).until(
         EC.element_to_be_clickable(MFA_CODE_INPUT)
     )

--- a/tests/selenium/requirements.txt
+++ b/tests/selenium/requirements.txt
@@ -4,3 +4,4 @@ pytest>=8.0
 pytest-html>=4.1
 pytest-timeout>=2.3
 python-dotenv>=1.0
+pyotp>=2.9


### PR DESCRIPTION
## Context
Selenium authenticated tests were blocked because the admin login account now reaches the TOTP MFA verification screen and `logged_in_driver` waited only for a `/login` redirect.

## Changes
- Add MFA screen detection to `tests/selenium/conftest.py::logged_in_driver`.
- Generate and submit a TOTP code from `ADMIN_TOTP_SECRET` when MFA is required.
- Add `pyotp` to Selenium requirements.
- Document authenticated Selenium env vars in `tests/selenium/README.md`.

## Testing Plan
- [x] `python3 -m py_compile tests/selenium/conftest.py tests/selenium/pages/login_page.py`
- [x] `python3 -m pip install --user --break-system-packages -r tests/selenium/requirements.txt`
- [x] `python3 -m pytest tests/selenium/tests/test_auth.py -q` — 10 passed
- [x] `python3 -m pytest tests/selenium/tests/test_admin_conta.py tests/selenium/tests/test_buscar.py -q` — 17 skipped because `ADMIN_PASSWORD`/`ADMIN_TOTP_SECRET` are not configured in this local shell
- [ ] Run the 17 authenticated tests with valid `ADMIN_PASSWORD` and `ADMIN_TOTP_SECRET` in CI or a secrets-enabled shell

Root npm scripts `lint`, `typecheck`, and `test` are not defined in this repository package.json. `npm --prefix frontend run lint` could not start because frontend dependencies are not installed in this worktree (`next: not found`).

## Risks & Rollback
If the MFA selectors drift, authenticated Selenium login may skip/fail before test bodies run. Roll back this commit to restore the previous password-only login fixture.

## Closes
Closes #654