### PR TITLE
fix(search): enforce PNCP date range limit (#206)

### DIFF
--- a/backend/schemas/search.py
+++ b/backend/schemas/search.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 from pydantic import BaseModel, Field, model_validator, field_validator
-from typing import Dict, List, Literal, Optional, Union
+from typing import ClassVar, Dict, List, Literal, Optional, Union
 
 from schemas.common import (
     StatusLicitacao,
@@ -90,13 +90,13 @@ class BuscaRequest(BaseModel):
     data_inicial: str = Field(
         ...,
         pattern=r"^\d{4}-\d{2}-\d{2}$",
-        description="Start date in YYYY-MM-DD format",
+        description="Start date in YYYY-MM-DD format. The date range may span at most 30 days.",
         examples=["2025-01-01"],
     )
     data_final: str = Field(
         ...,
         pattern=r"^\d{4}-\d{2}-\d{2}$",
-        description="End date in YYYY-MM-DD format",
+        description="End date in YYYY-MM-DD format. The date range may span at most 30 days.",
         examples=["2025-01-31"],
     )
 
@@ -261,7 +261,8 @@ class BuscaRequest(BaseModel):
     # search_sessions.valor_total (PostgreSQL rejects anything with more than
     # 16 integer digits with SQLSTATE 22003). We keep one decade of headroom
     # vs. the column ceiling to avoid sum-overflow when aggregating many rows.
-    _VALOR_MAX_CEILING: float = 1e15  # R$ 1 quatrilhão
+    _VALOR_MAX_CEILING: ClassVar[float] = 1e15  # R$ 1 quatrilhão
+    _MAX_DATE_RANGE_DAYS: ClassVar[int] = 30
 
     @field_validator("valor_maximo", "valor_minimo")
     @classmethod
@@ -299,6 +300,14 @@ class BuscaRequest(BaseModel):
         if d_ini > d_fin:
             raise ValueError(
                 "Data inicial deve ser anterior ou igual à data final"
+            )
+
+        range_days = (d_fin - d_ini).days
+        if range_days > self._MAX_DATE_RANGE_DAYS:
+            raise ValueError(
+                "Intervalo de datas excede o limite máximo de 30 dias "
+                f"(recebido: {range_days} dias). "
+                "Reduza data_inicial/data_final e tente novamente."
             )
 
         # Value range validation

--- a/backend/startup/exception_handlers.py
+++ b/backend/startup/exception_handlers.py
@@ -12,6 +12,21 @@ from fastapi.responses import JSONResponse
 logger = logging.getLogger(__name__)
 
 
+def _validation_error_messages(exc: RequestValidationError) -> list[str]:
+    """Extract validation messages without leaking raw request input."""
+    messages: list[str] = []
+    for error in exc.errors():
+        ctx = error.get("ctx")
+        if isinstance(ctx, dict):
+            ctx_error = ctx.get("error")
+            if ctx_error is not None:
+                messages.append(str(ctx_error))
+        msg = error.get("msg")
+        if isinstance(msg, str):
+            messages.append(msg)
+    return messages
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     """Attach global exception handlers to *app*."""
 
@@ -19,6 +34,24 @@ def register_exception_handlers(app: FastAPI) -> None:
     async def validation_exception_handler(request: Request, exc: RequestValidationError):
         """AC9: Validation errors in Portuguese."""
         logger.warning(f"Validation error on {request.url.path}: {exc.errors()}")
+        messages = _validation_error_messages(exc)
+        date_range_message = next(
+            (
+                message
+                for message in messages
+                if "Intervalo de datas excede o limite máximo de 30 dias" in message
+            ),
+            None,
+        )
+        if date_range_message and request.url.path.endswith("/buscar"):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "detail": date_range_message,
+                    "error_code": "date_range_exceeded",
+                },
+            )
+
         return JSONResponse(
             status_code=422,
             content={"detail": "Dados inválidos. Verifique os campos e tente novamente."},

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -899,7 +899,7 @@
             "type": "boolean"
           },
           "data_final": {
-            "description": "End date in YYYY-MM-DD format",
+            "description": "End date in YYYY-MM-DD format. The date range may span at most 30 days.",
             "examples": [
               "2025-01-31"
             ],
@@ -908,7 +908,7 @@
             "type": "string"
           },
           "data_inicial": {
-            "description": "Start date in YYYY-MM-DD format",
+            "description": "Start date in YYYY-MM-DD format. The date range may span at most 30 days.",
             "examples": [
               "2025-01-01"
             ],

--- a/backend/tests/test_api_buscar.py
+++ b/backend/tests/test_api_buscar.py
@@ -222,6 +222,28 @@ class TestBuscarFeatureFlagDisabled:
 class TestBuscarDateRangeValidation:
     """Test date range validation based on plan capabilities."""
 
+    def test_rejects_date_range_above_schema_limit_with_helpful_error(self):
+        """Should reject date ranges above 30 days before calling downstream services."""
+        cleanup = setup_auth_override("user-123")
+        try:
+            response = client.post(
+                "/v1/buscar",
+                json={
+                    "ufs": ["SC"],
+                    "data_inicial": "2026-01-01",
+                    "data_final": "2026-02-01",
+                    "setor_id": "vestuario",
+                },
+            )
+
+            assert response.status_code == 400
+            body = response.json()
+            assert body["error_code"] == "date_range_exceeded"
+            assert "limite máximo de 30 dias" in body["detail"]
+            assert "recebido: 31 dias" in body["detail"]
+        finally:
+            cleanup()
+
     @patch("routes.search.ENABLE_NEW_PRICING", True)
     @patch("quota.check_quota")
     @patch("quota.increment_monthly_quota")
@@ -276,7 +298,7 @@ class TestBuscarDateRangeValidation:
     @patch("quota.increment_monthly_quota")
     @patch("quota.save_search_session", new_callable=AsyncMock)
     @patch("routes.search.PNCPClient")
-    def test_accepts_full_range_for_sala_guerra(
+    def test_rejects_long_range_before_plan_capabilities(
         self,
         mock_pncp_client_class,
         mock_save_session,
@@ -284,7 +306,7 @@ class TestBuscarDateRangeValidation:
         mock_check_quota,
         mock_rate_limiter,
     ):
-        """Should accept up to 1825 days for Sala de Guerra plan."""
+        """BuscaRequest should enforce the 30-day PNCP safety limit for all plans."""
         cleanup = setup_auth_override("user-sala-guerra-test")
         try:
             from quota import QuotaInfo, PLAN_CAPABILITIES
@@ -307,7 +329,6 @@ class TestBuscarDateRangeValidation:
             mock_client_instance.fetch_all.return_value = []
             mock_increment_quota.return_value = 501
 
-            # 1000 days range (within 1825 days limit)
             response = client.post(
                 "/v1/buscar",
                 json={
@@ -318,7 +339,12 @@ class TestBuscarDateRangeValidation:
                 },
             )
 
-            assert response.status_code == 200
+            assert response.status_code == 400
+            body = response.json()
+            assert body["error_code"] == "date_range_exceeded"
+            assert "limite máximo de 30 dias" in body["detail"]
+            mock_check_quota.assert_not_called()
+            mock_pncp_client_class.assert_not_called()
         finally:
             cleanup()
 
@@ -1274,4 +1300,3 @@ class TestBuscarCustomSearchTerms:
                 assert stopword not in data["termos_utilizados"]
         finally:
             cleanup()
-

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -56,6 +56,23 @@ class TestBuscaRequest:
         )
         assert request.data_inicial == "2025-12-31"
 
+    def test_accepts_maximum_30_day_date_range(self):
+        """Date range with a 30-day delta should be accepted."""
+        request = BuscaRequest(
+            ufs=["SP"], data_inicial="2025-01-01", data_final="2025-01-31"
+        )
+        assert request.data_final == "2025-01-31"
+
+    def test_rejects_date_range_above_30_days(self):
+        """Date range above 30 days should be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            BuscaRequest(
+                ufs=["SP"], data_inicial="2025-01-01", data_final="2025-02-01"
+            )
+
+        assert "Intervalo de datas excede o limite máximo de 30 dias" in str(exc_info.value)
+        assert "recebido: 31 dias" in str(exc_info.value)
+
     def test_invalid_date_format_rejected(self):
         """Invalid date formats should be rejected."""
         invalid_formats = [

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -5573,13 +5573,13 @@ export interface components {
             check_sanctions: boolean;
             /**
              * Data Final
-             * @description End date in YYYY-MM-DD format
+             * @description End date in YYYY-MM-DD format. The date range may span at most 30 days.
              * @example 2025-01-31
              */
             data_final: string;
             /**
              * Data Inicial
-             * @description Start date in YYYY-MM-DD format
+             * @description Start date in YYYY-MM-DD format. The date range may span at most 30 days.
              * @example 2025-01-01
              */
             data_inicial: string;


### PR DESCRIPTION
## Context

`BuscaRequest` validated date format and ordering, but did not enforce the PNCP safety limit for large date ranges. Large ranges can time out or return incomplete results silently.

## Changes
- Add a schema-level max date range of 30 days for all `BuscaRequest` payloads.
- Document the constraint in the field descriptions/OpenAPI snapshot.
- Return a helpful `/v1/buscar` 400 response with `error_code=date_range_exceeded` for this specific validation case.
- Add schema and HTTP route tests.

## Testing Plan
- [x] `python3 -m pytest backend/tests/test_schemas.py::TestBuscaRequest backend/tests/test_api_buscar.py::TestBuscarDateRangeValidation backend/tests/test_openapi_schema.py::TestOpenAPISchema::test_openapi_schema_matches_snapshot` — 17 passed
- [x] `python3 -m ruff check backend/schemas/search.py backend/startup/exception_handlers.py backend/tests/test_schemas.py backend/tests/test_api_buscar.py`
- [x] `git diff --check`
- [ ] `npm run lint` — root script not defined in this repository
- [ ] `npm run typecheck` — root script not defined in this repository
- [ ] `npm test` — root script not defined in this repository

## Risks & Rollback
Medium risk because this intentionally narrows accepted date ranges, including high-tier plans. That matches the issue's PNCP API safety constraint. Rollback by reverting this commit.

## Closes
Closes #206