### PR TITLE
feat(seo): FoundersRibbon CTAs in high-intent pSEO routes (#788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added — Frontend / Founders
 - `FoundersTopBanner` component with availability gate and countdown (#787)
 - `FoundersRibbon` component (inline variant) for embedding in page sections (#787)
+- **FoundersRibbon CTAs em 5 rotas pSEO de alto-intent (#788)** — Integra `FoundersRibbon` (variant `contextual`) nas páginas `/observatorio/[slug]`, `/cnpj/[cnpj]`, `/orgaos/[slug]`, `/licitacoes/[setor]` e `/blog/programmatic/[setor]`. CTA posicionado abaixo do conteúdo principal (sem impacto no SEO acima da dobra). Prop `src` rastreia rota de origem no Mixpanel via evento `founders_pseo_conversion`. Não adiciona `cache:no-store` (SEN-FE-001 safe). Rollback: reverter commit.
 
 ### Added — Frontend / Legal
 - **Página de termos do Plano Fundadores (#793)** — `frontend/app/termos/fundadores/page.tsx` criado com 9 seções legais cobrindo escopo vitalício, fair use, sem garantia de êxito, período de resfriamento (CDC art. 49) e disclaimer de parceria governamental. `frontend/app/termos/page.tsx` atualizado com link para `/termos/fundadores`. Protege juridicamente o SmartLic e informa fundadores sobre os exatos direitos adquiridos.

--- a/frontend/app/blog/programmatic/[setor]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/page.tsx
@@ -6,6 +6,7 @@ import Footer from '../../../components/Footer';
 import SchemaMarkup from '@/components/blog/SchemaMarkup';
 import BlogCTA from '@/components/blog/BlogCTA';
 import RelatedPages from '@/components/blog/RelatedPages';
+import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 import {
   generateSectorParams,
   fetchSectorBlogStats,
@@ -280,6 +281,13 @@ export default async function SectorProgrammaticPage({
             setor={sector.name}
             count={stats?.total_editais}
             slug={slug}
+          />
+
+          {/* #788: Founders plan CTA for high-intent organic visitors */}
+          <FoundersRibbon
+            variant="contextual"
+            copy="Acesso vitalício durante a fase inicial do SmartLic — vagas limitadas."
+            src="pseo_blog"
           />
 
           {/* Related Pages */}

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -5,6 +5,7 @@ import CnpjPerfilClient from './CnpjPerfilClient';
 import InlineTrialCTA from '../../components/InlineTrialCTA';
 import IntelReportCTA from './IntelReportCTA';
 import { LeadCapture } from '@/components/LeadCapture';
+import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
 
@@ -226,6 +227,13 @@ export default async function CnpjPerfilPage({
           description={`Novos editais de ${perfil.setor_nome} em ${perfil.empresa.uf}, toda semana no seu email.`}
         />
       </div>
+
+      {/* #788: Founders plan CTA for high-intent organic visitors */}
+      <FoundersRibbon
+        variant="contextual"
+        copy="Acesso vitalício durante a fase inicial do SmartLic — vagas limitadas."
+        src="pseo_cnpj"
+      />
     </ContentPageLayout>
   );
 }

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -17,6 +17,7 @@ import { MicroDemo } from "@/components/seo/MicroDemo";
 import { MicroDemoSchema } from "@/components/seo/MicroDemoSchema";
 import StickyTrialCTA from "@/app/components/StickyTrialCTA";
 import { buildDatasetJsonLd } from "./_jsonld";
+import { FoundersRibbon } from "@/components/banners/FoundersRibbon";
 
 /**
  * STORY-324 AC5: SSG with ISR 6h for sector landing pages.
@@ -421,6 +422,15 @@ export default async function SectorPage({
             </Link>
           ))}
         </div>
+      </section>
+
+      {/* #788: Founders plan CTA for high-intent organic visitors */}
+      <section className="max-w-5xl mx-auto px-4 pb-4">
+        <FoundersRibbon
+          variant="contextual"
+          copy="Receba inteligência B2G sem mensalidade. Acesso vitalício R$997."
+          src="pseo_licitacoes"
+        />
       </section>
 
       {/* Footer: All sectors */}

--- a/frontend/app/observatorio/[slug]/page.tsx
+++ b/frontend/app/observatorio/[slug]/page.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import * as Sentry from '@sentry/nextjs';
 import ObservatorioRelatorioClient from './ObservatorioRelatorioClient';
+import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
@@ -228,6 +229,13 @@ export default async function RelatorioPage({
         ano={ano}
         mes={mes}
       />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <FoundersRibbon
+          variant="contextual"
+          copy="Receba inteligência B2G sem mensalidade. Acesso vitalício R$997."
+          src="pseo_observatorio"
+        />
+      </div>
     </>
   );
 }

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -4,6 +4,7 @@ import ContentPageLayout from '../../components/ContentPageLayout';
 import OrgaoPerfilClient from './OrgaoPerfilClient';
 import InlineTrialCTA from '../../components/InlineTrialCTA';
 import { LeadCapture } from '@/components/LeadCapture';
+import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
 
@@ -208,6 +209,13 @@ export default async function OrgaoPerfilPage({
           description={`Novos editais de ${stats.nome}, toda semana no seu email.`}
         />
       </div>
+
+      {/* #788: Founders plan CTA for high-intent organic visitors */}
+      <FoundersRibbon
+        variant="contextual"
+        copy="Transforme dados do PNCP em decisão. Vitalício por R$997."
+        src="pseo_orgao"
+      />
     </ContentPageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Add `FoundersRibbon` (contextual variant) to 5 high-intent pSEO routes: observatorio, cnpj, orgaos, licitacoes, blog
- CTAs placed below main content — does not affect SEO experience above fold
- Direct import of `'use client'` component in Server Components (Next.js handles the boundary automatically — no `next/dynamic` needed)
- JSON-LD structured data unchanged

## Testing Plan
- [ ] Each page still renders (no TypeScript errors)
- [ ] Ribbon appears below main content in each page
- [ ] JSON-LD unchanged
- [ ] No `cache: 'no-store'` added to Server Component fetches (SEN-FE-001)

## Closes
Closes #788