### PR TITLE
fix(selenium): add pyotp TOTP support to logged_in_driver fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Tests
+- **Suporte a TOTP/MFA no fixture `logged_in_driver` do Selenium (#654)** — fixture detecta tela "Verificação em dois fatores" (wait 5s) após submit do login. Se `ADMIN_TOTP_SECRET` configurado: gera código TOTP via `pyotp.TOTP` e submete; se não configurado: `pytest.skip` gracioso. Contas sem MFA continuam funcionando sem alteração (bloco `except Exception: pass`). Adiciona `pyotp>=2.9.0` a `tests/selenium/requirements.txt`. Rollback: reverter commit.
+
 ### Added — Frontend / GTM
 - **CTA de trial em /observatorio (#619)** — `ObservatorioCTA` client component adicionado ao hub do observatório. Usuários não autenticados veem link `/signup?ref=observatorio-hub`; autenticados veem link `/buscar`. Empty-state de relatórios agora inclui link ativo para `/licitacoes`.
 

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -10,6 +10,7 @@ from insight_collector import InsightCollector, get_collector
 BASE_URL = os.getenv("BASE_URL", "https://smartlic.tech")
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "tiago.sasaki@gmail.com")
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "")
+ADMIN_TOTP_SECRET = os.getenv("ADMIN_TOTP_SECRET", "")
 HEADLESS = os.getenv("HEADLESS", "true").lower() == "true"
 
 
@@ -53,9 +54,37 @@ def logged_in_driver(driver, base_url, collector):
     if not ADMIN_PASSWORD:
         pytest.skip("ADMIN_PASSWORD não configurado — pule testes autenticados")
     from pages.login_page import LoginPage
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+
     page = LoginPage(driver, base_url)
     login_time = page.login(ADMIN_EMAIL, ADMIN_PASSWORD)
     collector.metric("login_success_seconds", login_time)
+
+    # Check if MFA screen appeared after login
+    try:
+        WebDriverWait(driver, 5).until(
+            EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'dois fatores')]"))
+        )
+        if ADMIN_TOTP_SECRET:
+            import pyotp
+            totp = pyotp.TOTP(ADMIN_TOTP_SECRET)
+            code_input = driver.find_element(
+                By.CSS_SELECTOR, "input[type='text'], input[inputmode='numeric']"
+            )
+            code_input.clear()
+            code_input.send_keys(totp.now())
+            driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+            # Wait for redirect away from /login
+            WebDriverWait(driver, 30).until(
+                lambda d: "/login" not in d.current_url
+            )
+        else:
+            pytest.skip("MFA detectado mas ADMIN_TOTP_SECRET não configurado")
+    except Exception:
+        pass  # No MFA screen — login succeeded directly
+
     return driver
 
 

--- a/tests/selenium/requirements.txt
+++ b/tests/selenium/requirements.txt
@@ -4,3 +4,4 @@ pytest>=8.0
 pytest-html>=4.1
 pytest-timeout>=2.3
 python-dotenv>=1.0
+pyotp>=2.9.0


### PR DESCRIPTION
## Context
Selenium `logged_in_driver` fixture fails on MFA-enabled accounts. Admin account `tiago.sasaki@gmail.com` has 2FA active; after login submit the page shows "Verificação em dois fatores" and the URL stays at `/login`. The fixture waited 30s for a redirect that never came, blocking all 17 authenticated tests.

## Changes
- Added `pyotp>=2.9.0` to `tests/selenium/requirements.txt`
- Added `ADMIN_TOTP_SECRET` env var at module level in `conftest.py`
- `logged_in_driver` now detects MFA screen (5s wait for "dois fatores" text) and enters TOTP code via `pyotp.TOTP(secret).now()`
- Gracefully skips (not fails) when MFA detected but `ADMIN_TOTP_SECRET` not configured

## Testing Plan
- [ ] Unit verification: imports resolve, pyotp syntax correct
- [ ] AC4 deferred: full 17-test run requires `ADMIN_TOTP_SECRET` from authenticator app (never commit to repo — set as CI secret or local env var)

## Risks & Rollback
If `ADMIN_TOTP_SECRET` not set: tests skip gracefully (same behavior as before without password). No regression risk for non-MFA accounts — the `except Exception: pass` block means accounts without MFA continue to work unchanged.

## Closes
Closes #654