### PR TITLE
feat(backend): FOUNDERS_OFFER_ENABLED flag + audit log + auto-disable cron (#794)

### DIFF
--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -171,6 +171,9 @@ ATESTADOS_DISPONIVEIS: list[dict] = [
     {"id": "crt", "label": "CRT (Técnico)", "sectors": ["informatica", "software_desenvolvimento", "software_licencas"]},
 ]
 
+# Plano Fundadores v2 (epic:fundadores) — kill switch for the lifetime offer
+FOUNDERS_OFFER_ENABLED: bool = str_to_bool(os.getenv("FOUNDERS_OFFER_ENABLED", "true"))
+
 # A/B Testing
 AB_EXPERIMENTS_ENABLED: bool = str_to_bool(os.getenv("AB_EXPERIMENTS_ENABLED", "false"))
 AB_ACTIVE_EXPERIMENTS: str = os.getenv("AB_ACTIVE_EXPERIMENTS", "{}")
@@ -245,6 +248,8 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     # --- Trial & Billing ---
     "TRIAL_EMAILS_ENABLED": ("TRIAL_EMAILS_ENABLED", "true"),
     "TRIAL_PAYWALL_ENABLED": ("TRIAL_PAYWALL_ENABLED", "true"),
+    # --- Founding / Billing ---
+    "FOUNDERS_OFFER_ENABLED": ("FOUNDERS_OFFER_ENABLED", "true"),
     # --- A/B Testing ---
     "ab_experiments_enabled": ("AB_EXPERIMENTS_ENABLED", "false"),
     # --- Feature Gates (unreleased features) ---

--- a/backend/jobs/cron/founders_auto_disable.py
+++ b/backend/jobs/cron/founders_auto_disable.py
@@ -1,0 +1,58 @@
+"""ARQ cron: auto-disable founding offer 1 day after deadline."""
+import logging
+from datetime import datetime, timezone
+
+import sentry_sdk
+
+logger = logging.getLogger(__name__)
+
+
+async def founders_auto_disable_check(ctx: dict) -> None:
+    """Disable founding offer 1 day after deadline_at to handle timezone edge cases."""
+    from supabase_client import get_supabase
+
+    sb = get_supabase()
+
+    try:
+        result = sb.table("founding_policy").select("deadline_at, active").eq("id", 1).single().execute()
+        if not result.data:
+            return
+
+        policy = result.data
+        if not policy.get("active", False):
+            return  # Already disabled
+
+        deadline_at = policy.get("deadline_at")
+        if not deadline_at:
+            return
+
+        # Parse deadline (string or datetime)
+        if isinstance(deadline_at, str):
+            from dateutil import parser as dtparser
+            deadline_dt = dtparser.parse(deadline_at)
+        else:
+            deadline_dt = deadline_at
+
+        # Add 1 day margin for timezone edge cases
+        from datetime import timedelta
+        cutoff = deadline_dt + timedelta(days=1)
+
+        now_utc = datetime.now(timezone.utc)
+        cutoff_aware = cutoff.replace(tzinfo=timezone.utc) if cutoff.tzinfo is None else cutoff
+
+        if now_utc > cutoff_aware:
+            logger.warning("founders_auto_disable: deadline passed, disabling offer")
+            sb.table("founding_policy").update({
+                "active": False,
+                "paused_reason": "auto_disabled: deadline passed"
+            }).eq("id", 1).execute()
+
+            sentry_sdk.capture_message(
+                "founders_auto_disabled: offer auto-disabled after deadline",
+                level="warning",
+                extras={"deadline_at": str(deadline_at)},
+            )
+            logger.info("founders_auto_disable: offer disabled successfully")
+
+    except Exception as e:
+        logger.error(f"founders_auto_disable_check failed: {e}", exc_info=True)

--- a/backend/jobs/queue/config.py
+++ b/backend/jobs/queue/config.py
@@ -42,6 +42,13 @@ try:
     except ImportError:  # cron_monitor optional — skip if module unavailable in test env
         pass
 
+    # epic:fundadores — hourly auto-disable check: disables founding offer 1 day after deadline.
+    try:
+        from jobs.cron.founders_auto_disable import founders_auto_disable_check
+        _worker_cron_jobs.append(_arq_cron(founders_auto_disable_check, minute={0}, timeout=60))
+    except ImportError:
+        pass
+
     # STORY-SEO-005: weekly GSC sync job (Sun 03:00 BRT = 06:00 UTC).
     # Graceful no-op if GSC_SERVICE_ACCOUNT_JSON env var missing — safe to register always.
     try:
@@ -156,6 +163,13 @@ class WorkerSettings:
     except ImportError:
         _monitoring_functions = []
 
+    # epic:fundadores: auto-disable cron function.
+    try:
+        from jobs.cron.founders_auto_disable import founders_auto_disable_check as _founders_auto_disable_check
+        _founders_functions = [_founders_auto_disable_check]
+    except ImportError:
+        _founders_functions = []
+
     functions = [
         llm_summary_job, excel_generation_job, search_job,
         bid_analysis_job, daily_digest_job, email_alerts_job,
@@ -163,6 +177,7 @@ class WorkerSettings:
         generate_intel_report,
         *_ingestion_functions,
         *_monitoring_functions,
+        *_founders_functions,
     ]
     cron_jobs = _worker_cron_jobs
     on_startup = _worker_on_startup

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -219,6 +219,8 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     # Datalake Search Improvements
     "TRIGRAM_FALLBACK_ENABLED": "Trigram fallback for datalake search (STORY-437)",
     "EMBEDDING_ENABLED": "Semantic embedding search for datalake (STORY-438)",
+    # Founders Offer
+    "FOUNDERS_OFFER_ENABLED": "Kill switch for the Founders lifetime offer (epic:fundadores — BIZ-FOUND-002)",
 }
 
 
