### PR TITLE
fix(backend): guard supabase singleton init (#190)

### DIFF
--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -31,6 +31,7 @@ T = TypeVar("T")
 
 # Lazy import to avoid breaking existing tests that don't have supabase installed
 _supabase_client = None
+_supabase_client_lock = threading.Lock()
 
 # ============================================================================
 # CRIT-046 + DEBT-018 SYS-020: Connection pool configuration
@@ -84,11 +85,13 @@ def get_supabase():
     """
     global _supabase_client
     if _supabase_client is None:
-        from supabase import create_client
-        url, key = _get_config()
-        _supabase_client = create_client(url, key)
-        _configure_httpx_pool(_supabase_client)
-        logger.info("Supabase client initialized")
+        with _supabase_client_lock:
+            if _supabase_client is None:
+                from supabase import create_client
+                url, key = _get_config()
+                _supabase_client = create_client(url, key)
+                _configure_httpx_pool(_supabase_client)
+                logger.info("Supabase client initialized")
     return _supabase_client
 
 

--- a/backend/tests/test_supabase_client.py
+++ b/backend/tests/test_supabase_client.py
@@ -9,6 +9,7 @@ import time
 import threading
 import sys
 import os
+import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -305,3 +306,53 @@ class TestThreadSafety:
         assert len(errors) == 0
         # Should be OPEN after 200 failures in a 100-window
         assert cb.state == "OPEN"
+
+    @pytest.mark.timeout(30)
+    def test_get_supabase_singleton_initialized_once_under_concurrency(self, monkeypatch):
+        import supabase_client
+
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
+        monkeypatch.setattr(supabase_client, "_supabase_client", None)
+        monkeypatch.setattr(supabase_client, "_configure_httpx_pool", lambda client: None)
+
+        create_calls = []
+        create_started = threading.Event()
+        release_create = threading.Event()
+
+        def create_client(url, key):
+            create_calls.append((url, key))
+            create_started.set()
+            assert release_create.wait(timeout=5)
+            return object()
+
+        fake_supabase = types.ModuleType("supabase")
+        fake_supabase.create_client = create_client
+        monkeypatch.setitem(sys.modules, "supabase", fake_supabase)
+
+        results = []
+        errors = []
+
+        def get_client():
+            try:
+                results.append(supabase_client.get_supabase())
+            except Exception as exc:
+                errors.append(exc)
+
+        first = threading.Thread(target=get_client)
+        first.start()
+        assert create_started.wait(timeout=5)
+
+        contenders = [threading.Thread(target=get_client) for _ in range(8)]
+        for thread in contenders:
+            thread.start()
+
+        release_create.set()
+        first.join(timeout=5)
+        for thread in contenders:
+            thread.join(timeout=5)
+
+        assert errors == []
+        assert len(results) == 9
+        assert len({id(client) for client in results}) == 1
+        assert create_calls == [("https://test.supabase.co", "service-role-key")]


### PR DESCRIPTION
## Context

`backend/supabase_client.py` used a lazy global singleton without synchronization. Concurrent requests could race during first initialization and call `create_client()` multiple times.

## Changes
- Add a private `threading.Lock()` around singleton initialization with double-check locking.
- Preserve the existing `get_supabase()` public API.
- Add a concurrency regression test proving one `create_client()` call and one shared client instance across threads.

## Testing Plan
- [x] `python3 -m pytest backend/tests/test_supabase_client.py` — 25 passed
- [x] `python3 -m pytest backend/tests/test_supabase_client.py backend/tests/test_sys023_user_scoped_client.py backend/tests/startup/test_lifespan_supabase_probe.py` — 43 passed
- [x] `git diff --check`
- [ ] `npm run lint` — root script not defined in this repository
- [ ] `npm run typecheck` — root script not defined in this repository
- [ ] `npm test` — root script not defined in this repository

## Risks & Rollback
Low risk. The change only serializes first singleton creation and leaves subsequent reads unchanged. Rollback by reverting this commit.

## Closes
Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced client initialization to ensure stable and consistent operation in concurrent environments.

* **Tests**
  * Added comprehensive concurrency tests validating proper initialization behavior, verifying consistent results, and ensuring correct performance across multiple simultaneous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->