### PR TITLE
fix(frontend): remove guarantee/never-lose copy — REPO-021 (#773)

### DIFF
--- a/frontend/app/blog/content/sicaf-como-cadastrar-manter-ativo-2026.tsx
+++ b/frontend/app/blog/content/sicaf-como-cadastrar-manter-ativo-2026.tsx
@@ -236,7 +236,7 @@ export default function SicafComoCadastrarManterAtivo2026() {
       </p>
 
       <div className="not-prose my-8 sm:my-10 bg-brand/5 border border-brand/20 rounded-lg p-6 sm:p-8 text-center">
-        <h3 className="text-xl font-bold mb-2">Monitore Editais e Nunca Perca um Prazo de Habilitação</h3>
+        <h3 className="text-xl font-bold mb-2">Monitore Editais e Acompanhe Todos os Prazos de Habilitação</h3>
         <p className="text-ink-secondary mb-4">
           O SmartLic agrega editais do PNCP, ComprasNet e outros portais em uma busca única, com filtros por setor, UF e valor estimado. Saiba com antecedência quais licitações estão abertas no seu segmento — e prepare sua documentação antes que o prazo feche.
         </p>

--- a/frontend/app/fundadores/FundadoresClient.tsx
+++ b/frontend/app/fundadores/FundadoresClient.tsx
@@ -207,7 +207,7 @@ export default function FundadoresClient() {
           className="mt-16 rounded-xl border border-blue-200 bg-blue-50 p-8"
         >
           <h2 id="cta-final-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-            Garanta sua vaga agora
+            Reserve sua vaga agora
           </h2>
           <p className="text-slate-700 mb-6">
             Acesso vitalício por {price}. Pagamento único via Stripe — cartão de crédito ou boleto.

--- a/frontend/lib/copy/comparisons.ts
+++ b/frontend/lib/copy/comparisons.ts
@@ -174,7 +174,7 @@ export const defensiveMessaging: Record<string, DefensiveMessage> = {
     smartlicSolution:
       "No SmartLic, consolidamos fontes oficiais automaticamente com cobertura nacional",
     quantifiedBenefit:
-      "Nunca perca uma oportunidade. Visibilidade completa do mercado",
+      "Monitore todas as oportunidades. Visibilidade completa do mercado",
   },
 
   ai: {


### PR DESCRIPTION
## Context
REPO-021: Remove any copy suggesting guaranteed wins, per REPO-003 audit and CONAR/Procon compliance requirements. Replace with objective, non-promissory language per REPO-002 guidelines.

## Changes
- `frontend/app/fundadores/FundadoresClient.tsx`: "Garanta sua vaga agora" → "Reserve sua vaga agora"
- `frontend/lib/copy/comparisons.ts`: "Nunca perca uma oportunidade" → "Monitore todas as oportunidades"
- `frontend/app/blog/content/sicaf-como-cadastrar-manter-ativo-2026.tsx`: "Nunca Perca um Prazo de Habilitação" → "Acompanhe Todos os Prazos de Habilitação"

## Grep Validation
After these changes, the regulated patterns return 0 hits:
```
grep -roE "(garanta|ganhe certeza|sucesso garantido|automaticamente vencerá|nunca perca|alta chance de ganhar|100% das oportunidades)" frontend/app/ frontend/lib/copy/ backend/templates/
```

## Testing Plan
- [x] Grep regex returns 0 for all regulated patterns on user-facing surfaces
- [ ] Manual visual review of 3 changed strings in browser

## Closes
Closes #773