### PR TITLE
fix(db): correct gsc_metrics RLS — is_master is computed, not a column (#796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Database / Migrations
+- **RLS policy gsc_metrics corrigida + 14 migrations aplicadas (#796)** — `20260422120000_create_gsc_metrics.sql` referenciava `profiles.is_master` como coluna (inexistente — é computado em Python); corrigido para `profiles.plan_type = 'master'`. 14 migrations pendentes aplicadas ao DB de produção via Management API. Resolve falha crônica em `migration-check.yml`. Rollback: `supabase db push` com `.down.sql` dos arquivos afetados.
+
 ### Added — Frontend / Legal
 - **Página de termos do Plano Fundadores (#793)** — `frontend/app/termos/fundadores/page.tsx` criado com 9 seções legais cobrindo escopo vitalício, fair use, sem garantia de êxito, período de resfriamento (CDC art. 49) e disclaimer de parceria governamental. `frontend/app/termos/page.tsx` atualizado com link para `/termos/fundadores`. Protege juridicamente o SmartLic e informa fundadores sobre os exatos direitos adquiridos.
 

--- a/supabase/migrations/20260422120000_create_gsc_metrics.sql
+++ b/supabase/migrations/20260422120000_create_gsc_metrics.sql
@@ -33,7 +33,7 @@ CREATE POLICY "admin_read_gsc_metrics" ON gsc_metrics
     EXISTS (
       SELECT 1 FROM profiles
       WHERE profiles.id = auth.uid()
-        AND (profiles.is_admin = true OR profiles.is_master = true)
+        AND (profiles.is_admin = true OR profiles.plan_type = 'master')
     )
   );
 


### PR DESCRIPTION
## Summary/Context
`migration-check.yml` was failing because 14 migrations were unapplied in production (issue #796). Root cause: `20260422120000_create_gsc_metrics.sql` referenced `profiles.is_master` as a column, but `is_master` is computed in Python (`authorization.py`: `is_admin OR plan_type == 'master'`), not a DB column. Same `is_master` non-column bug previously fixed in `prevent_privilege_escalation` trigger (STORY-415, migration `20260410150000`).

## Changes
- Fixed `20260422120000_create_gsc_metrics.sql` RLS policy: `profiles.is_master = true` → `profiles.plan_type = 'master'`
- Applied all 14 unapplied migrations to production DB via Management API:
  - `20260422120000` gsc_metrics table + RLS
  - `20260428100000–101200` founding policy, founding RPC, consultoria MFA, auth_attempts, export survey, app_config, plan_billing_periods, billing_reconciliation, admin_billing_audit (April incident recovery batch)
  - `20260504140600` fix_signup_trigger_search_path (security — SECDEF SET search_path)
  - `20260505113800–113900` intel_reports_schema, cnae_setores, cnpj_supplier_intel_rpc

## Testing Plan
- [x] All 14 tables/objects confirmed created in prod DB
- [x] schema_migrations count: 169 → 183 (+14)
- [ ] migration-check.yml CI should pass on next run

## Risks & Rollback
Migration file fix is safe (corrects wrong column reference). DB changes already applied to prod. To rollback DB objects, use `.down.sql` files for individual migrations.

## Closes
Closes #796