### PR TITLE
feat(intel-reports): frontend CTA + checkout flow + polling + download (#632)

### DIFF
--- a/frontend/__tests__/intel-reports/checkout.test.tsx
+++ b/frontend/__tests__/intel-reports/checkout.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for IntelReportCTA component (#632).
+ *
+ * Validates the CTA on /cnpj/[cnpj] pages:
+ * - Renders with correct copy
+ * - Redirects to /signup when unauthenticated (401 from checkout endpoint)
+ * - Redirects to checkout_url on successful checkout
+ * - Fires Mixpanel events
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import IntelReportCTA from "../../app/cnpj/[cnpj]/IntelReportCTA";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
+}));
+
+describe("IntelReportCTA", () => {
+  const cnpj = "12345678000195";
+  let originalFetch: typeof global.fetch;
+  let originalLocation: typeof window.location;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    // jsdom does not allow direct assignment of window.location,
+    // so we keep a reference and spy/mock per test.
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("renders the buy button with correct copy", () => {
+    render(<IntelReportCTA cnpj={cnpj} />);
+    expect(
+      screen.getByRole("button", { name: /Comprar Raio-X.*R\$197/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("redirects to /signup when checkout returns 401", async () => {
+    const mockPush = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 401,
+      ok: false,
+      json: async () => ({ message: "Autenticação necessária" }),
+    });
+
+    render(<IntelReportCTA cnpj={cnpj} />);
+    fireEvent.click(screen.getByRole("button", { name: /Comprar Raio-X/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        `/signup?redirect=/cnpj/${cnpj}&intent=intel_report`,
+      );
+    });
+  });
+
+  it("navigates to checkout_url on successful response", async () => {
+    const checkoutUrl = "https://checkout.stripe.com/pay/cs_test_abc";
+
+    // window.location.href assignment is tracked by jsdom
+    delete (window as unknown as { location?: unknown }).location;
+    (window as unknown as { location: { href: string } }).location = {
+      href: "",
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ checkout_url: checkoutUrl, session_id: "cs_test_abc" }),
+    });
+
+    render(<IntelReportCTA cnpj={cnpj} />);
+    fireEvent.click(screen.getByRole("button", { name: /Comprar Raio-X/i }));
+
+    await waitFor(() => {
+      expect(
+        (window as unknown as { location: { href: string } }).location.href,
+      ).toBe(checkoutUrl);
+    });
+  });
+
+  it("fires intel_report_cta_clicked Mixpanel event on click", async () => {
+    const trackSpy = jest.fn();
+    (window as unknown as { mixpanel: { track: jest.Mock } }).mixpanel = {
+      track: trackSpy,
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 401,
+      ok: false,
+      json: async () => ({}),
+    });
+
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+
+    render(<IntelReportCTA cnpj={cnpj} />);
+    fireEvent.click(screen.getByRole("button", { name: /Comprar Raio-X/i }));
+
+    await waitFor(() => {
+      expect(trackSpy).toHaveBeenCalledWith("intel_report_cta_clicked", {
+        cnpj,
+        page_path: `/cnpj/${cnpj}`,
+      });
+    });
+
+    delete (window as unknown as { mixpanel?: unknown }).mixpanel;
+  });
+
+  it("does not throw when window.mixpanel is undefined", async () => {
+    delete (window as unknown as { mixpanel?: unknown }).mixpanel;
+
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 401,
+      ok: false,
+      json: async () => ({}),
+    });
+
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+
+    render(<IntelReportCTA cnpj={cnpj} />);
+    expect(() =>
+      fireEvent.click(screen.getByRole("button", { name: /Comprar Raio-X/i })),
+    ).not.toThrow();
+  });
+
+  it("shows loading state while fetching", () => {
+    global.fetch = jest.fn().mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    render(<IntelReportCTA cnpj={cnpj} />);
+    const btn = screen.getByRole("button", { name: /Comprar Raio-X/i });
+    fireEvent.click(btn);
+    expect(screen.getByRole("button", { name: /Aguarde/i })).toBeDisabled();
+  });
+});

