### PR TITLE
feat(frontend): add trial CTA to /observatorio hub + fix passive empty-state (#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Frontend / GTM
+- **CTA de trial em /observatorio (#619)** — `ObservatorioCTA` client component adicionado ao hub do observatório. Usuários não autenticados veem link `/signup?ref=observatorio-hub`; autenticados veem link `/buscar`. Empty-state de relatórios agora inclui link ativo para `/licitacoes`.
+
 ### Added — SEO Admin
 - **GSC API sync + dashboard /admin/seo (STORY-SEO-005 #478)** — ARQ cron semanal (dom 06 UTC) sincroniza Google Search Console searchanalytics para `gsc_metrics` (Supabase). Dashboard `/admin/seo` ganhou seção "Query Analytics" com top queries, top pages por CTR e oportunidades CTR <1%. Graceful no-op se `GSC_SERVICE_ACCOUNT_JSON` ausente. Prometheus: `smartlic_gsc_sync_duration_seconds` + `smartlic_gsc_sync_rows_upserted_total`. Migration: `20260422120000_create_gsc_metrics.sql`.
 

--- a/frontend/__tests__/app/ObservatorioCTA.test.tsx
+++ b/frontend/__tests__/app/ObservatorioCTA.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ObservatorioCTA } from '@/app/observatorio/ObservatorioCTA';
+
+jest.mock('@/contexts/UserContext', () => ({
+  useUser: jest.fn(),
+}));
+
+import { useUser } from '@/contexts/UserContext';
+const mockUseUser = useUser as jest.Mock;
+
+describe('ObservatorioCTA', () => {
+  it('renders signup link when user is not authenticated', () => {
+    mockUseUser.mockReturnValue({ user: null, authLoading: false });
+    render(<ObservatorioCTA />);
+    const link = screen.getByRole('link', { name: /ver editais do meu setor/i });
+    expect(link).toHaveAttribute('href', '/signup?ref=observatorio-hub');
+  });
+
+  it('renders buscar link when user is authenticated', () => {
+    mockUseUser.mockReturnValue({ user: { id: 'u1' }, authLoading: false });
+    render(<ObservatorioCTA />);
+    const link = screen.getByRole('link', { name: /ver editais personalizados/i });
+    expect(link).toHaveAttribute('href', '/buscar');
+  });
+
+  it('renders signup link while auth is loading (safe fallback)', () => {
+    mockUseUser.mockReturnValue({ user: null, authLoading: true });
+    render(<ObservatorioCTA />);
+    const link = screen.getByRole('link', { name: /ver editais do meu setor/i });
+    expect(link).toHaveAttribute('href', '/signup?ref=observatorio-hub');
+  });
+});

--- a/frontend/app/observatorio/ObservatorioCTA.tsx
+++ b/frontend/app/observatorio/ObservatorioCTA.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+/**
+ * Issue #619: Auth-aware trial CTA for /observatorio hub.
+ * - Unauthenticated: link to /signup?ref=observatorio-hub
+ * - Authenticated: link to /buscar
+ */
+
+import Link from 'next/link';
+import { useUser } from '../../contexts/UserContext';
+
+export function ObservatorioCTA() {
+  const { user, authLoading } = useUser();
+
+  const isAuthenticated = !authLoading && !!user;
+
+  return (
+    <section className="mt-10 rounded-xl bg-gradient-to-br from-brand-navy to-brand-blue p-8 text-white text-center">
+      <h2 className="text-xl font-bold mb-2">
+        Esses números são apenas o agregado público
+      </h2>
+      <p className="text-white/85 mb-5">
+        No SmartLic você filtra milhares de editais abertos pelo seu setor, valor mínimo
+        e UF — em 3 minutos, sem custo.
+      </p>
+      {isAuthenticated ? (
+        <Link
+          href="/buscar"
+          className="inline-block px-7 py-3 bg-white text-brand-navy font-bold rounded-xl hover:bg-gray-100 transition-colors"
+        >
+          Ver editais personalizados →
+        </Link>
+      ) : (
+        <Link
+          href="/signup?ref=observatorio-hub"
+          className="inline-block px-7 py-3 bg-white text-brand-navy font-bold rounded-xl hover:bg-gray-100 transition-colors"
+        >
+          Ver editais do meu setor →
+        </Link>
+      )}
+      <p className="mt-3 text-xs text-white/70">14 dias grátis, sem cartão de crédito.</p>
+    </section>
+  );
+}

--- a/frontend/app/observatorio/ObservatorioCTA.tsx
+++ b/frontend/app/observatorio/ObservatorioCTA.tsx
@@ -1,11 +1,5 @@
 'use client';
 
-/**
- * Issue #619: Auth-aware trial CTA for /observatorio hub.
- * - Unauthenticated: link to /signup?ref=observatorio-hub
- * - Authenticated: link to /buscar
- */
-
 import Link from 'next/link';
 import { useUser } from '../../contexts/UserContext';
 

--- a/frontend/app/observatorio/page.tsx
+++ b/frontend/app/observatorio/page.tsx
@@ -7,6 +7,7 @@
 
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { ObservatorioCTA } from './ObservatorioCTA';
 
 export const metadata: Metadata = {
   title: 'Observatório de Licitações',
@@ -79,7 +80,12 @@ export default function ObservatorioPage() {
           <h2 className="text-xl font-semibold text-gray-800 mb-4">Relatórios publicados</h2>
 
           {RELATORIOS_PUBLICADOS.length === 0 ? (
-            <p className="text-gray-500">Primeiro relatório em breve.</p>
+            <p className="text-gray-500">
+              Primeiro relatório em breve.{' '}
+              <Link href="/licitacoes" className="text-blue-700 hover:underline">
+                Enquanto isso, veja o que está aberto agora →
+              </Link>
+            </p>
           ) : (
             <div className="space-y-4">
               {RELATORIOS_PUBLICADOS.map((rel) => (
@@ -98,6 +104,9 @@ export default function ObservatorioPage() {
             </div>
           )}
         </section>
+
+        {/* Issue #619: Trial CTA — auth-aware (unauthenticated → /signup, authenticated → /buscar) */}
+        <ObservatorioCTA />
 
         <section className="mt-12 p-6 bg-blue-50 rounded-xl border border-blue-100">
           <h2 className="text-lg font-semibold text-gray-800 mb-2">Sobre os dados</h2>

--- a/frontend/app/observatorio/page.tsx
+++ b/frontend/app/observatorio/page.tsx
@@ -105,7 +105,6 @@ export default function ObservatorioPage() {
           )}
         </section>
 
-        {/* Issue #619: Trial CTA — auth-aware (unauthenticated → /signup, authenticated → /buscar) */}
         <ObservatorioCTA />
 
         <section className="mt-12 p-6 bg-blue-50 rounded-xl border border-blue-100">


### PR DESCRIPTION
## Context
/observatorio had zero conversion path. Empty-state was purely passive with no action. This eliminates a dead-end for organic SEO traffic.

## Changes
- Add `ObservatorioCTA` client component with auth-aware CTA card above Sobre os dados section
- Unauthenticated users: link to /signup?ref=observatorio-hub
- Authenticated users: link to /buscar
- Update empty-state to active (links to /licitacoes)

## Testing Plan
- [x] CTA card visible in /observatorio page
- [x] Link to /signup?ref=observatorio-hub for unauthenticated users
- [x] Link to /buscar for authenticated users
- [x] Empty-state has action link to /licitacoes
- [x] Existing observatorio tests pass (7 tests)
- [x] ObservatorioCTA.test.tsx — 3 unit tests (unauthenticated, authenticated, authLoading fallback)

## Risks & Rollback
Low risk — additive only, no API changes, no backend impact.
When authLoading=true, isAuthenticated=false renders signup link safely (no blank state).
Rollback: revert commit.

## Closes
Closes #619