### PR TITLE
fix(accessibility): add ARIA labels and modal focus management (#194, #196)

### DIFF
--- a/frontend/app/buscar/components/SearchCustomizePanel.tsx
+++ b/frontend/app/buscar/components/SearchCustomizePanel.tsx
@@ -158,6 +158,7 @@ export default function SearchCustomizePanel({
                   onClick={() => toggleUf(uf)}
                   type="button"
                   title={UF_NAMES[uf]}
+                  aria-label={`${ufsSelecionadas.has(uf) ? 'Remover' : 'Selecionar'} ${UF_NAMES[uf]}`}
                   aria-pressed={ufsSelecionadas.has(uf)}
                   className={`px-1.5 py-2.5 sm:px-4 sm:py-2 rounded-button border text-xs sm:text-base font-medium transition-all duration-200 min-h-[44px] ${
                     ufsSelecionadas.has(uf)


### PR DESCRIPTION
## Context
TD-UX-001 (#194): interactive elements missing aria-label attributes impacted screen reader users. TD-UX-003 (#196): Save Search modal lacked focus trapping and autoFocus, breaking keyboard navigation flow.

## Changes
- Add `aria-label` to SavedSearchesDropdown input and region selector buttons
- Add `autoFocus` to Save Search modal first input
- Add Escape key handler to Save Search modal

## Testing Plan
- [ ] `npx tsc --noEmit` passes with no new errors
- [ ] `npm run lint` passes
- [ ] Screen reader announces button/input purposes correctly
- [ ] Escape key closes Save Search modal
- [ ] Focus lands on input when modal opens

## Risks & Rollback
Additive accessibility attributes. No behavioral change to existing functionality. Rollback: revert commit.

## Closes
Closes #194
Closes #196