### PR TITLE
fix(ci): fix/disable failing workflows — prod-env allowlist + infra not configured

### DIFF
--- a/.github/audit/prod-env-allowlist.txt
+++ b/.github/audit/prod-env-allowlist.txt
@@ -38,11 +38,15 @@ RESEND_API_KEY
 RESEND_WEBHOOK_SECRET
 SENTRY_DSN
 SENTRY_AUTH_TOKEN
+SENTRY_PROJECT
+SENTRY_ORG
 MIXPANEL_TOKEN
 NEXT_PUBLIC_MIXPANEL_TOKEN
 NEXT_PUBLIC_CLARITY_PROJECT_ID
 GOOGLE_*
 BRASILAPI_*
+PORTAL_TRANSPARENCIA_API_KEY
+METRICS_TOKEN
 
 # ─── Resilience feature flags (epic EPIC-RES-BE-2026-Q2) ──────────────────────
 ENABLE_BUDGET_WRAP
@@ -88,6 +92,8 @@ PORT
 PYTHONUNBUFFERED
 PYTHONPATH
 TZ
+NODE_OPTIONS
+MIN_ACTIVE_BIDS_FOR_INDEX
 
 # ─── CORS / runtime ───────────────────────────────────────────────────────────
 CORS_ORIGINS
@@ -107,6 +113,8 @@ NEXT_*
 # ─── Stripe price/product IDs ─────────────────────────────────────────────────
 STRIPE_PRICE_*
 STRIPE_PRODUCT_*
+FOUNDING_ONE_TIME_PRICE_ID
+FOUNDERS_OFFER_ENABLED
 
 # ─── OAuth ────────────────────────────────────────────────────────────────────
 GOOGLE_OAUTH_CLIENT_ID

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -56,8 +56,13 @@ jobs:
         id: contracts
         run: |
           cd backend
+          # --ignore=tests/conftest.py: the parent conftest imports FastAPI/supabase_client
+          # which are not installed in the minimal contract-test environment. The contracts
+          # conftest (tests/contracts/conftest.py) is self-contained and loaded via
+          # --confcutdir. See #797 for root cause investigation.
           python -m pytest tests/contracts/ \
             --confcutdir=tests/contracts \
+            --ignore=tests/conftest.py \
             -m 'contract and not external' \
             --tb=short --no-header -v \
             --junitxml=contract-results.xml
@@ -163,6 +168,7 @@ jobs:
           cd backend
           python -m pytest tests/contracts/ \
             --confcutdir=tests/contracts \
+            --ignore=tests/conftest.py \
             -m external \
             --tb=short --no-header -v
         continue-on-error: true  # External APIs are flaky — failures go to the issue, don't break pipeline

--- a/.github/workflows/data-parity-nightly.yml
+++ b/.github/workflows/data-parity-nightly.yml
@@ -41,6 +41,10 @@ jobs:
           pip install pytest-asyncio pytest-timeout
 
       - name: Run parity contract tests
+        # Advisory-only: 404 on /v1/municipios/{slug}/profile indicates the endpoint
+        # does not exist at the current target. continue-on-error keeps the workflow
+        # from blocking while the underlying endpoint drift is investigated (#797).
+        continue-on-error: true
         env:
           PARITY_TARGET_URL: ${{ github.event.inputs.target_url || 'https://smartlic.tech' }}
         working-directory: backend

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -42,6 +42,9 @@ env:
 jobs:
   backup:
     name: pg_dump → S3
+    if: false  # Disabled: SUPABASE_DB_URL secret not configured in GitHub Actions (pg_dump fails at connection step).
+               # Also requires AWS_BACKUP_ACCESS_KEY_ID, AWS_BACKUP_SECRET_KEY, BACKUP_S3_BUCKET.
+               # Re-enable via #797 follow-up once Supabase DB URL and S3 bucket are set up in repo secrets/vars.
     runs-on: ubuntu-latest
     timeout-minutes: 30     # failsafe: dump de tabela grande não deve passar de 20min
 

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -47,6 +47,9 @@ permissions:
 jobs:
   k6-load-test:
     name: k6 baseline (${{ github.event.inputs.script || 'all' }})
+    if: false  # Disabled: STAGING_BACKEND_URL and LOAD_TEST_JWTS secrets not configured.
+               # Validate prerequisite step fails at startup. Re-enable via #797 follow-up
+               # once a staging environment + JWT fixture are in place.
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/load-test-weekly.yml
+++ b/.github/workflows/load-test-weekly.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   load-test:
+    if: false  # Disabled: runs 50 VUs against live prod (https://api.smartlic.tech) without a staging gate.
+               # Needs a staging target URL + explicit gating before re-enabling. See #797.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Context

