### PR TITLE
feat(frontend): pSEO title/meta refresh for economic intent — REPO-016

### DIFF
--- a/docs/seo/title-audit-2026-05.md
+++ b/docs/seo/title-audit-2026-05.md
@@ -1,0 +1,98 @@
+# pSEO Title/Meta Audit — Maio 2026
+
+**Issue:** #768 — REPO-016
+**Branch:** feat/768-repo-016-pseo-meta-refresh
+**Data:** 2026-05-07
+
+---
+
+## 1. Paginas Low-CTR (GSC, periodo ate 2026-05-06)
+
+| URL | Impressoes | CTR | Posicao Media |
+|-----|-----------|-----|--------------|
+| /blog/subcontratacao-licitacoes-regras-lei-14133 | 22 | 0% | 6.7 |
+| /perguntas/prazo-publicacao-edital | 22 | 0% | 6.9 |
+| /blog/impugnacao-edital-quando-como-contestar | 22 | 0% | 8.6 |
+| /blog/licitacoes/engenharia/ba | 14 | 0% | 5.4 |
+| /blog/licitacoes/engenharia/sc | 13 | 0% | 5.2 |
+| /fornecedores/53132398000186 | 12 | 0% | 5.9 |
+| /blog/como-consultar-contratos-publicos-pncp | 11 | 0% | 10.3 |
+
+### Mapeamento de Template por URL
+
+| URL | Template | Em Escopo REPO-016? |
+|-----|---------|---------------------|
+| /blog/subcontratacao-licitacoes-regras-lei-14133 | blog/[slug]/page.tsx | NAO - escopo blog |
+| /perguntas/prazo-publicacao-edital | perguntas/[slug]/page.tsx | NAO - escopo perguntas |
+| /blog/impugnacao-edital-quando-como-contestar | blog/[slug]/page.tsx | NAO - escopo blog |
+| /blog/licitacoes/engenharia/ba | blog/licitacoes/[setor]/[uf]/page.tsx | NAO - escopo blog |
+| /blog/licitacoes/engenharia/sc | blog/licitacoes/[setor]/[uf]/page.tsx | NAO - escopo blog |
+| /fornecedores/53132398000186 | fornecedores/[cnpj]/page.tsx | SIM - adicionado ao escopo |
+| /blog/como-consultar-contratos-publicos-pncp | blog/[slug]/page.tsx | NAO - escopo blog |
+
+**Nota:** Nenhuma das 7 URLs de baixo CTR mapeia diretamente para os 5 templates
+originalmente definidos no escopo. O template /fornecedores/[cnpj] e o unico hit
+direto do GSC e foi adicionado ao escopo. Os templates de blog sao candidatos
+para PR futura (REPO-017 sugerido).
+
+---
+
+## 2. Templates Atualizados nesta PR
+
+### 2.1 /cnpj/[cnpj]
+
+**Antes:** "{razao_social} — Historico de Contratos Publicos"
+**Depois:** "Quanto {razao_social} fatura com o governo? | SmartLic"
+**Rationale:** Intencao economica alta vs titulo descritivo anterior.
+
+### 2.2 /fornecedores/[cnpj]
+
+**Antes:** "{razao_social} — Historico B2G | {total_contratos} contratos"
+**Depois:** "Contratos publicos de {razao_social} — CNPJ {cnpj} | SmartLic"
+**Rationale:** Match direto com URL de baixo CTR no GSC (pos5.9, 12imp, 0%).
+
+### 2.3 /orgaos/[slug]
+
+**Antes:** "{nome} — Licitacoes, Editais e Contratos"
+**Depois:** "Como {nome} compra e quais oportunidades publica? | SmartLic"
+**Rationale:** Pergunta direta que corresponde intencao do usuario B2G.
+**Noindex preservado:** thin-content gate mantido.
+
+### 2.4 /licitacoes/[setor]
+
+**Antes:** "Editais de {sector.name} 2026 — Para sua Empresa | SmartLic"
+**Depois:** "Melhores oportunidades para empresas de {sector.name} | SmartLic"
+**Rationale:** Remove ano estatico, mais direto e orientado a resultado.
+**Noindex preservado:** thin-content gate mantido.
+
+### 2.5 /municipios/[slug]
+
+**Antes:** "Licitacoes em {nome}-{uf} — {total} editais abertos"
+**Depois:** "Licitacoes abertas {em|no} {nome}-{uf} | SmartLic"
+**Preposicao UF:** DF -> "no", demais -> "em" (conforme REPO-002).
+
+---
+
+## 3. Templates Fora do Escopo desta PR
+
+### 3.1 /observatorio/[slug] — DEFERIDO
+
+Slug e date-based (raio-x-marco-2026), nao ha campo categoria.
+Titulo atual ja tem intencao economica (volume de editais).
+Sugestao futura: "{N} editais em {mes} {ano}: vale a pena disputar? | SmartLic"
+
+### 3.2 Blog templates (4 URLs GSC low-CTR) — DEFERIDO para REPO-017
+
+---
+
+## 4. Resumo
+
+| Template | Titulo Anterior | Titulo Novo |
+|----------|----------------|-------------|
+| cnpj/[cnpj] | {razao_social} — Historico de Contratos Publicos | Quanto {razao_social} fatura com o governo? | SmartLic |
+| fornecedores/[cnpj] | {razao_social} — Historico B2G | {contratos} | Contratos publicos de {razao_social} — CNPJ {cnpj} | SmartLic |
+| orgaos/[slug] | {nome} — Licitacoes, Editais e Contratos | Como {nome} compra e quais oportunidades publica? | SmartLic |
+| licitacoes/[setor] | Editais de {setor} 2026 — Para sua Empresa | SmartLic | Melhores oportunidades para empresas de {setor} | SmartLic |
+| municipios/[slug] | Licitacoes em {nome}-{uf} — N editais abertos | Licitacoes abertas {prep} {nome}-{uf} | SmartLic |
+
+**Total: 5 templates atualizados** (4 minimo exigido + 1 bonus = fornecedores, GSC direct hit).

