### PR TITLE
feat(backend): pivot founding_policy to one-time R$997 lifetime offer

### DIFF
--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -93,6 +93,8 @@ class FoundingAvailabilityResponse(BaseModel):
     reason: str
     coupon_code: str
     discount_pct: int
+    price_brl_cents: int
+    offer_mode: str
 
 
 def _is_valid_cnpj_check_digits(cnpj: str) -> bool:
@@ -184,6 +186,8 @@ def _check_availability(sb) -> dict[str, Any]:
             "deadline_at": row.get("deadline_at"),
             "paused": bool(row.get("paused")),
             "reason": str(row.get("reason") or "unavailable"),
+            "offer_mode": str(row.get("offer_mode") or "lifetime"),
+            "price_brl_cents": int(row.get("price_brl_cents") or 99700),
         }
     except Exception as e:
         logger.error(f"founding: check_founding_availability RPC failed: {e}")
@@ -194,6 +198,8 @@ def _check_availability(sb) -> dict[str, Any]:
             "deadline_at": None,
             "paused": False,
             "reason": "unavailable",
+            "offer_mode": "lifetime",
+            "price_brl_cents": 99700,
         }
 
 
@@ -264,6 +270,8 @@ async def founding_availability(response: Response) -> Any:
         reason=snapshot["reason"],
         coupon_code=FOUNDING_COUPON_ID,
         discount_pct=50,
+        price_brl_cents=snapshot["price_brl_cents"],
+        offer_mode=snapshot["offer_mode"],
     )
 
 

