### PR TITLE
fix(backend): validate custom search terms (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added — Frontend / GTM
 - **CTA de trial em /observatorio (#619)** — `ObservatorioCTA` client component adicionado ao hub do observatório. Usuários não autenticados veem link `/signup?ref=observatorio-hub`; autenticados veem link `/buscar`. Empty-state de relatórios agora inclui link ativo para `/licitacoes`.
 
+### Fixed — Backend / Security
+- **Validação de termos de busca customizados (#212)** — `BuscaRequest.termos_busca` agora valida com allowlist conservadora pt-BR (letras latinas, dígitos, espaços, vírgulas e hífens). Rejeita payloads com `<`, `;`, `/`, `_` e similares. Limite `max_length=500`. Snapshot OpenAPI atualizado. Rollback: reverter commit.
+
 ### Added — SEO Admin
 - **GSC API sync + dashboard /admin/seo (STORY-SEO-005 #478)** — ARQ cron semanal (dom 06 UTC) sincroniza Google Search Console searchanalytics para `gsc_metrics` (Supabase). Dashboard `/admin/seo` ganhou seção "Query Analytics" com top queries, top pages por CTR e oportunidades CTR <1%. Graceful no-op se `GSC_SERVICE_ACCOUNT_JSON` ausente. Prometheus: `smartlic_gsc_sync_duration_seconds` + `smartlic_gsc_sync_rows_upserted_total`. Migration: `20260422120000_create_gsc_metrics.sql`.
 

--- a/backend/schemas/search.py
+++ b/backend/schemas/search.py
@@ -1,6 +1,8 @@
 """Search-related schemas: BuscaRequest, BuscaResponse, LicitacaoItem, etc."""
 
 from datetime import date
+import unicodedata
+
 from pydantic import BaseModel, Field, model_validator, field_validator
 from typing import Dict, List, Literal, Optional, Union
 
@@ -8,6 +10,8 @@ from schemas.common import (
     StatusLicitacao,
     EsferaGovernamental,
 )
+
+SEARCH_TERMS_MAX_LENGTH = 500
 
 
 class SearchQueuedResponse(BaseModel):
@@ -111,6 +115,7 @@ class BuscaRequest(BaseModel):
     )
     termos_busca: Optional[str] = Field(
         default=None,
+        max_length=SEARCH_TERMS_MAX_LENGTH,
         description="Custom search terms. Use commas to separate multi-word phrases "
                     "(e.g., 'levantamento topográfico, terraplenagem, drenagem'). "
                     "Without commas, spaces separate individual keywords (legacy mode).",
@@ -281,6 +286,29 @@ class BuscaRequest(BaseModel):
                 "STORY-419: se o edital realmente é maior, contate o suporte."
             )
         return v
+
+    @field_validator("termos_busca")
+    @classmethod
+    def validate_termos_busca(cls, v: Optional[str]) -> Optional[str]:
+        """Validate custom search terms using a conservative pt-BR allowlist."""
+        if v is None:
+            return v
+
+        normalized = unicodedata.normalize("NFC", v.strip())
+        if not normalized:
+            return None
+
+        for char in normalized:
+            is_latin_letter = char.isalpha() and "LATIN" in unicodedata.name(char, "")
+            is_digit = "0" <= char <= "9"
+            if is_latin_letter or is_digit or char in {" ", ",", "-"}:
+                continue
+            raise ValueError(
+                "termos_busca contém caracteres inválidos. Use apenas letras, "
+                "números, espaços, vírgulas e hífens."
+            )
+
+        return normalized
 
     @model_validator(mode="after")
     def validate_dates_and_values(self) -> "BuscaRequest":

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -1133,6 +1133,7 @@
           "termos_busca": {
             "anyOf": [
               {
+                "maxLength": 500,
                 "type": "string"
               },
               {

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -88,6 +88,51 @@ class TestBuscaRequest:
         errors = exc_info.value.errors()
         assert any(error["loc"] == ("data_final",) for error in errors)
 
+    def test_termos_busca_accepts_pt_br_terms(self):
+        """Custom search terms should accept pt-BR accents, numbers, spaces, commas, and hyphens."""
+        request = BuscaRequest(
+            ufs=["SP"],
+            data_inicial="2025-01-01",
+            data_final="2025-01-31",
+            termos_busca="levantamento topográfico, pavimentação, CA-50 número 2",
+        )
+
+        assert (
+            request.termos_busca
+            == "levantamento topográfico, pavimentação, CA-50 número 2"
+        )
+
+    def test_termos_busca_rejects_more_than_500_chars(self):
+        """Custom search terms should be capped at 500 chars."""
+        with pytest.raises(ValidationError) as exc_info:
+            BuscaRequest(
+                ufs=["SP"],
+                data_inicial="2025-01-01",
+                data_final="2025-01-31",
+                termos_busca="a" * 501,
+            )
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("termos_busca",) for error in errors)
+
+    def test_termos_busca_rejects_unsafe_characters(self):
+        """Custom search terms should reject punctuation used for injection payloads."""
+        invalid_terms = [
+            "<script>alert(1)</script>",
+            "software; DROP TABLE search_sessions",
+            "uniforme_escolar",
+            "drenagem/pluvial",
+        ]
+
+        for termos_busca in invalid_terms:
+            with pytest.raises(ValidationError):
+                BuscaRequest(
+                    ufs=["SP"],
+                    data_inicial="2025-01-01",
+                    data_final="2025-01-31",
+                    termos_busca=termos_busca,
+                )
+
 
 class TestResumoLicitacoes:
     """Test ResumoLicitacoes schema validation."""


### PR DESCRIPTION
## Context

`BuscaRequest.termos_busca` accepted arbitrary optional strings. Very long or punctuation-heavy input could reach downstream parsing/storage paths without a clear schema-level guard.

## Changes
- Add `max_length=500` to `termos_busca`.
- Normalize and validate custom terms with a conservative pt-BR allowlist: Latin letters, digits, spaces, commas, and hyphens.
- Preserve support for accents and common multi-term input.
- Update OpenAPI snapshot and schema tests.

## Testing Plan
- [x] `python3 -m pytest backend/tests/test_schemas.py -q` — 27 passed
- [x] `python3 -m pytest backend/tests/test_schemas.py backend/tests/test_term_parser.py -q` — 55 passed
- [x] `python3 -m ruff check backend/schemas/search.py backend/tests/test_schemas.py`
- [x] `python3 -m pytest backend/tests/test_openapi_schema.py::TestOpenAPISchema::test_openapi_schema_matches_snapshot -q`
- [x] `git diff --check`
- [ ] `npm run lint` — root script not defined in this repository
- [ ] `npm run typecheck` — root script not defined in this repository
- [ ] `npm test` — root script not defined in this repository

## Risks & Rollback
Medium-low risk. The validation intentionally rejects characters such as `<`, `;`, `/`, and `_`; if a legitimate search use case needs additional punctuation, extend the allowlist with tests. Rollback by reverting this commit.

## Closes
Closes #212