### PR TITLE
fix(ci): isolate contract test fixtures (#682)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           cd backend
           python -m pytest tests/contracts/ \
+            --confcutdir=tests/contracts \
             -m 'contract and not external' \
             --tb=short --no-header -v \
             --junitxml=contract-results.xml
@@ -161,6 +162,7 @@ jobs:
         run: |
           cd backend
           python -m pytest tests/contracts/ \
+            --confcutdir=tests/contracts \
             -m external \
             --tb=short --no-header -v
         continue-on-error: true  # External APIs are flaky — failures go to the issue, don't break pipeline


### PR DESCRIPTION
## Context

Issue #682 was opened as possible external API drift, but the workflow artifact showed all 41 contract tests failing during setup with `ModuleNotFoundError: No module named 'fastapi'`. The offline contract job installs intentionally minimal dependencies, but pytest still loaded the parent `backend/tests/conftest.py`, whose autouse fixtures import broader backend modules.

## Changes
- Add `--confcutdir=tests/contracts` to the offline contract test pytest command.
- Add the same isolation to the opt-in live contract check.
- Keep the minimal dependency install; no schema rebaseline needed.

## Testing Plan
- [x] `python3 -m pytest tests/contracts/ --confcutdir=tests/contracts -m 'contract and not external' --tb=short --no-header -q` — 41 passed, 3 deselected
- [x] `git diff --check`

## Risks & Rollback
Low risk. This only prevents unrelated global test fixtures from loading in the self-contained contract suite. Rollback by removing the pytest flag.

## Closes
Closes #682