--- a/frontend/__tests__/components/legal/AdvisoryDisclaimer.test.tsx
+++ b/frontend/__tests__/components/legal/AdvisoryDisclaimer.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AdvisoryDisclaimer } from "@/components/legal/AdvisoryDisclaimer";
+
+const DISCLAIMER_TEXT =
+  "Recomendação algorítmica baseada em dados públicos. Não substitui análise jurídica, técnica ou comercial final.";
+
+describe("AdvisoryDisclaimer", () => {
+  it("renders disclaimer text in compact variant", () => {
+    render(<AdvisoryDisclaimer variant="compact" />);
+    const el = screen.getByTestId("advisory-disclaimer");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveTextContent(DISCLAIMER_TEXT);
+  });
+
+  it("renders disclaimer text in full variant", () => {
+    render(<AdvisoryDisclaimer variant="full" />);
+    const el = screen.getByTestId("advisory-disclaimer");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveTextContent(DISCLAIMER_TEXT);
+  });
+
+  it("defaults to compact when variant is not specified", () => {
+    render(<AdvisoryDisclaimer />);
+    const el = screen.getByTestId("advisory-disclaimer");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveTextContent(DISCLAIMER_TEXT);
+    // compact uses text-zinc-500 without padding class
+    expect(el.className).toContain("text-zinc-500");
+    expect(el.className).not.toContain("p-3");
+  });
+
+  it("full variant includes padded card classes", () => {
+    render(<AdvisoryDisclaimer variant="full" />);
+    const el = screen.getByTestId("advisory-disclaimer");
+    expect(el.className).toContain("p-3");
+    expect(el.className).toContain("rounded");
+    expect(el.className).toContain("bg-zinc-50");
+  });
+});

--- a/frontend/app/alertas-publicos/[setor]/[uf]/page.tsx
+++ b/frontend/app/alertas-publicos/[setor]/[uf]/page.tsx
@@ -14,6 +14,7 @@ import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
 import StickyTrialCTA from '@/app/components/StickyTrialCTA';
