### PR TITLE
docs(partners): formalize partner program policy (#597)

### DIFF
--- a/backend/routes/partners.py
+++ b/backend/routes/partners.py
@@ -36,7 +36,8 @@ class CreatePartnerRequest(BaseModel):
     contact_email: str
     contact_name: Optional[str] = None
     stripe_coupon_id: Optional[str] = None
-    revenue_share_pct: float = 25.00
+    # Canonical partner commercial policy lives in docs/adr/partner-program.md.
+    revenue_share_pct: float = 20.00
 
 
 # ── Admin guard helper ────────────────────────────────────────────────────────

--- a/backend/services/partner_service.py
+++ b/backend/services/partner_service.py
@@ -143,14 +143,16 @@ async def create_partner_referral(
     if not partner_id:
         return None  # User not referred by any partner
 
-    # Get partner's revenue share percentage
+    # Partner commercial policy is documented in docs/adr/partner-program.md.
+    # Existing rows keep explicit negotiated values; missing legacy values use
+    # the current canonical default.
     partner_result = await sb_execute(
         sb.table("partners")
         .select("revenue_share_pct")
         .eq("id", partner_id)
         .single()
     )
-    share_pct = float((partner_result.data or {}).get("revenue_share_pct", 25.00))
+    share_pct = float((partner_result.data or {}).get("revenue_share_pct", 20.00))
     share_amount = round(monthly_revenue * share_pct / 100, 2)
 
     # Upsert referral (idempotent — handles duplicate webhooks)
@@ -359,11 +361,12 @@ async def create_partner(
     contact_email: str,
     contact_name: Optional[str] = None,
     stripe_coupon_id: Optional[str] = None,
-    revenue_share_pct: float = 25.00,
+    revenue_share_pct: float = 20.00,
 ) -> dict:
     """Create a new partner.
 
     AC11: Used by POST /v1/admin/partners.
+    Default commission follows docs/adr/partner-program.md.
     """
     sb = get_supabase()
     result = await sb_execute(

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -3313,7 +3313,7 @@
             "type": "string"
           },
           "revenue_share_pct": {
-            "default": 25.0,
+            "default": 20.0,
             "title": "Revenue Share Pct",
             "type": "number"
           },

--- a/backend/tests/test_partners.py
+++ b/backend/tests/test_partners.py
@@ -353,6 +353,8 @@ class TestPartnerRoutes:
             assert res.status_code == 201
             data = res.json()
             assert data["slug"] == "new-partner"
+            mock_create.assert_awaited_once()
+            assert mock_create.await_args.kwargs["revenue_share_pct"] == 20.00
 
             app.dependency_overrides.clear()
 

--- a/docs/adr/partner-program.md
+++ b/docs/adr/partner-program.md
@@ -1,0 +1,52 @@
+# ADR: Partner Program Policy
+
+**Status:** Accepted
+**Date:** 2026-05-06
+**Issue:** [#597](https://github.com/tjsasakifln/PNCP-poc/issues/597)
+
+---
+
+## Context
+
+The partner program already has production surfaces:
+
+- `partners` and `partner_referrals` tables.
+- `backend/routes/partners.py` admin and partner dashboard endpoints.
+- `backend/services/partner_service.py` signup attribution, coupon lookup, revenue share calculation, and monthly reporting.
+
+The commercial rules were not documented as a durable ADR. This created drift risk between implementation, GTM materials, and future payout automation.
+
+## Decision
+
+| Policy | Canonical rule | Notes |
+|--------|----------------|-------|
+| Commission | 20% lifetime revenue share | Applies to new partners unless a partner row has an explicit negotiated `revenue_share_pct`. |
+| Attribution | Last-click partner attribution with 30-day window | Signup attribution wins when present; Stripe coupon attribution is fallback. A 30-day expiry must be enforced by the payout automation story before money movement. |
+| Payout cadence | Pix payout monthly on day 5 | Monthly report generation is not the same as payout execution. |
+| Partner onboarding | Self-service with CPF/CNPJ | Partner identity data is required before payout activation. |
+| Source of truth | Database partner rows plus this ADR | Session memory is not an operational source of truth. |
+
+## Consequences
+
+New partners should default to 20% unless an admin explicitly sets another percentage. Existing partner rows keep their stored `revenue_share_pct`; this ADR does not backfill commercial contracts.
+
+The current backend can calculate monthly revenue share, but does not yet execute Pix payouts, enforce a 30-day attribution expiry, or verify CPF/CNPJ before payout activation. Those items remain implementation follow-up.
+
+## Implementation Follow-Up
+
+Create a Product Owner/Scrum Master story for payout automation covering:
+
+- CPF/CNPJ collection and validation for partners.
+- 30-day last-click attribution expiry.
+- Monthly Pix payout queue on day 5.
+- Admin approval/audit trail before payout execution.
+- Reconciliation between calculated `partner_referrals.revenue_share_amount` and paid amounts.
+
+Story creation is intentionally left to @po/@sm authority under the project Constitution.
+
+## References
+
+- `backend/routes/partners.py`
+- `backend/services/partner_service.py`
+- `docs/stories/STORY-323-revenue-share-tracking.md`
+- `docs/GTM-PLAYBOOK-2026-Q2.md`

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -6706,7 +6706,7 @@ export interface components {
             name: string;
             /**
              * Revenue Share Pct
-             * @default 25
+             * @default 20
              */
             revenue_share_pct: number;
             /** Slug */


### PR DESCRIPTION
## Context
Issue #597 flagged that partner-program commercial decisions lived only in memory/session context, while the code already exposes partner admin, dashboard, attribution, and monthly revenue-share surfaces.

## Changes
- Add `docs/adr/partner-program.md` as the canonical policy for partner commission, attribution, payout cadence, and onboarding identity requirements.
- Align new partner default commission from 25% to 20% while preserving explicit existing row values.
- Reference the ADR from partner route/service defaults.
- Update OpenAPI snapshot and partner route test for the 20% default.

## Testing Plan
- [x] `python3 -m pytest backend/tests/test_partners.py -q` — 13 passed, 6 xpassed; xpasses are existing batch-pollution markers in route tests, exit code 0.
- [x] `python3 -m pytest backend/tests/test_openapi_schema.py::TestOpenAPISchema::test_openapi_schema_matches_snapshot -q`
- [x] `python3 -m py_compile backend/routes/partners.py backend/services/partner_service.py`
- [x] `git diff --check`

## Risks & Rollback
Low-medium risk: this changes the default for newly created partners to the now-documented 20% policy. Existing partners with explicit `revenue_share_pct` values are not backfilled. Rollback by reverting this PR if the business policy remains 25%.

## Closes
Closes #597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Default revenue share percentage for newly created partners updated from 25% to 20%

* **Documentation**
  * Added partner program policy documentation establishing commission structure, attribution rules, monthly payout cadence, and onboarding requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->