### PR TITLE
docs: founders-policy.md internal guideline + go-live checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added — Frontend / Intel Reports
 - **Intel Reports frontend layer: CTA + checkout + polling + download (#632)** — Adiciona camada frontend completa para Intel Reports (one-time purchase): `IntelReportCTA` "use client" component em `/cnpj/[cnpj]` (parent Server Component com ISR); 4 API proxy routes (`/api/intel-reports/checkout`, `/api/intel-reports/`, `/api/intel-reports/[purchaseId]`, `/api/intel-reports/[purchaseId]/download`); página de sucesso pós-Stripe com polling até 120s (40×3s, `useRef` anti-stale-closure); página de cancelamento. Proxy routes usam factory `createProxyRoute` para rotas simples e padrão manual `getRefreshedToken` + `sanitizeProxyError` para rotas dinâmicas. PDF streaming com `Content-Disposition: attachment`. 6 testes unitários (CTA behavior, 401→signup redirect, checkout_url redirect, Mixpanel events, loading state). Rollback: remover seção #632 de `page.tsx` e deletar arquivos novos.
 
+### Added — Docs / Founders
+- **Política interna Plano Fundadores (#795)** — `docs/founders-policy.md` criado com escopo v2 lifetime R$997 one-time, checklist go-live, plano de rollback e diretrizes de comunicação (BIZ-FOUND-002). Revoga modelo v1 de subscription com 50% off.
+
 ### Added — Docs / Partners
 - **ADR de política do programa de parceiros (#597)** — `docs/adr/partner-program.md` formaliza a política canônica: comissão 20% lifetime, pagamento mensal via Pix no dia 5, atribuição last-click 30 dias, onboarding exige CPF/CNPJ. Default `revenue_share_pct` em `CreatePartnerRequest`, `create_partner()` e `create_partner_referral()` alinhado de 25% para 20%. Valores explícitos em parceiros existentes não são alterados. Snapshot OpenAPI e testes atualizados. Rollback: reverter PR #743.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,7 +550,7 @@ Supabase Auth with RLS on all tables. Input validation via Pydantic (backend) an
 
 | Category | Files |
 |----------|-------|
-| **Docs** | `PRD.md`, `ROADMAP.md`, `CHANGELOG.md`, `docs/summaries/gtm-resilience-summary.md`, `docs/summaries/gtm-fixes-summary.md` |
+| **Docs** | `PRD.md`, `ROADMAP.md`, `CHANGELOG.md`, `docs/founders-policy.md`, `docs/summaries/gtm-resilience-summary.md`, `docs/summaries/gtm-fixes-summary.md` |
 | **Config** | `.env.example`, `backend/requirements.txt`, `frontend/package.json`, `backend/sectors_data.yaml`, `backend/config.py` |
 | **Database** | `supabase/migrations/` (~183 migrations, 48 tables, 13+ RPCs — source of truth, paired `.down.sql` mandatory STORY-6.2), `backend/migrations/` (12 legacy Alembic — audit only, do NOT add new) |
 | **Ingestion** | `backend/ingestion/` (config, crawler, transformer, loader, checkpoint, scheduler), `backend/datalake_query.py` |

--- a/docs/founders-policy.md
+++ b/docs/founders-policy.md
@@ -118,7 +118,7 @@ Se necessário reverter a oferta após ativação:
 3. Rollback migrations se necessário: `supabase db push` com `.down.sql`
 4. Comunicar fundadores ativos por email (não remover acesso retroativamente)
 
-Ver `docs/runbooks/founders-rollback.md` para procedimento completo.
+Ver `docs/runbooks/rollback-procedure.md` para o procedimento geral de rollback.
 
 ---
 

--- a/docs/founders-policy.md
+++ b/docs/founders-policy.md
@@ -1,0 +1,139 @@
+# Plano Fundadores — Política Interna
+
+**Versão:** 1.0 | **Data:** 2026-05-07 | **Status:** Vigente  
+**Oferta:** R$997 one-time vitalício | **Deadline:** 30/06/2026 | **Cap:** 50 vagas
+
+---
+
+## 1. O que é o Plano Fundadores
+
+Acesso vitalício ao plano self-service **atual** do SmartLic em troca de financiamento antecipado da próxima fase do produto. Preço único R$997 (sem recorrência). Vagas limitadas a 50 ou até 30/06/2026, o que ocorrer primeiro.
+
+| Campo | Valor |
+|-------|-------|
+| Preço | R$997 one-time (sem recorrência) |
+| Deadline | 2026-06-30T23:59:59-03:00 |
+| Cap | 50 vagas |
+| Offer mode | `lifetime` |
+| Offer version | `v2_lifetime` |
+| Stripe Price | `FOUNDING_ONE_TIME_PRICE_ID` (env var) |
+
+---
+
+## 2. Incluído — Escopo permanente
+
+O Plano Fundadores garante acesso vitalício ao **escopo self-service atual**:
+
+- ✅ Busca multi-fonte de licitações (PNCP + ComprasGov + PCP v2)
+- ✅ Classificação IA por setor (20 setores, GPT-4.1-nano)
+- ✅ Análise de viabilidade (4 fatores)
+- ✅ Pipeline Kanban de oportunidades
+- ✅ Exportação Excel estilizado
+- ✅ Resumo executivo com IA
+- ✅ Histórico de buscas e sessões
+- ✅ Acesso a todos os setores disponíveis na plataforma
+- ✅ Desconto de 50% em serviços de **consultoria própria SmartLic** (contratos formais)
+
+---
+
+## 3. NÃO incluído
+
+Comunicar claramente para evitar passivo operacional perpétuo:
+
+- ❌ Features premium/enterprise futuras (sem previsão de escopo)
+- ❌ Suporte prioritário vitalício ou SLA enterprise
+- ❌ Customizações ilimitadas
+- ❌ Garantia de êxito em licitações
+- ❌ Parceria oficial com PNCP, ComprasNet, TCU, governo
+- ❌ Consultoria de terceiros com desconto (apenas serviços SmartLic)
+- ❌ Uso sem limites operacionais (rate limit e fair use aplicam)
+
+---
+
+## 4. Limitações Operacionais (Fair Use)
+
+As seguintes restrições aplicam mesmo para fundadores:
+
+- Rate limit de buscas (mesmo tier que plano Pro)
+- Anti-abuse: revenda, scraping massivo, automação que degrada o serviço = suspensão
+- Compute fair use: sem SLA enterprise de uptime
+
+---
+
+## 5. Política de Desconto Consultoria
+
+- **50%** nos serviços de consultoria **próprios SmartLic** (contratos formais)
+- Válido enquanto: o cliente mantiver status de fundador E o serviço de consultoria existir
+- NÃO se aplica a serviços de terceiros, parceiros ou assessorias externas
+- Forma de ativação: contato direto com time SmartLic para emissão de contrato
+
+---
+
+## 6. Comunicação Permitida
+
+### ✅ Pode dizer
+- "Acesso vitalício ao plano self-service atual do SmartLic"
+- "Ajude a financiar a próxima fase do SmartLic"
+- "Vagas limitadas: 50 ou até 30/06/2026"
+- "Sem mensalidade — pague uma vez, use para sempre"
+- "50% de desconto em consultoria SmartLic"
+- "Dados de licitações de todas as fontes oficiais"
+
+### ❌ Não pode dizer
+- "Acesso vitalício a TUDO que o SmartLic lançar"
+- "Suporte prioritário para sempre"
+- "Garantia de ganhar licitações"
+- "Parceria oficial com o governo"
+- "Nunca vai mudar"
+- "Desconto em qualquer consultoria"
+
+---
+
+## 7. Checklist Go-Live
+
+Antes de habilitar `FOUNDERS_OFFER_ENABLED=true` em produção:
+
+- [ ] Stripe Price one-time R$997 criada via `scripts/create_founding_lifetime_price.py` (idempotente)
+- [ ] `FOUNDING_ONE_TIME_PRICE_ID` setado em Railway prod (bidiq-backend)
+- [ ] Migration `founding_policy_lifetime_pivot` aplicada (`supabase db push`)
+- [ ] Migration `profiles_founder_fields` aplicada
+- [ ] `FOUNDERS_OFFER_ENABLED=true` em Railway prod
+- [ ] Webhook handler testado em staging (checkout.session.completed com mode=payment)
+- [ ] Página `/fundadores` publicada e acessível
+- [ ] Termos `/termos/fundadores` publicados
+- [ ] Email welcome founders testado (Resend staging)
+- [ ] Banner global QA em mobile + desktop
+- [ ] Lighthouse pSEO sem regressão (≥80)
+- [ ] Sentry sem novos erros nas 24h em staging
+- [ ] Backup DB pré go-live (`pg_dump` manual)
+
+---
+
+## 8. Checklist Rollback
+
+Se necessário reverter a oferta após ativação:
+
+1. `railway variables set FOUNDERS_OFFER_ENABLED=false` (imediato, sem deploy)
+2. Desativar Price no Stripe Dashboard (impede novos checkouts)
+3. Rollback migrations se necessário: `supabase db push` com `.down.sql`
+4. Comunicar fundadores ativos por email (não remover acesso retroativamente)
+
+Ver `docs/runbooks/founders-rollback.md` para procedimento completo.
+
+---
+
+## 9. Comunicação de Mudanças Futuras
+
+Se o escopo do Plano Fundadores mudar materialmente (ex.: descontinuação de feature incluída):
+
+1. Email para todos os fundadores com 90 dias de antecedência
+2. Opção de reembolso proporcional (CDC art. 49 e-commerce para casos graves)
+3. Registro em `CHANGELOG.md` com justificativa
+
+---
+
+## 10. Histórico de Versões
+
+| Versão | Data | Mudança |
+|--------|------|---------|
+| 1.0 | 2026-05-07 | Criação — pivot BIZ-FOUND-002 v1 (subscription -50%) → v2 (one-time R$997) |

--- a/docs/founders-policy.md
+++ b/docs/founders-policy.md
@@ -118,7 +118,7 @@ Se necessário reverter a oferta após ativação:
 3. Rollback migrations se necessário: `supabase db push` com `.down.sql`
 4. Comunicar fundadores ativos por email (não remover acesso retroativamente)
 
-Ver `docs/runbooks/rollback-procedure.md` para o procedimento geral de rollback.
+Ver `docs/runbooks/founders-rollback.md` para o procedimento completo de rollback.
 
 ---
 

--- a/docs/runbooks/founders-rollback.md
+++ b/docs/runbooks/founders-rollback.md
@@ -1,0 +1,76 @@
+# Runbook: Rollback do Plano Fundadores
+
+> Versão: 2026-05-07 | Owner: @tiago | Severidade: P1
+
+## Quando usar este runbook
+
+- Checkout failing para >50% das tentativas (Stripe error rate)
+- Webhook de entitlement não ativando is_founder=true (Sentry alerts)
+- Race condition no cap (fundadores além de 50 sendo ativados)
+- Erro crítico no Sentry relacionado a `/founding/` endpoints
+
+## Ação 1: Fast disable sem deploy (< 2 minutos)
+
+```bash
+# Opção A: Feature flag via Railway
+railway variables set FOUNDERS_OFFER_ENABLED=false
+
+# Opção B: Admin API (se feature flag implementada)
+curl -X PATCH https://api.smartlic.tech/v1/admin/founding/policy \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -d '{"active": false, "paused_reason": "rollback: <motivo>"}'
+```
+
+Isso bloqueia todos os novos checkouts imediatamente, sem redeploy.
+
+## Ação 2: Investigar causa
+
+```bash
+# Ver logs Railway
+railway logs --tail --service bidiq-backend | grep founding
+
+# Ver erros Sentry (últimas 24h)
+# Dashboard: https://confenge.sentry.io/issues/?project=smartlic-backend&query=founding
+```
+
+## Ação 3: Reverter entitlements incorretos (se cap violado)
+
+```bash
+# Via Supabase Management API ou psql
+# Identificar founders ativados indevidamente:
+SELECT id, email, is_founder, founder_since
+FROM profiles
+WHERE is_founder = true
+ORDER BY founder_since DESC;
+
+# Se necessário, reverter entitlement específico (coordenar com usuário):
+UPDATE profiles
+SET is_founder = false, founder_since = null, consulting_discount_pct = null
+WHERE id = '<user_id>';
+```
+
+## Ação 4: Reverter migrations (último recurso)
+
+Se houver problema nas migrations, aplique os `.down.sql` via Supabase Management API:
+
+```bash
+export SUPABASE_ACCESS_TOKEN=$(cat .env | grep SUPABASE_ACCESS_TOKEN | cut -d= -f2)
+# Aplicar down migrations na ordem reversa
+# 1. Primeiro: 20260507100100_founding_policy_lifetime_pivot.down.sql
+# 2. Depois: 20260507100000_profiles_founder_fields.down.sql
+curl -s "https://api.supabase.com/v1/projects/fqqyovlzdzimiwfofdjk/database/query" \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "<conteudo do .down.sql>"}'
+```
+
+## Comunicação
+
+Notificar founders por email via Resend se checkout foi interrompido por >30 min. Template: `email_founder_checkout_interruption` (criar se necessário).
+
+## Pós-rollback checklist
+
+- [ ] Sentry sem novos erros por 30min
+- [ ] Checkout funcionando para outros planos (não founders)
+- [ ] is_founder = false para todos os founders ativados indevidamente (se houver)
+- [ ] Post-mortem em `docs/incidents/YYYY-MM-DD-founders-rollback.md`


### PR DESCRIPTION
## Context
Internal policy document for the Plano Fundadores (v2 lifetime R$997 offer). Guides engineering, copy, and support on what's included/excluded + go-live checklist + rollback procedures.

## Changes
- Created `docs/founders-policy.md` with 10 sections covering: scope, what's included/excluded, fair use limits, communication guidelines, go-live checklist, and rollback procedures.

## Testing Plan
- [ ] Markdown renders correctly (no broken tables)
- [ ] Checklist items are actionable

## Risks & Rollback
Documentation only — no code changes. Rollback = revert file.

## Closes
Closes #795