### PR TITLE
feat(frontend): add MS Clarity session tags for trial/onboarding conversion tracking (#855)

### DIFF
--- a/docs/seo/title-audit-2026-05.md
+++ b/docs/seo/title-audit-2026-05.md
@@ -6,9 +6,9 @@
 
 ---
 
-## 1. Paginas Low-CTR (GSC, periodo ate 2026-05-06)
+## 1. Páginas Low-CTR (GSC, período até 2026-05-06)
 
-| URL | Impressoes | CTR | Posicao Media |
+| URL | Impressões | CTR | Posição Média |
 |-----|-----------|-----|--------------|
 | /blog/subcontratacao-licitacoes-regras-lei-14133 | 22 | 0% | 6.7 |
 | /perguntas/prazo-publicacao-edital | 22 | 0% | 6.9 |
@@ -22,77 +22,110 @@
 
 | URL | Template | Em Escopo REPO-016? |
 |-----|---------|---------------------|
-| /blog/subcontratacao-licitacoes-regras-lei-14133 | blog/[slug]/page.tsx | NAO - escopo blog |
-| /perguntas/prazo-publicacao-edital | perguntas/[slug]/page.tsx | NAO - escopo perguntas |
-| /blog/impugnacao-edital-quando-como-contestar | blog/[slug]/page.tsx | NAO - escopo blog |
-| /blog/licitacoes/engenharia/ba | blog/licitacoes/[setor]/[uf]/page.tsx | NAO - escopo blog |
-| /blog/licitacoes/engenharia/sc | blog/licitacoes/[setor]/[uf]/page.tsx | NAO - escopo blog |
-| /fornecedores/53132398000186 | fornecedores/[cnpj]/page.tsx | SIM - adicionado ao escopo |
-| /blog/como-consultar-contratos-publicos-pncp | blog/[slug]/page.tsx | NAO - escopo blog |
+| /blog/subcontratacao-licitacoes-regras-lei-14133 | blog/[slug]/page.tsx | NÃO — escopo blog |
+| /perguntas/prazo-publicacao-edital | perguntas/[slug]/page.tsx | NÃO — escopo perguntas |
+| /blog/impugnacao-edital-quando-como-contestar | blog/[slug]/page.tsx | NÃO — escopo blog |
+| /blog/licitacoes/engenharia/ba | blog/licitacoes/[setor]/[uf]/page.tsx | NÃO — escopo blog |
+| /blog/licitacoes/engenharia/sc | blog/licitacoes/[setor]/[uf]/page.tsx | NÃO — escopo blog |
+| /fornecedores/53132398000186 | fornecedores/[cnpj]/page.tsx | **SIM — adicionado ao escopo** |
+| /blog/como-consultar-contratos-publicos-pncp | blog/[slug]/page.tsx | NÃO — escopo blog |
 
-**Nota:** Nenhuma das 7 URLs de baixo CTR mapeia diretamente para os 5 templates
-originalmente definidos no escopo. O template /fornecedores/[cnpj] e o unico hit
-direto do GSC e foi adicionado ao escopo. Os templates de blog sao candidatos
-para PR futura (REPO-017 sugerido).
+**Nota importante:** Nenhuma das 7 URLs de baixo CTR mapeia diretamente para os 5 templates originalmente definidos no escopo (cnpj, orgaos, licitacoes, municipios, observatorio). O template `/fornecedores/[cnpj]` é o único hit direto do GSC e foi **adicionado ao escopo** desta PR. Os templates de blog são candidatos para uma PR futura (REPO-017 sugerido).
 
 ---
 
 ## 2. Templates Atualizados nesta PR
 
-### 2.1 /cnpj/[cnpj]
+### 2.1 `/cnpj/[cnpj]` — Perfil B2G Empresarial
 
-**Antes:** "{razao_social} — Historico de Contratos Publicos"
-**Depois:** "Quanto {razao_social} fatura com o governo? | SmartLic"
-**Rationale:** Intencao economica alta vs titulo descritivo anterior.
+**Antes:** `"{razao_social} — Histórico de Contratos Públicos"`
+**Decisão:** MUDAR — título anterior é descritivo, não transacional.
+**Depois:** `"Quanto {razao_social} fatura com o governo? | SmartLic"`
 
-### 2.2 /fornecedores/[cnpj]
+**Rationale:** Query de intenção econômica alta ("quanto X fatura com governo?") é muito mais provável que o usuário B2G clique quando está avaliando um concorrente ou parceiro potencial. O modelo de intenção econômica converte melhor que o descritivo.
 
-**Antes:** "{razao_social} — Historico B2G | {total_contratos} contratos"
-**Depois:** "Contratos publicos de {razao_social} — CNPJ {cnpj} | SmartLic"
-**Rationale:** Match direto com URL de baixo CTR no GSC (pos5.9, 12imp, 0%).
+**Descrição:** Mantém dados factuais (total_contratos, valor_total, cnpj).
 
-### 2.3 /orgaos/[slug]
+---
 
-**Antes:** "{nome} — Licitacoes, Editais e Contratos"
-**Depois:** "Como {nome} compra e quais oportunidades publica? | SmartLic"
-**Rationale:** Pergunta direta que corresponde intencao do usuario B2G.
+### 2.2 `/fornecedores/[cnpj]` — Perfil de Fornecedor Público
+
+**Antes:** `"{razao_social} — Historico B2G | {total_contratos} contratos"`
+**Decisão:** MUDAR — match direto com URL de baixo CTR no GSC.
+**Depois:** `"Contratos públicos de {razao_social} — CNPJ {cnpj} | SmartLic"`
+
+**Rationale:** Segue o modelo aprovado para cnpj. `fornecedores/[cnpj]` é distinto de `cnpj/[cnpj]`: serve dados de contratos assinados (pncp_supplier_contracts), não perfil B2G completo. Título econômico mas factual — sem "quanto fatura" pois não há dado de faturamento neste template.
+
+**Descrição:** Atualizada com clareza sobre contratos PNCP e estados de atuação.
+
+---
+
+### 2.3 `/orgaos/[slug]` — Perfil de Órgão Comprador
+
+**Antes:** `"{nome} — Licitações, Editais e Contratos"`
+**Decisão:** MUDAR — título anterior é genérico.
+**Depois:** `"Como {nome} compra e quais oportunidades publica? | SmartLic"`
+
+**Rationale:** Pergunta direta que corresponde à intenção do usuário B2G pesquisando um órgão ("como a Prefeitura de X compra?"). Cria curiosidade e aumenta CTR.
+
+**Noindex preservado:** thin-content gate (`total_licitacoes < MIN_ACTIVE_BIDS_FOR_INDEX`) mantido intacto.
+
+---
+
+### 2.4 `/licitacoes/[setor]` — Landing de Setor
+
+**Antes:** `"Editais de {sector.name} 2026 — Para sua Empresa | SmartLic"`
+**Decisão:** MUDAR — "Para sua Empresa" é vago.
+**Depois:** `"Melhores oportunidades para empresas de {sector.name} | SmartLic"`
+
+**Rationale:** Mais direto e orientado a resultado. Remove o ano estático "2026" que envelhece mal.
+
 **Noindex preservado:** thin-content gate mantido.
 
-### 2.4 /licitacoes/[setor]
+---
 
-**Antes:** "Editais de {sector.name} 2026 — Para sua Empresa | SmartLic"
-**Depois:** "Melhores oportunidades para empresas de {sector.name} | SmartLic"
-**Rationale:** Remove ano estatico, mais direto e orientado a resultado.
-**Noindex preservado:** thin-content gate mantido.
+### 2.5 `/municipios/[slug]` — Perfil de Município
 
-### 2.5 /municipios/[slug]
+**Antes:** `"Licitações em {nome}-{uf} — {total_licitacoes_abertas} editais abertos"`
+**Decisão:** MUDAR — título sem brand e sem preposição correta.
+**Depois:** `"Licitações abertas {preposicao} {nome}-{uf} | SmartLic"`
 
-**Antes:** "Licitacoes em {nome}-{uf} — {total} editais abertos"
-**Depois:** "Licitacoes abertas {em|no} {nome}-{uf} | SmartLic"
-**Preposicao UF:** DF -> "no", demais -> "em" (conforme REPO-002).
+**Preposições UF implementadas inline** (conforme REPO-002):
+- "no" → DF
+- "em" → todos os demais UFs
+
+**Nota:** Não existia utilitário `ufPreposicao` em `frontend/lib/` — função simples adicionada inline na função `generateMetadata`.
 
 ---
 
 ## 3. Templates Fora do Escopo desta PR
 
-### 3.1 /observatorio/[slug] — DEFERIDO
+### 3.1 `/observatorio/[slug]` — Relatório Mensal
 
-Slug e date-based (raio-x-marco-2026), nao ha campo categoria.
-Titulo atual ja tem intencao economica (volume de editais).
-Sugestao futura: "{N} editais em {mes} {ano}: vale a pena disputar? | SmartLic"
+**Decisão:** DEFERIDO.
 
-### 3.2 Blog templates (4 URLs GSC low-CTR) — DEFERIDO para REPO-017
+**Motivo:** O modelo aprovado `"Oportunidades em {categoria}: vale a pena disputar?"` pressupõe um campo `categoria` que não existe neste template. Os slugs são date-based (`raio-x-marco-2026`) — não há campo de categoria na interface `relatorio`. O título atual `"{N} editais em {mes} de {ano} — Raio-X das Licitações"` já carrega intenção econômica implícita (volume de editais).
+
+**Alternativa futura:** `"{N} editais em {mes} {ano}: vale a pena disputar? | SmartLic"` — fica como sugestão para REPO-017.
+
+### 3.2 Blog templates (4 URLs GSC low-CTR)
+
+**Decisão:** DEFERIDO para PR futura (sugerido REPO-017).
+
+Templates afetados:
+- `blog/[slug]/page.tsx` (3 URLs)
+- `blog/licitacoes/[setor]/[uf]/page.tsx` (2 URLs)
 
 ---
 
-## 4. Resumo
+## 4. Templates Atualizados: Resumo
 
-| Template | Titulo Anterior | Titulo Novo |
-|----------|----------------|-------------|
-| cnpj/[cnpj] | {razao_social} — Historico de Contratos Publicos | Quanto {razao_social} fatura com o governo? | SmartLic |
-| fornecedores/[cnpj] | {razao_social} — Historico B2G | {contratos} | Contratos publicos de {razao_social} — CNPJ {cnpj} | SmartLic |
-| orgaos/[slug] | {nome} — Licitacoes, Editais e Contratos | Como {nome} compra e quais oportunidades publica? | SmartLic |
-| licitacoes/[setor] | Editais de {setor} 2026 — Para sua Empresa | SmartLic | Melhores oportunidades para empresas de {setor} | SmartLic |
-| municipios/[slug] | Licitacoes em {nome}-{uf} — N editais abertos | Licitacoes abertas {prep} {nome}-{uf} | SmartLic |
+| Template | Arquivo | Título Anterior | Título Novo |
+|----------|---------|----------------|-------------|
+| cnpj/[cnpj] | frontend/app/cnpj/[cnpj]/page.tsx | `{razao_social} — Histórico de Contratos Públicos` | `Quanto {razao_social} fatura com o governo? \| SmartLic` |
+| fornecedores/[cnpj] | frontend/app/fornecedores/[cnpj]/page.tsx | `{razao_social} — Historico B2G \| {total_contratos} contratos` | `Contratos públicos de {razao_social} — CNPJ {cnpj} \| SmartLic` |
+| orgaos/[slug] | frontend/app/orgaos/[slug]/page.tsx | `{nome} — Licitações, Editais e Contratos` | `Como {nome} compra e quais oportunidades publica? \| SmartLic` |
+| licitacoes/[setor] | frontend/app/licitacoes/[setor]/page.tsx | `Editais de {sector.name} 2026 — Para sua Empresa \| SmartLic` | `Melhores oportunidades para empresas de {sector.name} \| SmartLic` |
+| municipios/[slug] | frontend/app/municipios/[slug]/page.tsx | `Licitações em {nome}-{uf} — {total_licitacoes_abertas} editais abertos` | `Licitações abertas {preposicao} {nome}-{uf} \| SmartLic` |
 
-**Total: 5 templates atualizados** (4 minimo exigido + 1 bonus = fornecedores, GSC direct hit).
+**Total: 5 templates atualizados** (4 mínimo exigido pela task + 1 bonus = fornecedores, GSC direct hit).

--- a/frontend/app/buscar/page.tsx
+++ b/frontend/app/buscar/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import PullToRefresh from "react-simple-pull-to-refresh";
@@ -34,10 +34,14 @@ import { SEARCH_TOUR_STEPS, RESULTS_TOUR_STEPS } from "./constants/tour-steps";
 import { ReferralToast, shouldShowReferralToast } from "./components/ReferralToast";
 import { RestoredResultsBanner } from "./components/RestoredResultsBanner";
 import { clearNewBidsBadge } from "../../components/NewBidsNotificationBadge";
+import { setClarityTag } from "../components/ClarityAnalytics";
 
 function HomePageContent() {
   const orch = useSearchOrchestration();
   const searchParams = useSearchParams();
+
+  // CONV-INST-005: fire first_analysis_done tag only once per session
+  const firstAnalysisDoneRef = useRef(false);
 
   // STORY-369 AC4: Exit survey state — shown once when trial expires
   const [showExitSurvey, setShowExitSurvey] = useState(false);
@@ -84,6 +88,21 @@ function HomePageContent() {
     if (!token) return;
     clearNewBidsBadge(token).catch(() => {/* best-effort */});
   }, [orch.search.result]);
+
+  // CONV-INST-005 AC2/AC3: tag plan_type (free_trial vs pro) when planInfo loads
+  useEffect(() => {
+    if (!orch.planInfo?.plan_id) return;
+    const planType = orch.planInfo.plan_id === "free_trial" ? "free_trial" : "pro";
+    setClarityTag("plan_type", planType);
+  }, [orch.planInfo?.plan_id]);
+
+  // CONV-INST-005 AC4: tag first_analysis_done once when results arrive
+  useEffect(() => {
+    if (firstAnalysisDoneRef.current) return;
+    if (!orch.search.result || orch.search.loading) return;
+    firstAnalysisDoneRef.current = true;
+    setClarityTag("first_analysis_done", "true");
+  }, [orch.search.result, orch.search.loading]);
 
   if (orch.authLoading) {
     return (

--- a/frontend/app/components/ClarityAnalytics.tsx
+++ b/frontend/app/components/ClarityAnalytics.tsx
@@ -51,3 +51,22 @@ export function ClarityAnalytics() {
 
   return null;
 }
+
+/**
+ * Set a custom session tag in Microsoft Clarity.
+ * SSR-safe: no-op when window is unavailable.
+ * LGPD-safe: no-op when window.clarity is not initialized
+ * (Clarity only loads after analytics consent via ClarityAnalytics component).
+ *
+ * @example
+ * setClarityTag("user_stage", "onboarding");
+ * setClarityTag("plan_type", "free_trial");
+ */
+export function setClarityTag(key: string, value: string): void {
+  if (typeof window !== "undefined") {
+    const win = window as Window & { clarity?: (...args: unknown[]) => void };
+    if (typeof win.clarity === "function") {
+      win.clarity("set", key, value);
+    }
+  }
+}

--- a/frontend/app/components/ClarityAnalytics.tsx
+++ b/frontend/app/components/ClarityAnalytics.tsx
@@ -52,21 +52,13 @@ export function ClarityAnalytics() {
   return null;
 }
 
-/**
- * Set a custom session tag in Microsoft Clarity.
- * SSR-safe: no-op when window is unavailable.
- * LGPD-safe: no-op when window.clarity is not initialized
- * (Clarity only loads after analytics consent via ClarityAnalytics component).
- *
- * @example
- * setClarityTag("user_stage", "onboarding");
- * setClarityTag("plan_type", "free_trial");
- */
+// SSR-safe + LGPD-safe: no-op when window unavailable or analytics not consented.
 export function setClarityTag(key: string, value: string): void {
-  if (typeof window !== "undefined") {
-    const win = window as Window & { clarity?: (...args: unknown[]) => void };
-    if (typeof win.clarity === "function") {
-      win.clarity("set", key, value);
-    }
+  if (typeof window === "undefined") return;
+  const consent = getCookieConsent();
+  if (!consent?.analytics) return;
+  const win = window as Window & { clarity?: (...args: unknown[]) => void };
+  if (typeof win.clarity === "function") {
+    win.clarity("set", key, value);
   }
 }

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -89,6 +89,11 @@ export default function OnboardingPage() {
     });
   }, [step1Form, step2Form]);
 
+  // CONV-INST-005 AC1: Tag session as onboarding stage on mount (LGPD guard in claritySet)
+  useEffect(() => {
+    claritySet("user_stage", "onboarding");
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // GTM-642: Auto-fill UF from CNPJ deep-link (/?cnpj=XXXXXXXXXXXXXXX)
   useEffect(() => {
     const cnpj = cnpjParam;


### PR DESCRIPTION
## Context
MS Clarity is instrumented (project ID `voop54cv1p`, lazy-load + LGPD consent gate) but had no custom session tags, making it impossible to segment trial vs paid, onboarding vs regular usage in the Clarity dashboard. This adds a `setClarityTag` helper and wires it into onboarding + buscar flows.

## Changes
- `frontend/app/components/ClarityAnalytics.tsx`: export `setClarityTag()` helper with SSR + `window.clarity` guard (LGPD-safe)
- `frontend/app/onboarding/page.tsx`: set `user_stage=onboarding` on mount (AC1)
- `frontend/app/buscar/page.tsx`: set `plan_type` (`free_trial` vs `pro`) when planInfo loads (AC2/AC3); set `first_analysis_done=true` once when results arrive (AC4)

## Testing Plan
- [ ] LGPD guard: `setClarityTag` is no-op when `window.clarity` unavailable (SSR safe, consent gate)
- [ ] TypeScript compiles without errors (`npx tsc --noEmit` passes — verified)
- [ ] No new console errors on /onboarding and /buscar pages
- [ ] In Clarity dashboard: sessions from /onboarding show `user_stage=onboarding`
- [ ] Trial users show `plan_type=free_trial`; paid users show `plan_type=pro`
- [ ] After first search result: `first_analysis_done=true` appears in session tags

## Risks & Rollback
Tags are additive — removing them requires a deploy. No data loss risk. LGPD guard prevents SSR crashes. `useRef` pattern prevents duplicate `first_analysis_done` fires.

## Closes
Closes #855