--- a/frontend/app/api/intel-reports/[purchaseId]/download/route.ts
+++ b/frontend/app/api/intel-reports/[purchaseId]/download/route.ts
@@ -1,0 +1,69 @@
+/**
+ * Intel Report PDF download proxy — GET /v1/intel-reports/{purchaseId}/download
+ * Streams the PDF back to the browser as an attachment.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getRefreshedToken } from "../../../../../lib/serverAuth";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ purchaseId: string }> },
+) {
+  const backendUrl = process.env.BACKEND_URL;
+  if (!backendUrl) {
+    console.error("[intel-reports-download] BACKEND_URL not configured");
+    return NextResponse.json({ message: "Servidor não configurado" }, { status: 503 });
+  }
+
+  const token = await getRefreshedToken();
+  const authHeader = token
+    ? `Bearer ${token}`
+    : request.headers.get("authorization");
+
+  if (!authHeader) {
+    return NextResponse.json({ message: "Autenticação necessária" }, { status: 401 });
+  }
+
+  const { purchaseId } = await params;
+
+  const correlationId = request.headers.get("X-Correlation-ID");
+  const headers: Record<string, string> = { Authorization: authHeader };
+  if (correlationId) headers["X-Correlation-ID"] = correlationId;
+
+  try {
+    const res = await fetch(
+      `${backendUrl}/v1/intel-reports/${purchaseId}/download`,
+      { method: "GET", headers },
+    );
+
+    if (!res.ok) {
+      let detail = "Erro ao baixar relatório";
+      try {
+        const err = await res.json();
+        detail = err.detail || err.message || detail;
+      } catch {
+        // ignore parse error
+      }
+      return NextResponse.json({ detail }, { status: res.status });
+    }
+
+    const pdfBuffer = await res.arrayBuffer();
+
+    return new NextResponse(pdfBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="intel-report-${purchaseId.slice(0, 8)}.pdf"`,
+      },
+    });
+  } catch (error) {
+    console.error(
+      "[intel-reports-download] Network error:",
+      error instanceof Error ? error.message : error,
+    );
+    return NextResponse.json(
+      { detail: "Erro de rede ao baixar relatório" },
+      { status: 502 },
+    );
+  }
+}

--- a/frontend/app/api/intel-reports/[purchaseId]/route.ts
+++ b/frontend/app/api/intel-reports/[purchaseId]/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Intel Report status polling proxy — GET /v1/intel-reports/{purchaseId}
+ * Returns { status, pdf_url, expires_at } for a purchase.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getRefreshedToken } from "../../../../lib/serverAuth";
+import {
+  sanitizeProxyError,
+  sanitizeNetworkError,
+} from "../../../../lib/proxy-error-handler";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ purchaseId: string }> },
+) {
+  const backendUrl = process.env.BACKEND_URL;
+  if (!backendUrl) {
+    console.error("[intel-reports-status] BACKEND_URL not configured");
+    return NextResponse.json({ message: "Servidor não configurado" }, { status: 503 });
+  }
+
+  const token = await getRefreshedToken();
+  const authHeader = token
+    ? `Bearer ${token}`
+    : request.headers.get("authorization");
+
+  if (!authHeader) {
+    return NextResponse.json({ message: "Autenticação necessária" }, { status: 401 });
+  }
+
+  const { purchaseId } = await params;
+
+  const correlationId = request.headers.get("X-Correlation-ID");
+  const headers: Record<string, string> = { Authorization: authHeader };
+  if (correlationId) headers["X-Correlation-ID"] = correlationId;
+
+  try {
+    const res = await fetch(
+      `${backendUrl}/v1/intel-reports/${purchaseId}`,
+      { method: "GET", headers },
+    );
+
+    const body = await res.text();
+    const sanitized = sanitizeProxyError(
+      res.status,
+      body,
+      res.headers.get("content-type"),
+    );
+    if (sanitized) return sanitized;
+
+    try {
+      return NextResponse.json(JSON.parse(body), { status: res.status });
+    } catch {
+      return NextResponse.json(
+        { message: "Erro ao carregar status do relatório" },
+        { status: res.status },
+      );
+    }
+  } catch (error) {
+    console.error(
+      "[intel-reports-status] Network error:",
+      error instanceof Error ? error.message : error,
+    );
+    return sanitizeNetworkError(error);
+  }
+}

--- a/frontend/app/api/intel-reports/checkout/route.ts
+++ b/frontend/app/api/intel-reports/checkout/route.ts
@@ -1,0 +1,13 @@
+/**
+ * Intel Report checkout proxy — POST /v1/intel-reports/checkout
+ * Returns { checkout_url, session_id } from backend.
+ * Frontend redirects user to checkout_url (Stripe Checkout).
+ */
+import { createProxyRoute } from "../../../../lib/create-proxy-route";
+
+export const { POST } = createProxyRoute({
+  backendPath: "/v1/intel-reports/checkout",
+  methods: ["POST"],
+  requireAuth: true,
+  errorMessage: "Não foi possível iniciar o checkout do Intel Report.",
+});

