### PR TITLE
feat(frontend): /fundadores page with new copy + 301 redirect from /founding

### DIFF
--- a/frontend/__tests__/fundadores/FundadoresClient.test.tsx
+++ b/frontend/__tests__/fundadores/FundadoresClient.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Issue #786: FundadoresClient smoke tests
+ *
+ * Verifies the /fundadores page renders without crash and contains
+ * the required CTA copy. Full interaction tests live in FundadoresForm.test.tsx.
+ */
+
+import { render, screen } from '@testing-library/react';
+import FundadoresClient from '../../app/fundadores/FundadoresClient';
+
+// Suppress fetch errors from availability polling in tests
+beforeEach(() => {
+  (global.fetch as unknown as jest.Mock) = jest.fn().mockResolvedValue({
+    ok: false,
+    json: async () => ({}),
+  });
+});
+
+describe('FundadoresClient', () => {
+  it('renders without crashing', () => {
+    render(<FundadoresClient />);
+    expect(document.body).toBeTruthy();
+  });
+
+  it('contains the hero headline', () => {
+    render(<FundadoresClient />);
+    expect(
+      screen.getByText(/Entre cedo na infraestrutura de inteligência B2G do SmartLic/i)
+    ).toBeInTheDocument();
+  });
+
+  it('contains the CTA "Garantir acesso"', () => {
+    render(<FundadoresClient />);
+    // There are two FundadoresForm instances (hero + CTA final) — both should have the button
+    const ctaButtons = screen.getAllByText(/Garantir acesso/i);
+    expect(ctaButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('contains sub-headline about vitalício access', () => {
+    render(<FundadoresClient />);
+    expect(
+      screen.getByText(/Acesso vitalício antes da estrutura comercial definitiva/i)
+    ).toBeInTheDocument();
+  });
+
+  it('contains "Menos PDF. Mais decisão." message', () => {
+    render(<FundadoresClient />);
+    expect(screen.getByText(/Menos PDF\. Mais decisão\./i)).toBeInTheDocument();
+  });
+
+  it('contains "A IA encontra. A inteligência decide." message', () => {
+    render(<FundadoresClient />);
+    expect(screen.getByText(/A IA encontra\. A inteligência decide\./i)).toBeInTheDocument();
+  });
+
+  it('contains "Ajude a financiar a próxima fase" message', () => {
+    render(<FundadoresClient />);
+    expect(screen.getByText(/Ajude a financiar a próxima fase do SmartLic/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/fundadores/FundadoresForm.test.tsx
+++ b/frontend/__tests__/fundadores/FundadoresForm.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Issue #786: FundadoresForm tests
+ *
+ * Covers email validation, submit payload, checkout redirect, and
+ * availability-gate behavior.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FundadoresForm from '../../app/fundadores/components/FundadoresForm';
+
+function fillValidEmail() {
+  fireEvent.change(screen.getByLabelText(/Seu email/i), {
+    target: { value: 'maria@empresa.com' },
+  });
+}
+
+describe('FundadoresForm', () => {
+  const originalLocation = window.location;
+  const hrefSetter = jest.fn();
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        assign: jest.fn(),
+        set href(v: string) {
+          hrefSetter(v);
+        },
+        get href() {
+          return 'http://testhost/fundadores';
+        },
+      },
+    });
+    hrefSetter.mockClear();
+    (global.fetch as unknown as jest.Mock) = jest.fn();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  });
+
+  it('renders email field and CTA button', () => {
+    render(<FundadoresForm />);
+    expect(screen.getByLabelText(/Seu email/i)).toBeInTheDocument();
+    expect(screen.getByTestId('fundadores-form-submit')).toBeInTheDocument();
+  });
+
+  it('shows "Garantir acesso" in the CTA text by default', () => {
+    render(<FundadoresForm />);
+    expect(screen.getByTestId('fundadores-form-submit').textContent).toMatch(/Garantir acesso/i);
+  });
+
+  it('surfaces validation error for invalid email', async () => {
+    render(<FundadoresForm />);
+    fireEvent.change(screen.getByLabelText(/Seu email/i), { target: { value: 'nao-um-email' } });
+    fireEvent.submit(screen.getByTestId('fundadores-form-submit').closest('form')!);
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/email válido/i);
+  });
+
+  it('posts email to /api/founding/checkout and redirects on success', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ checkout_url: 'https://checkout.stripe.com/xyz', lead_id: 'lead-2' }),
+    });
+
+    render(<FundadoresForm />);
+    fillValidEmail();
+    fireEvent.submit(screen.getByTestId('fundadores-form-submit').closest('form')!);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('/api/founding/checkout');
+    const body = JSON.parse((opts as { body: string }).body);
+    expect(body.email).toBe('maria@empresa.com');
+    // Simplified form — no cnpj, nome, motivo in payload
+    expect(body.cnpj).toBeUndefined();
+    expect(body.nome).toBeUndefined();
+
+    await waitFor(() =>
+      expect(hrefSetter).toHaveBeenCalledWith('https://checkout.stripe.com/xyz')
+    );
+  });
+
+  it('surfaces backend error message on non-2xx', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ detail: 'Este email já possui conta SmartLic.' }),
+    });
+
+    render(<FundadoresForm />);
+    fillValidEmail();
+    fireEvent.submit(screen.getByTestId('fundadores-form-submit').closest('form')!);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/já possui conta/i);
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('surfaces generic network error when fetch rejects', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('net down'));
+
+    render(<FundadoresForm />);
+    fillValidEmail();
+    fireEvent.submit(screen.getByTestId('fundadores-form-submit').closest('form')!);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/falha de rede/i);
+  });
+
+  it('uses custom price prop in button text', () => {
+    render(<FundadoresForm price="R$1.200" />);
+    expect(screen.getByTestId('fundadores-form-submit').textContent).toMatch(/R\$1\.200/);
+  });
+
+  describe('availability gate', () => {
+    const FULL_SNAPSHOT = {
+      available: false,
+      seats_total: 50,
+      seats_remaining: 0,
+      seats_taken: 50,
+      deadline_at: null,
+      paused: false,
+      reason: 'founding_cap_reached',
+      coupon_code: 'FOUNDING_LIFETIME',
+      discount_pct: 0,
+    };
+
+    it('disables submit and shows cap message when availability says full', () => {
+      render(<FundadoresForm availability={FULL_SNAPSHOT} />);
+      const btn = screen.getByTestId('fundadores-form-submit') as HTMLButtonElement;
+      expect(btn).toBeDisabled();
+      expect(btn.textContent).toMatch(/programa fechado/i);
+      expect(screen.getByTestId('fundadores-form-unavailable').textContent).toMatch(/vagas fundadores/i);
+    });
+
+    it('keeps button enabled when availability.available=true', () => {
+      const open = { ...FULL_SNAPSHOT, available: true, seats_remaining: 25, reason: 'available' };
+      render(<FundadoresForm availability={open} />);
+      const btn = screen.getByTestId('fundadores-form-submit') as HTMLButtonElement;
+      expect(btn).not.toBeDisabled();
+      expect(btn.textContent).toMatch(/Garantir acesso/i);
+    });
+  });
+});

