### PR TITLE
feat(intel-reports): deliver generated reports (#631)

### DIFF
--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -27,6 +27,8 @@ import logging
 import os
 import time
 import threading
+from html import escape
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,8 @@ logger = logging.getLogger(__name__)
 RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 EMAIL_FROM = os.getenv("EMAIL_FROM", "SmartLic <noreply@smartlic.tech>")
 EMAIL_ENABLED = os.getenv("EMAIL_ENABLED", "true").lower() in ("true", "1", "yes", "on")
+INTEL_REPORT_EMAIL_FROM = "SmartLic <tiago@smartlic.tech>"
+INTEL_REPORT_REPLY_TO = "tiago.sasaki@gmail.com"
 
 # Retry configuration
 MAX_RETRIES = 3
@@ -59,6 +63,7 @@ def send_email(
     tags: Optional[list[dict[str, str]]] = None,
     reply_to: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
+    from_email: Optional[str] = None,
 ) -> Optional[str]:
     """
     Send a transactional email via Resend.
@@ -85,7 +90,7 @@ def send_email(
     resend.api_key = RESEND_API_KEY
 
     params: dict = {
-        "from": EMAIL_FROM,
+        "from": from_email or EMAIL_FROM,
         "to": [to],
         "subject": subject,
         "html": html,
@@ -198,6 +203,7 @@ def send_email_async(
     tags: Optional[list[dict[str, str]]] = None,
     reply_to: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
+    from_email: Optional[str] = None,
 ) -> None:
     """
     Fire-and-forget email send in a background thread.
@@ -211,10 +217,63 @@ def send_email_async(
     """
     def _send():
         try:
-            send_email(to=to, subject=subject, html=html, tags=tags, reply_to=reply_to, headers=headers)
+            send_email(
+                to=to,
+                subject=subject,
+                html=html,
+                tags=tags,
+                reply_to=reply_to,
+                headers=headers,
+                from_email=from_email,
+            )
         except Exception as e:
             # Belt-and-suspenders: send_email already catches, but just in case
             logger.error(f"Async email send unexpected error: {e}")
 
     thread = threading.Thread(target=_send, daemon=True)
     thread.start()
+
+
+def send_intel_report_ready(
+    user_email: str,
+    name: str,
+    pdf_url: str,
+    product_name: str,
+    purchase_id: str,
+) -> Optional[str]:
+    """Send the Intel Report ready transactional email.
+
+    This path waits for Resend's response so the ARQ job can report delivery
+    failures in logs/tests without requiring a real email service.
+    """
+    from templates.emails.base import FRONTEND_URL, email_base
+
+    template_path = Path(__file__).parent / "templates" / "emails" / "intel_report_ready.html"
+    body_html = template_path.read_text(encoding="utf-8").format(
+        name=escape(name or user_email.split("@")[0]),
+        product_name=escape(product_name),
+        pdf_url=escape(pdf_url, quote=True),
+        trial_url=escape(
+            f"{FRONTEND_URL}/signup?utm_source=intel_report&utm_medium=email"
+            f"&purchase_id={purchase_id}",
+            quote=True,
+        ),
+    )
+    html = email_base(
+        title="Seu Raio-X do Concorrente está pronto — SmartLic",
+        body_html=body_html,
+        is_transactional=True,
+    )
+
+    return send_email(
+        to=user_email,
+        subject="Seu Raio-X do Concorrente está pronto — SmartLic",
+        html=html,
+        reply_to=INTEL_REPORT_REPLY_TO,
+        from_email=INTEL_REPORT_EMAIL_FROM,
+        tags=[
+            {"name": "category", "value": "intel_report"},
+            {"name": "status", "value": "ready"},
+            {"name": "purchase_id", "value": purchase_id[:32]},
+        ],
+    )

--- a/backend/job_queue.py
+++ b/backend/job_queue.py
@@ -158,6 +158,7 @@ from jobs.queue.jobs import (  # noqa: F401
     llm_summary_job, excel_generation_job, bid_analysis_job,
     daily_digest_job, email_alerts_job,
     reclassify_pending_bids_job, classify_zero_match_job,
+    generate_intel_report,
 )
 
 # --- Search job ---

--- a/backend/jobs/queue/config.py
+++ b/backend/jobs/queue/config.py
@@ -124,6 +124,7 @@ class WorkerSettings:
         llm_summary_job, excel_generation_job, bid_analysis_job,
         daily_digest_job, email_alerts_job,
         reclassify_pending_bids_job, classify_zero_match_job,
+        generate_intel_report,
     )
     from jobs.queue.search import search_job
 
@@ -159,6 +160,7 @@ class WorkerSettings:
         llm_summary_job, excel_generation_job, search_job,
         bid_analysis_job, daily_digest_job, email_alerts_job,
         reclassify_pending_bids_job, classify_zero_match_job,
+        generate_intel_report,
         *_ingestion_functions,
         *_monitoring_functions,
     ]

--- a/backend/jobs/queue/jobs.py
+++ b/backend/jobs/queue/jobs.py
@@ -4,9 +4,381 @@ from __future__ import annotations
 import json
 import logging
 import time
+import asyncio
+from datetime import datetime, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+INTEL_REPORT_BUCKET = "intel-reports"
+INTEL_REPORT_SIGNED_URL_TTL_SECONDS = 60 * 60 * 24 * 30
+INTEL_REPORT_RETRY_BACKOFF_SECONDS = (30, 60, 120)
+
+
+def _sentry_breadcrumb(message: str, **data: Any) -> None:
+    try:
+        import sentry_sdk
+        sentry_sdk.add_breadcrumb(
+            category="intel_report_job",
+            message=message,
+            level="info",
+            data=data,
+        )
+    except Exception:
+        pass
+
+
+async def _execute_supabase(query: Any) -> Any:
+    return await asyncio.to_thread(lambda: query.execute())
+
+
+def _first_row(result: Any) -> dict | None:
+    data = getattr(result, "data", None)
+    if isinstance(data, list):
+        return data[0] if data else None
+    return data if isinstance(data, dict) else None
+
+
+def _signed_url_from_response(response: Any) -> str:
+    if isinstance(response, dict):
+        return (
+            response.get("signedURL")
+            or response.get("signedUrl")
+            or response.get("signed_url")
+            or response.get("url")
+            or ""
+        )
+    return (
+        getattr(response, "signedURL", "")
+        or getattr(response, "signedUrl", "")
+        or getattr(response, "signed_url", "")
+        or getattr(response, "url", "")
+    )
+
+
+async def _fetch_intel_report_purchase(db: Any, purchase_id: str) -> dict | None:
+    result = await _execute_supabase(
+        db.table("intel_report_purchases")
+        .select(
+            "id, user_id, product_type, entity_key, status, pdf_url, "
+            "stripe_payment_intent_id"
+        )
+        .eq("id", purchase_id)
+        .single()
+    )
+    return _first_row(result)
+
+
+async def _fetch_profile(db: Any, user_id: str) -> dict | None:
+    result = await _execute_supabase(
+        db.table("profiles")
+        .select("email, full_name")
+        .eq("id", user_id)
+        .single()
+    )
+    return _first_row(result)
+
+
+async def _update_intel_report_purchase(
+    db: Any,
+    purchase_id: str,
+    values: dict[str, Any],
+) -> None:
+    payload = {
+        **values,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        await _execute_supabase(
+            db.table("intel_report_purchases")
+            .update(payload)
+            .eq("id", purchase_id)
+        )
+    except Exception as exc:
+        if "updated_at" not in str(exc):
+            raise
+        fallback_payload = dict(values)
+        await _execute_supabase(
+            db.table("intel_report_purchases")
+            .update(fallback_payload)
+            .eq("id", purchase_id)
+        )
+
+
+async def _generate_cnpj_report_pdf(db: Any, entity_key: str) -> bytes:
+    result = await _execute_supabase(
+        db.rpc(
+            "cnpj_supplier_intel",
+            {"p_cnpj": entity_key, "p_window_months": 36},
+        )
+    )
+    payload = getattr(result, "data", None)
+    if not payload:
+        raise ValueError("cnpj_supplier_intel returned no data")
+
+    from pdf_generator_intel_report import generate_cnpj_report
+
+    buffer = generate_cnpj_report(payload)
+    return buffer.getvalue() if hasattr(buffer, "getvalue") else buffer.read()
+
+
+async def _generate_sector_uf_report_pdf(db: Any, entity_key: str) -> bytes:
+    try:
+        from pdf_generator_sector_uf_report import generate_sector_uf_report
+    except ImportError as exc:
+        raise NotImplementedError("sector_uf report generator is not available") from exc
+
+    buffer = generate_sector_uf_report(db=db, entity_key=entity_key)
+    if asyncio.iscoroutine(buffer):
+        buffer = await buffer
+    return buffer.getvalue() if hasattr(buffer, "getvalue") else buffer.read()
+
+
+async def _generate_intel_report_pdf(db: Any, purchase: dict) -> bytes:
+    product_type = purchase.get("product_type")
+    entity_key = purchase.get("entity_key") or ""
+    if product_type == "cnpj":
+        return await asyncio.wait_for(
+            _generate_cnpj_report_pdf(db, entity_key),
+            timeout=90,
+        )
+    if product_type == "sector_uf":
+        return await asyncio.wait_for(
+            _generate_sector_uf_report_pdf(db, entity_key),
+            timeout=90,
+        )
+    raise ValueError(f"unsupported intel report product_type={product_type!r}")
+
+
+def _is_duplicate_storage_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(token in message for token in ("already exists", "duplicate", "exists"))
+
+
+async def _upload_intel_report_pdf(db: Any, purchase_id: str, pdf_bytes: bytes) -> str:
+    def _upload_and_sign() -> str:
+        storage = db.storage
+        try:
+            buckets = storage.list_buckets()
+            bucket_names = [
+                getattr(bucket, "name", None) if not isinstance(bucket, dict) else bucket.get("name")
+                for bucket in (buckets or [])
+            ]
+            if INTEL_REPORT_BUCKET not in bucket_names:
+                storage.create_bucket(
+                    INTEL_REPORT_BUCKET,
+                    options={
+                        "public": False,
+                        "file_size_limit": 50 * 1024 * 1024,
+                    },
+                )
+        except Exception as exc:
+            logger.debug("Intel Report bucket ensure skipped: %s", exc)
+
+        bucket = storage.from_(INTEL_REPORT_BUCKET)
+        path = f"{purchase_id}.pdf"
+        try:
+            bucket.upload(
+                path=path,
+                file=pdf_bytes,
+                file_options={"content-type": "application/pdf", "upsert": "false"},
+            )
+        except Exception as exc:
+            if not _is_duplicate_storage_error(exc):
+                raise
+            logger.info("Intel Report PDF already exists in storage: %s", path)
+
+        signed_response = bucket.create_signed_url(
+            path=path,
+            expires_in=INTEL_REPORT_SIGNED_URL_TTL_SECONDS,
+        )
+        signed_url = _signed_url_from_response(signed_response)
+        if not signed_url:
+            raise RuntimeError("Supabase Storage returned empty signed URL")
+        return signed_url
+
+    return await asyncio.wait_for(asyncio.to_thread(_upload_and_sign), timeout=10)
+
+
+def _intel_report_product_name(product_type: str) -> str:
+    if product_type == "sector_uf":
+        return "Relatório Setor/UF SmartLic"
+    return "Raio-X do Concorrente SmartLic"
+
+
+def _refund_intel_report_purchase(purchase: dict) -> bool:
+    payment_intent = purchase.get("stripe_payment_intent_id")
+    if not payment_intent:
+        logger.warning("Intel Report refund skipped: purchase has no payment_intent")
+        return False
+    try:
+        import os
+        import stripe as stripe_lib
+
+        stripe_lib.Refund.create(
+            payment_intent=payment_intent,
+            reason="requested_by_customer",
+            metadata={
+                "source": "intel_report_job",
+                "purchase_id": purchase.get("id", ""),
+            },
+            api_key=os.getenv("STRIPE_SECRET_KEY") or None,
+        )
+        return True
+    except Exception as exc:
+        logger.error("Intel Report refund failed: purchase_id=%s error=%s", purchase.get("id"), exc)
+        return False
+
+
+def _send_intel_report_failed_email(profile: dict | None, purchase: dict) -> None:
+    if not profile or not profile.get("email"):
+        return
+    try:
+        from templates.emails.base import email_base
+        from email_service import send_email_async
+
+        body = """
+        <h1 style="color: #333; font-size: 24px; margin: 0 0 16px;">
+          Não conseguimos gerar seu relatório
+        </h1>
+        <p style="color: #555; font-size: 16px; line-height: 1.6;">
+          Tivemos uma falha ao gerar o relatório comprado. Já iniciamos o
+          reembolso automático e, se precisar, responda este email para falar
+          com nosso suporte.
+        </p>
+        """
+        send_email_async(
+            to=profile["email"],
+            subject="Não conseguimos gerar seu relatório — SmartLic",
+            html=email_base(
+                title="Não conseguimos gerar seu relatório — SmartLic",
+                body_html=body,
+                is_transactional=True,
+            ),
+            reply_to="tiago.sasaki@gmail.com",
+            tags=[
+                {"name": "category", "value": "intel_report"},
+                {"name": "status", "value": "failed"},
+                {"name": "purchase_id", "value": str(purchase.get("id", ""))[:32]},
+            ],
+        )
+    except Exception:
+        logger.exception("Intel Report failure email failed: purchase_id=%s", purchase.get("id"))
+
+
+async def generate_intel_report(ctx: dict, purchase_id: str) -> dict:
+    """Generate, upload, and deliver an Intel Report PDF for a paid purchase."""
+    start = time.monotonic()
+    attempt = int(ctx.get("job_try") or 1) if isinstance(ctx, dict) else 1
+
+    from supabase_client import get_supabase
+    from metrics import INTEL_REPORT_GENERATED
+
+    db = get_supabase()
+    _sentry_breadcrumb("lookup", purchase_id=purchase_id, attempt=attempt)
+    purchase = await _fetch_intel_report_purchase(db, purchase_id)
+    if not purchase:
+        INTEL_REPORT_GENERATED.labels(product_type="unknown", status="failed").inc()
+        return {"status": "not_found", "purchase_id": purchase_id}
+
+    product_type = purchase.get("product_type") or "unknown"
+    if purchase.get("status") == "ready" and purchase.get("pdf_url"):
+        return {"status": "already_ready", "purchase_id": purchase_id}
+    if purchase.get("status") != "pending":
+        return {
+            "status": "skipped",
+            "purchase_id": purchase_id,
+            "purchase_status": purchase.get("status"),
+        }
+
+    profile = await _fetch_profile(db, purchase.get("user_id", ""))
+
+    try:
+        await _update_intel_report_purchase(db, purchase_id, {"status": "generating"})
+
+        _sentry_breadcrumb("generation", purchase_id=purchase_id, product_type=product_type)
+        pdf_bytes = await _generate_intel_report_pdf(db, purchase)
+
+        _sentry_breadcrumb(
+            "upload",
+            purchase_id=purchase_id,
+            product_type=product_type,
+            pdf_size_bytes=len(pdf_bytes),
+        )
+        signed_url = await _upload_intel_report_pdf(db, purchase_id, pdf_bytes)
+
+        await _update_intel_report_purchase(
+            db,
+            purchase_id,
+            {"status": "ready", "pdf_url": signed_url},
+        )
+
+        _sentry_breadcrumb("email", purchase_id=purchase_id, product_type=product_type)
+        if profile and profile.get("email"):
+            from email_service import send_intel_report_ready
+
+            send_intel_report_ready(
+                user_email=profile["email"],
+                name=profile.get("full_name") or profile["email"].split("@")[0],
+                pdf_url=signed_url,
+                product_name=_intel_report_product_name(product_type),
+                purchase_id=purchase_id,
+            )
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        INTEL_REPORT_GENERATED.labels(product_type=product_type, status="success").inc()
+        try:
+            from analytics_events import track_event
+            track_event(
+                "intel_report_generated",
+                {
+                    "user_id": purchase.get("user_id"),
+                    "product_type": product_type,
+                    "entity_key": purchase.get("entity_key"),
+                    "generation_time_ms": duration_ms,
+                    "pdf_size_bytes": len(pdf_bytes),
+                },
+            )
+        except Exception:
+            pass
+
+        return {
+            "status": "ready",
+            "purchase_id": purchase_id,
+            "product_type": product_type,
+            "pdf_size_bytes": len(pdf_bytes),
+            "generation_time_ms": duration_ms,
+        }
+    except Exception as exc:
+        logger.error(
+            "Intel Report generation failed: purchase_id=%s attempt=%s error=%s",
+            purchase_id,
+            attempt,
+            exc,
+            exc_info=True,
+        )
+        await _update_intel_report_purchase(db, purchase_id, {"status": "pending"})
+
+        if attempt < 3:
+            try:
+                from arq import Retry
+                raise Retry(defer=INTEL_REPORT_RETRY_BACKOFF_SECONDS[attempt - 1]) from exc
+            except ImportError:
+                raise exc
+
+        await _update_intel_report_purchase(db, purchase_id, {"status": "failed"})
+        INTEL_REPORT_GENERATED.labels(product_type=product_type, status="failed").inc()
+        refunded = _refund_intel_report_purchase(purchase)
+        if refunded:
+            INTEL_REPORT_GENERATED.labels(product_type=product_type, status="refunded").inc()
+        _send_intel_report_failed_email(profile, purchase)
+        return {
+            "status": "failed",
+            "purchase_id": purchase_id,
+            "product_type": product_type,
+            "refunded": refunded,
+            "error": str(exc),
+        }
 
 
 async def llm_summary_job(ctx: dict, search_id: str, licitacoes: list, sector_name: str, termos_busca: str | None = None, **kwargs) -> dict:

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1266,6 +1266,13 @@ smartlic_gsc_sync_rows_upserted_total = _create_counter(
     "Total rows upserted by the GSC weekly sync job",
 )
 
+# Issue #631: Intel Report background generation delivery funnel.
+INTEL_REPORT_GENERATED = _create_counter(
+    "smartlic_intel_report_generated_total",
+    "Intel Report generation outcomes by product type",
+    labelnames=["product_type", "status"],  # success | failed | refunded
+)
+
 # ============================================================================
 # MON-FN-005: Mixpanel init + health check failure counters
 # ============================================================================

--- a/backend/templates/emails/intel_report_ready.html
+++ b/backend/templates/emails/intel_report_ready.html
@@ -1,0 +1,42 @@
+<h1 style="color: #333; font-size: 24px; margin: 0 0 16px;">
+  Olá, {name}
+</h1>
+
+<p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+  Seu <strong>{product_name}</strong> está pronto para download.
+</p>
+
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 24px auto;">
+  <tr>
+    <td align="center" style="background: #2E7D32; border-radius: 8px;">
+      <a href="{pdf_url}"
+         style="display: inline-block; padding: 14px 32px; color: #ffffff;
+                text-decoration: none; font-weight: 600; font-size: 16px;">
+        Baixar Relatório
+      </a>
+    </td>
+  </tr>
+</table>
+
+<p style="color: #777; font-size: 14px; line-height: 1.6; margin: 0 0 24px;">
+  Este link expira em 30 dias. Guarde uma cópia local se quiser consultar o
+  relatório depois desse prazo.
+</p>
+
+<div style="border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 24px 0;">
+  <p style="color: #333; font-size: 15px; line-height: 1.6; margin: 0 0 12px;">
+    Este relatório é uma amostra do poder SmartLic Pro. Comece seu trial
+    gratuito de 14 dias.
+  </p>
+  <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 0;">
+    Seu investimento de R$197 vale como crédito integral na primeira
+    mensalidade SmartLic Pro (R$297). Ative em até 30 dias.
+  </p>
+</div>
+
+<p style="text-align: center; margin: 24px 0 0;">
+  <a href="{trial_url}"
+     style="color: #2E7D32; font-weight: 600; text-decoration: underline;">
+    Começar trial gratuito de 14 dias
+  </a>
+</p>

--- a/backend/tests/test_intel_report_job.py
+++ b/backend/tests/test_intel_report_job.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeQuery:
+    def __init__(self, db, table_name: str, operation: str = "select", values=None):
+        self.db = db
+        self.table_name = table_name
+        self.operation = operation
+        self.values = values or {}
+        self.filters: dict[str, str] = {}
+
+    def select(self, *_args, **_kwargs):
+        self.operation = "select"
+        return self
+
+    def update(self, values):
+        self.operation = "update"
+        self.values = values
+        return self
+
+    def eq(self, key, value):
+        self.filters[key] = value
+        return self
+
+    def single(self):
+        return self
+
+    def execute(self):
+        if self.table_name == "intel_report_purchases":
+            purchase_id = self.filters.get("id")
+            if self.operation == "update":
+                self.db.updates.append(dict(self.values))
+                self.db.purchases[purchase_id].update(self.values)
+                return FakeResult([self.db.purchases[purchase_id]])
+            row = self.db.purchases.get(purchase_id)
+            return FakeResult(row)
+
+        if self.table_name == "profiles":
+            return FakeResult(self.db.profiles.get(self.filters.get("id")))
+
+        raise AssertionError(f"unexpected table {self.table_name}")
+
+
+class FakeBucket:
+    def __init__(self, upload_error: Exception | None = None):
+        self.upload_error = upload_error
+        self.upload_calls = []
+        self.signed_calls = []
+
+    def upload(self, **kwargs):
+        self.upload_calls.append(kwargs)
+        if self.upload_error:
+            raise self.upload_error
+        return {"path": kwargs["path"]}
+
+    def create_signed_url(self, **kwargs):
+        self.signed_calls.append(kwargs)
+        return {"signedURL": f"https://storage.test/{kwargs['path']}?token=signed"}
+
+
+class FakeStorage:
+    def __init__(self, bucket: FakeBucket):
+        self.bucket = bucket
+
+    def from_(self, bucket_name):
+        assert bucket_name == "intel-reports"
+        return self.bucket
+
+
+class FakeSupabase:
+    def __init__(
+        self,
+        purchase: dict,
+        profile: dict | None = None,
+        bucket: FakeBucket | None = None,
+    ):
+        self.purchases = {purchase["id"]: dict(purchase)}
+        self.profiles = {purchase["user_id"]: profile or {
+            "email": "ana@example.com",
+            "full_name": "Ana Cliente",
+        }}
+        self.storage = FakeStorage(bucket or FakeBucket())
+        self.updates: list[dict] = []
+
+    def table(self, table_name):
+        return FakeQuery(self, table_name)
+
+
+def _purchase(**overrides):
+    base = {
+        "id": "purchase-001",
+        "user_id": "user-001",
+        "product_type": "cnpj",
+        "entity_key": "12345678000195",
+        "status": "pending",
+        "pdf_url": None,
+        "stripe_payment_intent_id": "pi_123",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_generate_intel_report_success_uploads_updates_ready_and_emails():
+    from jobs.queue.jobs import generate_intel_report
+
+    db = FakeSupabase(_purchase())
+    pdf_bytes = b"%PDF-1.4 smartlic"
+
+    with patch("supabase_client.get_supabase", return_value=db), \
+         patch("jobs.queue.jobs._generate_cnpj_report_pdf", new=AsyncMock(return_value=pdf_bytes)), \
+         patch("email_service.send_intel_report_ready", return_value="email-123") as mock_email, \
+         patch("analytics_events.track_event") as mock_track:
+        result = await generate_intel_report({}, "purchase-001")
+
+    assert result["status"] == "ready"
+    assert db.purchases["purchase-001"]["status"] == "ready"
+    assert db.purchases["purchase-001"]["pdf_url"].startswith("https://storage.test/purchase-001.pdf")
+    assert db.storage.bucket.upload_calls == [{
+        "path": "purchase-001.pdf",
+        "file": pdf_bytes,
+        "file_options": {"content-type": "application/pdf", "upsert": "false"},
+    }]
+    mock_email.assert_called_once()
+    mock_track.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_intel_report_third_failure_marks_failed_and_refunds():
+    from jobs.queue.jobs import generate_intel_report
+
+    db = FakeSupabase(_purchase())
+
+    with patch("supabase_client.get_supabase", return_value=db), \
+         patch("jobs.queue.jobs._generate_cnpj_report_pdf", new=AsyncMock(side_effect=RuntimeError("pdf failed"))), \
+         patch("stripe.Refund.create", return_value=SimpleNamespace(id="re_123")) as mock_refund, \
+         patch("email_service.send_email_async") as mock_failed_email:
+        result = await generate_intel_report({"job_try": 3}, "purchase-001")
+
+    assert result["status"] == "failed"
+    assert result["refunded"] is True
+    assert db.purchases["purchase-001"]["status"] == "failed"
+    mock_refund.assert_called_once()
+    mock_failed_email.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_intel_report_duplicate_storage_upload_is_idempotent():
+    from jobs.queue.jobs import generate_intel_report
+
+    bucket = FakeBucket(upload_error=RuntimeError("resource already exists"))
+    db = FakeSupabase(_purchase(), bucket=bucket)
+
+    with patch("supabase_client.get_supabase", return_value=db), \
+         patch("jobs.queue.jobs._generate_cnpj_report_pdf", new=AsyncMock(return_value=b"%PDF duplicate")), \
+         patch("email_service.send_intel_report_ready", return_value="email-123"):
+        result = await generate_intel_report({}, "purchase-001")
+
+    assert result["status"] == "ready"
+    assert db.purchases["purchase-001"]["status"] == "ready"
+    assert len(bucket.upload_calls) == 1
+    assert len(bucket.signed_calls) == 1
+
+
+def test_worker_settings_registers_generate_intel_report():
+    from jobs.queue.config import WorkerSettings
+
+    assert any(fn.__name__ == "generate_intel_report" for fn in WorkerSettings.functions)


### PR DESCRIPTION
## Context

Issue #631 completes the post-payment delivery path for Intel Reports: Stripe webhook enqueues generation, ARQ builds the PDF, uploads it to private storage, marks the purchase ready, and emails the customer.

## Changes
- Add `generate_intel_report(ctx, purchase_id)` ARQ job.
- Register the job in worker settings and the legacy `job_queue.py` export surface.
- Fetch purchase/profile data, generate CNPJ report PDFs, upload to Supabase Storage bucket `intel-reports`, create 30-day signed URLs, and mark purchases ready.
- Send transactional Resend email using a new Intel Report template.
- Add failure handling: ARQ retry/backoff for first failures, final failed status, Stripe refund attempt, and failure email.
- Add Prometheus counter `smartlic_intel_report_generated_total{product_type,status}` and Mixpanel `intel_report_generated` event.
- Add focused tests for success, final failure/refund, duplicate upload idempotency, and worker registration.

## Testing Plan
- [x] `python3 -m pytest backend/tests/test_intel_report_job.py -q` — 4 passed
- [x] `python3 -m pytest backend/tests/test_intel_report_job.py backend/tests/test_intel_report_billing.py backend/tests/test_intel_report_pdf.py -q` — 48 passed
- [x] `python3 -m pytest backend/tests/test_intel_report_job.py backend/tests/test_intel_report_billing.py backend/tests/test_intel_report_pdf.py backend/tests/test_analytics_events.py -q` — 59 passed
- [x] `python3 -m pytest backend/tests/test_intel_report_job.py backend/tests/test_email_service.py -q` — 16 passed
- [x] `python3 -m py_compile` on changed Python files
- [x] `python3 -m ruff check backend/tests/test_intel_report_job.py`
- [x] `git diff --check`
- [ ] `npm run lint` — root script not defined in this repository
- [ ] `npm run typecheck` — root script not defined in this repository
- [ ] `npm test` — root script not defined in this repository

## Risks & Rollback
Medium risk: this is a new async fulfillment path touching storage, email, metrics, refund fallback, and analytics. The tests mock external services, so staging should verify a sandbox purchase end-to-end before production announcement. Rollback by reverting this commit and disabling webhook enqueue for the job if needed.

## Closes
Closes #631