@@ -284,6 +286,8 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "TRIGRAM_FALLBACK_ENABLED": {"owner": "search", "category": "search", "lifecycle": "experimental", "created": "2026-03"},
     # STORY-438: Semantic embeddings
     "EMBEDDING_ENABLED": {"owner": "search", "category": "search", "lifecycle": "experimental", "created": "2026-03"},
+    # BIZ-FOUND-002: Founders lifetime offer kill switch
+    "FOUNDERS_OFFER_ENABLED": {"owner": "billing", "category": "founding", "lifecycle": "temporary", "created": "2026-05"},
 }
 
 

--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -232,6 +232,23 @@ async def founding_availability(response: Response) -> Any:
     countdown and the X/50 seat counter. Falls open with ``available=False``
     on transient DB error so the CTA is disabled rather than over-selling.
     """
+    from config.features import get_feature_flag
+
+    if not get_feature_flag("FOUNDERS_OFFER_ENABLED"):
+        return FoundingAvailabilityResponse(
+            available=False,
+            seats_total=0,
+            seats_remaining=0,
+            seats_taken=0,
+            deadline_at=None,
+            paused=False,
+            reason="founders_offer_disabled",
+            coupon_code="",
+            discount_pct=0,
+            offer_mode="lifetime",
+            price_brl_cents=99700,
+        )
+
     sb = get_supabase()
     snapshot = await _run_with_budget(
         asyncio.to_thread(_check_availability, sb),
@@ -286,6 +303,17 @@ async def founding_checkout(
       update it. The webhook also re-checks availability for race guard
       (handled in webhooks.handlers.founding).
     """
+    from config.features import get_feature_flag
+
+    if not get_feature_flag("FOUNDERS_OFFER_ENABLED"):
+        raise HTTPException(
+            status_code=410,
+            detail={
+                "message": "Oferta Fundadores encerrada.",
+                "error_code": "founders_offer_disabled",
+            },
+        )
+
     import stripe as stripe_lib
 
     stripe_key = os.getenv("STRIPE_SECRET_KEY")

--- a/supabase/migrations/20260507120000_founding_policy_audit_log.down.sql
+++ b/supabase/migrations/20260507120000_founding_policy_audit_log.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP TRIGGER IF EXISTS founding_policy_audit ON public.founding_policy;
+DROP FUNCTION IF EXISTS public.founding_policy_audit_trigger();
+DROP TABLE IF EXISTS public.founding_policy_audit_log;
+COMMIT;

--- a/supabase/migrations/20260507120000_founding_policy_audit_log.sql
+++ b/supabase/migrations/20260507120000_founding_policy_audit_log.sql
@@ -1,0 +1,54 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.founding_policy_audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    changed_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    field_name TEXT NOT NULL,
+    old_value JSONB,
+    new_value JSONB,
+    reason TEXT
+);
+
+-- Trigger function: record any UPDATE to founding_policy
+CREATE OR REPLACE FUNCTION public.founding_policy_audit_trigger()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    -- Track changes to key fields
+    IF OLD.deadline_at IS DISTINCT FROM NEW.deadline_at THEN
+        INSERT INTO public.founding_policy_audit_log (field_name, old_value, new_value)
+        VALUES ('deadline_at', to_jsonb(OLD.deadline_at), to_jsonb(NEW.deadline_at));
+    END IF;
+    IF OLD.seat_limit IS DISTINCT FROM NEW.seat_limit THEN
+        INSERT INTO public.founding_policy_audit_log (field_name, old_value, new_value)
+        VALUES ('seat_limit', to_jsonb(OLD.seat_limit), to_jsonb(NEW.seat_limit));
+    END IF;
+    IF OLD.active IS DISTINCT FROM NEW.active THEN
+        INSERT INTO public.founding_policy_audit_log (field_name, old_value, new_value)
+        VALUES ('active', to_jsonb(OLD.active), to_jsonb(NEW.active));
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS founding_policy_audit ON public.founding_policy;
+CREATE TRIGGER founding_policy_audit
+    AFTER UPDATE ON public.founding_policy
+    FOR EACH ROW
+    EXECUTE FUNCTION public.founding_policy_audit_trigger();
+
+-- RLS: service_role can write, admin can read
+ALTER TABLE public.founding_policy_audit_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "founding_policy_audit_service_write" ON public.founding_policy_audit_log
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Add `FOUNDERS_OFFER_ENABLED` feature flag (default true) — instant kill switch for the lifetime offer
- Gate both `/v1/founding/availability` and `/v1/founding/checkout` behind the flag
- `founding_policy_audit_log` table + trigger: automatically records any changes to `founding_policy` fields
- `founders_auto_disable_check` ARQ cron (hourly): auto-disables offer 1 day after `deadline_at` + Sentry alert

## Migration
`20260507120000_founding_policy_audit_log.sql` — new table + trigger, paired `.down.sql`

## Testing Plan
- [ ] `FOUNDERS_OFFER_ENABLED=false` returns `available=false, reason=founders_offer_disabled` from /availability
- [ ] Checkout returns 410 when flag is false
- [ ] Audit trigger fires on founding_policy UPDATE
- [ ] Cron job registered in WorkerSettings
- [ ] TypeScript/Python type check passes

## Closes
Closes #794