CI-HEALTH-001 (#797): 7 workflows failing on main. `migration-check` already self-healed on its own. This PR addresses the remaining 6 by either fixing the root cause or disabling with documented rationale.

All failures were confirmed by reading actual CI run logs and JUnit XML artifacts before applying fixes — no speculative changes.

## Changes

### audit-prod-env — Allowlist fix (advisory, no deploy gate)
Added missing vars to `.github/audit/prod-env-allowlist.txt`:
- `SENTRY_PROJECT`, `SENTRY_ORG` — legitimately set on Railway prod (used in contract-tests.yml itself via secrets, also present as Railway env vars)
- `PORTAL_TRANSPARENCIA_API_KEY`, `METRICS_TOKEN` — prod API keys not previously documented
- `NODE_OPTIONS`, `MIN_ACTIVE_BIDS_FOR_INDEX` — runtime/process vars found on frontend service
- `FOUNDING_ONE_TIME_PRICE_ID`, `FOUNDERS_OFFER_ENABLED` — new billing vars from founders plan (issue #782-#795 epic), not covered by `STRIPE_PRICE_*` wildcard

Note: allowlist changes only run on schedule (daily 14:00 UTC) or manual dispatch — NOT on this PR (path filter `pull_request.paths` excludes non-allowlist files). Verify via `workflow_dispatch` after merge.

### contract-tests — Fix: --ignore=tests/conftest.py
Root cause (confirmed from JUnit XML): `ModuleNotFoundError: No module named 'fastapi'` on **every** test. `tests/conftest.py` (parent of `tests/contracts/`) has autouse fixtures importing `rate_limiter`, `supabase_client`, `bulkhead` — all requiring FastAPI. The `--confcutdir=tests/contracts` flag cuts conftest loading at the given dir boundary, but `tests/conftest.py` is one level ABOVE that boundary (at `tests/`), so it still gets loaded. Fix: `--ignore=tests/conftest.py` on both offline and live-check runs.

### data-parity-nightly — Fix: continue-on-error: true
Root cause (confirmed from job logs): `/v1/municipios/sao-paulo-sp/profile` returns HTTP 404 in production — endpoint missing or renamed. The test raises `httpx.HTTPStatusError` which is unhandled. The workflow header already says "Advisory-only: failure here does NOT block PRs" but was missing `continue-on-error: true` to actually enforce that. Added it to the test step with a comment pointing to #797 for follow-up.

### db-backup — Disabled with if: false
Root cause (confirmed from job logs): `SUPABASE_DB_URL` secret is empty in GitHub Actions — `pg_dump` fails at connection with `"connection to server on socket /var/run/postgresql/.s.PGSQL.5432 failed: No such file or directory"`. The S3 upload step never runs. Requires both `SUPABASE_DB_URL` + AWS secrets/vars before re-enabling.

### k6-load-test — Disabled with if: false
Root cause: `STAGING_BACKEND_URL` and `LOAD_TEST_JWTS` secrets not configured. The validate-prerequisites step exits 1 immediately with explicit error messages.

### load-test-weekly — Disabled with if: false
Root cause: runs Locust with 50 VUs directly against live prod (`https://api.smartlic.tech`) without staging gate or operator approval. Beyond infra configuration, this represents operational risk. Needs a staging target before re-enabling.

## Dependency check
None of the disabled/modified workflows are referenced as `needs:` by other workflows (verified via `grep -r "db-backup\|k6-load-test\|load-test-weekly\|data-parity-nightly\|contract-tests" .github/`). No cascade effect.

## Testing Plan
- [ ] After merge: trigger `audit-prod-env` via `workflow_dispatch` → verify no WARNING for the newly added vars
- [ ] After merge: trigger `contract-tests` via `workflow_dispatch` → expect green offline snapshot validation
- [ ] After merge: verify `db-backup`, `k6-load-test`, `load-test-weekly` show as "skipped" (not failed) in Actions tab
- [ ] After merge: verify `data-parity-nightly` next scheduled run reports but doesn't fail the workflow job

## Risks & Rollback
All changes are low-risk:
- Allowlist is advisory (never blocks deploy)
- `continue-on-error: true` on data-parity doesn't hide failures — the step still shows red, just doesn't fail the job
- `if: false` disables purely optional workflows not in any PR gate

Rollback = revert this PR.

## Closes
Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)