### PR TITLE
feat(tracking): founders analytics utility + Prometheus counters (#790)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added — Frontend / Legal
 - **Página de termos do Plano Fundadores (#793)** — `frontend/app/termos/fundadores/page.tsx` criado com 9 seções legais cobrindo escopo vitalício, fair use, sem garantia de êxito, período de resfriamento (CDC art. 49) e disclaimer de parceria governamental. `frontend/app/termos/page.tsx` atualizado com link para `/termos/fundadores`. Protege juridicamente o SmartLic e informa fundadores sobre os exatos direitos adquiridos.
 
+### Added — Frontend / Analytics
+- **Typed Mixpanel wrappers para eventos founders (#790)** — `lib/analytics/founders.ts` expõe 9 funções tipadas (`trackFoundersPageView`, `trackFoundersBannerView`, `trackFoundersBannerClick`, `trackFoundersBannerDismiss`, `trackFoundersRibbonView`, `trackFoundersRibbonClick`, `trackFoundersCtaClick`, `trackFoundersCheckoutStart`, `trackFoundersPseoConversion`). Todas usam `safeTrack` interno que silencia erros do Mixpanel (SSR / consent não dado). Testes unitários em `lib/analytics/__tests__/founders.test.ts`: cobertura de `safeTrack` (error swallowing) + todos os 9 wrappers com props forwarding. Backend: `mark_founding_lead_completed` corrigido para incrementar `founders_checkout_success` após o race guard (não antes) — evita overcount em violações de cap. 4 novos testes de counter em `test_founding_webhook_race_guard.py`. Rollback: reverter PR #790.
+
 ### Fixed — Backend / Infra
 - **Graceful shutdown uvicorn configurável via env var (#799)** — `--timeout-graceful-shutdown` em `backend/start.sh` e `backend/railway.toml` usa `${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-120}` (padrão 120s, alinhado com Railway drainingSeconds=120). Override via Railway env var sem redeploy. Teste `TestAC9GracefulTimeout` atualizado para verificar novo padrão parametrizado.
 

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1291,6 +1291,23 @@ HEALTH_CHECK_FAILURES = _create_counter(
 
 
 # ============================================================================
+# Plano Fundadores metrics (epic:fundadores)
+# ============================================================================
+
+founders_checkout_success = _create_counter(
+    "smartlic_founders_checkout_success_total",
+    "Successful founding lifetime checkouts",
+    labelnames=["offer_version"],
+)
+
+founders_checkout_failed = _create_counter(
+    "smartlic_founders_checkout_failed_total",
+    "Failed founding checkout attempts",
+    labelnames=["reason"],
+)
+
+
+# ============================================================================
 # ASGI app factory for /metrics endpoint
 # ============================================================================
 

--- a/backend/tests/test_founding_webhook_race_guard.py
+++ b/backend/tests/test_founding_webhook_race_guard.py
@@ -266,3 +266,86 @@ def test_refund_helper_skips_when_payment_intent_missing():
 
     # Should not raise; should return False.
     assert _refund_session_charge(session) is False
+
+
+# ---------------------------------------------------------------------------
+# Prometheus counter assertions
+# ---------------------------------------------------------------------------
+
+
+@patch("webhooks.handlers.founding.founders_checkout_success")
+@patch("webhooks.handlers.founding.founders_checkout_failed")
+@patch("webhooks.handlers.founding._send_cap_violation_email")
+@patch("webhooks.handlers.founding._refund_session_charge")
+def test_success_counter_incremented_on_available(
+    mock_refund, mock_email, mock_failed, mock_success
+):
+    """reason=available -> success counter incremented, failed counter NOT called."""
+    sb = _make_sb_with_rpc_sequence([
+        [{"available": True, "seats_remaining": 5, "seats_total": 50,
+          "deadline_at": "2026-05-30T23:59:59-03:00", "paused": False, "reason": "available"}]
+    ])
+
+    mark_founding_lead_completed(sb, _founding_session())
+
+    mock_success.labels.return_value.inc.assert_called_once()
+    mock_failed.labels.assert_not_called()
+
+
+@patch("webhooks.handlers.founding.founders_checkout_success")
+@patch("webhooks.handlers.founding.founders_checkout_failed")
+@patch("webhooks.handlers.founding._send_cap_violation_email")
+@patch("webhooks.handlers.founding._refund_session_charge")
+def test_failed_counter_incremented_on_cap_violated_not_success(
+    mock_refund, mock_email, mock_failed, mock_success
+):
+    """reason=founding_cap_reached -> failed(cap_violated) counter incremented, success NOT called."""
+    mock_refund.return_value = True
+
+    sb = _make_sb_with_rpc_sequence([
+        [{"available": False, "seats_remaining": 0, "seats_total": 50,
+          "deadline_at": "2026-05-30T23:59:59-03:00", "paused": False,
+          "reason": "founding_cap_reached"}]
+    ])
+
+    mark_founding_lead_completed(sb, _founding_session())
+
+    mock_failed.labels.assert_called_with(reason="cap_violated")
+    mock_success.labels.assert_not_called()
+
+
+@patch("webhooks.handlers.founding.founders_checkout_success")
+@patch("webhooks.handlers.founding.founders_checkout_failed")
+@patch("webhooks.handlers.founding._send_cap_violation_email")
+@patch("webhooks.handlers.founding._refund_session_charge")
+def test_success_counter_incremented_on_rpc_unavailable(
+    mock_refund, mock_email, mock_failed, mock_success
+):
+    """RPC unavailable (fail-safe path) -> success counter still incremented (legitimate purchase)."""
+    fake_sb = MagicMock()
+    fake_sb.rpc.return_value = MagicMock(execute=MagicMock(side_effect=Exception("db down")))
+    fake_sb.table.return_value = fake_sb
+    fake_sb.update.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.execute.return_value = MagicMock(data=[{"id": "lead-1"}])
+
+    mark_founding_lead_completed(fake_sb, _founding_session())
+
+    mock_success.labels.return_value.inc.assert_called_once()
+    mock_failed.labels.assert_not_called()
+
+
+@patch("webhooks.handlers.founding.founders_checkout_success")
+@patch("webhooks.handlers.founding.founders_checkout_failed")
+def test_failed_counter_incremented_on_db_error(mock_failed, mock_success):
+    """DB update error -> failed(db_error) counter, success NOT called."""
+    fake_sb = MagicMock()
+    fake_sb.table.return_value = fake_sb
+    fake_sb.update.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.execute.side_effect = Exception("connection refused")
+
+    mark_founding_lead_completed(fake_sb, _founding_session())
+
+    mock_failed.labels.assert_called_with(reason="db_error")
+    mock_success.labels.assert_not_called()

--- a/backend/webhooks/handlers/founding.py
+++ b/backend/webhooks/handlers/founding.py
@@ -330,8 +330,6 @@ def mark_founding_lead_completed(sb, session: Any) -> None:
             lead_id = str(result.data[0]["id"])
 
         logger.info(f"Founding lead marked completed: session_id={sid} rows={updated}")
-        # Optimistic success counter — may be reverted by race guard below
-        founders_checkout_success.labels(offer_version="v2_lifetime").inc()
     except Exception as e:
         logger.error(f"Failed to mark founding lead completed: session_id={sid} err={e}")
         founders_checkout_failed.labels(reason="db_error").inc()
@@ -344,6 +342,7 @@ def mark_founding_lead_completed(sb, session: Any) -> None:
         # Fail safe: never auto-refund a paying customer when the DB is
         # uncooperative. Operator alerting (Sentry) can catch the gap.
         logger.warning(f"founding race guard: RPC unavailable, skipping cap re-check — session_id={sid}")
+        founders_checkout_success.labels(offer_version="v2_lifetime").inc()
         return
 
     reason = snapshot.get("reason") or ""
@@ -354,6 +353,7 @@ def mark_founding_lead_completed(sb, session: Any) -> None:
         # refund post-hoc.
         # #785: activate lifetime founder entitlement on the happy path.
         _activate_lifetime_founder_entitlement(sb, session, lead_id)
+        founders_checkout_success.labels(offer_version="v2_lifetime").inc()
         return
 
     # The only "race" we need to refund for is founding_cap_reached. For
@@ -363,6 +363,7 @@ def mark_founding_lead_completed(sb, session: Any) -> None:
         logger.warning(
             f"founding race guard: unexpected post-completion reason={reason} session_id={sid}"
         )
+        founders_checkout_success.labels(offer_version="v2_lifetime").inc()
         return
 
     logger.error(

--- a/backend/webhooks/handlers/founding.py
+++ b/backend/webhooks/handlers/founding.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from log_sanitizer import get_sanitized_logger
+from metrics import founders_checkout_success, founders_checkout_failed
 
 logger = get_sanitized_logger(__name__)
 
@@ -329,8 +330,11 @@ def mark_founding_lead_completed(sb, session: Any) -> None:
             lead_id = str(result.data[0]["id"])
 
         logger.info(f"Founding lead marked completed: session_id={sid} rows={updated}")
+        # Optimistic success counter — may be reverted by race guard below
+        founders_checkout_success.labels(offer_version="v2_lifetime").inc()
     except Exception as e:
         logger.error(f"Failed to mark founding lead completed: session_id={sid} err={e}")
+        founders_checkout_failed.labels(reason="db_error").inc()
         return
 
     # BIZ-FOUND-002 race guard — re-check availability AFTER the flip so the
@@ -367,6 +371,7 @@ def mark_founding_lead_completed(sb, session: Any) -> None:
         f"{snapshot.get('seats_total', 0)} — initiating refund + email."
     )
 
+    founders_checkout_failed.labels(reason="cap_violated").inc()
     refunded = _refund_session_charge(session)
 
     try:

--- a/docs/analytics/founders-events.md
+++ b/docs/analytics/founders-events.md
@@ -1,0 +1,65 @@
+# Founders Analytics Events
+
+Schema reference for all analytics events related to the Plano Fundadores (epic:fundadores).
+
+## Frontend (Mixpanel)
+
+| Event | Props | Trigger |
+|-------|-------|---------|
+| `founders_page_view` | `{utm_source, utm_medium, utm_campaign, src, seats_remaining, deadline_at}` | /fundadores page mount |
+| `founders_banner_view` | `{route, dismissed_count}` | FoundersTopBanner mount |
+| `founders_banner_click` | `{route}` | CTA click in banner |
+| `founders_banner_dismiss` | `{route}` | Dismiss button click |
+| `founders_ribbon_view` | `{route, variant}` | FoundersRibbon mount in pSEO |
+| `founders_ribbon_click` | `{route, variant}` | FoundersRibbon CTA click |
+| `founders_cta_click` | `{cta_location, src}` | Any CTA on /fundadores page |
+| `founders_checkout_start` | `{email_provided, src}` | Form submit on /fundadores |
+| `founders_pseo_conversion` | `{from_route, variant}` | Arrival at /fundadores from pSEO ribbon |
+
+## Backend (Prometheus)
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `smartlic_founders_checkout_success_total` | `offer_version` | Webhook: lifetime entitlement activated |
+| `smartlic_founders_checkout_failed_total` | `reason` | Checkout rejection (`cap_violated`, `db_error`, etc.) |
+
+### Label values
+
+**`offer_version`**
+- `v2_lifetime` — current offer (one-time R$997, issued epic:fundadores v2)
+
+**`reason`**
+- `cap_violated` — BIZ-FOUND-002 race guard detected over-sell after completion flip
+- `db_error` — Supabase error when marking lead as completed
+- `deadline_passed` — Checkout attempted after offer deadline (logged, not a webhook path)
+
+## Usage
+
+Import from `@/lib/analytics/founders`:
+
+```typescript
+import { trackFoundersPageView } from '@/lib/analytics/founders';
+
+// On /fundadores page mount
+trackFoundersPageView({
+  utm_source: searchParams.get('utm_source'),
+  utm_medium: searchParams.get('utm_medium'),
+  utm_campaign: searchParams.get('utm_campaign'),
+  src: searchParams.get('src'),
+  seats_remaining: offerData?.seats_remaining,
+  deadline_at: offerData?.deadline_at,
+});
+```
+
+## Notes
+
+- All frontend functions use a `safeTrack` wrapper — they never throw, even in SSR
+  or when Mixpanel has not been initialized (cookie consent not given).
+- Backend counters are instrumented in `backend/webhooks/handlers/founding.py`
+  via the `mark_founding_lead_completed` webhook handler (Stripe
+  `checkout.session.completed` with `metadata.source == "founding"`).
+- The optimistic `founders_checkout_success_total` increment happens immediately
+  after the DB flip; if the BIZ-FOUND-002 race guard reverts the row, a
+  `founders_checkout_failed_total{reason="cap_violated"}` counter is also
+  incremented. The net value of `success - cap_violated` gives the true
+  net-completed count.

--- a/frontend/app/api/founding/checkout/route.ts
+++ b/frontend/app/api/founding/checkout/route.ts
@@ -2,6 +2,11 @@
  * STORY-BIZ-001: founding customer checkout proxy.
  * No auth required — called from the public /founding landing.
  * Backend enforces rate-limiting, CNPJ validation, and duplicate-email check.
+ *
+ * Analytics: trackFoundersCheckoutStart should be called on the CLIENT SIDE
+ * in the form submit handler (before calling this route), not here.
+ * See: frontend/lib/analytics/founders.ts → trackFoundersCheckoutStart
+ * TODO: track founders_checkout_start on client side in form submit handler
  */
 import { createProxyRoute } from "../../../../lib/create-proxy-route";
 

--- a/frontend/lib/analytics/__tests__/founders.test.ts
+++ b/frontend/lib/analytics/__tests__/founders.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for founders analytics wrappers (lib/analytics/founders.ts).
+ *
+ * Verifies:
+ * - safeTrack swallows errors from Mixpanel (never throws)
+ * - Each exported event wrapper calls mixpanel.track with the correct event
+ *   name and forwards props unchanged
+ */
+
+import mixpanel from 'mixpanel-browser';
+
+jest.mock('mixpanel-browser', () => ({
+  __esModule: true,
+  default: { track: jest.fn() },
+}));
+
+import {
+  trackFoundersPageView,
+  trackFoundersBannerView,
+  trackFoundersBannerClick,
+  trackFoundersBannerDismiss,
+  trackFoundersRibbonView,
+  trackFoundersRibbonClick,
+  trackFoundersCtaClick,
+  trackFoundersCheckoutStart,
+  trackFoundersPseoConversion,
+} from '../founders';
+
+const mockTrack = mixpanel.track as jest.Mock;
+
+beforeEach(() => {
+  mockTrack.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// safeTrack — error swallowing
+// ---------------------------------------------------------------------------
+
+describe('safeTrack error swallowing', () => {
+  it('does not throw when mixpanel.track throws', () => {
+    mockTrack.mockImplementationOnce(() => {
+      throw new Error('Mixpanel not initialized');
+    });
+
+    expect(() =>
+      trackFoundersPageView({ utm_source: null, utm_medium: null, utm_campaign: null })
+    ).not.toThrow();
+  });
+
+  it('does not throw when mixpanel.track throws a non-Error value', () => {
+    mockTrack.mockImplementationOnce(() => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw 'consent not given';
+    });
+
+    expect(() => trackFoundersCtaClick({ cta_location: 'hero' })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Individual event wrappers
+// ---------------------------------------------------------------------------
+
+describe('trackFoundersPageView', () => {
+  it('calls mixpanel.track with founders_page_view and forwarded props', () => {
+    const props = {
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'founders-2026',
+      src: 'banner',
+      seats_remaining: 10,
+      deadline_at: '2026-05-30T23:59:59-03:00',
+    };
+    trackFoundersPageView(props);
+    expect(mockTrack).toHaveBeenCalledWith('founders_page_view', props);
+  });
+
+  it('accepts nullish optional props', () => {
+    trackFoundersPageView({ utm_source: null, utm_medium: null, utm_campaign: null });
+    expect(mockTrack).toHaveBeenCalledWith('founders_page_view', {
+      utm_source: null,
+      utm_medium: null,
+      utm_campaign: null,
+    });
+  });
+});
+
+describe('trackFoundersBannerView', () => {
+  it('calls mixpanel.track with founders_banner_view', () => {
+    trackFoundersBannerView({ route: '/buscar', dismissed_count: 2 });
+    expect(mockTrack).toHaveBeenCalledWith('founders_banner_view', {
+      route: '/buscar',
+      dismissed_count: 2,
+    });
+  });
+});
+
+describe('trackFoundersBannerClick', () => {
+  it('calls mixpanel.track with founders_banner_click', () => {
+    trackFoundersBannerClick({ route: '/planos' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_banner_click', { route: '/planos' });
+  });
+});
+
+describe('trackFoundersBannerDismiss', () => {
+  it('calls mixpanel.track with founders_banner_dismiss', () => {
+    trackFoundersBannerDismiss({ route: '/dashboard' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_banner_dismiss', { route: '/dashboard' });
+  });
+});
+
+describe('trackFoundersRibbonView', () => {
+  it('calls mixpanel.track with founders_ribbon_view and variant', () => {
+    trackFoundersRibbonView({ route: '/licitacoes/tecnologia', variant: 'compact' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_ribbon_view', {
+      route: '/licitacoes/tecnologia',
+      variant: 'compact',
+    });
+  });
+});
+
+describe('trackFoundersRibbonClick', () => {
+  it('calls mixpanel.track with founders_ribbon_click and variant', () => {
+    trackFoundersRibbonClick({ route: '/observatorio/setor-ti', variant: 'default' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_ribbon_click', {
+      route: '/observatorio/setor-ti',
+      variant: 'default',
+    });
+  });
+});
+
+describe('trackFoundersCtaClick', () => {
+  it('calls mixpanel.track with founders_cta_click and cta_location', () => {
+    trackFoundersCtaClick({ cta_location: 'pricing_table', src: 'email' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_cta_click', {
+      cta_location: 'pricing_table',
+      src: 'email',
+    });
+  });
+});
+
+describe('trackFoundersCheckoutStart', () => {
+  it('calls mixpanel.track with founders_checkout_start', () => {
+    trackFoundersCheckoutStart({ email_provided: true, src: 'ribbon' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_checkout_start', {
+      email_provided: true,
+      src: 'ribbon',
+    });
+  });
+});
+
+describe('trackFoundersPseoConversion', () => {
+  it('calls mixpanel.track with founders_pseo_conversion', () => {
+    trackFoundersPseoConversion({ from_route: '/contratos/tecnologia/SP', variant: 'default' });
+    expect(mockTrack).toHaveBeenCalledWith('founders_pseo_conversion', {
+      from_route: '/contratos/tecnologia/SP',
+      variant: 'default',
+    });
+  });
+});

--- a/frontend/lib/analytics/founders.ts
+++ b/frontend/lib/analytics/founders.ts
@@ -1,0 +1,93 @@
+/**
+ * Typed Mixpanel analytics wrappers for all founders-related events.
+ *
+ * All functions are safe to call unconditionally — they never throw even if
+ * Mixpanel is not initialized (SSR, consent not given, token missing).
+ *
+ * Import pattern:
+ *   import { trackFoundersPageView } from '@/lib/analytics/founders';
+ */
+
+import mixpanel from 'mixpanel-browser';
+
+// Safe wrapper — never throws even if Mixpanel not initialized
+function safeTrack(event: string, props?: Record<string, unknown>): void {
+  try {
+    mixpanel.track(event, props);
+  } catch {
+    // Mixpanel not initialized (SSR or consent not given)
+  }
+}
+
+// ============================================================
+// Page & Banner Events
+// ============================================================
+
+export function trackFoundersPageView(props: {
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  src?: string | null;
+  seats_remaining?: number;
+  deadline_at?: string | null;
+}): void {
+  safeTrack('founders_page_view', props);
+}
+
+export function trackFoundersBannerView(props: {
+  route: string;
+  dismissed_count?: number;
+}): void {
+  safeTrack('founders_banner_view', props);
+}
+
+export function trackFoundersBannerClick(props: { route: string }): void {
+  safeTrack('founders_banner_click', props);
+}
+
+export function trackFoundersBannerDismiss(props: { route: string }): void {
+  safeTrack('founders_banner_dismiss', props);
+}
+
+// ============================================================
+// pSEO Ribbon Events
+// ============================================================
+
+export function trackFoundersRibbonView(props: {
+  route: string;
+  variant: string;
+}): void {
+  safeTrack('founders_ribbon_view', props);
+}
+
+export function trackFoundersRibbonClick(props: {
+  route: string;
+  variant: string;
+}): void {
+  safeTrack('founders_ribbon_click', props);
+}
+
+// ============================================================
+// Checkout Events
+// ============================================================
+
+export function trackFoundersCtaClick(props: {
+  cta_location: string;
+  src?: string | null;
+}): void {
+  safeTrack('founders_cta_click', props);
+}
+
+export function trackFoundersCheckoutStart(props: {
+  email_provided: boolean;
+  src?: string | null;
+}): void {
+  safeTrack('founders_checkout_start', props);
+}
+
+export function trackFoundersPseoConversion(props: {
+  from_route: string;
+  variant: string;
+}): void {
+  safeTrack('founders_pseo_conversion', props);
+}


### PR DESCRIPTION
## Summary
- Create `frontend/lib/analytics/founders.ts`: typed Mixpanel event wrappers (9 events) with safe try/catch wrapper that never throws in SSR or when consent is not given
- Add `smartlic_founders_checkout_success_total` and `smartlic_founders_checkout_failed_total` Prometheus counters to `backend/metrics.py`
- Instrument `backend/webhooks/handlers/founding.py` with counter increments on successful activation and `cap_violated`/`db_error` failure paths
- Document complete event schema in `docs/analytics/founders-events.md`
- Add analytics TODO comment to founding checkout API route proxy

## Testing Plan
- [ ] TypeScript: `founders.ts` has correct types, no `any`, compiles cleanly
- [ ] Backend: `from metrics import founders_checkout_success, founders_checkout_failed` works without error
- [ ] Metrics counters are visible in `/metrics` endpoint output after a founding webhook fires
- [ ] Event names in `founders.ts` match the spec in `docs/analytics/founders-events.md`
- [ ] `trackFoundersCheckoutStart` and other wrappers are importable via `@/lib/analytics/founders`
- [ ] `safeTrack` swallows errors gracefully (no unhandled exceptions in SSR)

## Closes
Closes #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive founders analytics (page views, banner/ribbon interactions, CTA clicks, checkout starts, pSEO conversions) and backend metrics for founding checkout success/failure.

* **Documentation**
  * Added analytics doc detailing events, properties, triggers, and metric semantics; includes safe-tracking guidance and usage examples.

* **Bug Fixes**
  * Adjusted metric incrementing to avoid overcounting in race conditions.

* **Tests**
  * Added unit tests for analytics wrappers and backend metric behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->