--- a/frontend/app/api/intel-reports/route.ts
+++ b/frontend/app/api/intel-reports/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Intel Report list proxy — GET /v1/intel-reports/
+ * Returns array of user's Intel Report purchases.
+ */
+import { createProxyRoute } from "../../../lib/create-proxy-route";
+
+export const { GET } = createProxyRoute({
+  backendPath: "/v1/intel-reports/",
+  methods: ["GET"],
+  requireAuth: true,
+  errorMessage: "Não foi possível carregar seus relatórios.",
+});

--- a/frontend/app/cnpj/[cnpj]/IntelReportCTA.tsx
+++ b/frontend/app/cnpj/[cnpj]/IntelReportCTA.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  cnpj: string;
+}
+
+/**
+ * Intel Report CTA for /cnpj/[cnpj] pages (#632).
+ *
+ * Unauthenticated click → redirect to /signup?intent=intel_report.
+ * Authenticated click → Stripe Checkout for Raio-X do Concorrente (R$197).
+ *
+ * Must be a separate "use client" file because the parent page.tsx is a
+ * Server Component with ISR (revalidate=86400).
+ */
+export default function IntelReportCTA({ cnpj }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleBuy = async () => {
+    setLoading(true);
+    try {
+      if (typeof window !== "undefined" && window.mixpanel) {
+        window.mixpanel.track("intel_report_cta_clicked", {
+          cnpj,
+          page_path: `/cnpj/${cnpj}`,
+        });
+      }
+
+      const res = await fetch("/api/intel-reports/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ product_type: "cnpj", entity_key: cnpj }),
+      });
+
+      if (res.status === 401) {
+        router.push(`/signup?redirect=/cnpj/${cnpj}&intent=intel_report`);
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error(`checkout failed: ${res.status}`);
+      }
+
+      const { checkout_url } = await res.json();
+
+      if (typeof window !== "undefined" && window.mixpanel) {
+        window.mixpanel.track("intel_report_checkout_started", {
+          product_type: "cnpj",
+          entity_key: cnpj,
+        });
+      }
+
+      window.location.href = checkout_url;
+    } catch {
+      setLoading(false);
+      alert("Não foi possível iniciar o checkout. Tente novamente.");
+    }
+  };
+
+  return (
+    <button
+      onClick={handleBuy}
+      disabled={loading}
+      className="w-full rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-60"
+    >
+      {loading ? "Aguarde..." : "Comprar Raio-X — R$197"}
+    </button>
+  );
+}

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import CnpjPerfilClient from './CnpjPerfilClient';
 import InlineTrialCTA from '../../components/InlineTrialCTA';
+import IntelReportCTA from './IntelReportCTA';
 import { LeadCapture } from '@/components/LeadCapture';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