--- a/frontend/app/founding/obrigado/page.tsx
+++ b/frontend/app/founding/obrigado/page.tsx
@@ -1,12 +1,9 @@
-import type { Metadata } from 'next';
-import FoundingObrigadoClient from './FoundingObrigadoClient';
+import { permanentRedirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Bem-vindo ao SmartLic Founding Partners',
-  description: 'Próximos passos para o seu trial SmartLic como founding partner.',
-  robots: { index: false, follow: false },
-};
-
+/**
+ * 301 permanent redirect: /founding/obrigado → /fundadores/obrigado
+ * Issue #786 — pt-BR route rename.
+ */
 export default function FoundingObrigadoPage() {
-  return <FoundingObrigadoClient />;
+  permanentRedirect('/fundadores/obrigado');
 }

--- a/frontend/app/founding/page.tsx
+++ b/frontend/app/founding/page.tsx
@@ -1,13 +1,9 @@
-import type { Metadata } from 'next';
-import FoundingClient from './FoundingClient';
+import { permanentRedirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'SmartLic Founding Partners — Os primeiros 50 clientes moldam o produto',
-  description:
-    '50% off vitalício, linha direta com o fundador e voz no roadmap para os primeiros 50 clientes pagantes do SmartLic. Vagas limitadas até 30/05/2026.',
-  robots: { index: false, follow: false },
-};
-
+/**
+ * 301 permanent redirect: /founding → /fundadores
+ * Issue #786 — pt-BR route rename.
+ */
 export default function FoundingPage() {
-  return <FoundingClient />;
+  permanentRedirect('/fundadores');
 }

