### PR TITLE
fix(backend,frontend): founding URLs /founding → /fundadores + 301 redirects (#862, #870)

### DIFF
--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -445,8 +445,8 @@ async def founding_checkout(
         "payment_method_types": ["card", "boleto"],
         "line_items": [{"price": founding_price_id, "quantity": 1}],
         "mode": "payment",
-        "success_url": f"{frontend_url}/founding/obrigado?session_id={{CHECKOUT_SESSION_ID}}",
-        "cancel_url": f"{frontend_url}/founding?cancelled=true",
+        "success_url": f"{frontend_url}/fundadores/obrigado?session_id={{CHECKOUT_SESSION_ID}}",
+        "cancel_url": f"{frontend_url}/fundadores?cancelled=true",
         "customer_email": payload.email,
         "metadata": {
             "source": "founding",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -54,9 +54,25 @@ const nextConfig = {
 
   // SEO: Redirect acentuado → slug canônico (ISSUE-SEO-004)
   // SEO: Consolidar pricing pages — /pricing → /planos (ISSUE-SEO-005)
+  // Fix #870: Redirecionar /founding → /fundadores (301 permanente)
   async redirects() {
     return [
       ...buildLegacyLicitacoesRedirects(),
+      {
+        source: '/founding/obrigado',
+        destination: '/fundadores/obrigado',
+        permanent: true,
+      },
+      {
+        source: '/founding',
+        destination: '/fundadores',
+        permanent: true,
+      },
+      {
+        source: '/founding/:path*',
+        destination: '/fundadores/:path*',
+        permanent: true,
+      },
       {
         source: '/gloss%C3%A1rio',
         destination: '/glossario',


### PR DESCRIPTION
## Contexto

Após o renomeio da página `/founding` para `/fundadores` (português), as URLs de retorno do Stripe Checkout continuavam apontando para `/founding` (inglês), quebrando o fluxo pós-pagamento. Além disso, usuários com links antigos ou bookmarks em `/founding` recebiam 404.

## Alterações

### #862 — `backend/routes/founding.py`

Corrige as duas URLs passadas ao Stripe na criação da sessão de checkout:

- `success_url`: `/founding/obrigado` → `/fundadores/obrigado`
- `cancel_url`: `/founding` → `/fundadores`

### #870 — `frontend/next.config.js`

Adiciona três redirecionamentos 301 permanentes no bloco `redirects()`:

- `/founding/obrigado` → `/fundadores/obrigado` (específico primeiro, para evitar conflito com catch-all)
- `/founding` → `/fundadores`
- `/founding/:path*` → `/fundadores/:path*` (catch-all para sub-rotas futuras)

A ordenação coloca `/founding/obrigado` antes do catch-all `/:path*` para garantir que o Next.js aplique a regra mais específica primeiro.

## Testing Plan

- [ ] Verificar que `POST /v1/founding/checkout` retorna `checkout_url` com `success_url` apontando para `/fundadores/obrigado`
- [ ] Verificar que `checkout_url` tem `cancel_url` apontando para `/fundadores`
- [ ] Acessar `/founding` em produção → confirmar redirect 301 para `/fundadores`
- [ ] Acessar `/founding/obrigado` → confirmar redirect 301 para `/fundadores/obrigado`
- [ ] Acessar `/founding/qualquer-subpagina` → confirmar redirect 301 para `/fundadores/qualquer-subpagina`
- [ ] Testes unitários: `pytest tests/ -k "founding" --ignore=tests/fuzz` → 71 passed ✅

## Riscos e Rollback

**Risco:** Baixo. Alterações pontuais de string (backend) e adição de redirects passivos (frontend). Não há mudança de lógica de negócio.

**Rollback:** Reverter o commit. Os redirects 301 são cacheados pelo browser, mas o Stripe sempre gera novas sessões com as URLs atuais — sem estado persistente afetado.

## Closes

Closes #862
Closes #870