### PR TITLE
feat(frontend): hero headline + dual CTAs — REPO-006 (#758)

### DIFF
--- a/frontend/__tests__/landing/HeroSection.test.tsx
+++ b/frontend/__tests__/landing/HeroSection.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import HeroSection from '@/app/components/landing/HeroSection';
 
 // Mock next/image — render as plain img with all props
@@ -19,52 +18,47 @@ jest.mock('next/image', () => {
   };
 });
 
+// Mock next/link — render as plain anchor
+jest.mock('next/link', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ href, children, ...rest }: { href: string; children: React.ReactNode; [key: string]: unknown }) =>
+      React.createElement('a', { href, ...rest }, children),
+  };
+});
+
 describe('HeroSection', () => {
-  it('renders headline with financial impact positioning (GTM-COPY-001 AC1)', () => {
+  it('renders headline with B2G intelligence positioning (REPO-006)', () => {
     render(<HeroSection />);
 
-    expect(screen.getByText(/Pare de perder dinheiro/i)).toBeInTheDocument();
-    expect(screen.getByText(/com licitações erradas/i)).toBeInTheDocument();
+    expect(screen.getByText(/Decisão comercial em licitação não nasce de PDF/i)).toBeInTheDocument();
+    expect(screen.getByText(/Nasce de inteligência/i)).toBeInTheDocument();
   });
 
-  it('renders subheadline explaining filtering mechanism (GTM-COPY-001 AC2)', () => {
+  it('renders subheadline with go/no-go decision framing (REPO-006)', () => {
     render(<HeroSection />);
 
-    expect(screen.getByText(/O SmartLic analisa cada edital contra o perfil da sua empresa/i)).toBeInTheDocument();
-    expect(screen.getByText(/justificativa objetiva/i)).toBeInTheDocument();
+    expect(screen.getByText(/SmartLic lê o edital, mapeia o concorrente, calcula a chance real/i)).toBeInTheDocument();
+    expect(screen.getByText(/go\/no-go em minutos/i)).toBeInTheDocument();
   });
 
-  it('renders primary CTA with action verb (GTM-COPY-002 AC1)', () => {
+  it('renders primary CTA with correct data-testid and href (REPO-006)', () => {
     render(<HeroSection />);
 
-    const primaryCTA = screen.getByRole('button', { name: /Ver oportunidades para meu setor/i });
+    const primaryCTA = screen.getByTestId('hero-cta-primary');
     expect(primaryCTA).toBeInTheDocument();
+    expect(primaryCTA).toHaveAttribute('href', '/signup?source=hero-primary');
+    expect(primaryCTA).toHaveTextContent('Testar plataforma');
   });
 
-  it('renders secondary CTA linking to como-funciona (SAB-006 AC1)', () => {
+  it('renders secondary CTA with correct data-testid and href (REPO-006)', () => {
     render(<HeroSection />);
 
-    const secondaryCTA = screen.getByRole('button', { name: /Ver como funciona/i });
+    const secondaryCTA = screen.getByTestId('hero-cta-secondary');
     expect(secondaryCTA).toBeInTheDocument();
-  });
-
-  it('scrolls to como-funciona section when secondary CTA is clicked', async () => {
-    const user = userEvent.setup();
-
-    const mockScrollIntoView = jest.fn();
-    const mockElement = { scrollIntoView: mockScrollIntoView };
-    jest.spyOn(document, 'getElementById').mockReturnValue(mockElement as any);
-
-    render(<HeroSection />);
-
-    const secondaryCTA = screen.getByRole('button', { name: /Ver como funciona/i });
-    await user.click(secondaryCTA);
-
-    expect(document.getElementById).toHaveBeenCalledWith('como-funciona');
-    expect(mockScrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'start',
-    });
+    expect(secondaryCTA).toHaveAttribute('href', '/consultoria-b2g#diagnostico');
+    expect(secondaryCTA).toHaveTextContent('Solicitar diagnóstico B2G');
   });
 
   it('does NOT use forbidden terms (AC11)', () => {
@@ -76,7 +70,6 @@ describe('HeroSection', () => {
     expect(text).not.toMatch(/ferramenta de busca/i);
     expect(text).not.toMatch(/planilha automatizada/i);
     expect(text).not.toMatch(/10h\/semana/i);
-    // GTM-COPY-001 banned phrases
     expect(text).not.toMatch(/inteligência automatizada/i);
     expect(text).not.toMatch(/inovador/i);
   });
@@ -92,7 +85,6 @@ describe('HeroSection', () => {
     const { container } = render(<HeroSection />);
     const text = container.textContent || '';
 
-    // Stats badges removed — these values should NOT appear in HeroSection
     expect(text).not.toMatch(/87%/);
     expect(text).not.toMatch(/UFs cobertas/i);
   });
@@ -108,7 +100,6 @@ describe('HeroSection', () => {
       });
       expect(img).toBeInTheDocument();
 
-      // 50/50 layout uses flex-row on lg breakpoint
       const flexContainer = container.querySelector('.lg\\:flex-row');
       expect(flexContainer).toBeInTheDocument();
     });
@@ -147,7 +138,6 @@ describe('HeroSection', () => {
       const img = screen.getByRole('img', {
         name: /Tela de resultados do SmartLic/i,
       });
-      // dark:brightness-[0.85] dark:contrast-[1.1]
       expect(img.className).toContain('dark:brightness-');
       expect(img.className).toContain('dark:contrast-');
     });
@@ -155,10 +145,8 @@ describe('HeroSection', () => {
     it('renders browser chrome frame around screenshot', () => {
       const { container } = render(<HeroSection />);
 
-      // Browser URL bar text
       expect(screen.getByText('smartlic.tech/buscar')).toBeInTheDocument();
 
-      // Browser dots (red, yellow, green)
       const dots = container.querySelectorAll('.rounded-full');
       // 3 browser dots + 3 trust indicator dots = 6
       expect(dots.length).toBeGreaterThanOrEqual(6);
@@ -186,7 +174,6 @@ describe('HeroSection', () => {
     it('AC2: mobile layout stacks screenshot below headline (flex-col default)', () => {
       const { container } = render(<HeroSection />);
 
-      // Default is flex-col (mobile), lg:flex-row (desktop)
       const flexContainer = container.querySelector('.flex-col.lg\\:flex-row');
       expect(flexContainer).toBeInTheDocument();
     });

--- a/frontend/app/components/landing/HeroSection.tsx
+++ b/frontend/app/components/landing/HeroSection.tsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { ChevronDown } from 'lucide-react';
 import { GradientButton } from '@/app/components/ui/GradientButton';
 import { useScrollAnimation } from '@/lib/animations';
 import { fadeInUp, staggerContainer } from '@/lib/animations';
@@ -19,16 +19,10 @@ const HERO_SCREENSHOT_BLUR =
  * STORY-174 AC1: Hero Section Redesign - Premium SaaS Aesthetic
  * SAB-006 AC2/AC5: Removed stats badges (consolidated into StatsSection), CTA above fold
  * DEBT-125: 50/50 layout with annotated product screenshot
+ * REPO-006: Copymasters consensus v1 — B2G intelligence positioning
  */
 export default function HeroSection({ className = '' }: HeroSectionProps) {
   const { ref, isVisible } = useScrollAnimation(0.1);
-
-  const scrollToSection = (id: string) => {
-    const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  };
 
   return (
     <section
@@ -76,11 +70,11 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
             variants={fadeInUp}
           >
             <span className="text-ink">
-              Pare de perder dinheiro
+              Decisão comercial em licitação não nasce de PDF.
             </span>
             <br />
             <span className="text-gradient">
-              com licitações erradas.
+              Nasce de inteligência.
             </span>
           </motion.h1>
 
@@ -97,7 +91,7 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
             "
             variants={fadeInUp}
           >
-            O SmartLic analisa cada edital contra o perfil da sua empresa. Elimina o que não faz sentido. Entrega só o que tem chance real de retorno — com justificativa objetiva.
+            SmartLic lê o edital, mapeia o concorrente, calcula a chance real. Sua empresa decide go/no-go em minutos — não em três dias de leitura.
           </motion.p>
 
           {/* CTA Buttons — AC5: Primary CTA visible above the fold */}
@@ -105,24 +99,25 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
             className="flex flex-col sm:flex-row items-center lg:items-start justify-center lg:justify-start gap-4 mt-10"
             variants={fadeInUp}
           >
-            <GradientButton
-              variant="primary"
-              size="lg"
-              glow={true}
-              onClick={() => window.location.href = '/signup?source=landing-cta'}
-            >
-              Ver oportunidades para meu setor
-            </GradientButton>
+            <Link href="/signup?source=hero-primary" data-testid="hero-cta-primary">
+              <GradientButton
+                variant="primary"
+                size="lg"
+                glow={true}
+              >
+                Testar plataforma
+              </GradientButton>
+            </Link>
 
-            <GradientButton
-              variant="secondary"
-              size="lg"
-              glow={false}
-              onClick={() => scrollToSection('como-funciona')}
-            >
-              Ver como funciona
-              <ChevronDown size={20} className="ml-2 transition-transform" aria-hidden="true" />
-            </GradientButton>
+            <Link href="/consultoria-b2g#diagnostico" data-testid="hero-cta-secondary">
+              <GradientButton
+                variant="secondary"
+                size="lg"
+                glow={false}
+              >
+                Solicitar diagnóstico B2G
+              </GradientButton>
+            </Link>
           </motion.div>
 
           {/* Trust indicators */}

--- a/frontend/lib/copy/valueProps.ts
+++ b/frontend/lib/copy/valueProps.ts
@@ -16,20 +16,21 @@ import { Target, Globe, Bot, Search, ShieldCheck } from '@/lib/icons';
 // ============================================================================
 
 export const hero = {
-  // GTM-COPY-001: Financial impact positioning
+  // REPO-006: Copymasters consensus v1 — B2G intelligence positioning
   headlines: {
+    b2gIntelligence: "Decisão comercial em licitação não nasce de PDF. Nasce de inteligência.",
     financialImpact: "Pare de perder dinheiro com licitações erradas.",
     filterFocus: "Só o que vale a pena chega até você.",
     wasteCut: "Licitações que realmente pagam. O resto, a gente descarta.",
-    // Recommended for GTM-COPY-001
-    default: "Pare de perder dinheiro com licitações erradas.",
+    default: "Decisão comercial em licitação não nasce de PDF. Nasce de inteligência.",
   },
 
-  // GTM-COPY-001 AC2: Mechanism of value (not abstract)
+  // REPO-006: Copymasters consensus v1 subheadline
   subheadlines: {
+    b2gIntelligence: "SmartLic lê o edital, mapeia o concorrente, calcula a chance real. Sua empresa decide go/no-go em minutos — não em três dias de leitura.",
     mechanism: "O SmartLic analisa cada edital contra o perfil da sua empresa. Elimina o que não faz sentido. Entrega só o que tem chance real de retorno — com justificativa objetiva.",
     filter: "Cada edital passa por análise de compatibilidade com seu perfil. Você só vê o que merece investimento de tempo e proposta.",
-    default: "O SmartLic analisa cada edital contra o perfil da sua empresa. Elimina o que não faz sentido. Entrega só o que tem chance real de retorno — com justificativa objetiva.",
+    default: "SmartLic lê o edital, mapeia o concorrente, calcula a chance real. Sua empresa decide go/no-go em minutos — não em três dias de leitura.",
   },
 
   // GTM-COPY-001 AC3: Trust badges — practical confidence, not abstract metrics
@@ -51,12 +52,14 @@ export const hero = {
     },
   ],
 
-  // GTM-COPY-002: Action-oriented CTAs
+  // GTM-COPY-002: Action-oriented CTAs. REPO-006: dual-CTA with diagnostico secondary
   cta: {
-    primary: "Ver oportunidades para meu setor",
-    secondary: "Ver exemplo de análise real",
+    primary: "Testar plataforma",
+    primaryHref: "/signup?source=hero-primary",
+    secondary: "Solicitar diagnóstico B2G",
+    secondaryHref: "/consultoria-b2g#diagnostico",
     pricing: "Começar a filtrar oportunidades",
-    default: "Ver oportunidades para meu setor",
+    default: "Testar plataforma",
   },
 };
 


### PR DESCRIPTION
## Context
REPO-006 Phase 0 reposicionamento. Copymasters consensus v1 approved (8/8). Updates hero copy to new B2G intelligence positioning.

## Changes
- Updated hero headline to: "Decisão comercial em licitação não nasce de PDF. Nasce de inteligência."
- Updated subheadline to go/no-go framing: "SmartLic lê o edital, mapeia o concorrente, calcula a chance real..."
- Added primary CTA (`data-testid="hero-cta-primary"`) → "Testar plataforma" → `/signup?source=hero-primary`
- Added secondary CTA (`data-testid="hero-cta-secondary"`) → "Solicitar diagnóstico B2G" → `/consultoria-b2g#diagnostico`
- CTAs use `next/link` href (accessible, crawlable) instead of onClick navigation
- Updated `valueProps.ts` hero block to match locked copy (source of truth)
- Rewrote HeroSection tests: 17 passing, all DEBT-125 screenshot tests preserved

## Testing Plan
- [ ] `npm test -- HeroSection` passes (17/17 tests green)
- [ ] Both `data-testid="hero-cta-primary"` and `data-testid="hero-cta-secondary"` present in DOM
- [ ] `hero-cta-primary` links to `/signup?source=hero-primary`
- [ ] `hero-cta-secondary` links to `/consultoria-b2g#diagnostico`
- [ ] Visual: desktop + mobile viewports match design intent
- [ ] Banned-phrase check still passes (no forbidden terms in new copy)

## Risks & Rollback
Low risk — copy-only change. Revert: `git revert`.

## Closes
Closes #758