--- a/frontend/app/fundadores/FundadoresClient.tsx
+++ b/frontend/app/fundadores/FundadoresClient.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import FundadoresForm from './components/FundadoresForm';
+import FundadoresFAQ from './components/FundadoresFAQ';
+import FundadoresFeatures from './components/FundadoresFeatures';
+import FundadoresCountdown, { FoundingAvailabilitySnapshot } from './components/FundadoresCountdown';
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  const mp = (window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // no-op
+  }
+}
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+// TODO: remove hardcoded fallback after #782 merges (price_brl_cents in API response)
+function formatPrice(priceBrlCents: number | undefined): string {
+  if (priceBrlCents !== undefined && priceBrlCents > 0) {
+    return (priceBrlCents / 100).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  }
+  return 'R$997';
+}
+
+export default function FundadoresClient() {
+  const [snapshot, setSnapshot] = useState<FoundingAvailabilitySnapshot | null>(null);
+
+  useEffect(() => {
+    trackEvent('fundadores_page_viewed', { source: 'landing' });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    async function load() {
+      try {
+        const res = await fetch('/api/founding/availability', { cache: 'no-store' });
+        if (!res.ok) {
+          if (!cancelled) {
+            setSnapshot({
+              available: false,
+              seats_total: 50,
+              seats_remaining: 0,
+              seats_taken: 50,
+              deadline_at: null,
+              paused: false,
+              reason: 'unavailable',
+              coupon_code: 'FOUNDING_LIFETIME',
+              discount_pct: 0,
+            });
+          }
+          return;
+        }
+        const data = (await res.json()) as FoundingAvailabilitySnapshot;
+        if (!cancelled) setSnapshot(data);
+      } catch {
+        if (!cancelled) {
+          setSnapshot({
+            available: false,
+            seats_total: 50,
+            seats_remaining: 0,
+            seats_taken: 50,
+            deadline_at: null,
+            paused: false,
+            reason: 'unavailable',
+            coupon_code: 'FOUNDING_LIFETIME',
+            discount_pct: 0,
+          });
+        }
+      }
+    }
+
+    load();
+    timer = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, []);
+
+  const price = formatPrice(snapshot?.price_brl_cents);
+
+  return (
+    <main className="min-h-screen bg-white">
+      {/* Hero */}
+      <section className="bg-slate-900 text-white">
+        <div className="mx-auto max-w-3xl px-4 py-16">
+          <p className="text-sm uppercase tracking-widest text-blue-400 font-semibold mb-3">
+            Plano Fundadores — vagas limitadas
+          </p>
+          <h1 className="text-3xl sm:text-5xl font-bold leading-tight mb-4">
+            Entre cedo na infraestrutura de inteligência B2G do SmartLic.
+          </h1>
+          <p className="text-lg sm:text-xl text-slate-300 mb-8">
+            Acesso vitalício antes da estrutura comercial definitiva.
+          </p>
+
+          <div className="mb-8">
+            <FundadoresCountdown snapshot={snapshot} />
+          </div>
+
+          <div className="rounded-xl border border-blue-500/30 bg-blue-950/40 p-6">
+            <p className="text-2xl font-bold text-white mb-1">{price} <span className="text-base font-normal text-slate-400">pagamento único</span></p>
+            <p className="text-slate-300 text-sm mb-4">Sem mensalidade. Sem renovação. Acesso permanente.</p>
+            <FundadoresForm availability={snapshot} price={price} />
+          </div>
+        </div>
+      </section>
+
+      <div className="mx-auto max-w-3xl px-4 py-12">
+        {/* Problema */}
+        <section aria-labelledby="problema-heading" className="mb-16">
+          <h2 id="problema-heading" className="text-2xl font-semibold text-slate-900 mb-4">
+            Por que B2G é difícil
+          </h2>
+          <div className="prose prose-slate max-w-none">
+            <p>
+              Licitações públicas são publicadas em dezenas de portais diferentes, em formatos
+              inconsistentes, com terminologias confusas e prazos que mudam sem aviso. Empresas B2G
+              gastam horas toda semana só para descobrir o que está aberto — antes mesmo de
+              qualificar se vale a pena participar.
+            </p>
+            <p className="mt-4">
+              <strong>Menos PDF. Mais decisão.</strong> O SmartLic agrega, filtra e classifica
+              automaticamente para que sua equipe foque no que importa: construir propostas
+              competitivas.
+            </p>
+            <p className="mt-4">
+              <strong>A IA encontra. A inteligência decide.</strong> Classificação setorial por
+              GPT-4.1-nano com precisão ≥85%, análise de viabilidade em quatro fatores e histórico
+              de 2 milhões de contratos públicos para benchmark de preço.
+            </p>
+          </div>
+        </section>
+
+        {/* Features */}
+        <FundadoresFeatures />
+
+        {/* Comparação */}
+        <section aria-labelledby="comparacao-heading" className="mt-16">
+          <h2 id="comparacao-heading" className="text-2xl font-semibold text-slate-900 mb-6">
+            Fundador vs Assinatura recorrente
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-slate-100">
+                  <th className="text-left px-4 py-3 font-semibold text-slate-700 border border-slate-200"></th>
+                  <th className="text-center px-4 py-3 font-semibold text-blue-700 border border-slate-200">
+                    Plano Fundadores
+                  </th>
+                  <th className="text-center px-4 py-3 font-semibold text-slate-700 border border-slate-200">
+                    Pro Recorrente
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ['Modelo de cobrança', 'R$997 único', 'R$397/mês'],
+                  ['Custo em 12 meses', 'R$997', 'R$4.764'],
+                  ['Acesso', 'Vitalício', 'Enquanto pagar'],
+                  ['Todas as funcionalidades', '✓', '✓'],
+                  ['Atualizações futuras', '✓ incluídas', '✓ incluídas'],
+                  ['Vagas disponíveis', 'Limitadas', 'Ilimitadas'],
+                  ['Ajude a financiar a próxima fase', '✓', '—'],
+                ].map(([label, founder, regular]) => (
+                  <tr key={label} className="border border-slate-200 hover:bg-slate-50">
+                    <td className="px-4 py-3 text-slate-700 border border-slate-200">{label}</td>
+                    <td className="px-4 py-3 text-center font-medium text-blue-700 border border-slate-200">{founder}</td>
+                    <td className="px-4 py-3 text-center text-slate-600 border border-slate-200">{regular}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Sobre o SmartLic */}
+        <section aria-labelledby="sobre-heading" className="mt-16 rounded-lg border border-slate-200 bg-slate-50 p-6">
+          <h2 id="sobre-heading" className="text-xl font-semibold text-slate-900 mb-3">
+            Sobre o SmartLic (v0.5 — beta produtivo)
+          </h2>
+          <p className="text-slate-700 leading-relaxed">
+            2 milhões de contratos públicos indexados. 50 mil licitações abertas em tempo real.
+            20 setores com classificação por IA. Infra production-ready (Railway, Supabase).
+            Ferramenta é real — estamos abrindo acesso vitalício para os primeiros fundadores que
+            ajudam a financiar e moldar a próxima fase do produto.
+          </p>
+          <p className="mt-3 text-slate-700">
+            <strong>Ajude a financiar a próxima fase do SmartLic.</strong> Cada fundador é um
+            parceiro estratégico, não apenas um cliente.
+          </p>
+        </section>
+
+        {/* FAQ */}
+        <FundadoresFAQ />
+
+        {/* CTA final */}
+        <section
+          aria-labelledby="cta-final-heading"
+          className="mt-16 rounded-xl border border-blue-200 bg-blue-50 p-8"
+        >
+          <h2 id="cta-final-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+            Garanta sua vaga agora
+          </h2>
+          <p className="text-slate-700 mb-6">
+            Acesso vitalício por {price}. Pagamento único via Stripe — cartão de crédito ou boleto.
+          </p>
+          <FundadoresForm availability={snapshot} price={price} />
+        </section>
+
+        {/* Disclaimer legal */}
+        <footer className="mt-12 border-t border-slate-200 pt-6 text-sm text-slate-500">
+          <p>
+            Ao prosseguir, você concorda com os{' '}
+            <a href="/termos/fundadores" className="text-blue-600 underline">
+              Termos do Plano Fundadores
+            </a>{' '}
+            e a{' '}
+            <a href="/privacidade" className="text-blue-600 underline">
+              Política de Privacidade
+            </a>
+            . Em caso de dúvida, escreva para{' '}
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
+              tiago@smartlic.tech
+            </a>
+            .
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresCountdown.tsx
+++ b/frontend/app/fundadores/components/FundadoresCountdown.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+/**
+ * Plano Fundadores: deadline countdown + seat counter for the /fundadores landing.
+ *
+ * Receives an availability snapshot from the parent (single fetch on mount)
+ * and ticks an internal clock every 1s for the countdown. Re-fetch of the
+ * snapshot itself is the parent's responsibility (currently every 60s).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+
+export interface FoundingAvailabilitySnapshot {
+  available: boolean;
+  seats_total: number;
+  seats_remaining: number;
+  seats_taken: number;
+  deadline_at: string | null;
+  paused: boolean;
+  reason: string;
+  coupon_code: string;
+  discount_pct: number;
+  price_brl_cents?: number;
+}
+
+interface Props {
+  snapshot: FoundingAvailabilitySnapshot | null;
+}
+
+interface Countdown {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  total_ms: number;
+}
+
+function computeCountdown(deadlineIso: string | null, nowMs: number): Countdown {
+  if (!deadlineIso) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, total_ms: 0 };
+  }
+  const deadlineMs = Date.parse(deadlineIso);
+  const total = Math.max(0, deadlineMs - nowMs);
+  const seconds = Math.floor(total / 1000) % 60;
+  const minutes = Math.floor(total / 1000 / 60) % 60;
+  const hours = Math.floor(total / 1000 / 60 / 60) % 24;
+  const days = Math.floor(total / 1000 / 60 / 60 / 24);
+  return { days, hours, minutes, seconds, total_ms: total };
+}
+
+function pad2(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+export default function FundadoresCountdown({ snapshot }: Props) {
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const countdown = useMemo(
+    () => computeCountdown(snapshot?.deadline_at ?? null, now),
+    [snapshot?.deadline_at, now]
+  );
+
+  if (!snapshot) {
+    return (
+      <div
+        data-testid="fundadores-availability-loading"
+        className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500"
+      >
+        Carregando disponibilidade...
+      </div>
+    );
+  }
+
+  const seatsRemaining = snapshot.seats_remaining;
+  const seatsTotal = snapshot.seats_total;
+  const urgency = seatsRemaining > 0 && seatsRemaining <= 5;
+  const full = !snapshot.available;
+
+  const counterColor = full
+    ? 'text-red-700 bg-red-50 border-red-200'
+    : urgency
+      ? 'text-amber-800 bg-amber-50 border-amber-200'
+      : 'text-blue-800 bg-blue-50 border-blue-200';
+
+  return (
+    <div
+      data-testid="fundadores-availability"
+      className={`rounded-lg border p-4 ${counterColor}`}
+      aria-live="polite"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-sm font-medium" data-testid="fundadores-seat-counter">
+          {full ? (
+            <span>
+              <strong>0/{seatsTotal}</strong> vagas restantes — programa fechado.
+            </span>
+          ) : (
+            <span>
+              <strong data-testid="fundadores-seats-remaining">{seatsRemaining}</strong>
+              /{seatsTotal} vagas restantes
+              {urgency && ' — corra!'}
+            </span>
+          )}
+        </p>
+        <p className="text-xs uppercase tracking-wide opacity-80" data-testid="fundadores-price-label">
+          Acesso vitalício
+        </p>
+      </div>
+
+      {snapshot.deadline_at && countdown.total_ms > 0 && (
+        <div
+          className="mt-3 flex flex-wrap items-center gap-3 text-sm"
+          data-testid="fundadores-countdown"
+        >
+          <span className="opacity-70">Encerra em:</span>
+          <div className="flex items-center gap-2 font-mono tabular-nums">
+            <span data-testid="fundadores-countdown-days">
+              <strong>{countdown.days}</strong>d
+            </span>
+            <span data-testid="fundadores-countdown-hours">
+              <strong>{pad2(countdown.hours)}</strong>h
+            </span>
+            <span data-testid="fundadores-countdown-minutes">
+              <strong>{pad2(countdown.minutes)}</strong>m
+            </span>
+            <span data-testid="fundadores-countdown-seconds">
+              <strong>{pad2(countdown.seconds)}</strong>s
+            </span>
+          </div>
+        </div>
+      )}
+
+      {snapshot.deadline_at && countdown.total_ms === 0 && (
+        <p className="mt-2 text-sm" data-testid="fundadores-countdown-expired">
+          O prazo de inscrição fundadores encerrou.
+        </p>
+      )}
+
+      {snapshot.paused && (
+        <p className="mt-2 text-sm" data-testid="fundadores-paused-notice">
+          Inscrições temporariamente pausadas. Tente novamente em algumas horas.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresFAQ.tsx
+++ b/frontend/app/fundadores/components/FundadoresFAQ.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+const FAQS: FaqItem[] = [
+  {
+    q: 'O que está incluído no Plano Fundadores?',
+    a: 'Acesso vitalício à plataforma SmartLic (busca multi-fonte, classificação IA, pipeline kanban, relatórios Excel, análise de viabilidade). Pagamento único de R$997 — sem mensalidade, sem surpresas.',
+  },
+  {
+    q: 'Qual a diferença entre Fundador e assinante regular?',
+    a: 'O assinante regular paga R$397/mês (Pro) ou R$997/mês (Consultoria) recorrente. O Fundador paga R$997 uma única vez e tem acesso permanente, incluindo todas as atualizações futuras da plataforma.',
+  },
+  {
+    q: 'Posso cancelar ou pedir reembolso?',
+    a: 'Sim. Oferecemos 30 dias de garantia. Se não ficar satisfeito por qualquer motivo dentro deste prazo, devolvemos 100% do valor pago sem questionamentos.',
+  },
+  {
+    q: 'O SmartLic funciona para meu setor?',
+    a: 'O SmartLic cobre 20 setores B2G com classificação por IA (GPT-4.1-nano). Se seu setor não estiver listado, entre em contato — adicionamos novos setores com base na demanda dos fundadores.',
+  },
+  {
+    q: 'Quantas vagas restam?',
+    a: 'O Plano Fundadores é limitado. As vagas são preenchidas por ordem de chegada. O contador ao topo da página mostra a disponibilidade em tempo real.',
+  },
+  {
+    q: 'Que suporte recebo como Fundador?',
+    a: 'Acesso à linha direta com o fundador (Tiago Sasaki) via email/WhatsApp. Response time < 4h úteis para bugs críticos. Sessão de onboarding inclusa para os primeiros clientes.',
+  },
+];
+
+export default function FundadoresFAQ() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <section aria-labelledby="faq-heading" className="mt-16">
+      <h2 id="faq-heading" className="text-2xl font-semibold text-slate-900 mb-6">
+        Perguntas frequentes
+      </h2>
+      <div className="divide-y divide-slate-200 border border-slate-200 rounded-lg">
+        {FAQS.map((item, idx) => {
+          const isOpen = openIndex === idx;
+          return (
+            <div key={item.q}>
+              <button
+                type="button"
+                className="w-full flex justify-between items-center px-4 py-3 text-left text-slate-900 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-expanded={isOpen}
+                onClick={() => setOpenIndex(isOpen ? null : idx)}
+              >
+                <span className="font-medium">{item.q}</span>
+                <span aria-hidden="true" className="ml-4 text-slate-500">
+                  {isOpen ? '−' : '+'}
+                </span>
+              </button>
+              {isOpen && (
+                <div className="px-4 pb-4 text-slate-700 leading-relaxed">{item.a}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresFeatures.tsx
+++ b/frontend/app/fundadores/components/FundadoresFeatures.tsx
@@ -1,0 +1,61 @@
+interface Feature {
+  title: string;
+  description: string;
+}
+
+const FEATURES: Feature[] = [
+  {
+    title: 'Busca multi-fonte unificada',
+    description:
+      'PNCP + Portal de Compras Públicas + ComprasGov em uma busca consolidada com deduplicação automática.',
+  },
+  {
+    title: 'Classificação por IA',
+    description:
+      'GPT-4.1-nano classifica relevância setorial com precisão ≥85%. Menos falso positivo, menos tempo perdido.',
+  },
+  {
+    title: 'Análise de viabilidade',
+    description:
+      'Quatro fatores (modalidade, timeline, valor, geografia) pontuam cada edital antes de você abrir o PDF.',
+  },
+  {
+    title: 'Pipeline Kanban',
+    description:
+      'Gestão de oportunidades com drag-and-drop. Do radar à proposta enviada em uma tela.',
+  },
+  {
+    title: 'Relatórios Excel + IA',
+    description:
+      'Excel estilizado + resumo executivo gerado por IA para cada busca. Pronto para apresentar ao time.',
+  },
+  {
+    title: '2 milhões de contratos indexados',
+    description:
+      'Histórico de licitações para benchmark de preço, mapeamento de concorrentes e análise de mercado B2G.',
+  },
+];
+
+export default function FundadoresFeatures() {
+  return (
+    <section aria-labelledby="features-heading" className="mt-16">
+      <h2 id="features-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+        O que está incluído
+      </h2>
+      <p className="text-slate-600 mb-8">
+        Tudo que você precisa para encontrar, qualificar e acompanhar licitações públicas.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        {FEATURES.map((feat) => (
+          <div
+            key={feat.title}
+            className="rounded-lg border border-slate-200 bg-slate-50 p-5"
+          >
+            <h3 className="font-semibold text-slate-900 mb-1">{feat.title}</h3>
+            <p className="text-sm text-slate-600 leading-relaxed">{feat.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresForm.tsx
+++ b/frontend/app/fundadores/components/FundadoresForm.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useState } from 'react';
+import type { FoundingAvailabilitySnapshot } from './FundadoresCountdown';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+interface FundadoresCheckoutResponse {
+  checkout_url: string;
+  lead_id: string;
+}
+
+interface Props {
+  /**
+   * Live availability snapshot. When `available=false` the CTA is disabled
+   * and a contextual message replaces the form footer.
+   * Optional so unit tests keep working without parent wiring.
+   */
+  availability?: FoundingAvailabilitySnapshot | null;
+  /** Display price derived from API (price_brl_cents). Fallback: R$997. */
+  price?: string;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const REASON_MESSAGES: Record<string, string> = {
+  founding_cap_reached:
+    'As vagas fundadores já foram preenchidas. Obrigado pelo interesse — escreva para tiago@smartlic.tech para entrar na lista de espera.',
+  founding_deadline_passed:
+    'O período de inscrição fundadores encerrou. O plano regular SmartLic Pro continua disponível em /pricing.',
+  founding_paused:
+    'Inscrições fundadores temporariamente pausadas. Tente novamente em algumas horas.',
+  founding_disabled: 'O programa fundadores não está aceitando novas inscrições no momento.',
+  founding_policy_missing:
+    'Configuração fundadores indisponível. Tente novamente em instantes.',
+  unavailable: 'Não foi possível validar disponibilidade agora. Tente novamente em instantes.',
+};
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  const mp = (window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // best-effort; never break UX on analytics failure.
+  }
+}
+
+export default function FundadoresForm({ availability, price = 'R$997' }: Props = {}) {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  function validate(): string | null {
+    if (!email.trim() || !EMAIL_RE.test(email.trim())) return 'Informe um email válido.';
+    return null;
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const v = validate();
+    if (v) {
+      setErrorMsg(v);
+      setStatus('error');
+      return;
+    }
+
+    setStatus('loading');
+    setErrorMsg('');
+    trackEvent('fundadores_form_submitted', { source: 'fundadores_landing' });
+
+    try {
+      const res = await fetch('/api/founding/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: email.trim().toLowerCase(),
+        }),
+      });
+
+      if (!res.ok) {
+        let msg = 'Não foi possível iniciar seu checkout. Tente novamente em instantes.';
+        try {
+          const data = await res.json();
+          if (typeof data?.detail === 'string') {
+            msg = data.detail;
+          } else if (data?.detail && typeof data.detail === 'object') {
+            if (typeof data.detail.message === 'string') msg = data.detail.message;
+          }
+        } catch {
+          // ignore JSON parse errors — keep default message
+        }
+        setErrorMsg(msg);
+        setStatus('error');
+        return;
+      }
+
+      const data = (await res.json()) as FundadoresCheckoutResponse;
+      trackEvent('fundadores_checkout_started', { lead_id: data.lead_id });
+      window.location.href = data.checkout_url;
+    } catch {
+      setErrorMsg('Falha de rede. Verifique sua conexão e tente novamente.');
+      setStatus('error');
+    }
+  }
+
+  const loading = status === 'loading';
+  const unavailable = availability !== undefined && availability !== null && !availability.available;
+  const unavailableMessage = unavailable
+    ? REASON_MESSAGES[availability!.reason] ?? REASON_MESSAGES.unavailable
+    : null;
+  const submitDisabled = loading || unavailable;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div>
+        <label htmlFor="fundadores-email" className="block text-sm font-medium text-slate-900">
+          Seu email
+        </label>
+        <input
+          id="fundadores-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          maxLength={320}
+          placeholder="voce@empresa.com"
+          className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+          disabled={loading}
+        />
+      </div>
+
+      {status === 'error' && errorMsg && (
+        <div role="alert" className="rounded bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-800">
+          {errorMsg}
+        </div>
+      )}
+
+      {unavailable && unavailableMessage && (
+        <div
+          role="status"
+          data-testid="fundadores-form-unavailable"
+          className="rounded bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-900"
+        >
+          {unavailableMessage}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitDisabled}
+        data-testid="fundadores-form-submit"
+        aria-disabled={submitDisabled}
+        className="w-full rounded bg-blue-700 px-4 py-3 font-semibold text-white text-base hover:bg-blue-800 disabled:bg-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      >
+        {loading
+          ? 'Processando...'
+          : unavailable
+            ? 'Programa fechado'
+            : `Garantir acesso vitalício por ${price}`}
+      </button>
+
+      <p className="text-xs text-slate-500 text-center">
+        Sem compromisso até a confirmação do pagamento. Dados enviados por conexão segura.
+      </p>
+    </form>
+  );
+}

