### PR TITLE
fix(planos): open WhatsApp Web support handoff (#719)

### DIFF
--- a/frontend/__tests__/planos-page.test.tsx
+++ b/frontend/__tests__/planos-page.test.tsx
@@ -546,13 +546,14 @@ describe("DEBT-126: Contact row (WhatsApp + Email)", () => {
     expect(screen.getByTestId("icon-mail")).toBeInTheDocument();
   });
 
-  it("AC5: WhatsApp link uses wa.me format with pre-filled message", () => {
+  it("AC5: WhatsApp link opens WhatsApp Web for support with pre-filled message", () => {
     setupMocks({ session: false });
     render(<PlanosPage />);
     const link = screen.getByTestId("whatsapp-link") as HTMLAnchorElement;
-    expect(link.href).toMatch(/https:\/\/wa\.me\//);
+    expect(link.href).toMatch(/^https:\/\/web\.whatsapp\.com\/send/);
+    expect(link.href).toContain("phone=5548988344559");
     expect(link.href).toContain("text=");
-    expect(decodeURIComponent(link.href)).toContain("SmartLic Pro");
+    expect(decodeURIComponent(link.href)).toContain("Preciso de suporte no SmartLic");
   });
 
   it("AC3: Email link has correct mailto href", () => {

--- a/frontend/app/planos/page.tsx
+++ b/frontend/app/planos/page.tsx
@@ -35,6 +35,9 @@ type UserProfile = Partial<components["schemas"]["UserProfileResponse"]>;
 // STORY-360 AC2 + STORY-SEO-004: pricing source of truth lives in `lib/plan-pricing.ts`
 // (consumed here and by ProductSchema.tsx to keep JSON-LD in sync with UI).
 const PRICING_FALLBACK = PRO_PRICING;
+const SUPPORT_WHATSAPP_NUMBER = "5548988344559";
+const SUPPORT_WHATSAPP_MESSAGE = "Olá! Preciso de suporte no SmartLic.";
+const SUPPORT_WHATSAPP_URL = `https://web.whatsapp.com/send?phone=${SUPPORT_WHATSAPP_NUMBER}&text=${encodeURIComponent(SUPPORT_WHATSAPP_MESSAGE)}`;
 
 // Coupon → discount % mapping. Day 16 trial-expired email sends TRIAL_COMEBACK_20.
 // Keep in sync with Stripe coupon configuration (Stripe is source of truth for actual billing).
@@ -500,7 +503,7 @@ export default function PlanosPage() {
           <div className="py-8 text-center">
             <p className="text-lg font-semibold text-[var(--ink)] mb-4">Precisa de mais informações?</p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-8">
-              <a href={`https://wa.me/${process.env.NEXT_PUBLIC_WHATSAPP_NUMBER || "5548988344559"}?text=${encodeURIComponent("Olá! Gostaria de saber mais sobre o SmartLic Pro.")}`} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-[var(--ink-secondary)] hover:text-[var(--brand-blue)] transition-colors" data-testid="whatsapp-link">
+              <a href={SUPPORT_WHATSAPP_URL} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-[var(--ink-secondary)] hover:text-[var(--brand-blue)] transition-colors" data-testid="whatsapp-link">
                 <MessageCircle className="w-5 h-5" /><span className="font-medium">Fale conosco</span>
               </a>
               <a href="mailto:tiago.sasaki@confenge.com.br" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-[var(--ink-secondary)] hover:text-[var(--brand-blue)] transition-colors" data-testid="email-link">


### PR DESCRIPTION
## Context
Issue #719 was clarified during execution: do not call Meta Cloud API or implement push alerts. The expected first step is a support handoff that opens WhatsApp Web to `+55 48 98834-4559` with an initial support message.

## Changes
- Replace the `/planos` WhatsApp contact CTA target with `https://web.whatsapp.com/send`.
- Use fixed phone `5548988344559` and a support-oriented prefilled message.
- Update the existing `/planos` contact-row test expectation from `wa.me` sales copy to WhatsApp Web support copy.

## Testing Plan
- [x] `git diff --check`
- [ ] `npm --prefix frontend test -- planos-page.test.tsx --runInBand` — could not run locally because `jest` is not installed in this worktree (`sh: 1: jest: not found`)

## Risks & Rollback
Low risk. This changes only the public contact CTA href and its unit-test expectation. Rollback by reverting this commit.

## Closes
Closes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp contact integration updated to use WhatsApp Web with pre-filled support messages and centralized configuration.

* **Tests**
  * Updated WhatsApp contact flow tests to validate the new implementation and message pre-filling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->