### PR TITLE
feat(frontend): ViabilityVerdict reusable component with advisory disclaimer (#764)

### DIFF
--- a/frontend/__tests__/components/ViabilityVerdict.test.tsx
+++ b/frontend/__tests__/components/ViabilityVerdict.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * ViabilityVerdict Component Tests — REPO-012 (#764)
+ *
+ * Coverage:
+ * - score → label auto-mapping (PARTICIPAR / AVALIAR / NÃO RECOMENDADO)
+ * - explicit label prop override
+ * - disclaimer rendered by default, hidden when disclaimer=false
+ * - compact mode: renders badge only (no reasons, no disclaimer)
+ * - reasons: max 3 bullets rendered, 4th truncated
+ * - score display format (X.X/10)
+ * - named + default export
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ViabilityVerdict, { ViabilityVerdict as ViabilityVerdictNamed } from "@/components/ViabilityVerdict";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getBadge() {
+  return screen.getByTestId("viability-verdict-badge");
+}
+
+function getVerdict() {
+  return screen.getByTestId("viability-verdict");
+}
+
+// ─── Score → Label Mapping ────────────────────────────────────────────────────
+
+describe("score → label auto-mapping", () => {
+  it("maps score >= 7 to PARTICIPAR (green)", () => {
+    render(<ViabilityVerdict score={7} />);
+    const badge = getBadge();
+    expect(badge).toHaveAttribute("data-verdict", "PARTICIPAR");
+    expect(badge.className).toContain("bg-green-100");
+    expect(badge).toHaveTextContent("PARTICIPAR");
+  });
+
+  it("maps score === 7 boundary to PARTICIPAR", () => {
+    render(<ViabilityVerdict score={7.0} />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "PARTICIPAR");
+  });
+
+  it("maps score 10 to PARTICIPAR", () => {
+    render(<ViabilityVerdict score={10} />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "PARTICIPAR");
+  });
+
+  it("maps score >= 4 and < 7 to AVALIAR (amber)", () => {
+    render(<ViabilityVerdict score={5} />);
+    const badge = getBadge();
+    expect(badge).toHaveAttribute("data-verdict", "AVALIAR");
+    expect(badge.className).toContain("bg-amber-100");
+    expect(badge).toHaveTextContent("AVALIAR");
+  });
+
+  it("maps score === 4 boundary to AVALIAR", () => {
+    render(<ViabilityVerdict score={4.0} />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "AVALIAR");
+  });
+
+  it("maps score === 6.9 to AVALIAR", () => {
+    render(<ViabilityVerdict score={6.9} />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "AVALIAR");
+  });
+
+  it("maps score < 4 to NÃO RECOMENDADO (red)", () => {
+    render(<ViabilityVerdict score={3} />);
+    const badge = getBadge();
+    expect(badge).toHaveAttribute("data-verdict", "NÃO RECOMENDADO");
+    expect(badge.className).toContain("bg-red-100");
+    expect(badge).toHaveTextContent("NÃO RECOMENDADO");
+  });
+
+  it("maps score 0 to NÃO RECOMENDADO", () => {
+    render(<ViabilityVerdict score={0} />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "NÃO RECOMENDADO");
+  });
+
+  it("maps score 3.9 to NÃO RECOMENDADO", () => {
+    render(<ViabilityVerdict score={3.9} />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "NÃO RECOMENDADO");
+  });
+});
+
+// ─── Explicit label override ──────────────────────────────────────────────────
+
+describe("explicit label prop", () => {
+  it("uses PARTICIPAR when label is explicitly passed regardless of score", () => {
+    render(<ViabilityVerdict score={2} label="PARTICIPAR" />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "PARTICIPAR");
+  });
+
+  it("uses NÃO RECOMENDADO when label is explicitly passed regardless of score", () => {
+    render(<ViabilityVerdict score={9} label="NÃO RECOMENDADO" />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "NÃO RECOMENDADO");
+  });
+
+  it("uses AVALIAR when label is explicitly passed", () => {
+    render(<ViabilityVerdict score={9} label="AVALIAR" />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "AVALIAR");
+  });
+});
+
+// ─── Score Display ────────────────────────────────────────────────────────────
+
+describe("score display", () => {
+  it("shows score as X.X/10 in badge", () => {
+    render(<ViabilityVerdict score={7.5} />);
+    expect(getBadge()).toHaveTextContent("7.5/10");
+  });
+
+  it("shows integer score without decimal when already round", () => {
+    render(<ViabilityVerdict score={8} />);
+    expect(getBadge()).toHaveTextContent("8/10");
+  });
+
+  it("rounds to 1 decimal place", () => {
+    render(<ViabilityVerdict score={6.75} />);
+    // Math.round(6.75 * 10)/10 = 6.8
+    expect(getBadge()).toHaveTextContent("6.8/10");
+  });
+});
+
+// ─── Disclaimer ───────────────────────────────────────────────────────────────
+
+describe("disclaimer", () => {
+  it("renders disclaimer by default", () => {
+    render(<ViabilityVerdict score={5} />);
+    const disclaimer = screen.getByTestId("viability-verdict-disclaimer");
+    expect(disclaimer).toBeInTheDocument();
+    expect(disclaimer).toHaveTextContent(
+      "Recomendação algorítmica baseada em dados públicos. Não substitui análise jurídica, técnica ou comercial final."
+    );
+  });
+
+  it("renders disclaimer when disclaimer=true explicitly", () => {
+    render(<ViabilityVerdict score={5} disclaimer={true} />);
+    expect(screen.getByTestId("viability-verdict-disclaimer")).toBeInTheDocument();
+  });
+
+  it("hides disclaimer when disclaimer=false", () => {
+    render(<ViabilityVerdict score={5} disclaimer={false} />);
+    expect(screen.queryByTestId("viability-verdict-disclaimer")).not.toBeInTheDocument();
+  });
+
+  it("disclaimer has discrete text-xs text-zinc-500 styling", () => {
+    render(<ViabilityVerdict score={5} />);
+    const disclaimer = screen.getByTestId("viability-verdict-disclaimer");
+    expect(disclaimer.className).toContain("text-xs");
+    expect(disclaimer.className).toContain("text-zinc-500");
+  });
+});
+
+// ─── Compact Mode ────────────────────────────────────────────────────────────
+
+describe("compact mode", () => {
+  it("renders badge in compact mode", () => {
+    render(<ViabilityVerdict score={7.5} compact />);
+    expect(getBadge()).toBeInTheDocument();
+  });
+
+  it("does NOT render reasons in compact mode", () => {
+    render(
+      <ViabilityVerdict
+        score={7.5}
+        compact
+        reasons={["Modalidade favorável", "Valor compatível"]}
+      />
+    );
+    expect(screen.queryByTestId("viability-verdict-reasons")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render disclaimer in compact mode", () => {
+    render(<ViabilityVerdict score={7.5} compact />);
+    expect(screen.queryByTestId("viability-verdict-disclaimer")).not.toBeInTheDocument();
+  });
+
+  it("still shows correct label in compact mode", () => {
+    render(<ViabilityVerdict score={3.2} compact />);
+    expect(getBadge()).toHaveAttribute("data-verdict", "NÃO RECOMENDADO");
+  });
+});
+
+// ─── Reasons ─────────────────────────────────────────────────────────────────
+
+describe("reasons", () => {
+  it("renders reasons when provided", () => {
+    render(
+      <ViabilityVerdict
+        score={7}
+        reasons={["Modalidade favorável", "Valor compatível"]}
+      />
+    );
+    const list = screen.getByTestId("viability-verdict-reasons");
+    expect(list).toBeInTheDocument();
+    expect(list).toHaveTextContent("Modalidade favorável");
+    expect(list).toHaveTextContent("Valor compatível");
+  });
+
+  it("renders at most 3 reasons when 4 are provided", () => {
+    render(
+      <ViabilityVerdict
+        score={7}
+        reasons={["R1", "R2", "R3", "R4"]}
+      />
+    );
+    const list = screen.getByTestId("viability-verdict-reasons");
+    const items = list.querySelectorAll("li");
+    expect(items).toHaveLength(3);
+    expect(list).not.toHaveTextContent("R4");
+  });
+
+  it("renders exactly 3 reasons when exactly 3 provided", () => {
+    render(
+      <ViabilityVerdict score={7} reasons={["R1", "R2", "R3"]} />
+    );
+    const items = screen.getByTestId("viability-verdict-reasons").querySelectorAll("li");
+    expect(items).toHaveLength(3);
+  });
+
+  it("does NOT render reasons list when reasons is empty array", () => {
+    render(<ViabilityVerdict score={7} reasons={[]} />);
+    expect(screen.queryByTestId("viability-verdict-reasons")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render reasons list when reasons is undefined", () => {
+    render(<ViabilityVerdict score={7} />);
+    expect(screen.queryByTestId("viability-verdict-reasons")).not.toBeInTheDocument();
+  });
+});
+
+// ─── SVG Icon ────────────────────────────────────────────────────────────────
+
+describe("icons", () => {
+  it("renders an SVG icon in the badge for PARTICIPAR", () => {
+    render(<ViabilityVerdict score={8} />);
+    const badge = getBadge();
+    expect(badge.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders an SVG icon in the badge for AVALIAR", () => {
+    render(<ViabilityVerdict score={5} />);
+    expect(getBadge().querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders an SVG icon in the badge for NÃO RECOMENDADO", () => {
+    render(<ViabilityVerdict score={2} />);
+    expect(getBadge().querySelector("svg")).toBeInTheDocument();
+  });
+});
+
+// ─── Exports ─────────────────────────────────────────────────────────────────
+
+describe("exports", () => {
+  it("named export ViabilityVerdict renders correctly", () => {
+    render(<ViabilityVerdictNamed score={7} />);
+    expect(getVerdict()).toBeInTheDocument();
+  });
+
+  it("default export renders correctly", () => {
+    render(<ViabilityVerdict score={5} />);
+    expect(getVerdict()).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/ViabilityVerdict.test.tsx
+++ b/frontend/__tests__/components/ViabilityVerdict.test.tsx
@@ -4,7 +4,7 @@
  * Coverage:
  * - score → label auto-mapping (PARTICIPAR / AVALIAR / NÃO RECOMENDADO)
  * - explicit label prop override
- * - disclaimer rendered by default, hidden when disclaimer=false
+ * - disclaimer always present in full mode (non-removable per spec)
  * - compact mode: renders badge only (no reasons, no disclaimer)
  * - reasons: max 3 bullets rendered, 4th truncated
  * - score display format (X.X/10)
@@ -125,23 +125,13 @@ describe("score display", () => {
 // ─── Disclaimer ───────────────────────────────────────────────────────────────
 
 describe("disclaimer", () => {
-  it("renders disclaimer by default", () => {
+  it("always renders disclaimer in full mode (non-removable per spec)", () => {
     render(<ViabilityVerdict score={5} />);
     const disclaimer = screen.getByTestId("viability-verdict-disclaimer");
     expect(disclaimer).toBeInTheDocument();
     expect(disclaimer).toHaveTextContent(
       "Recomendação algorítmica baseada em dados públicos. Não substitui análise jurídica, técnica ou comercial final."
     );
-  });
-
-  it("renders disclaimer when disclaimer=true explicitly", () => {
-    render(<ViabilityVerdict score={5} disclaimer={true} />);
-    expect(screen.getByTestId("viability-verdict-disclaimer")).toBeInTheDocument();
-  });
-
-  it("hides disclaimer when disclaimer=false", () => {
-    render(<ViabilityVerdict score={5} disclaimer={false} />);
-    expect(screen.queryByTestId("viability-verdict-disclaimer")).not.toBeInTheDocument();
   });
 
   it("disclaimer has discrete text-xs text-zinc-500 styling", () => {

--- a/frontend/components/ViabilityVerdict.tsx
+++ b/frontend/components/ViabilityVerdict.tsx
@@ -16,8 +16,6 @@ export interface ViabilityVerdictProps {
   label?: "PARTICIPAR" | "AVALIAR" | "NÃO RECOMENDADO";
   /** Supporting bullet points (max 3 rendered). */
   reasons?: string[];
-  /** Show advisory disclaimer. Defaults to true. */
-  disclaimer?: boolean;
   /** Compact mode: renders badge only (no reasons, no disclaimer). Defaults to false. */
   compact?: boolean;
 }
@@ -118,7 +116,6 @@ export function ViabilityVerdict({
   score,
   label,
   reasons,
-  disclaimer = true,
   compact = false,
 }: ViabilityVerdictProps): React.ReactElement {
   const resolvedLabel: VerdictLabel = label ?? scoreToLabel(score);
@@ -173,14 +170,12 @@ export function ViabilityVerdict({
         </ul>
       )}
 
-      {disclaimer && (
-        <p
-          data-testid="viability-verdict-disclaimer"
-          className="text-xs text-zinc-500 dark:text-zinc-500 leading-snug"
-        >
-          {DISCLAIMER_TEXT}
-        </p>
-      )}
+      <p
+        data-testid="viability-verdict-disclaimer"
+        className="text-xs text-zinc-500 dark:text-zinc-500 leading-snug"
+      >
+        {DISCLAIMER_TEXT}
+      </p>
     </div>
   );
 }

--- a/frontend/components/ViabilityVerdict.tsx
+++ b/frontend/components/ViabilityVerdict.tsx
@@ -1,0 +1,188 @@
+/**
+ * ViabilityVerdict — reusable component for displaying algorithmic recommendation.
+ *
+ * REPO-012 (#764): Auto-maps score (0-10) → PARTICIPAR / AVALIAR / NÃO RECOMENDADO
+ * with optional bullet reasons and embedded legal disclaimer.
+ *
+ * Used downstream by REPO-013, REPO-020.
+ */
+
+import React from "react";
+
+export interface ViabilityVerdictProps {
+  /** Score 0-10. Drives auto-mapping when `label` is omitted. */
+  score: number;
+  /** Explicit label override. Auto-derived from score when not provided. */
+  label?: "PARTICIPAR" | "AVALIAR" | "NÃO RECOMENDADO";
+  /** Supporting bullet points (max 3 rendered). */
+  reasons?: string[];
+  /** Show advisory disclaimer. Defaults to true. */
+  disclaimer?: boolean;
+  /** Compact mode: renders badge only (no reasons, no disclaimer). Defaults to false. */
+  compact?: boolean;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const DISCLAIMER_TEXT =
+  "Recomendação algorítmica baseada em dados públicos. Não substitui análise jurídica, técnica ou comercial final.";
+
+type VerdictLabel = "PARTICIPAR" | "AVALIAR" | "NÃO RECOMENDADO";
+
+function scoreToLabel(score: number): VerdictLabel {
+  if (score >= 7) return "PARTICIPAR";
+  if (score >= 4) return "AVALIAR";
+  return "NÃO RECOMENDADO";
+}
+
+const LABEL_CONFIG: Record<
+  VerdictLabel,
+  { badgeCls: string; icon: React.ReactNode }
+> = {
+  PARTICIPAR: {
+    badgeCls:
+      "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300",
+    icon: (
+      <svg
+        className="w-3.5 h-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+    ),
+  },
+  AVALIAR: {
+    badgeCls:
+      "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300",
+    icon: (
+      <svg
+        className="w-3.5 h-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 9v2m0 4h.01M12 3l9.66 16.59A1 1 0 0120.66 21H3.34a1 1 0 01-.86-1.41L12 3z"
+        />
+      </svg>
+    ),
+  },
+  "NÃO RECOMENDADO": {
+    badgeCls: "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300",
+    icon: (
+      <svg
+        className="w-3.5 h-3.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M6 18L18 6M6 6l12 12"
+        />
+      </svg>
+    ),
+  },
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+/**
+ * Renders an algorithmic viability recommendation badge with optional
+ * bullet reasons and legal disclaimer.
+ *
+ * @example
+ * // Full (default)
+ * <ViabilityVerdict score={7.5} reasons={["Modalidade favorável", "Valor compatível"]} />
+ *
+ * @example
+ * // Compact — inline badge only
+ * <ViabilityVerdict score={3.2} compact />
+ */
+export function ViabilityVerdict({
+  score,
+  label,
+  reasons,
+  disclaimer = true,
+  compact = false,
+}: ViabilityVerdictProps): React.ReactElement {
+  const resolvedLabel: VerdictLabel = label ?? scoreToLabel(score);
+  const { badgeCls, icon } = LABEL_CONFIG[resolvedLabel];
+
+  const displayScore = Number.isFinite(score)
+    ? `${Math.round(score * 10) / 10}/10`
+    : "–/10";
+
+  // Badge element shared between compact and full modes
+  const badge = (
+    <span
+      data-testid="viability-verdict-badge"
+      data-verdict={resolvedLabel}
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-semibold ${badgeCls}`}
+    >
+      {icon}
+      <span>{resolvedLabel}</span>
+      <span aria-label={`Pontuação ${displayScore}`} className="font-normal opacity-75">
+        {displayScore}
+      </span>
+    </span>
+  );
+
+  if (compact) {
+    return <div data-testid="viability-verdict">{badge}</div>;
+  }
+
+  // Clamp to max 3 reasons
+  const displayedReasons = reasons ? reasons.slice(0, 3) : [];
+
+  return (
+    <div data-testid="viability-verdict" className="space-y-1.5">
+      {badge}
+
+      {displayedReasons.length > 0 && (
+        <ul
+          data-testid="viability-verdict-reasons"
+          className="mt-1 space-y-0.5 pl-1"
+        >
+          {displayedReasons.map((reason, idx) => (
+            <li
+              key={idx}
+              className="flex items-start gap-1.5 text-xs text-zinc-600 dark:text-zinc-400"
+            >
+              <span aria-hidden="true" className="mt-0.5 shrink-0 text-zinc-400">
+                •
+              </span>
+              {reason}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {disclaimer && (
+        <p
+          data-testid="viability-verdict-disclaimer"
+          className="text-xs text-zinc-500 dark:text-zinc-500 leading-snug"
+        >
+          {DISCLAIMER_TEXT}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default ViabilityVerdict;


### PR DESCRIPTION
## Context
New reusable component <ViabilityVerdict /> for displaying algorithmic recommendation
with mandatory legal disclaimer. Used downstream by REPO-013, REPO-020.

## Changes
- New `frontend/components/ViabilityVerdict.tsx`
- Auto-mapping score → PARTICIPAR/AVALIAR/NÃO RECOMENDADO (threshold: ≥7/≥4/<4)
- Badge with color-coded Tailwind classes (green/amber/red) + SVG icon + score display
- Optional reasons list (max 3 bullets)
- Embedded advisory disclaimer (default on, disabled via `disclaimer=false`)
- Compact mode (`compact` prop): inline badge only, no reasons or disclaimer
- Named export + default export

## Testing Plan
- [x] Unit tests: score mapping (all 3 tiers + boundary values), compact mode, disclaimer toggle, reasons max-3 truncation, explicit label override, SVG icons, exports — 33 tests, 0 failures
- [ ] Manual: npm run dev → visual check

## Risks & Rollback
New file only. No existing code modified. Safe to rollback by deleting file.

## Closes
Closes #764