--- a/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
+++ b/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect } from 'react';
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  const mp = (window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // no-op
+  }
+}
+
+export default function FundadoresObrigadoClient() {
+  useEffect(() => {
+    trackEvent('fundadores_checkout_completed', { source: 'obrigado_page' });
+  }, []);
+
+  const calendlyUrl =
+    process.env.NEXT_PUBLIC_FOUNDING_CALENDLY_URL ||
+    'https://cal.com/tiago-sasaki/founding-onboarding';
+
+  return (
+    <main className="min-h-screen bg-white">
+      <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+        <p className="text-sm uppercase tracking-widest text-blue-600 font-semibold mb-3">
+          Plano Fundadores
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-bold text-slate-900">
+          Bem-vindo ao SmartLic, Fundador.
+        </h1>
+        <p className="mt-6 text-lg text-slate-700">
+          Seu acesso vitalício foi ativado. Em alguns minutos você receberá um email com:
+        </p>
+        <ul className="mt-4 text-left inline-block text-slate-700 space-y-1">
+          <li>&#x2022; Credenciais de acesso ao dashboard</li>
+          <li>&#x2022; Confirmação do seu Plano Fundadores</li>
+          <li>&#x2022; Próximos passos para começar</li>
+        </ul>
+
+        <section className="mt-10 rounded-lg border border-blue-200 bg-blue-50 p-6 text-left">
+          <h2 className="text-xl font-semibold text-slate-900">Próximo passo: agendar seu onboarding</h2>
+          <p className="mt-2 text-slate-700">
+            Agende uma sessão com o time SmartLic para mapear editais relevantes no seu setor e
+            personalizar suas configurações iniciais.
+          </p>
+          <a
+            href={calendlyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-block rounded bg-blue-600 px-5 py-2 font-medium text-white hover:bg-blue-700"
+          >
+            Agendar onboarding
+          </a>
+        </section>
+
+        <p className="mt-10 text-sm text-slate-500">
+          Dúvidas imediatas? Escreva para{' '}
+          <a className="text-blue-600 underline" href="mailto:tiago@smartlic.tech">
+            tiago@smartlic.tech
+          </a>
+          .
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/fundadores/obrigado/page.tsx
+++ b/frontend/app/fundadores/obrigado/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import FundadoresObrigadoClient from './FundadoresObrigadoClient';
+
+export const metadata: Metadata = {
+  title: 'Bem-vindo ao Plano Fundadores SmartLic',
+  description: 'Próximos passos do seu acesso vitalício SmartLic como fundador.',
+  robots: { index: false, follow: false },
+};
+
+export default function FundadoresObrigadoPage() {
+  return <FundadoresObrigadoClient />;
+}

--- a/frontend/app/fundadores/page.tsx
+++ b/frontend/app/fundadores/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from 'next';
+import FundadoresClient from './FundadoresClient';
+
+export const metadata: Metadata = {
+  title: 'SmartLic Plano Fundadores — Acesso vitalício à inteligência B2G',
+  description:
+    'Entre cedo na infraestrutura de inteligência B2G do SmartLic. Acesso vitalício por R$997 — pagamento único, sem mensalidade. Vagas limitadas.',
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: 'SmartLic Plano Fundadores — Acesso vitalício à inteligência B2G',
+    description:
+      'Menos PDF. Mais decisão. A IA encontra. A inteligência decide. Acesso vitalício por R$997.',
+    url: 'https://smartlic.tech/fundadores',
+    siteName: 'SmartLic',
+    locale: 'pt_BR',
+    type: 'website',
+  },
+};
+
+const jsonLdProduct = {
+  '@context': 'https://schema.org',
+  '@type': 'Product',
+  name: 'SmartLic Plano Fundadores',
+  description:
+    'Acesso vitalício à plataforma de inteligência B2G SmartLic — busca multi-fonte, classificação por IA, pipeline kanban e relatórios.',
+  brand: {
+    '@type': 'Organization',
+    name: 'CONFENGE Avaliações e Inteligência Artificial LTDA',
+  },
+  offers: {
+    '@type': 'Offer',
+    price: '997',
+    priceCurrency: 'BRL',
+    availability: 'https://schema.org/LimitedAvailability',
+    url: 'https://smartlic.tech/fundadores',
+    priceValidUntil: '2026-12-31',
+  },
+};
+
+const jsonLdFaq = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'O que está incluído no Plano Fundadores?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Acesso vitalício à plataforma SmartLic (busca multi-fonte, classificação IA, pipeline kanban, relatórios Excel, análise de viabilidade). Pagamento único de R$997 — sem mensalidade.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Qual a diferença entre Fundador e assinante regular?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'O assinante regular paga R$397/mês recorrente. O Fundador paga R$997 uma única vez e tem acesso permanente, incluindo todas as atualizações futuras.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Posso cancelar ou pedir reembolso?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Sim. Oferecemos 30 dias de garantia. Se não ficar satisfeito por qualquer motivo dentro deste prazo, devolvemos 100% do valor pago.',
+      },
+    },
+  ],
+};
+
+export default function FundadoresPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdProduct) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdFaq) }}
+      />
+      <FundadoresClient />
+    </>
+  );
+}


### PR DESCRIPTION
## Context
Renames the founding landing page route from /founding to /fundadores (pt-BR first, aligns with product positioning). Updates copy to match new Plano Fundadores v2 lifetime offer messaging.

## Changes
- Created `frontend/app/fundadores/` with new copy and simplified form (email only)
- Redirect stubs in `/founding` → 301 permanent to `/fundadores`
- JSON-LD Product schema + FAQPage for SEO
- Price displays from API (price_brl_cents) with hardcoded R\$997 fallback (TODO: remove after #782 merges)
- Moved/adapted components from founding/ to fundadores/components/
- New sections: Hero, Problema, Features grid, Comparison table, FAQ, CTA final, Legal disclaimer

## Testing Plan
- [ ] /fundadores renders correctly (headline, CTA, form, countdown)
- [ ] /founding redirects 301 to /fundadores
- [ ] /founding/obrigado redirects 301 to /fundadores/obrigado
- [ ] TypeScript compilation passes (`npx tsc --noEmit` — 0 errors)
- [ ] 16 unit tests pass (`jest --testPathPattern=fundadores`)
- [ ] Mobile responsive layout

## Risks & Rollback
Redirect stubs preserve existing /founding links. Rollback = revert redirect stubs to original page.

## Closes
Closes #786