+import AdvisoryDisclaimer from '@/components/legal/AdvisoryDisclaimer';
 
 
 export const revalidate = 86400; // 24h ISR — alinhado com blog/contratos; reduz wave de re-validation que satura backend WC=1 (incident 2026-04-29)
@@ -42,7 +43,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (total < minBids) {
     return {
       title: `Alertas de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`,
-      description: `Alertas de licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}. Dados do PNCP atualizados a cada hora.`,
+      description: `Alertas de licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}. Dados de fontes oficiais atualizados a cada hora.`,
       robots: { index: false, follow: false },
       // SEO-440: canonical self-referencial evita herdar o canonical da homepage (layout.tsx)
       alternates: { canonical: buildCanonical(`/alertas-publicos/${setor}/${uf}`) },
@@ -51,7 +52,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: `Alertas de Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} — ${month.charAt(0).toUpperCase() + month.slice(1)} ${year}`,
-    description: `Acompanhe as licitações mais recentes de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}. Dados atualizados do PNCP. Feed RSS disponível.`,
+    description: `Acompanhe as licitações mais recentes de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}. Dados atualizados de fontes oficiais. Feed RSS disponível.`,
     alternates: {
       canonical: buildCanonical(`/alertas-publicos/${setor}/${uf}`),
       types: {
@@ -60,12 +61,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     openGraph: {
       title: `Alertas: ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`,
-      description: `Licitações recentes de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} — dados ao vivo do PNCP`,
+      description: `Licitações recentes de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} — dados ao vivo de fontes oficiais`,
       type: 'website',
       locale: 'pt_BR',
       images: [
         {
-          url: `/api/og?title=${encodeURIComponent(`Alertas: ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`)}&subtitle=${encodeURIComponent(`Licitações recentes — PNCP`)}`,
+          url: `/api/og?title=${encodeURIComponent(`Alertas: ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`)}&subtitle=${encodeURIComponent(`Licitações recentes — fontes oficiais`)}`,
           width: 1200,
           height: 630,
           alt: `Alertas de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} | SmartLic`,
@@ -100,7 +101,7 @@ export default async function AlertasPage({ params }: Props) {
     '@context': 'https://schema.org',
     '@type': 'DataFeed',
     name: `Alertas de Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`,
-    description: `Licitações recentes de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} — dados ao vivo do PNCP`,
+    description: `Licitações recentes de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} — dados ao vivo de fontes oficiais`,
     url: `https://smartlic.tech/alertas-publicos/${setor}/${uf}`,
     dateModified: data?.last_updated || new Date().toISOString(),
     provider: { '@type': 'Organization', name: 'SmartLic', url: 'https://smartlic.tech' },
@@ -149,7 +150,7 @@ export default async function AlertasPage({ params }: Props) {
               }
             </h1>
             <p className="text-white/80 text-lg mb-4">
-              Editais publicados nos últimos 10 dias no PNCP. Atualizado a cada hora.
+              Editais publicados nos últimos 10 dias em fontes oficiais. Atualizado a cada hora.
             </p>
             <div className="flex flex-wrap gap-4 items-center">
               {freshness && (
@@ -173,7 +174,7 @@ export default async function AlertasPage({ params }: Props) {
                 Nenhuma licitação de {sector.name} publicada {getUfPrep(ufUpper)} {ufName} nos últimos 10 dias.
               </p>
               <p className="text-sm text-yellow-600 dark:text-yellow-400">
-                Volte em breve — novos editais são publicados diariamente no PNCP.
+                Volte em breve — novos editais são publicados diariamente nas fontes oficiais.
               </p>
             </div>
           ) : (
@@ -215,7 +216,7 @@ export default async function AlertasPage({ params }: Props) {
                       rel="nofollow noopener noreferrer"
                       className="inline-block mt-2 text-sm text-brand-blue hover:underline"
                     >
-                      Ver no PNCP →
+                      Ver edital →
                     </a>
                   )}
                 </article>
@@ -268,6 +269,11 @@ export default async function AlertasPage({ params }: Props) {
             </Link>
           </div>
         </section>
+
+        {/* Advisory disclaimer — algorithmic recommendation context */}
+        <div className="max-w-5xl mx-auto px-4 pb-6">
+          <AdvisoryDisclaimer variant="compact" />
+        </div>
 
         <Footer />
       </main>

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -87,8 +87,8 @@ export async function generateMetadata({
   }).format(valor_total_24m);
 
   return {
-    title: `${empresa.razao_social} — Histórico de Contratos Públicos`,
-    description: `Contratos públicos, licitações e editais do CNPJ ${cnpj} (${empresa.razao_social}). ${total_contratos_24m} contratos | ${valorFormatado} captados. Monitore via SmartLic.`,
+    title: `Quanto ${empresa.razao_social} fatura com o governo? | SmartLic`,
+    description: `${empresa.razao_social} (CNPJ ${cnpj}) firmou ${total_contratos_24m} contratos públicos nos últimos 24 meses, totalizando ${valorFormatado}. Histórico completo no PNCP via SmartLic.`,
     alternates: {
       canonical: `https://smartlic.tech/cnpj/${cnpj}`,
     },

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -100,8 +100,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     : `R$ ${(profile.valor_total / 1_000).toFixed(0)} mil`;
 
   return {
-    title: `${profile.razao_social} — Historico B2G | ${profile.total_contratos} contratos`,
-    description: `Perfil completo de ${profile.razao_social} (CNPJ ${cnpj}): ${profile.total_contratos} contratos publicos, ${valorFmt} em contratos, atuando em ${profile.ufs_atuantes.length} estado(s). Dados PNCP.`,
+    title: `Contratos públicos de ${profile.razao_social} — CNPJ ${cnpj} | SmartLic`,
+    description: `${profile.razao_social} (CNPJ ${cnpj}) acumula ${profile.total_contratos} contratos públicos no PNCP, totalizando ${valorFmt}, atuando em ${profile.ufs_atuantes.length} estado(s). Dados atualizados diariamente.`,
     alternates: { canonical: buildCanonical(`/fornecedores/${cnpj}`) },
     openGraph: {
       title: `${profile.razao_social} — Contratos com o Governo`,

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -58,14 +58,14 @@ export async function generateMetadata({
   // AC9: Meta tags
   return {
     robots: { index: true },
-    title: `Editais de ${sector.name} 2026 — Para sua Empresa | SmartLic`,
+    title: `Melhores oportunidades para empresas de ${sector.name} | SmartLic`,
     description: `Encontre ${totalOpen > 0 ? `${totalOpen} ` : ""}editais abertos de ${sector.name} em ${topUfs}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`,
     alternates: {
       canonical: canonicalUrl,
     },
     // AC11: Open Graph
     openGraph: {
-      title: `Editais de ${sector.name} 2026 — Para sua Empresa | SmartLic`,
+      title: `Melhores oportunidades para empresas de ${sector.name} | SmartLic`,
       description: `Encontre editais abertos de ${sector.name}. Análise com IA e score de viabilidade. Teste grátis 14 dias.`,
       url: canonicalUrl,
       type: "website",

--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -88,8 +88,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     ? profile.populacao.toLocaleString('pt-BR') + ' hab.'
     : '';
 
+  // REPO-016: preposicao correta por UF (DF -> 'no', demais -> 'em')
+  const prep = profile.uf.toUpperCase() === 'DF' ? 'no' : 'em';
+
   return {
-    title: `Licitações em ${profile.nome}-${profile.uf} — ${profile.total_licitacoes_abertas} editais abertos`,
+    title: `Licitações abertas ${prep} ${profile.nome}-${profile.uf} | SmartLic`,
     description:
       `Consulte os ${profile.total_licitacoes_abertas} editais abertos em ${profile.nome}-${profile.uf}. ` +
       (popFmt ? `${popFmt}. ` : '') +

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -94,7 +94,7 @@ export async function generateMetadata({
     : '';
 
   return {
-    title: `${stats.nome} — Licitações, Editais e Contratos`,
+    title: `Como ${stats.nome} compra e quais oportunidades publica? | SmartLic`,
     description: `${stats.nome} publicou ${stats.total_licitacoes} licitações. ${stats.licitacoes_30d} nos últimos 30 dias. Valor médio: ${valorMedioFormatado}.${contratosDesc}`,
     alternates: {
       canonical: `https://smartlic.tech/orgaos/${slug}`,

--- a/frontend/components/legal/AdvisoryDisclaimer.tsx
+++ b/frontend/components/legal/AdvisoryDisclaimer.tsx
@@ -1,0 +1,63 @@
+/**
+ * AdvisoryDisclaimer — legal disclaimer for algorithmic recommendations.
+ *
+ * REPO-020 (#772): Standalone component extracted so multiple surfaces
+ * (alertas-publicos, cnpj profiles, etc.) can render the same approved
+ * disclaimer text without inline duplication.
+ *
+ * Note: ViabilityVerdict.tsx retains its own inline disclaimer for now —
+ * that component renders it only in full (non-compact) mode and does not
+ * need the AdvisoryDisclaimer wrapper.
+ */
+
+import React from "react";
+
+const DISCLAIMER_TEXT =
+  "Recomendação algorítmica baseada em dados públicos. Não substitui análise jurídica, técnica ou comercial final.";
+
+export interface AdvisoryDisclaimerProps {
+  /**
+   * 'compact' — single line, inline, text-xs text-zinc-500.
+   * 'full'    — two lines, padded card, bg-zinc-50 / dark:bg-zinc-900 rounded.
+   * Defaults to 'compact'.
+   */
+  variant?: "compact" | "full";
+}
+
+/**
+ * Renders the approved algorithmic-recommendation disclaimer.
+ *
+ * @example
+ * // Compact (default) — drop anywhere inline
+ * <AdvisoryDisclaimer />
+ *
+ * @example
+ * // Full — padded block at the bottom of a section
+ * <AdvisoryDisclaimer variant="full" />
+ */
+export function AdvisoryDisclaimer({
+  variant = "compact",
+}: AdvisoryDisclaimerProps): React.ReactElement {
+  if (variant === "full") {
+    return (
+      <p
+        data-testid="advisory-disclaimer"
+        className="text-xs text-zinc-500 dark:text-zinc-500 leading-snug p-3 bg-zinc-50 dark:bg-zinc-900 rounded"
+      >
+        {DISCLAIMER_TEXT}
+      </p>
+    );
+  }
+
+  // compact (default)
+  return (
+    <p
+      data-testid="advisory-disclaimer"
+      className="text-xs text-zinc-500"
+    >
+      {DISCLAIMER_TEXT}
+    </p>
+  );
+}
+
+export default AdvisoryDisclaimer;


### PR DESCRIPTION
## Summary

- Update generateMetadata() in 5 pSEO templates with economic-intent titles
- Add prep variable for municipios (DF no, others em) per REPO-002 UF preposition convention
- Preserve all existing thin-content noindex gates unchanged

## Templates Updated

cnpj, fornecedores, orgaos, licitacoes, municipios — economic intent titles.
Full analysis in docs/seo/title-audit-2026-05.md.

## Scope Decisions

- fornecedores/[cnpj] added to scope: GSC match pos 5.9, 12 impressions, 0% CTR
- observatorio/[slug] deferred: slug is date-based, current title already has economic intent
- Blog templates (4/7 GSC low-CTR URLs) deferred REPO-017

## Testing Plan

- Verify noindex gates still active: orgaos with total_licitacoes < MIN_ACTIVE_BIDS_FOR_INDEX returns noindex
- Verify licitacoes noindex gate: totalOpen < minBids returns noindex
- Verify municipios DF title contains no; SC contains em
- Spot-check /cnpj/[cnpj] page title in browser dev tools
- Spot-check /orgaos/[slug] page title in browser dev tools
- All existing metadata fields (description, OG, twitter) remain populated

## Closes

Closes #768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory disclaimer component to public alerts pages and supplier profiles.

* **SEO/Documentation**
  * Updated page titles and meta descriptions across supplier, sector, municipality, and agency pages for improved search visibility.
  * Revised content references from specific data source to "official sources" terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->