--- a/backend/tests/test_founding_policy_lifetime_pivot.py
+++ b/backend/tests/test_founding_policy_lifetime_pivot.py
@@ -1,0 +1,198 @@
+"""#782: Tests for founding_policy lifetime pivot.
+
+Covers:
+- GET /availability exposes price_brl_cents and offer_mode from RPC v2.
+- Safe defaults when RPC v2 columns are absent (v1 RPC still live during deploy gap).
+- price_brl_cents=99700 and offer_mode='lifetime' on the canonical path.
+- Fallback values on RPC exception (same safe defaults).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_fake")
+
+from routes.founding import router as founding_router  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_founding():
+    app = FastAPI()
+    app.include_router(founding_router, prefix="/v1")
+    return app
+
+
+def _make_supabase_mock(rpc_data: list[dict]) -> MagicMock:
+    """Build a fake supabase client whose rpc() returns ``rpc_data``."""
+    fake_sb = MagicMock()
+    rpc_result = MagicMock(data=rpc_data)
+    fake_sb.rpc.return_value = MagicMock(execute=MagicMock(return_value=rpc_result))
+    fake_sb.table.return_value = fake_sb
+    fake_sb.select.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.limit.return_value = fake_sb
+    fake_sb.execute.return_value = MagicMock(data=[])
+    return fake_sb
+
+
+# ---------------------------------------------------------------------------
+# price_brl_cents + offer_mode returned from RPC v2
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.founding.get_supabase")
+def test_availability_exposes_price_brl_cents_and_offer_mode(mock_get_sb, app_with_founding):
+    """RPC v2 supplies offer_mode and price_brl_cents — route must surface both."""
+    mock_get_sb.return_value = _make_supabase_mock([
+        {
+            "available": True,
+            "seats_remaining": 47,
+            "seats_total": 50,
+            "deadline_at": "2026-06-30T23:59:59-03:00",
+            "paused": False,
+            "reason": "available",
+            "offer_mode": "lifetime",
+            "price_brl_cents": 99700,
+        }
+    ])
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/availability")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["price_brl_cents"] == 99700
+    assert body["offer_mode"] == "lifetime"
+
+
+@patch("routes.founding.get_supabase")
+def test_availability_price_brl_cents_safe_default_when_rpc_v1(mock_get_sb, app_with_founding):
+    """v1 RPC still live (no new columns) — safe defaults must kick in."""
+    mock_get_sb.return_value = _make_supabase_mock([
+        {
+            "available": True,
+            "seats_remaining": 40,
+            "seats_total": 50,
+            "deadline_at": "2026-06-30T23:59:59-03:00",
+            "paused": False,
+            "reason": "available",
+            # offer_mode and price_brl_cents intentionally absent (v1 RPC)
+        }
+    ])
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/availability")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["price_brl_cents"] == 99700, "safe default when column absent"
+    assert body["offer_mode"] == "lifetime", "safe default when column absent"
+
+
+@patch("routes.founding.get_supabase")
+def test_availability_safe_defaults_on_rpc_exception(mock_get_sb, app_with_founding):
+    """RPC raises — _check_availability returns safe defaults including new fields."""
+    fake_sb = MagicMock()
+    fake_sb.rpc.return_value = MagicMock(execute=MagicMock(side_effect=Exception("db flaky")))
+    mock_get_sb.return_value = fake_sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/availability")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["price_brl_cents"] == 99700
+    assert body["offer_mode"] == "lifetime"
+
+
+@patch("routes.founding.get_supabase")
+def test_availability_custom_price_from_rpc(mock_get_sb, app_with_founding):
+    """If DB has a different price (e.g. future price change) it flows through."""
+    mock_get_sb.return_value = _make_supabase_mock([
+        {
+            "available": True,
+            "seats_remaining": 10,
+            "seats_total": 50,
+            "deadline_at": "2026-06-30T23:59:59-03:00",
+            "paused": False,
+            "reason": "available",
+            "offer_mode": "lifetime",
+            "price_brl_cents": 149700,  # hypothetical future price
+        }
+    ])
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/availability")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["price_brl_cents"] == 149700
+    assert body["offer_mode"] == "lifetime"
+
+
+@patch("routes.founding.get_supabase")
+def test_availability_offer_mode_subscription_passthrough(mock_get_sb, app_with_founding):
+    """If DB is rolled back to subscription mode it flows through too."""
+    mock_get_sb.return_value = _make_supabase_mock([
+        {
+            "available": True,
+            "seats_remaining": 30,
+            "seats_total": 50,
+            "deadline_at": "2026-06-30T23:59:59-03:00",
+            "paused": False,
+            "reason": "available",
+            "offer_mode": "subscription",
+            "price_brl_cents": 49700,
+        }
+    ])
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/availability")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["offer_mode"] == "subscription"
+    assert body["price_brl_cents"] == 49700
+
+
+@patch("routes.founding.get_supabase")
+def test_availability_full_response_shape_with_new_fields(mock_get_sb, app_with_founding):
+    """Complete shape contract including the two new fields."""
+    mock_get_sb.return_value = _make_supabase_mock([
+        {
+            "available": True,
+            "seats_remaining": 47,
+            "seats_total": 50,
+            "deadline_at": "2026-06-30T23:59:59-03:00",
+            "paused": False,
+            "reason": "available",
+            "offer_mode": "lifetime",
+            "price_brl_cents": 99700,
+        }
+    ])
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/availability")
+    assert r.status_code == 200
+    body = r.json()
+
+    # Existing fields still intact
+    assert body["available"] is True
+    assert body["seats_total"] == 50
+    assert body["seats_remaining"] == 47
+    assert body["seats_taken"] == 3
+    assert body["paused"] is False
+    assert body["reason"] == "available"
+    assert "coupon_code" in body
+    assert body["discount_pct"] == 50
+
+    # New fields
+    assert body["price_brl_cents"] == 99700
+    assert body["offer_mode"] == "lifetime"

--- a/supabase/migrations/20260507110000_founding_policy_lifetime_pivot.down.sql
+++ b/supabase/migrations/20260507110000_founding_policy_lifetime_pivot.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE public.founding_policy
+    DROP COLUMN IF EXISTS offer_mode,
+    DROP COLUMN IF EXISTS price_brl_cents,
+    DROP COLUMN IF EXISTS consulting_discount_pct;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260507110000_founding_policy_lifetime_pivot.sql
+++ b/supabase/migrations/20260507110000_founding_policy_lifetime_pivot.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+ALTER TABLE public.founding_policy
+    ADD COLUMN IF NOT EXISTS offer_mode TEXT NOT NULL DEFAULT 'lifetime'
+        CHECK (offer_mode IN ('subscription', 'lifetime')),
+    ADD COLUMN IF NOT EXISTS price_brl_cents INT NOT NULL DEFAULT 99700
+        CHECK (price_brl_cents > 0),
+    ADD COLUMN IF NOT EXISTS consulting_discount_pct INT NOT NULL DEFAULT 50
+        CHECK (consulting_discount_pct >= 0 AND consulting_discount_pct <= 100);
+
+UPDATE public.founding_policy
+SET deadline_at = '2026-06-30T23:59:59-03:00'::TIMESTAMPTZ,
+    offer_mode = 'lifetime',
+    price_brl_cents = 99700,
+    consulting_discount_pct = 50
+WHERE id = 1;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260507111000_check_founding_availability_rpc_v2.down.sql
+++ b/supabase/migrations/20260507111000_check_founding_availability_rpc_v2.down.sql
@@ -1,0 +1,118 @@
+-- Rollback: restore check_founding_availability() to v1 shape (without offer_mode / price_brl_cents)
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.check_founding_availability();
+
+CREATE FUNCTION public.check_founding_availability()
+RETURNS TABLE (
+    available           BOOLEAN,
+    seats_remaining     INT,
+    seats_total         INT,
+    deadline_at         TIMESTAMPTZ,
+    paused              BOOLEAN,
+    reason              TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_seat_limit       INT;
+    v_deadline         TIMESTAMPTZ;
+    v_active           BOOLEAN;
+    v_paused_at        TIMESTAMPTZ;
+    v_completed_count  INT;
+BEGIN
+    SELECT
+        seat_limit,
+        deadline_at,
+        active,
+        paused_at
+    INTO
+        v_seat_limit,
+        v_deadline,
+        v_active,
+        v_paused_at
+    FROM public.founding_policy
+    WHERE id = 1
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := 0;
+        deadline_at     := NULL;
+        paused          := FALSE;
+        reason          := 'founding_policy_missing';
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    IF NOT v_active THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := v_paused_at IS NOT NULL;
+        reason          := 'founding_disabled';
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    IF v_paused_at IS NOT NULL THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := TRUE;
+        reason          := 'founding_paused';
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    IF NOW() > v_deadline THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := FALSE;
+        reason          := 'founding_deadline_passed';
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    SELECT COUNT(*)::INT
+    INTO v_completed_count
+    FROM public.founding_leads
+    WHERE checkout_status = 'completed';
+
+    IF v_completed_count >= v_seat_limit THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := FALSE;
+        reason          := 'founding_cap_reached';
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    available       := TRUE;
+    seats_remaining := v_seat_limit - v_completed_count;
+    seats_total     := v_seat_limit;
+    deadline_at     := v_deadline;
+    paused          := FALSE;
+    reason          := 'available';
+    RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_founding_availability() IS
+    'BIZ-FOUND-002: race-safe availability check for the founding cohort (v1 restored by rollback).';
+
+GRANT EXECUTE ON FUNCTION public.check_founding_availability()
+    TO service_role, authenticated, anon;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260507111000_check_founding_availability_rpc_v2.sql
+++ b/supabase/migrations/20260507111000_check_founding_availability_rpc_v2.sql
@@ -1,0 +1,165 @@
+-- ============================================================================
+-- Migration: 20260507111000_check_founding_availability_rpc_v2
+-- Issue: #782 — pivot founding_policy to one-time R$997 lifetime offer
+-- Date: 2026-05-07
+--
+-- Purpose:
+--   Recreates public.check_founding_availability() adding two new output
+--   columns — offer_mode and price_brl_cents — populated from the new columns
+--   added in 20260507110000_founding_policy_lifetime_pivot.sql.
+--
+--   The route helper _check_availability() uses safe defaults so the gap
+--   between migration apply and route deploy is safe:
+--     offer_mode      fallback = 'lifetime'
+--     price_brl_cents fallback = 99700
+--
+--   Returns shape is now:
+--     {available, seats_remaining, seats_total, deadline_at, paused, reason,
+--      offer_mode, price_brl_cents}
+-- ============================================================================
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.check_founding_availability();
+
+CREATE FUNCTION public.check_founding_availability()
+RETURNS TABLE (
+    available           BOOLEAN,
+    seats_remaining     INT,
+    seats_total         INT,
+    deadline_at         TIMESTAMPTZ,
+    paused              BOOLEAN,
+    reason              TEXT,
+    offer_mode          TEXT,
+    price_brl_cents     INT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_seat_limit            INT;
+    v_deadline              TIMESTAMPTZ;
+    v_active                BOOLEAN;
+    v_paused_at             TIMESTAMPTZ;
+    v_offer_mode            TEXT;
+    v_price_brl_cents       INT;
+    v_completed_count       INT;
+BEGIN
+    -- SELECT FOR UPDATE serializes concurrent callers on the policy row.
+    SELECT
+        seat_limit,
+        deadline_at,
+        active,
+        paused_at,
+        offer_mode,
+        price_brl_cents
+    INTO
+        v_seat_limit,
+        v_deadline,
+        v_active,
+        v_paused_at,
+        v_offer_mode,
+        v_price_brl_cents
+    FROM public.founding_policy
+    WHERE id = 1
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := 0;
+        deadline_at     := NULL;
+        paused          := FALSE;
+        reason          := 'founding_policy_missing';
+        offer_mode      := 'lifetime';
+        price_brl_cents := 99700;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    -- Hard kill switch (structural disable).
+    IF NOT v_active THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := v_paused_at IS NOT NULL;
+        reason          := 'founding_disabled';
+        offer_mode      := v_offer_mode;
+        price_brl_cents := v_price_brl_cents;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    -- Soft pause from admin UI (operational disable).
+    IF v_paused_at IS NOT NULL THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := TRUE;
+        reason          := 'founding_paused';
+        offer_mode      := v_offer_mode;
+        price_brl_cents := v_price_brl_cents;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    -- Deadline passed.
+    IF NOW() > v_deadline THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := FALSE;
+        reason          := 'founding_deadline_passed';
+        offer_mode      := v_offer_mode;
+        price_brl_cents := v_price_brl_cents;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    -- Count completed founding_leads (canonical cap signal).
+    SELECT COUNT(*)::INT
+    INTO v_completed_count
+    FROM public.founding_leads
+    WHERE checkout_status = 'completed';
+
+    IF v_completed_count >= v_seat_limit THEN
+        available       := FALSE;
+        seats_remaining := 0;
+        seats_total     := v_seat_limit;
+        deadline_at     := v_deadline;
+        paused          := FALSE;
+        reason          := 'founding_cap_reached';
+        offer_mode      := v_offer_mode;
+        price_brl_cents := v_price_brl_cents;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    -- Available path.
+    available       := TRUE;
+    seats_remaining := v_seat_limit - v_completed_count;
+    seats_total     := v_seat_limit;
+    deadline_at     := v_deadline;
+    paused          := FALSE;
+    reason          := 'available';
+    offer_mode      := v_offer_mode;
+    price_brl_cents := v_price_brl_cents;
+    RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_founding_availability() IS
+    '#782 (v2): race-safe availability check for the founding cohort. '
+    'Adds offer_mode and price_brl_cents to the return set. '
+    'Called by GET /v1/founding/availability and POST /v1/founding/checkout.';
+
+GRANT EXECUTE ON FUNCTION public.check_founding_availability()
+    TO service_role, authenticated, anon;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **Migration 1** (`20260507110000`): adds `offer_mode TEXT` (CHECK `subscription|lifetime`), `price_brl_cents INT` (CHECK `>0`), `consulting_discount_pct INT` to `founding_policy`; sets canonical row id=1 to `offer_mode='lifetime'`, `price_brl_cents=99700`, `deadline_at='2026-06-30T23:59:59-03:00'`
- **Migration 2** (`20260507111000`): recreates `check_founding_availability()` RPC to include `offer_mode` and `price_brl_cents` in the `RETURNS TABLE` shape; both migrations include paired `.down.sql` rollback scripts (STORY-6.2 compliance)
- **Route** (`backend/routes/founding.py`): adds `price_brl_cents: int` and `offer_mode: str` to `FoundingAvailabilityResponse`; `_check_availability()` populates both with safe defaults (`'lifetime'` / `99700`) when the v1 RPC is still live during deploy gap
- **Tests** (`test_founding_policy_lifetime_pivot.py`): 6 new tests — new fields from RPC v2, safe defaults on v1 RPC (no new columns), safe defaults on exception, custom price passthrough, subscription passthrough, full shape contract

## Testing Plan

- [x] `pytest tests/test_founding_policy_lifetime_pivot.py` — 6 passed
- [x] `pytest tests/test_founding_canonical_policy.py` — 10 passed, zero regressions
- [ ] `migration-gate.yml` will validate `.down.sql` pairing on CI
- [ ] `api-types-check.yml` will flag `FoundingAvailabilityResponse` schema drift — expected, requires frontend type regen after merge (STORY-2.1 procedure: run `npm --prefix frontend run generate:api-types` locally against a running backend)

## Closes

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)