### PR TITLE
test(stripe): document one-time ops validation (#718)

### DIFF
--- a/backend/tests/test_stripe_webhook_matrix.py
+++ b/backend/tests/test_stripe_webhook_matrix.py
@@ -158,6 +158,81 @@ class TestIdempotency:
         result = await stripe_webhook(mock_request)
         assert result["status"] == "already_processed"
 
+    @pytest.mark.timeout(30)
+    @pytest.mark.asyncio
+    @patch("webhooks.stripe.STRIPE_WEBHOOK_SECRET", "whsec_test")
+    @patch("webhooks.stripe.stripe.Webhook.construct_event")
+    @patch("webhooks.stripe.get_supabase")
+    async def test_payment_intent_succeeded_replay_is_deduped_before_delivery(
+        self, mock_get_sb, mock_construct, mock_request
+    ):
+        """Issue #718: payment_intent.succeeded is covered by event-id dedup.
+
+        The one-time purchase delivery handler is not implemented yet. This
+        verifies the dispatcher still claims the Stripe event before routing, so
+        a replay of the same payment_intent.succeeded event cannot reach future
+        delivery logic twice unless that logic bypasses /webhooks/stripe.
+        """
+        from webhooks.stripe import stripe_webhook
+
+        event = _make_event(
+            event_id="evt_pi_succeeded_718",
+            event_type="payment_intent.succeeded",
+            data_object={
+                "id": "pi_718",
+                "metadata": {"purchase_id": "purchase_718"},
+            },
+        )
+        mock_construct.return_value = event
+
+        def make_sb(*, replay: bool):
+            sb = MagicMock()
+            table_chains = {}
+            events_execute_calls = {"n": 0}
+
+            def table_side_effect(name):
+                if name in table_chains:
+                    return table_chains[name]
+
+                chain = _make_chain_mock()
+                if name == "stripe_webhook_events":
+                    def execute_side_effect():
+                        events_execute_calls["n"] += 1
+                        if not replay:
+                            return Mock(data=[{"id": "evt_pi_succeeded_718"}])
+                        if events_execute_calls["n"] == 1:
+                            return Mock(data=[])
+                        return Mock(data=[{
+                            "id": "evt_pi_succeeded_718",
+                            "status": "completed",
+                            "received_at": None,
+                        }])
+
+                    chain.execute = Mock(side_effect=execute_side_effect)
+
+                table_chains[name] = chain
+                return chain
+
+            sb.table = Mock(side_effect=table_side_effect)
+            sb._table_chains = table_chains
+            return sb
+
+        first_sb = make_sb(replay=False)
+        replay_sb = make_sb(replay=True)
+        mock_get_sb.side_effect = [first_sb, replay_sb]
+
+        first_result = await stripe_webhook(mock_request)
+        replay_result = await stripe_webhook(mock_request)
+
+        assert first_result["status"] == "success"
+        assert replay_result["status"] == "already_processed"
+        assert {
+            call.args[0] for call in first_sb.table.call_args_list
+        } == {"stripe_webhook_events"}
+        assert {
+            call.args[0] for call in replay_sb.table.call_args_list
+        } == {"stripe_webhook_events"}
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Event Handler Routing

--- a/docs/runbooks/issue-718-intel-reports-ops-validation.md
+++ b/docs/runbooks/issue-718-intel-reports-ops-validation.md
@@ -1,0 +1,53 @@
+# Issue #718: Intel Reports Ops Validation
+
+Status: local triage documented on 2026-05-05.
+
+## Scope
+
+This runbook records the pre-launch validation for Intel Reports billing and analytics from GitHub issue #718.
+
+Do not treat local code inspection as evidence for Railway variables or Mixpanel dashboard counts. Those checks require production access.
+
+## Local Findings
+
+- Stripe webhook dispatcher `backend/webhooks/stripe.py` claims every verified Stripe event in `stripe_webhook_events` before routing by `event.type`.
+- Duplicate event IDs return `{"status": "already_processed"}` after the existing-row/stuck-event check.
+- `payment_intent.succeeded` is not routed to a one-time purchase handler today. It is logged as an unhandled event, then marked completed in `stripe_webhook_events`.
+- The existing one-time purchase implementation story is `docs/stories/2026-04/MON-REP-01-stripe-one-time-purchases-webhook.md`, currently Draft.
+- The canonical one-time purchase table for Intel Reports should be `purchases`, not `profiles`, `user_subscriptions`, or a separate `intel_report_purchases` table. Intel report specificity belongs in `purchases.product_type`, `purchases.product_params`, and downstream report tables from MON-REP-02+.
+
+## Required External Checks
+
+Run these with production access before closing issue #718:
+
+```bash
+railway variables --service bidiq-backend --kv | grep MIXPANEL_TOKEN
+```
+
+Expected result: non-empty `MIXPANEL_TOKEN`.
+
+In Mixpanel, verify both events have count greater than zero in the last 7 days:
+
+- `paywall_hit`
+- `trial_started`
+
+If either count is zero, keep #718 open and investigate analytics ingestion before deploying Intel Reports purchases.
+
+## One-Time Purchase Guardrails
+
+When MON-REP-01 or #628 starts implementation:
+
+- Reuse `/webhooks/stripe` as the only Stripe webhook entry point.
+- Keep `stripe_webhook_events.id` as the first replay barrier for all event types, including `payment_intent.succeeded`.
+- Add the payment handler behind the dispatcher; do not bypass the dispatcher with a second webhook endpoint.
+- Persist Intel Reports purchases in `purchases`.
+- Keep unique constraints on `purchases.stripe_checkout_session_id` and `purchases.stripe_payment_intent_id`.
+- Make report delivery idempotent using a unique `purchase_id` in the generated-report/delivery table.
+
+## Local Evidence Added
+
+`backend/tests/test_stripe_webhook_matrix.py::TestIdempotency::test_payment_intent_succeeded_replay_is_deduped_before_delivery` simulates a replay of `payment_intent.succeeded` and verifies:
+
+- first delivery claims the event and returns success;
+- replay returns `already_processed`;
+- no purchase/subscription table is touched while the one-time handler is absent.


### PR DESCRIPTION
## Context

Issue #718 asks for production checks before Intel Reports launch: backend Mixpanel token, Mixpanel event presence, Stripe one-time idempotency, and table-source clarity. The production Railway/Mixpanel checks require external access, so this PR only records local evidence and guardrails.

## Changes
- Add an explicit replay test for `payment_intent.succeeded` through the existing Stripe dispatcher.
- Verify first delivery is claimed and replay returns `already_processed` before any purchase/subscription delivery table is touched.
- Add `docs/runbooks/issue-718-intel-reports-ops-validation.md` with local findings, required external checks, and one-time purchase guardrails.
- Document the table decision from existing MON-REP docs: one-time purchases should use `purchases`, not `profiles` or `user_subscriptions`.

## Testing Plan
- [x] `python3 -m pytest backend/tests/test_stripe_webhook_matrix.py::TestIdempotency::test_payment_intent_succeeded_replay_is_deduped_before_delivery -q`
- [x] `python3 -m pytest backend/tests/test_stripe_webhook_matrix.py -q` — 24 passed
- [x] `python3 -m py_compile backend/tests/test_stripe_webhook_matrix.py`
- [x] `python3 -m ruff check backend/tests/test_stripe_webhook_matrix.py`
- [x] `git diff --check`
- [ ] `railway variables --service bidiq-backend --kv | grep MIXPANEL_TOKEN` — requires production access
- [ ] Mixpanel `paywall_hit` and `trial_started` counts in last 7 days — requires dashboard access

## Risks & Rollback
Low risk. Test and documentation only.

## Closes
N/A — production validation pending (Railway/Mixpanel checks need external access). See Refs below.

## Refs
Refs #718