### PR TITLE
feat(backend): extend lead_capture schema for REPO reposicionamento (#756)

### DIFF
--- a/backend/routes/lead_capture.py
+++ b/backend/routes/lead_capture.py
@@ -1,28 +1,55 @@
-"""A2: Lead capture endpoint for calculadora/CNPJ/alertas.
+"""A2: Lead capture endpoint for calculadora/CNPJ/alertas + REPO-004 reposicionamento sources.
 
 Public (no auth) endpoint that stores email + context for lead nurturing.
+Extended in REPO-004 (#756) to support consultoria, radar, report, intel, diagnostico sources
+plus optional UTM, contact, and form fields.
 """
 
 import asyncio
 import logging
 from datetime import datetime, timezone
+from typing import Literal, Optional
 
 from pipeline.budget import _run_with_budget
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
-from typing import Optional
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/lead-capture", tags=["lead-capture"])
 
+LeadCaptureSource = Literal[
+    "calculadora",
+    "cnpj",
+    "alertas",
+    "consultoria",
+    "radar",
+    "report",
+    "intel",
+    "diagnostico",
+]
+
+ModalidadeInteresse = Literal["radar", "report", "intel", "nao_sei"]
+
 
 class LeadCaptureRequest(BaseModel):
     email: str
-    source: str  # 'calculadora' | 'cnpj' | 'alertas'
+    source: LeadCaptureSource
     setor: Optional[str] = None
     uf: Optional[str] = None
     captured_at: Optional[str] = None
+    # Contact fields (REPO-004)
+    nome: Optional[str] = None
+    empresa: Optional[str] = None
+    cnpj: Optional[str] = None
+    telefone: Optional[str] = None
+    # Diagnostico form fields (REPO-004)
+    modalidade_interesse: Optional[ModalidadeInteresse] = None
+    mensagem: Optional[str] = Field(None, max_length=500)
+    # UTM tracking (REPO-004)
+    utm_source: Optional[str] = None
+    utm_campaign: Optional[str] = None
+    referer_path: Optional[str] = None
 
 
 class LeadCaptureResponse(BaseModel):
@@ -44,6 +71,16 @@ async def capture_lead(req: LeadCaptureRequest):
             "setor": req.setor,
             "uf": req.uf.upper() if req.uf else None,
             "captured_at": req.captured_at or datetime.now(timezone.utc).isoformat(),
+            # REPO-004 optional fields (null-safe — DB columns are nullable)
+            "nome": req.nome,
+            "empresa": req.empresa,
+            "cnpj": req.cnpj,
+            "telefone": req.telefone,
+            "modalidade_interesse": req.modalidade_interesse,
+            "mensagem": req.mensagem,
+            "utm_source": req.utm_source,
+            "utm_campaign": req.utm_campaign,
+            "referer_path": req.referer_path,
         }
 
         def _sync_upsert():

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -6382,9 +6382,82 @@
             ],
             "title": "Captured At"
           },
+          "cnpj": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cnpj"
+          },
           "email": {
             "title": "Email",
             "type": "string"
+          },
+          "empresa": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Empresa"
+          },
+          "mensagem": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mensagem"
+          },
+          "modalidade_interesse": {
+            "anyOf": [
+              {
+                "enum": [
+                  "radar",
+                  "report",
+                  "intel",
+                  "nao_sei"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modalidade Interesse"
+          },
+          "nome": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nome"
+          },
+          "referer_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referer Path"
           },
           "setor": {
             "anyOf": [
@@ -6398,8 +6471,29 @@
             "title": "Setor"
           },
           "source": {
+            "enum": [
+              "calculadora",
+              "cnpj",
+              "alertas",
+              "consultoria",
+              "radar",
+              "report",
+              "intel",
+              "diagnostico"
+            ],
             "title": "Source",
             "type": "string"
+          },
+          "telefone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telefone"
           },
           "uf": {
             "anyOf": [
@@ -6411,6 +6505,28 @@
               }
             ],
             "title": "Uf"
+          },
+          "utm_campaign": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Utm Campaign"
+          },
+          "utm_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Utm Source"
           }
         },
         "required": [

--- a/backend/tests/test_lead_capture.py
+++ b/backend/tests/test_lead_capture.py
@@ -1,0 +1,252 @@
+"""Tests for POST /v1/lead-capture — REPO-004 (#756) schema extension.
+
+Covers:
+- All 8 valid sources return 200
+- Invalid source returns 422 (Pydantic Literal validation)
+- mensagem > 500 chars returns 422 (Field max_length)
+- modalidade_interesse invalid value returns 422
+- Backward compat: 3 legacy sources + old field-only payloads still work
+- New optional fields are accepted and passed through
+- Invalid email format returns 400
+"""
+
+import pytest
+from unittest.mock import patch, Mock
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from startup.app_factory import create_app
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_supabase():
+    """Mock Supabase client — patches supabase_client.get_supabase."""
+    mock = Mock()
+    mock.table.return_value = mock
+    mock.upsert.return_value = mock
+    mock.execute.return_value = Mock(data=[{"id": "test-uuid"}])
+    return mock
+
+
+def _post(client, payload):
+    """Helper: POST to /v1/lead-capture with payload."""
+    return client.post("/v1/lead-capture", json=payload)
+
+
+# ---------------------------------------------------------------------------
+# Valid sources — all 8 must return 200
+# ---------------------------------------------------------------------------
+
+ALL_SOURCES = [
+    "calculadora",
+    "cnpj",
+    "alertas",
+    "consultoria",
+    "radar",
+    "report",
+    "intel",
+    "diagnostico",
+]
+
+
+class TestAllSourcesAccepted:
+    @pytest.mark.parametrize("source", ALL_SOURCES)
+    def test_valid_source_returns_200(self, client, mock_supabase, source):
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {"email": "test@example.com", "source": source})
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True}
+
+
+# ---------------------------------------------------------------------------
+# Validation — bad source → 422
+# ---------------------------------------------------------------------------
+
+class TestSourceValidation:
+    def test_invalid_source_returns_422(self, client):
+        resp = _post(client, {"email": "test@example.com", "source": "unknown_source"})
+        assert resp.status_code == 422
+
+    def test_empty_source_returns_422(self, client):
+        resp = _post(client, {"email": "test@example.com", "source": ""})
+        assert resp.status_code == 422
+
+    def test_missing_source_returns_422(self, client):
+        resp = _post(client, {"email": "test@example.com"})
+        assert resp.status_code == 422
+
+    def test_missing_email_returns_422(self, client):
+        resp = _post(client, {"source": "calculadora"})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# mensagem max_length = 500
+# ---------------------------------------------------------------------------
+
+class TestMensagemValidation:
+    def test_mensagem_at_max_length_accepted(self, client, mock_supabase):
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "test@example.com",
+                "source": "diagnostico",
+                "mensagem": "a" * 500,
+            })
+        assert resp.status_code == 200
+
+    def test_mensagem_over_max_length_returns_422(self, client):
+        resp = _post(client, {
+            "email": "test@example.com",
+            "source": "diagnostico",
+            "mensagem": "a" * 501,
+        })
+        assert resp.status_code == 422
+
+    def test_mensagem_none_accepted(self, client, mock_supabase):
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "test@example.com",
+                "source": "diagnostico",
+                "mensagem": None,
+            })
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# modalidade_interesse validation
+# ---------------------------------------------------------------------------
+
+class TestModalidadeInteresse:
+    @pytest.mark.parametrize("value", ["radar", "report", "intel", "nao_sei"])
+    def test_valid_modalidade_accepted(self, client, mock_supabase, value):
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "test@example.com",
+                "source": "diagnostico",
+                "modalidade_interesse": value,
+            })
+        assert resp.status_code == 200
+
+    def test_invalid_modalidade_returns_422(self, client):
+        resp = _post(client, {
+            "email": "test@example.com",
+            "source": "diagnostico",
+            "modalidade_interesse": "outro",
+        })
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — legacy sources + legacy-only fields
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompat:
+    def test_calculadora_legacy_payload(self, client, mock_supabase):
+        """Original calculadora payload still works unchanged."""
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "legado@example.com",
+                "source": "calculadora",
+                "setor": "saude",
+                "uf": "SP",
+                "captured_at": "2026-05-07T12:00:00Z",
+            })
+        assert resp.status_code == 200
+
+    def test_cnpj_legacy_payload(self, client, mock_supabase):
+        """Original cnpj source payload still works."""
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "legado@example.com",
+                "source": "cnpj",
+                "setor": "construcao",
+            })
+        assert resp.status_code == 200
+
+    def test_alertas_legacy_payload(self, client, mock_supabase):
+        """Original alertas source payload still works."""
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "legado@example.com",
+                "source": "alertas",
+                "uf": "RJ",
+            })
+        assert resp.status_code == 200
+
+    def test_minimal_payload_only_email_and_source(self, client, mock_supabase):
+        """Minimal required fields work with any source."""
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {"email": "min@example.com", "source": "radar"})
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# New optional fields accepted (REPO-004)
+# ---------------------------------------------------------------------------
+
+class TestNewOptionalFields:
+    def test_full_diagnostico_payload_accepted(self, client, mock_supabase):
+        """Full diagnostico form payload with all new fields."""
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "empresa@example.com",
+                "source": "diagnostico",
+                "nome": "João Silva",
+                "empresa": "Acme Ltda",
+                "cnpj": "12.345.678/0001-90",
+                "telefone": "11999990000",
+                "modalidade_interesse": "report",
+                "mensagem": "Quero saber mais sobre relatórios de inteligência.",
+                "utm_source": "google",
+                "utm_campaign": "b2g-q2-2026",
+                "referer_path": "/observatorio/licitacoes-ti",
+                "setor": "tecnologia",
+                "uf": "SP",
+            })
+        assert resp.status_code == 200
+
+    def test_utm_fields_only(self, client, mock_supabase):
+        """UTM fields alone work without other new fields."""
+        with patch("supabase_client.get_supabase", return_value=mock_supabase):
+            resp = _post(client, {
+                "email": "utm@example.com",
+                "source": "consultoria",
+                "utm_source": "linkedin",
+                "utm_campaign": "founders",
+            })
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Invalid email → 400 (existing behavior, must remain)
+# ---------------------------------------------------------------------------
+
+class TestEmailValidation:
+    def test_invalid_email_returns_400(self, client):
+        with patch("supabase_client.get_supabase", return_value=Mock()):
+            resp = _post(client, {"email": "not-an-email", "source": "calculadora"})
+        assert resp.status_code == 400
+
+    def test_empty_email_returns_400(self, client):
+        with patch("supabase_client.get_supabase", return_value=Mock()):
+            resp = _post(client, {"email": "", "source": "calculadora"})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# DB failure — fail-open behavior preserved
+# ---------------------------------------------------------------------------
+
+class TestFailOpen:
+    def test_db_failure_still_returns_success(self, client):
+        """Route fails-open: DB errors logged but 200 returned."""
+        mock_sb = Mock()
+        mock_sb.table.side_effect = Exception("DB connection failed")
+        with patch("supabase_client.get_supabase", return_value=mock_sb):
+            resp = _post(client, {"email": "test@example.com", "source": "calculadora"})
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True}

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -8076,14 +8076,35 @@ export interface components {
         LeadCaptureRequest: {
             /** Captured At */
             captured_at?: string | null;
+            /** Cnpj */
+            cnpj?: string | null;
             /** Email */
             email: string;
+            /** Empresa */
+            empresa?: string | null;
+            /** Mensagem */
+            mensagem?: string | null;
+            /** Modalidade Interesse */
+            modalidade_interesse?: ("radar" | "report" | "intel" | "nao_sei") | null;
+            /** Nome */
+            nome?: string | null;
+            /** Referer Path */
+            referer_path?: string | null;
             /** Setor */
             setor?: string | null;
-            /** Source */
-            source: string;
+            /**
+             * Source
+             * @enum {string}
+             */
+            source: "calculadora" | "cnpj" | "alertas" | "consultoria" | "radar" | "report" | "intel" | "diagnostico";
+            /** Telefone */
+            telefone?: string | null;
             /** Uf */
             uf?: string | null;
+            /** Utm Campaign */
+            utm_campaign?: string | null;
+            /** Utm Source */
+            utm_source?: string | null;
         };
         /** LeadCaptureResponse */
         LeadCaptureResponse: {

--- a/supabase/migrations/20260507130000_extend_lead_capture.down.sql
+++ b/supabase/migrations/20260507130000_extend_lead_capture.down.sql
@@ -1,0 +1,13 @@
+-- Rollback REPO-004 (#756): Remove added columns from leads table
+DROP INDEX IF EXISTS idx_leads_utm_source;
+
+ALTER TABLE public.leads
+    DROP COLUMN IF EXISTS nome,
+    DROP COLUMN IF EXISTS empresa,
+    DROP COLUMN IF EXISTS cnpj,
+    DROP COLUMN IF EXISTS telefone,
+    DROP COLUMN IF EXISTS modalidade_interesse,
+    DROP COLUMN IF EXISTS mensagem,
+    DROP COLUMN IF EXISTS utm_source,
+    DROP COLUMN IF EXISTS utm_campaign,
+    DROP COLUMN IF EXISTS referer_path;

--- a/supabase/migrations/20260507130000_extend_lead_capture.sql
+++ b/supabase/migrations/20260507130000_extend_lead_capture.sql
@@ -1,0 +1,18 @@
+-- REPO-004 (#756): Extend leads table with contact, form, and UTM fields
+-- All columns are nullable with NULL defaults for backward compatibility.
+-- No CHECK constraint on source column (none existed before).
+
+ALTER TABLE public.leads
+    ADD COLUMN IF NOT EXISTS nome TEXT,
+    ADD COLUMN IF NOT EXISTS empresa TEXT,
+    ADD COLUMN IF NOT EXISTS cnpj TEXT,
+    ADD COLUMN IF NOT EXISTS telefone TEXT,
+    ADD COLUMN IF NOT EXISTS modalidade_interesse TEXT,
+    ADD COLUMN IF NOT EXISTS mensagem TEXT,
+    ADD COLUMN IF NOT EXISTS utm_source TEXT,
+    ADD COLUMN IF NOT EXISTS utm_campaign TEXT,
+    ADD COLUMN IF NOT EXISTS referer_path TEXT;
+
+-- Index to speed up UTM attribution queries
+CREATE INDEX IF NOT EXISTS idx_leads_utm_source ON public.leads (utm_source)
+    WHERE utm_source IS NOT NULL;


### PR DESCRIPTION
## Context
Extends POST /v1/lead-capture to support reposicionamento B2G Phase 0.
New sources: consultoria, radar, report, intel, diagnostico.
New optional fields: nome, empresa, cnpj, telefone, modalidade_interesse, mensagem, utm_source, utm_campaign, referer_path.

## Changes
- Extended `LeadCaptureRequest` schema with 5 new sources (Pydantic `Literal`) + 9 optional fields
- `modalidade_interesse` uses `Literal['radar','report','intel','nao_sei']` with automatic 422 on invalid
- `mensagem` has `Field(max_length=500)` enforced by Pydantic before DB hit
- Migration `20260507130000_extend_lead_capture.sql` adds nullable columns to `leads` table (additive, zero downtime)
- Migration `20260507130000_extend_lead_capture.down.sql` drops added columns on rollback
- Regenerated `frontend/app/api-types.generated.ts` from updated OpenAPI schema

## Testing Plan
- [x] Unit tests: all 8 valid sources return 200
- [x] Unit tests: invalid source → 422 (Pydantic Literal validation)
- [x] Unit tests: `mensagem` > 500 chars → 422
- [x] Unit tests: invalid `modalidade_interesse` → 422
- [x] Unit tests: backward compat — 3 legacy sources (`calculadora`, `cnpj`, `alertas`) + old field-only payloads still return 200
- [x] Unit tests: new optional fields accepted (full diagnostico payload, UTM-only)
- [x] Unit tests: invalid email → 400 (existing behavior preserved)
- [x] Unit tests: DB failure → 200 (fail-open behavior preserved)
- [x] Migration SQL created (not applied — apply on deploy via `supabase db push`)

## Risks & Rollback
Migration is fully additive (NULL columns, no constraint changes). Rollback: `20260507130000_extend_lead_capture.down.sql` drops the 9 added columns.

## Closes
Closes #756