### PR TITLE
fix(infra): scope Railway watchPatterns + remove deploy.yml self-trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
-      - '.github/workflows/deploy.yml'
       - 'railway.toml'
       - 'backend/railway.toml'
       - 'frontend/railway.toml'

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -8,7 +8,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
-watchPatterns = ["**"]
+watchPatterns = ["backend/**"]
 
 [deploy]
 # CRIT-083: uvicorn --workers (spawn-based) — SAFE with cryptography>=46.

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -8,7 +8,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
-watchPatterns = ["**"]
+watchPatterns = ["frontend/**"]
 
 [deploy]
 healthcheckPath = "/api/health"


### PR DESCRIPTION
## Summary

- `watchPatterns = ["**"]` em ambos os `railway.toml` causava Railway auto-triggerar build em **qualquer commit do repo** (docs, stories, .claude/, etc.), independente do GitHub Actions
- `deploy.yml` também se auto-triggerava quando o próprio arquivo era editado
- Combinados com commits "retrigger CI" que tocavam `deploy.yml`, cada push disparava 2 builds simultâneos → fila com 40+ builds → "build queue is still saturated"

**Mudanças:**
- `backend/railway.toml`: `watchPatterns ["**"]` → `["backend/**"]`
- `frontend/railway.toml`: `watchPatterns ["**"]` → `["frontend/**"]`
- `deploy.yml`: remove `.github/workflows/deploy.yml` dos push paths

## Testing Plan

- [ ] CI passes (sem mudança de código backend/frontend — apenas config)
- [ ] Após merge: verificar que `railway deployment list` para de acumular FAILED
- [ ] Após merge: disparar `gh workflow run deploy.yml --ref main -f service=all` para deployar 20+ commits pendentes

## Closes

N/A — fix de infraestrutura operacional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment pipeline configurations to refine build trigger patterns for backend and frontend services, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->