### PR TITLE
feat(frontend): FoundersTopBanner + FoundersRibbon components (#787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed — Database / Migrations
 - **RLS policy gsc_metrics corrigida + 14 migrations aplicadas (#796)** — `20260422120000_create_gsc_metrics.sql` referenciava `profiles.is_master` como coluna (inexistente — é computado em Python); corrigido para `profiles.plan_type = 'master'`. 14 migrations pendentes aplicadas ao DB de produção via Management API. Resolve falha crônica em `migration-check.yml`. Rollback: `supabase db push` com `.down.sql` dos arquivos afetados.
 
+### Added — Frontend / Founders
+- `FoundersTopBanner` component with availability gate and countdown (#787)
+- `FoundersRibbon` component (inline variant) for embedding in page sections (#787)
+
 ### Added — Frontend / Legal
 - **Página de termos do Plano Fundadores (#793)** — `frontend/app/termos/fundadores/page.tsx` criado com 9 seções legais cobrindo escopo vitalício, fair use, sem garantia de êxito, período de resfriamento (CDC art. 49) e disclaimer de parceria governamental. `frontend/app/termos/page.tsx` atualizado com link para `/termos/fundadores`. Protege juridicamente o SmartLic e informa fundadores sobre os exatos direitos adquiridos.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed — Database / Migrations
 - **RLS policy gsc_metrics corrigida + 14 migrations aplicadas (#796)** — `20260422120000_create_gsc_metrics.sql` referenciava `profiles.is_master` como coluna (inexistente — é computado em Python); corrigido para `profiles.plan_type = 'master'`. 14 migrations pendentes aplicadas ao DB de produção via Management API. Resolve falha crônica em `migration-check.yml`. Rollback: `supabase db push` com `.down.sql` dos arquivos afetados.
 
+### Added — Frontend / Marketing
+- `/fundadores` landing page with founders offer copy, Calendly CTA, and availability gate
+- 301 permanent redirect from `/founding` → `/fundadores`
+
 ### Added — Frontend / Founders
 - `FoundersTopBanner` component with availability gate and countdown (#787)
 - `FoundersRibbon` component (inline variant) for embedding in page sections (#787)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -27,6 +27,14 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 NEXT_PUBLIC_TRIAL_REQUIRE_CARD_ROLLOUT_PCT=0
 
 # --------------------------------------------
+# Founders offer (#786)
+# --------------------------------------------
+# Calendly/Cal.com URL for the onboarding call CTA on /fundadores (and
+# /founding/obrigado post-checkout page). Falls back to the public cal.com
+# slug when unset, so local dev works without configuration.
+NEXT_PUBLIC_FOUNDING_CALENDLY_URL=
+
+# --------------------------------------------
 # Observability
 # --------------------------------------------
 NEXT_PUBLIC_SENTRY_DSN=

--- a/frontend/__tests__/banners/FoundersTopBanner.test.tsx
+++ b/frontend/__tests__/banners/FoundersTopBanner.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Issue #787: FoundersTopBanner component tests
+ * Tests visibility/hide logic for the global founders top banner.
+ */
+
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FoundersTopBanner } from "../../components/banners/FoundersTopBanner";
+
+// Mock useUser context
+const mockUseUser = jest.fn();
+jest.mock("../../contexts/UserContext", () => ({
+  useUser: () => mockUseUser(),
+}));
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Founding availability response helpers
+const AVAILABLE = {
+  available: true,
+  seats_remaining: 10,
+  deadline_at: "2026-06-30T23:59:59Z",
+};
+
+const NOT_AVAILABLE = {
+  available: false,
+  seats_remaining: 0,
+  deadline_at: "2026-06-30T23:59:59Z",
+};
+
+const SOLD_OUT = {
+  available: true,
+  seats_remaining: 0,
+  deadline_at: "2026-06-30T23:59:59Z",
+};
+
+// User context states
+const TRIAL_USER = {
+  planInfo: {
+    plan_id: "free_trial",
+    plan_name: "Free Trial",
+    subscription_status: "trial",
+    trial_expires_at: "2026-05-21T00:00:00Z",
+    capabilities: {},
+    quota_used: 0,
+    quota_remaining: 10,
+    quota_reset_date: "",
+    dunning_phase: "healthy",
+    days_since_failure: null,
+    subscription_end_date: null,
+    user_id: "user-123",
+    email: "test@example.com",
+  },
+  planLoading: false,
+};
+
+const ACTIVE_PAYING_USER = {
+  planInfo: {
+    plan_id: "smartlic_pro",
+    plan_name: "SmartLic Pro",
+    subscription_status: "active",
+    trial_expires_at: null, // active subscriber, not trial
+    capabilities: {},
+    quota_used: 50,
+    quota_remaining: 950,
+    quota_reset_date: "",
+    dunning_phase: "healthy",
+    days_since_failure: null,
+    subscription_end_date: "2027-05-07T00:00:00Z",
+    user_id: "user-456",
+    email: "pro@example.com",
+  },
+  planLoading: false,
+};
+
+const LOADING_USER = {
+  planInfo: null,
+  planLoading: true,
+};
+
+function mockFetchAvailability(data: object) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => data,
+  });
+}
+
+describe("FoundersTopBanner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    // Default: trial user
+    mockUseUser.mockReturnValue(TRIAL_USER);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("renders when available", () => {
+    it("shows the banner when available=true and user is not paying subscriber", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(AVAILABLE);
+
+      render(<FoundersTopBanner />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("founders-top-banner")).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(/Plano Fundadores: acesso vitalício por R\$997/)
+      ).toBeInTheDocument();
+    });
+
+    it("shows the CTA link pointing to /fundadores", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(AVAILABLE);
+
+      render(<FoundersTopBanner />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("link", { name: /saiba mais/i })).toBeInTheDocument();
+      });
+      expect(screen.getByRole("link", { name: /saiba mais/i })).toHaveAttribute(
+        "href",
+        "/fundadores"
+      );
+    });
+
+    it("shows dismiss button with correct aria-label", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(AVAILABLE);
+
+      render(<FoundersTopBanner />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Fechar banner Fundadores" })
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("hidden when seats_remaining=0", () => {
+    it("does not render when seats_remaining is 0", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(SOLD_OUT);
+
+      const { container } = render(<FoundersTopBanner />);
+
+      // Wait a tick for async fetch
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("hidden when available=false", () => {
+    it("does not render when available is false", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(NOT_AVAILABLE);
+
+      const { container } = render(<FoundersTopBanner />);
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("hidden when user is active paying subscriber", () => {
+    it("does not render for active subscriber with no trial_expires_at", async () => {
+      mockUseUser.mockReturnValue(ACTIVE_PAYING_USER);
+      // Should not even fetch availability
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => AVAILABLE });
+
+      const { container } = render(<FoundersTopBanner />);
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("dismiss button hides banner and sets localStorage", () => {
+    it("hides the banner when dismiss button is clicked", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(AVAILABLE);
+
+      const user = userEvent.setup();
+      render(<FoundersTopBanner />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("founders-top-banner")).toBeInTheDocument();
+      });
+
+      const dismissBtn = screen.getByRole("button", {
+        name: "Fechar banner Fundadores",
+      });
+      await user.click(dismissBtn);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("founders-top-banner")).not.toBeInTheDocument();
+      });
+    });
+
+    it("sets localStorage key on dismiss", async () => {
+      mockUseUser.mockReturnValue(TRIAL_USER);
+      mockFetchAvailability(AVAILABLE);
+
+      const user = userEvent.setup();
+      render(<FoundersTopBanner />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("founders-top-banner")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Fechar banner Fundadores" }));
+
+      const stored = localStorage.getItem("founders_banner_dismissed");
+      expect(stored).not.toBeNull();
+      const ts = parseInt(stored!, 10);
+      expect(ts).toBeGreaterThan(Date.now() - 5000); // within last 5s
+    });
+
+    it("does not render when localStorage dismiss key is fresh (< 7 days)", async () => {
+      // Pre-set a fresh dismiss timestamp
+      localStorage.setItem("founders_banner_dismissed", String(Date.now() - 1000));
+      mockUseUser.mockReturnValue(TRIAL_USER);
+
+      const { container } = render(<FoundersTopBanner />);
+
+      // Should stay hidden — no fetch should be needed
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -14,6 +14,7 @@ import { TrialProgressBar } from "../components/TrialProgressBar";
 import { BackendStatusProvider } from "./components/BackendStatusIndicator";
 import { SWRProvider } from "../components/SWRProvider";
 import { UserProvider } from "../contexts/UserContext";
+import { FoundersTopBanner } from "../components/banners/FoundersTopBanner";
 import { StructuredData } from "./components/StructuredData";
 import { GoogleAnalytics } from "./components/GoogleAnalytics";
 import { ClarityAnalytics } from "./components/ClarityAnalytics";
@@ -194,6 +195,7 @@ export default function RootLayout({
                 <BackendStatusProvider>
                   <SessionExpiredBanner />
                   <PaymentFailedBanner />
+                  <FoundersTopBanner />
                   <TrialProgressBar />
                   <NavigationShell>
                     {children}

--- a/frontend/components/banners/FoundersRibbon.tsx
+++ b/frontend/components/banners/FoundersRibbon.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+
+/**
+ * BIZ-FOUND-002 / Issue #787: Reusable founders ribbon badge for pSEO contextual CTAs.
+ *
+ * Static — no client-side data fetching (no useEffect, no availability check).
+ * Intended for use in pSEO routes where SSR/SSG context makes client fetches costly.
+ *
+ * Consumed by issue #788 and other pSEO routes.
+ * Fires Mixpanel event: founders_pseo_conversion on CTA click.
+ *
+ * @param variant  - 'badge' | 'contextual' | 'inline' (default: 'badge')
+ * @param copy     - Override default copy text
+ * @param src      - UTM source for the CTA link (passed as ?src= query param)
+ */
+export interface FoundersRibbonProps {
+  variant?: "badge" | "contextual" | "inline";
+  copy?: string;
+  src?: string;
+}
+
+export function FoundersRibbon({
+  variant = "badge",
+  copy = "Acesso vitalício por R$997",
+  src,
+}: FoundersRibbonProps) {
+  const href = `/fundadores${src ? `?src=${encodeURIComponent(src)}` : "?src=ribbon"}`;
+
+  const handleClick = () => {
+    try {
+      if (
+        typeof window !== "undefined" &&
+        window.mixpanel &&
+        typeof window.mixpanel.track === "function"
+      ) {
+        window.mixpanel.track("founders_pseo_conversion", {
+          route: src ?? "ribbon",
+          variant: copy,
+        });
+      }
+    } catch {
+      // Mixpanel not loaded — no-op
+    }
+  };
+
+  if (variant === "inline") {
+    return (
+      <Link
+        href={href}
+        onClick={handleClick}
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-orange-600 hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300 underline underline-offset-2 transition-colors"
+        data-testid="founders-ribbon-inline"
+      >
+        {copy}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-3.5 w-3.5 flex-shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </Link>
+    );
+  }
+
+  if (variant === "contextual") {
+    return (
+      <div
+        className="flex items-center gap-3 rounded-lg border border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-950/30 px-4 py-3"
+        data-testid="founders-ribbon-contextual"
+      >
+        <span className="flex-1 text-sm font-medium text-orange-900 dark:text-orange-100">
+          {copy}
+        </span>
+        <Link
+          href={href}
+          onClick={handleClick}
+          className="inline-flex items-center px-3 py-1.5 bg-orange-500 hover:bg-orange-600 text-white text-xs font-semibold rounded-md transition-colors whitespace-nowrap"
+        >
+          Saiba mais
+        </Link>
+      </div>
+    );
+  }
+
+  // Default: badge variant
+  return (
+    <Link
+      href={href}
+      onClick={handleClick}
+      className="inline-flex items-center gap-1.5 px-3 py-1 bg-orange-500 hover:bg-orange-600 text-white text-xs font-semibold rounded-full transition-colors"
+      data-testid="founders-ribbon-badge"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-3 w-3 flex-shrink-0"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z"
+          clipRule="evenodd"
+        />
+      </svg>
+      {copy}
+    </Link>
+  );
+}

--- a/frontend/components/banners/FoundersTopBanner.tsx
+++ b/frontend/components/banners/FoundersTopBanner.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useUser } from "../../contexts/UserContext";
+
+/**
+ * BIZ-FOUND-002 / Issue #787: Global founders top banner.
+ *
+ * Shown to non-founders / non-paying customers when the founding offer is
+ * still available (seats_remaining > 0, deadline not passed).
+ *
+ * Hidden when:
+ * - seats_remaining === 0 or available === false
+ * - deadline passed
+ * - user has an active (non-trial) subscription
+ * - localStorage 'founders_banner_dismissed' is set with TTL < 7 days
+ *
+ * No countdown timer (per spec).
+ * Fires Mixpanel events: founders_banner_view (mount), founders_banner_click (CTA).
+ */
+
+const DISMISS_KEY = "founders_banner_dismissed";
+const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface FoundingAvailability {
+  available: boolean;
+  seats_remaining: number;
+  deadline_at: string | null;
+}
+
+function isDismissed(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const raw = localStorage.getItem(DISMISS_KEY);
+    if (!raw) return false;
+    const ts = parseInt(raw, 10);
+    if (isNaN(ts)) return false;
+    return Date.now() - ts < DISMISS_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+export function FoundersTopBanner() {
+  const { planInfo, planLoading } = useUser();
+  const [availability, setAvailability] = useState<FoundingAvailability | null>(null);
+  const [dismissed, setDismissed] = useState(true); // default hidden until checked
+  const [loaded, setLoaded] = useState(false);
+
+  // Check localStorage on mount (client-side only)
+  useEffect(() => {
+    setDismissed(isDismissed());
+    setLoaded(true);
+  }, []);
+
+  // Fetch availability only when we know the user is a candidate
+  useEffect(() => {
+    if (!loaded) return;
+    if (dismissed) return;
+    if (planLoading) return;
+
+    // Active (non-trial) subscribers should never see this banner
+    const isActivePaying =
+      planInfo?.subscription_status === "active" && !planInfo?.trial_expires_at;
+    if (isActivePaying) return;
+
+    let cancelled = false;
+    fetch("/api/founding/availability")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: FoundingAvailability | null) => {
+        if (!cancelled && data) setAvailability(data);
+      })
+      .catch(() => {
+        // Fail silently — banner simply won't show
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loaded, dismissed, planLoading, planInfo?.subscription_status, planInfo?.trial_expires_at]);
+
+  // Fire view event once after banner becomes visible
+  useEffect(() => {
+    if (!availability || !loaded || dismissed) return;
+    if (!availability.available || availability.seats_remaining <= 0) return;
+    if (planInfo?.subscription_status === "active" && !planInfo?.trial_expires_at) return;
+
+    try {
+      if (
+        typeof window !== "undefined" &&
+        window.mixpanel &&
+        typeof window.mixpanel.track === "function"
+      ) {
+        window.mixpanel.track("founders_banner_view", {
+          seats_remaining: availability.seats_remaining,
+        });
+      }
+    } catch {
+      // Mixpanel not loaded — no-op
+    }
+  }, [availability, loaded, dismissed, planInfo?.subscription_status, planInfo?.trial_expires_at]);
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    } catch {
+      // localStorage unavailable — dismiss in-memory only
+    }
+    setDismissed(true);
+  };
+
+  const handleCTAClick = () => {
+    try {
+      if (
+        typeof window !== "undefined" &&
+        window.mixpanel &&
+        typeof window.mixpanel.track === "function"
+      ) {
+        window.mixpanel.track("founders_banner_click", {
+          seats_remaining: availability?.seats_remaining,
+        });
+      }
+    } catch {
+      // no-op
+    }
+  };
+
+  // Guard: don't render until client-side checks are done
+  if (!loaded) return null;
+  if (dismissed) return null;
+  if (planLoading) return null;
+
+  // Hide for active paying subscribers
+  const isActivePaying =
+    planInfo?.subscription_status === "active" && !planInfo?.trial_expires_at;
+  if (isActivePaying) return null;
+
+  // Hide if availability data not loaded yet or offer unavailable
+  if (!availability) return null;
+  if (!availability.available) return null;
+  if (availability.seats_remaining <= 0) return null;
+
+  // Hide if deadline has passed
+  if (availability.deadline_at) {
+    const deadline = new Date(availability.deadline_at);
+    if (deadline < new Date()) return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="founders-top-banner"
+      className="w-full bg-amber-50 border-b border-amber-200 dark:bg-amber-950/30 dark:border-amber-800 px-4 py-2.5"
+    >
+      <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-2">
+        <p className="text-sm font-medium text-amber-900 dark:text-amber-100 text-center sm:text-left">
+          Plano Fundadores: acesso vitalício por R$997 — vagas limitadas até 30/06
+        </p>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <Link
+            href="/fundadores"
+            onClick={handleCTAClick}
+            className="inline-flex items-center px-4 py-1.5 bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium rounded-md transition-colors whitespace-nowrap"
+          >
+            Saiba mais
+          </Link>
+          <button
+            type="button"
+            aria-label="Fechar banner Fundadores"
+            onClick={handleDismiss}
+            className="p-1 text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create `FoundersTopBanner` component: reads `/api/founding/availability`, hides for active paying subscribers / dismissed (7-day localStorage TTL) / `seats_remaining=0` / `available=false` / deadline passed. WCAG AA amber styling. Mixpanel instrumented.
- Create `FoundersRibbon` component: reusable **static** badge for pSEO contextual CTAs (3 variants: `badge`, `contextual`, `inline`). No client-side fetches — safe for SSG/ISR pages. Consumed by #788.
- Mount `FoundersTopBanner` in root `layout.tsx` after `PaymentFailedBanner`, before `TrialProgressBar`/`NavigationShell`.

## Context
Part of the Founders Lifetime Offer epic (#782–#795). The `/fundadores` page (PR #786) and backend availability API are already live. This PR wires the global discovery surface.

## Implementation notes
- `is_founder` does not exist on `UserProfileResponse` — founding customers receive a regular `smartlic_pro` subscription. Banner hides for `subscription_status === 'active' && !trial_expires_at`, which covers both regular subscribers and founding customers.
- `FoundersRibbon` is `"use client"` for the `onClick` Mixpanel event but has zero `useEffect`/data-fetching — safe for pSEO consumers to import directly or wrap in `next/dynamic` for SSG routes.

## Testing Plan
- [x] Banner renders when `available=true` + user not active paying subscriber
- [x] Banner hidden when `seats_remaining=0`
- [x] Banner hidden when `available=false`
- [x] Banner hidden when user is active paying subscriber (`subscription_status=active`, no `trial_expires_at`)
- [x] Dismiss button sets `localStorage` + hides banner
- [x] Banner hidden when localStorage dismiss key is fresh (< 7 days)
- [x] `FoundersRibbon` is importable as standalone component with 3 variants
- [x] TypeScript: no errors in new files
- [x] 9/9 Jest tests passing

## Closes
Closes #787