### PR TITLE
fix(frontend): CNPJ CONFENGE correto 52.407.089/0001-09 — REPO-005 (#757)

### DIFF
--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -272,9 +272,8 @@ export default function Footer() {
             <p className="text-sm text-ink-secondary">
               © 2026 SmartLic.tech. Todos os direitos reservados.
             </p>
-            {/* TODO(REPO-005): replace with truth-source CNPJ once REPO-005 lands */}
             <p className="text-xs text-ink-muted">
-              CONFENGE Avaliações e Inteligência Artificial LTDA — CNPJ 56.688.745/0001-00 — Av. Pref. Osmar Cunha, 416 - Centro, Florianópolis - SC, 88015-100
+              CONFENGE Avaliações e Inteligência Artificial LTDA — CNPJ 52.407.089/0001-09 — Av. Pref. Osmar Cunha, 416 - Centro, Florianópolis - SC, 88015-100
             </p>
 
             {/* LGPD Badge */}

--- a/frontend/app/privacidade/page.tsx
+++ b/frontend/app/privacidade/page.tsx
@@ -25,7 +25,7 @@ export default function PrivacidadePage() {
               </h2>
               <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
                 A <strong>CONFENGE Avaliacoes e Inteligencia Artificial LTDA</strong> (&quot;SmartLic&quot;, &quot;nos&quot; ou &quot;empresa&quot;),
-                inscrita no CNPJ sob o n. 56.528.581/0001-00, com sede na cidade de Sao Paulo/SP,
+                inscrita no CNPJ sob o n. 52.407.089/0001-09, com sede na cidade de Florianopolis/SC,
                 respeita sua privacidade e esta comprometida em proteger seus dados pessoais em conformidade com
                 a <strong>Lei Geral de Protecao de Dados (LGPD - Lei 13.709/2018)</strong>.
                 Esta Politica de Privacidade descreve como coletamos, usamos, armazenamos e protegemos suas informacoes


### PR DESCRIPTION
## Context

Footer.tsx e privacidade/page.tsx tinham CNPJs incorretos (dois valores diferentes), identificados como risco ALTO no audit legal REPO-003. CNPJ correto confirmado pelo owner da empresa em 2026-05-07: **52.407.089/0001-09** (CONFENGE Avaliações e Inteligência Artificial LTDA).

## Changes

- `frontend/app/components/Footer.tsx` — `56.688.745/0001-00` → `52.407.089/0001-09` (remove TODO comment)
- `frontend/app/privacidade/page.tsx` — `56.528.581/0001-00` → `52.407.089/0001-09` + corrige sede de "Sao Paulo/SP" → "Florianopolis/SC"

**Nota:** `StructuredData.tsx` já tinha o CNPJ correto (`52.407.089/0001-09`) — não alterado.

## Testing Plan

- [ ] Footer renders correct CNPJ text
- [ ] Privacidade page shows correct CNPJ and city
- [ ] `npm test` passes (Footer.test.tsx)

## Risks & Rollback

Cosmético — apenas texto. Rollback: reverter 2 arquivos.

## Closes

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)