### PR TITLE
feat(frontend): Footer — adicionar coluna Soluções com links B2G (#763)

### DIFF
--- a/frontend/__tests__/components/Footer.test.tsx
+++ b/frontend/__tests__/components/Footer.test.tsx
@@ -2,6 +2,7 @@
  * Footer Component Tests
  * STORY-230 AC1-AC4: Footer navigation links
  * GTM-COPY-005 AC5: Address, /sobre link, CONFENGE attribution
+ * REPO-011: "Soluções" column with 4 entries (#763)
  *
  * Tests:
  * - AC1: "Central de Ajuda" links to /ajuda
@@ -9,6 +10,7 @@
  * - AC3: Footer links consistent across pages
  * - AC4: All footer links accessible to unauthenticated users
  * - GTM-COPY-005 AC5: Fiscal address visible, /sobre link, CONFENGE mention
+ * - REPO-011: Soluções column renders 3 links + 1 disabled placeholder
  */
 
 import { render, screen } from '@testing-library/react';
@@ -55,6 +57,42 @@ describe('Footer Component', () => {
       expect(screen.getByText('Planos')).toBeInTheDocument();
       expect(screen.getByText('Suporte')).toBeInTheDocument();
       expect(screen.getByText('Legal')).toBeInTheDocument();
+    });
+  });
+
+  describe('REPO-011: Soluções column', () => {
+    it('should render the Soluções column heading', () => {
+      expect(screen.getByText('Soluções')).toBeInTheDocument();
+    });
+
+    it('should render SaaS link pointing to /planos', () => {
+      const links = screen.getAllByRole('link', { name: /^saas$/i });
+      expect(links.length).toBeGreaterThanOrEqual(1);
+      expect(links[0]).toHaveAttribute('href', '/planos');
+    });
+
+    it('should render Radar B2G link pointing to /consultoria-b2g?modalidade=radar', () => {
+      const link = screen.getByRole('link', { name: 'Radar B2G' });
+      expect(link).toHaveAttribute('href', '/consultoria-b2g?modalidade=radar');
+    });
+
+    it('should render Consultoria B2G link pointing to /consultoria-b2g', () => {
+      const links = screen.getAllByRole('link', { name: 'Consultoria B2G' });
+      const exactLink = links.find((l) => l.getAttribute('href') === '/consultoria-b2g');
+      expect(exactLink).toBeDefined();
+    });
+
+    it('should render "Exemplos" as disabled text, not a link', () => {
+      // Exemplos must NOT be an anchor/link element
+      const exemplosLink = screen.queryByRole('link', { name: /exemplos/i });
+      expect(exemplosLink).toBeNull();
+      // But text must still be visible
+      expect(screen.getByText(/exemplos/i)).toBeInTheDocument();
+    });
+
+    it('should preserve the transparency disclaimer section', () => {
+      // The transparency section heading from STORY-173
+      expect(screen.getByText('Transparência de Fontes de Dados')).toBeInTheDocument();
     });
   });
 

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -143,6 +143,30 @@ export default function Footer() {
             </ul>
           </div>
 
+          {/* Soluções — REPO-011 (#763) */}
+          <div>
+            <h3 className="font-bold text-lg mb-4 text-ink">Soluções</h3>
+            <ul className="space-y-2 text-sm text-ink-secondary">
+              <li>
+                {/* SaaS: /planos preferred over /buscar (auth-gated) per footer public-access policy */}
+                <FooterLink href="/planos">SaaS</FooterLink>
+              </li>
+              <li>
+                <FooterLink href="/consultoria-b2g?modalidade=radar">Radar B2G</FooterLink>
+              </li>
+              <li>
+                <FooterLink href="/consultoria-b2g">Consultoria B2G</FooterLink>
+              </li>
+              <li>
+                {/* Exemplos: Phase 1 placeholder — disabled text, not a link */}
+                <span className="text-ink-muted cursor-not-allowed select-none">
+                  Exemplos{' '}
+                  <span className="text-xs">(em breve)</span>
+                </span>
+              </li>
+            </ul>
+          </div>
+
           {/* Planos */}
           <div>
             <h3 className="font-bold text-lg mb-4 text-ink">Planos</h3>
@@ -248,6 +272,7 @@ export default function Footer() {
             <p className="text-sm text-ink-secondary">
               © 2026 SmartLic.tech. Todos os direitos reservados.
             </p>
+            {/* TODO(REPO-005): replace with truth-source CNPJ once REPO-005 lands */}
             <p className="text-xs text-ink-muted">
               CONFENGE Avaliações e Inteligência Artificial LTDA — CNPJ 56.688.745/0001-00 — Av. Pref. Osmar Cunha, 416 - Centro, Florianópolis - SC, 88015-100
             </p>


### PR DESCRIPTION
## Context
REPO-011: Adds "Soluções" column to footer reflecting new B2G commercial architecture.
Links for SaaS, Radar B2G, Consultoria B2G and Exemplos (Phase 1 placeholder).
Preserves existing disclaimer and columns.

## Changes
- `frontend/app/components/Footer.tsx`: new "Soluções" column with 4 entries (3 active links + 1 disabled span placeholder)
- Mobile layout uses existing responsive grid pattern (no accordion needed — Footer is RSC, consistent with current pattern)
- Unit/component tests: 5 new assertions in REPO-011 describe block
- CNPJ `TODO(REPO-005)` comment added — value unchanged, deferred to REPO-005

## Key Decisions
- **SaaS → `/planos`** (not `/buscar`): footer links must be accessible to unauthenticated users (AC4 enforces this); `/buscar` is auth-gated
- **Exemplos → `<span>` disabled**: rendered as non-link text to avoid polluting `getAllByRole('link')` invariant in existing tests
- **No accordion**: Footer is an RSC (`DEBT-FE-017`); accordion would require `useState`/`'use client'` — responsive grid wrap is the correct existing pattern

## Testing Plan
- [x] Unit tests: column renders (heading + 3 links + 1 disabled), disclaimer preserved, existing AC1-AC4 + GTM-COPY-005 all pass (15/15)
- [ ] Manual: `npm run dev` → verify footer layout desktop + mobile

## Risks & Rollback
Additive change only. Rollback: `git revert`.

## Closes
Closes #763