@@ -186,6 +187,27 @@ export default async function CnpjPerfilPage({
       />
 
       <CnpjPerfilClient perfil={perfil} />
+
+      {/* #632: Intel Report one-time purchase CTA */}
+      <section className="mt-8 rounded-xl border border-blue-100 bg-gradient-to-r from-blue-50 to-indigo-50 p-6">
+        <h2 className="mb-2 text-xl font-bold text-gray-900">
+          Inteligência Competitiva
+        </h2>
+        <p className="mb-1 font-semibold text-gray-600">
+          Raio-X Completo do Concorrente
+        </p>
+        <p className="mb-4 text-sm text-gray-500">
+          8–12 páginas: histórico de contratos, órgãos compradores, evolução temporal, análise IA
+        </p>
+        <div className="mb-4 text-2xl font-bold text-gray-900">
+          R$197{" "}
+          <span className="text-sm font-normal text-gray-500">— download imediato</span>
+        </div>
+        <IntelReportCTA cnpj={cnpj} />
+        <p className="mt-3 text-xs text-gray-400">
+          ✓ PDF imediato &nbsp; ✓ 30 dias de acesso &nbsp; ✓ Dados PNCP atualizados
+        </p>
+      </section>
 
       {/* #652: Inline trial CTA after contratos section */}
       <InlineTrialCTA

--- a/frontend/app/intel-reports/[sessionId]/page.tsx
+++ b/frontend/app/intel-reports/[sessionId]/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+type PurchaseStatus = "pending" | "generating" | "ready" | "failed";
+
+interface IntelReportPurchase {
+  id: string;
+  status: PurchaseStatus;
+  pdf_url?: string;
+  expires_at?: string;
+}
+
+const MAX_POLLS = 40; // 40 × 3s = 120s max
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Post-Stripe success page for Intel Report one-time purchases (#632).
+ *
+ * URL pattern: /intel-reports/{CHECKOUT_SESSION_ID}?status=processing
+ * The page polls GET /api/intel-reports (list) to find the most recent
+ * purchase and tracks it until status reaches "ready" or "failed".
+ *
+ * NOTE: The backend status endpoint (GET /v1/intel-reports/{purchase_id})
+ * accepts a DB UUID, not the Stripe session ID in the URL. We resolve the
+ * purchase by listing and taking the most recent pending/generating entry.
+ */
+export default function IntelReportSuccessPage() {
+  const params = useParams();
+  const sessionId = params.sessionId as string;
+
+  const [purchase, setPurchase] = useState<IntelReportPurchase | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+  const pollCountRef = useRef(0);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const fetchLatestPurchase = async (): Promise<IntelReportPurchase | null> => {
+      try {
+        const res = await fetch("/api/intel-reports");
+        if (!res.ok) return null;
+        const items: IntelReportPurchase[] = await res.json();
+        // Most recent purchase is first (backend orders by created_at DESC)
+        return items.length > 0 ? items[0] : null;
+      } catch {
+        return null;
+      }
+    };
+
+    const doPoll = async () => {
+      const item = await fetchLatestPurchase();
+      pollCountRef.current += 1;
+
+      if (item) {
+        setPurchase(item);
+        if (item.status === "ready" || item.status === "failed") {
+          return; // terminal state — stop polling
+        }
+      }
+
+      if (pollCountRef.current >= MAX_POLLS) {
+        setTimedOut(true);
+        return;
+      }
+
+      timerRef.current = setTimeout(doPoll, POLL_INTERVAL_MS);
+    };
+
+    // Small initial delay to let Stripe webhook land
+    timerRef.current = setTimeout(doPoll, 1500);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [sessionId]);
+
+  const handleDownload = () => {
+    if (!purchase) return;
+    window.open(`/api/intel-reports/${purchase.id}/download`, "_blank");
+    if (typeof window !== "undefined" && window.mixpanel) {
+      window.mixpanel.track("intel_report_downloaded", {
+        purchase_id: purchase.id,
+      });
+    }
+  };
+
+  const isTerminal =
+    purchase?.status === "ready" || purchase?.status === "failed";
+  const isProcessing =
+    !purchase || purchase.status === "pending" || purchase.status === "generating";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white p-8 text-center shadow-sm">
+        {/* Title */}
+        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          {purchase?.status === "ready"
+            ? "Relatório pronto!"
+            : purchase?.status === "failed"
+              ? "Erro ao gerar relatório"
+              : timedOut
+                ? "Processando..."
+                : "Gerando seu relatório..."}
+        </h1>
+
+        {/* Ready state */}
+        {purchase?.status === "ready" && (
+          <>
+            <p className="mb-6 text-gray-600">
+              Seu relatório de inteligência está disponível para download.
+            </p>
+            <button
+              onClick={handleDownload}
+              className="mb-4 w-full rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white hover:bg-blue-700"
+            >
+              Baixar Relatório (PDF)
+            </button>
+            <p className="text-sm text-gray-500">
+              Link válido por 30 dias. Você também receberá o link por email.
+            </p>
+            <div className="mt-6 rounded-lg bg-blue-50 p-4">
+              <p className="text-sm text-blue-800">
+                Ative 14 dias grátis SmartLic Pro →{" "}
+                <Link href="/planos" className="font-semibold underline">
+                  Conhecer planos
+                </Link>
+              </p>
+            </div>
+          </>
+        )}
+
+        {/* Failed state */}
+        {purchase?.status === "failed" && (
+          <p className="text-gray-600">
+            Ocorreu um erro ao gerar seu relatório. Nossa equipe foi notificada.
+            Entre em contato:{" "}
+            <a
+              href="mailto:tiago.sasaki@confenge.com.br"
+              className="text-blue-600 underline"
+            >
+              tiago.sasaki@confenge.com.br
+            </a>
+          </p>
+        )}
+
+        {/* Processing / initial load */}
+        {isProcessing && !timedOut && (
+          <>
+            <div className="mb-4 flex justify-center">
+              <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-blue-600" />
+            </div>
+            <p className="text-sm text-gray-500">
+              Isso leva em torno de 30–60 segundos...
+            </p>
+          </>
+        )}
+
+        {/* Timed out but not yet in terminal state */}
+        {timedOut && !isTerminal && (
+          <p className="text-sm text-gray-600">
+            Seu relatório está sendo processado. Você receberá um email quando
+            estiver pronto. Não feche esta página ainda.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/intel-reports/cancelado/page.tsx
+++ b/frontend/app/intel-reports/cancelado/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Cancel URL after abandoned Stripe Checkout for Intel Report (#632).
+ */
+export default function IntelReportCanceladoPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white p-8 text-center shadow-sm">
+        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          Compra cancelada
+        </h1>
+        <p className="mb-6 text-gray-600">
+          Nenhuma cobrança foi realizada. Você pode voltar e tentar novamente quando quiser.
+        </p>
+        <Link
+          href="/"
+          className="inline-block rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white hover:bg-blue-700"
+        >
+          Voltar ao início
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Context
Intel Reports backend (#628–#631) is complete. This PR adds the frontend layer: CTA on CNPJ programmatic SEO pages, Stripe checkout proxy, post-payment polling page, and streaming PDF download.

## Changes
- `frontend/app/api/intel-reports/checkout/route.ts` — POST proxy via `createProxyRoute` factory
- `frontend/app/api/intel-reports/route.ts` — GET list proxy
- `frontend/app/api/intel-reports/[purchaseId]/route.ts` — GET status polling proxy (dynamic params)
- `frontend/app/api/intel-reports/[purchaseId]/download/route.ts` — PDF streaming proxy
- `frontend/app/cnpj/[cnpj]/IntelReportCTA.tsx` — `"use client"` CTA button (separate file required since parent is a Server Component with ISR)
- `frontend/app/cnpj/[cnpj]/page.tsx` — Intel Report CTA section added after `CnpjPerfilClient`
- `frontend/app/intel-reports/[sessionId]/page.tsx` — Post-Stripe success page with polling (resolves purchase via list endpoint since URL contains Stripe session ID, not DB UUID)
- `frontend/app/intel-reports/cancelado/page.tsx` — Cancel URL page
- `frontend/__tests__/intel-reports/checkout.test.tsx` — 6 tests covering CTA behavior

## Implementation Notes
- API proxies use the established `createProxyRoute` factory for simple routes; manual `getRefreshedToken` + `sanitizeProxyError` pattern for dynamic `[purchaseId]` routes (matches `sessions/[searchId]/download` pattern)
- Next.js 16 dynamic params are `Promise<{ ... }>` — properly awaited in all dynamic route handlers
- The success page polls `GET /api/intel-reports` (list) to find the most recent purchase, because Stripe's `{CHECKOUT_SESSION_ID}` template puts the Stripe `cs_...` ID in the URL while the backend status endpoint expects the DB UUID
- Polling uses `useRef` counter to avoid stale closure bug; 40 polls × 3s = 120s max
- `window.mixpanel` uses the existing `MixpanelClient` type from `types/external.d.ts` (no `any` casts)

## Testing Plan
- [x] TypeScript: `npx tsc --noEmit` passes (0 errors)
- [x] Tests: 6/6 pass (`npm test -- --testPathPattern=intel-reports`)
- [x] Existing cnpj + InlineTrialCTA tests: 17/17 pass
- [ ] CTA renders on /cnpj/* pages
- [ ] Unauthenticated click redirects to `/signup?redirect=/cnpj/{cnpj}&intent=intel_report`
- [ ] Authenticated click → Stripe checkout redirect
- [ ] Post-payment page polls and shows download button when ready

## Risks & Rollback
Stripe checkout redirect is production-only (requires `STRIPE_SECRET_KEY` + Stripe Products configured). The CTA on `/cnpj/*` is safe to deploy — the checkout proxy returns 422/503 gracefully if Stripe is not configured. All new routes are additive.

## Closes
Closes #632