### PR TITLE
fix(frontend): melhorias de copy /fundadores — FAQ, urgência, social proof (#867)

### DIFF
--- a/frontend/app/fundadores/FundadoresClient.tsx
+++ b/frontend/app/fundadores/FundadoresClient.tsx
@@ -92,13 +92,13 @@ export default function FundadoresClient() {
       <section className="bg-slate-900 text-white">
         <div className="mx-auto max-w-3xl px-4 py-16">
           <p className="text-sm uppercase tracking-widest text-blue-400 font-semibold mb-3">
-            Plano Fundadores — vagas limitadas
+            Plano Fundadores — oferta por tempo limitado
           </p>
           <h1 className="text-3xl sm:text-5xl font-bold leading-tight mb-4">
-            Entre cedo na infraestrutura de inteligência B2G do SmartLic.
+            Sua empresa B2G encontra a licitação certa em minutos, não em dias.
           </h1>
           <p className="text-lg sm:text-xl text-slate-300 mb-8">
-            Acesso vitalício antes da estrutura comercial definitiva.
+            Acesso vitalício ao SmartLic por R$997 pagamento único — antes do preço subir para R$397/mês.
           </p>
 
           <div className="mb-8">
@@ -117,24 +117,24 @@ export default function FundadoresClient() {
         {/* Problema */}
         <section aria-labelledby="problema-heading" className="mb-16">
           <h2 id="problema-heading" className="text-2xl font-semibold text-slate-900 mb-4">
-            Por que B2G é difícil
+            4 a 8 horas por semana perdidas pesquisando editais
           </h2>
           <div className="prose prose-slate max-w-none">
             <p>
               Licitações públicas são publicadas em dezenas de portais diferentes, em formatos
               inconsistentes, com terminologias confusas e prazos que mudam sem aviso. Empresas B2G
-              gastam horas toda semana só para descobrir o que está aberto — antes mesmo de
-              qualificar se vale a pena participar.
+              gastam entre 4 e 8 horas toda semana só para descobrir o que está aberto — antes mesmo
+              de qualificar se vale a pena participar.
             </p>
             <p className="mt-4">
-              <strong>Menos PDF. Mais decisão.</strong> O SmartLic agrega, filtra e classifica
+              <strong>O SmartLic resolve isso em minutos.</strong> Agrega, filtra e classifica
               automaticamente para que sua equipe foque no que importa: construir propostas
-              competitivas.
+              competitivas para editais que realmente valem a pena.
             </p>
             <p className="mt-4">
-              <strong>A IA encontra. A inteligência decide.</strong> Classificação setorial por
-              GPT-4.1-nano com precisão ≥85%, análise de viabilidade em quatro fatores e histórico
-              de 2 milhões de contratos públicos para benchmark de preço.
+              <strong>A IA encontra. Você decide.</strong> Classificação setorial por IA com
+              precisão ≥85%, análise de viabilidade em quatro fatores e histórico de 2 milhões de
+              contratos públicos para benchmark de preço — tudo em uma tela, em segundos.
             </p>
           </div>
         </section>
@@ -145,7 +145,7 @@ export default function FundadoresClient() {
         {/* Comparação */}
         <section aria-labelledby="comparacao-heading" className="mt-16">
           <h2 id="comparacao-heading" className="text-2xl font-semibold text-slate-900 mb-6">
-            Fundador vs Assinatura recorrente
+            Fundadores vs Pro — a conta fecha rápido
           </h2>
           <div className="overflow-x-auto">
             <table className="w-full text-sm border-collapse">
@@ -156,19 +156,20 @@ export default function FundadoresClient() {
                     Plano Fundadores
                   </th>
                   <th className="text-center px-4 py-3 font-semibold text-slate-700 border border-slate-200">
-                    Pro Recorrente
+                    Plano Pro
                   </th>
                 </tr>
               </thead>
               <tbody>
                 {[
-                  ['Modelo de cobrança', 'R$997 único', 'R$397/mês'],
+                  ['Modelo de cobrança', 'R$997 pagamento único', 'R$397/mês'],
                   ['Custo em 12 meses', 'R$997', 'R$4.764'],
+                  ['Custo em 24 meses', 'R$997', 'R$9.528'],
                   ['Acesso', 'Vitalício', 'Enquanto pagar'],
                   ['Todas as funcionalidades', '✓', '✓'],
                   ['Atualizações futuras', '✓ incluídas', '✓ incluídas'],
-                  ['Vagas disponíveis', 'Limitadas', 'Ilimitadas'],
-                  ['Ajude a financiar a próxima fase', '✓', '—'],
+                  ['Suporte prioritário com o fundador', '✓', '—'],
+                  ['Oferta disponível até', 'Data limite ativa', 'Sempre disponível'],
                 ].map(([label, founder, regular]) => (
                   <tr key={label} className="border border-slate-200 hover:bg-slate-50">
                     <td className="px-4 py-3 text-slate-700 border border-slate-200">{label}</td>
@@ -207,10 +208,10 @@ export default function FundadoresClient() {
           className="mt-16 rounded-xl border border-blue-200 bg-blue-50 p-8"
         >
           <h2 id="cta-final-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-            Reserve sua vaga agora
+            Garanta seu acesso antes do prazo encerrar
           </h2>
           <p className="text-slate-700 mb-6">
-            Acesso vitalício por {price}. Pagamento único via Stripe — cartão de crédito ou boleto.
+            {price} pagamento único — acesso vitalício, sem mensalidade, sem renovação. Via Stripe — cartão de crédito ou boleto.
           </p>
           <FundadoresForm availability={snapshot} price={price} />
         </section>

--- a/frontend/app/fundadores/components/FundadoresFAQ.tsx
+++ b/frontend/app/fundadores/components/FundadoresFAQ.tsx
@@ -9,28 +9,32 @@ interface FaqItem {
 
 const FAQS: FaqItem[] = [
   {
-    q: 'O que está incluído no Plano Fundadores?',
-    a: 'Acesso vitalício à plataforma SmartLic (busca multi-fonte, classificação IA, pipeline kanban, relatórios Excel, análise de viabilidade). Pagamento único de R$997 — sem mensalidade, sem surpresas.',
+    q: 'Por que pagar R$997 de uma vez em vez de assinar mensalmente?',
+    a: 'Matemática simples: o plano Pro custa R$397/mês. Em 12 meses, você pagaria R$4.764. Com o Plano Fundadores, paga R$997 uma única vez e nunca mais paga nada — acesso permanente. A partir do segundo ano, o SmartLic é gratuito para você. Sem mensalidade, sem cobrança automática, sem surpresas no cartão.',
   },
   {
-    q: 'Qual a diferença entre Fundador e assinante regular?',
-    a: 'O assinante regular paga R$397/mês (Pro) ou R$997/mês (Consultoria) recorrente. O Fundador paga R$997 uma única vez e tem acesso permanente, incluindo todas as atualizações futuras da plataforma.',
+    q: 'O que acontece se o SmartLic fechar ou mudar de direção?',
+    a: 'Entendemos a preocupação — é exatamente por isso que temos 30 dias de garantia incondicional. Se dentro desse prazo você não ficar satisfeito por qualquer motivo, devolvemos 100% do valor sem perguntas. Além disso, o compromisso vitalício é real: o Tiago Sasaki (fundador) está disponível diretamente em tiago@smartlic.tech para qualquer dúvida ou problema.',
   },
   {
-    q: 'Posso cancelar ou pedir reembolso?',
-    a: 'Sim. Oferecemos 30 dias de garantia. Se não ficar satisfeito por qualquer motivo dentro deste prazo, devolvemos 100% do valor pago sem questionamentos.',
+    q: 'Tem suporte incluso? Como funciona?',
+    a: 'Sim, e é suporte prioritário. Como Fundador, você tem acesso direto ao fundador via email (tiago@smartlic.tech) com tempo de resposta inferior a 4 horas úteis para problemas críticos. Você não cai em fila de chamados — fala direto com quem construiu o produto. Os primeiros Fundadores também recebem uma sessão de onboarding personalizada.',
+  },
+  {
+    q: 'Posso usar em quantas empresas ou CNPJs?',
+    a: 'O Plano Fundadores cobre 1 conta vinculada a 1 CNPJ. Se você gerencia licitações para múltiplas empresas (consultoria, assessoria), entre em contato para discutir um plano adequado. Upgrades estão disponíveis e Fundadores têm condições especiais.',
+  },
+  {
+    q: 'Como acesso o SmartLic após o pagamento?',
+    a: 'Imediatamente após a confirmação do pagamento pelo Stripe, você recebe um email automático com magic link de acesso. Em até 24 horas, sua conta é configurada com o Plano Fundadores ativo. Se houver qualquer problema, escreva para tiago@smartlic.tech e resolvemos na hora.',
   },
   {
     q: 'O SmartLic funciona para meu setor?',
-    a: 'O SmartLic cobre 20 setores B2G com classificação por IA (GPT-4.1-nano). Se seu setor não estiver listado, entre em contato — adicionamos novos setores com base na demanda dos fundadores.',
+    a: 'O SmartLic cobre 20 setores B2G com classificação por IA — de construção e TI a saúde e meio ambiente. Se o seu setor não estiver listado, entre em contato antes de comprar. Fundadores têm voz direta na priorização de novos setores.',
   },
   {
-    q: 'Quantas vagas restam?',
-    a: 'O Plano Fundadores é limitado. As vagas são preenchidas por ordem de chegada. O contador ao topo da página mostra a disponibilidade em tempo real.',
-  },
-  {
-    q: 'Que suporte recebo como Fundador?',
-    a: 'Acesso à linha direta com o fundador (Tiago Sasaki) via email/WhatsApp. Response time < 4h úteis para bugs críticos. Sessão de onboarding inclusa para os primeiros clientes.',
+    q: 'O que está incluído no Plano Fundadores?',
+    a: 'Acesso vitalício completo: busca multi-fonte unificada, classificação por IA com precisão ≥85%, análise de viabilidade em 4 fatores, pipeline Kanban de oportunidades, relatórios Excel estilizados, resumo executivo por IA e histórico de 2 milhões de contratos públicos para benchmark de preço. Tudo que existe hoje e tudo que for lançado no futuro.',
   },
 ];
 

--- a/frontend/app/fundadores/components/FundadoresFeatures.tsx
+++ b/frontend/app/fundadores/components/FundadoresFeatures.tsx
@@ -5,57 +5,85 @@ interface Feature {
 
 const FEATURES: Feature[] = [
   {
-    title: 'Busca multi-fonte unificada',
+    title: 'Busca multi-fonte em minutos, não horas',
     description:
-      'PNCP + Portal de Compras Públicas + ComprasGov em uma busca consolidada com deduplicação automática.',
+      'Agrega nossas fontes de dados públicos em uma busca consolidada com deduplicação automática. O que levava 4–8h/semana de pesquisa manual, o SmartLic faz em minutos.',
   },
   {
-    title: 'Classificação por IA',
+    title: 'IA decide o que é relevante para você',
     description:
-      'GPT-4.1-nano classifica relevância setorial com precisão ≥85%. Menos falso positivo, menos tempo perdido.',
+      'GPT-4.1-nano classifica a relevância setorial com precisão ≥85%. Você vê apenas editais que fazem sentido para o seu negócio — sem ruído, sem perda de tempo com falsos positivos.',
   },
   {
-    title: 'Análise de viabilidade',
+    title: 'Análise de viabilidade antes de abrir o PDF',
     description:
-      'Quatro fatores (modalidade, timeline, valor, geografia) pontuam cada edital antes de você abrir o PDF.',
+      'Quatro fatores (modalidade, timeline, valor, geografia) pontuam cada edital automaticamente. Você decide em segundos se vale ou não vale o esforço de uma proposta.',
   },
   {
-    title: 'Pipeline Kanban',
+    title: 'Pipeline Kanban: do radar à proposta em uma tela',
     description:
-      'Gestão de oportunidades com drag-and-drop. Do radar à proposta enviada em uma tela.',
+      'Gestão de oportunidades com drag-and-drop. Acompanhe todos os editais do seu funil — prospecção, análise, proposta — sem planilha, sem post-it.',
   },
   {
-    title: 'Relatórios Excel + IA',
+    title: 'Relatórios prontos para apresentar',
     description:
-      'Excel estilizado + resumo executivo gerado por IA para cada busca. Pronto para apresentar ao time.',
+      'Excel estilizado + resumo executivo gerado por IA para cada busca. Apresente resultados profissionais ao seu time ou cliente sem formatação manual.',
   },
   {
-    title: '2 milhões de contratos indexados',
+    title: 'Benchmark de preço com 2 milhões de contratos',
     description:
-      'Histórico de licitações para benchmark de preço, mapeamento de concorrentes e análise de mercado B2G.',
+      'Histórico completo de licitações para saber quanto concorrentes cobram, quem ganha em cada órgão e qual é o preço justo para sua proposta vencer.',
   },
 ];
 
 export default function FundadoresFeatures() {
   return (
-    <section aria-labelledby="features-heading" className="mt-16">
-      <h2 id="features-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-        O que está incluído
-      </h2>
-      <p className="text-slate-600 mb-8">
-        Tudo que você precisa para encontrar, qualificar e acompanhar licitações públicas.
-      </p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        {FEATURES.map((feat) => (
-          <div
-            key={feat.title}
-            className="rounded-lg border border-slate-200 bg-slate-50 p-5"
-          >
-            <h3 className="font-semibold text-slate-900 mb-1">{feat.title}</h3>
-            <p className="text-sm text-slate-600 leading-relaxed">{feat.description}</p>
-          </div>
-        ))}
-      </div>
-    </section>
+    <>
+      <section aria-labelledby="features-heading" className="mt-16">
+        <h2 id="features-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+          O que você ganha — permanentemente
+        </h2>
+        <p className="text-slate-600 mb-8">
+          Acesso vitalício a tudo que existe hoje e a tudo que for lançado no futuro. Sem mensalidade.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          {FEATURES.map((feat) => (
+            <div
+              key={feat.title}
+              className="rounded-lg border border-slate-200 bg-slate-50 p-5"
+            >
+              <h3 className="font-semibold text-slate-900 mb-1">{feat.title}</h3>
+              <p className="text-sm text-slate-600 leading-relaxed">{feat.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Social proof */}
+      {/* TODO: adicionar depoimentos reais de usuários beta assim que coletados */}
+      <section aria-labelledby="social-proof-heading" className="mt-16">
+        <h2 id="social-proof-heading" className="text-2xl font-semibold text-slate-900 mb-6">
+          O que dizem os primeiros usuários
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <blockquote className="rounded-lg border border-slate-200 bg-slate-50 p-5">
+            <p className="text-slate-700 leading-relaxed italic mb-3">
+              &ldquo;[TODO: adicionar depoimento real — ex: &apos;Antes gastava 6 horas na segunda-feira só pesquisando portais. Agora abro o SmartLic e em 10 minutos sei o que vale a pena trabalhar na semana.&apos;]&rdquo;
+            </p>
+            <footer className="text-sm text-slate-500">
+              — [TODO: Nome, Cargo, Empresa]
+            </footer>
+          </blockquote>
+          <blockquote className="rounded-lg border border-slate-200 bg-slate-50 p-5">
+            <p className="text-slate-700 leading-relaxed italic mb-3">
+              &ldquo;[TODO: adicionar depoimento real — ex: &apos;A análise de viabilidade mudou nossa forma de decidir quais editais vale disputar. Deixamos de perder tempo com processos impossíveis de ganhar.&apos;]&rdquo;
+            </p>
+            <footer className="text-sm text-slate-500">
+              — [TODO: Nome, Cargo, Empresa]
+            </footer>
+          </blockquote>
+        </div>
+      </section>
+    </>
   );
 }


### PR DESCRIPTION
## Contexto

A página `/fundadores` oferece acesso **vitalício** ao SmartLic por R$997 pagamento único. O copy anterior comunicava a oferta de forma técnica e genérica, sem responder às objeções reais de compra e sem transmitir o ROI principal para empresas B2G.

## Mudanças

**`FundadoresClient.tsx`**
- Hero badge: `"vagas limitadas"` → `"oferta por tempo limitado"` (apenas countdown de prazo, sem contagem de seats)
- Headline: `"Entre cedo na infraestrutura..."` → `"Sua empresa B2G encontra a licitação certa em minutos, não em dias."` — ROI/velocidade como promessa central
- Subtítulo hero: explícita a comparação de preço (R$997 único vs R$397/mês) para ancoragem de valor imediata
- Seção "Problema": headline quantifica o tempo perdido (4–8h/semana); body reforça "em minutos"
- Tabela comparação: nova linha "Custo em 24 meses", "Vagas disponíveis" removida, "Pro Recorrente" → "Plano Pro", "Suporte prioritário com o fundador" adicionado
- CTA final: `"Reserve sua vaga agora"` → `"Garanta seu acesso antes do prazo encerrar"` (urgência de tempo, não de seats)

**`FundadoresFAQ.tsx`**
- 6 FAQs genéricas → 7 perguntas focadas em objeções reais de compra:
  1. Por que pagar R$997 de uma vez? (cálculo R$4.764 vs R$997)
  2. O que acontece se o SmartLic fechar? (garantia 30 dias + contato direto Tiago)
  3. Tem suporte? (suporte prioritário direto ao fundador)
  4. Quantos CNPJs? (1 por conta + upgrade disponível)
  5. Como acesso após o pagamento? (email automático + magic link + 24h)
  6. Funciona para meu setor? (20 setores + voz direta na priorização)
  7. O que está incluído? (completo, com menção de funcionalidades)
- Removida: "Quantas vagas restam?" (substituída por prazo no countdown)

**`FundadoresFeatures.tsx`**
- Títulos de features: técnicos → orientados a resultado/tempo poupado
  - `"Busca multi-fonte unificada"` → `"Busca multi-fonte em minutos, não horas"`
  - `"Classificação por IA"` → `"IA decide o que é relevante para você"`
  - etc.
- Heading da seção: `"O que está incluído"` → `"O que você ganha — permanentemente"`
- Subtítulo: reforça "vitalício" e "sem mensalidade"
- Nova seção **Social Proof** adicionada com 2 placeholders marcados explicitamente com `[TODO: adicionar depoimento real]`

## Testing Plan

- [ ] Abrir `/fundadores` em produção/staging e verificar que headline e badge estão corretos
- [ ] Expandir todos os 7 itens da FAQ e verificar que as respostas renderizam sem quebra de layout
- [ ] Confirmar que countdown de prazo aparece e não há nenhuma menção a "vagas" na hero section
- [ ] Verificar que a tabela comparativa exibe todas as 8 linhas corretamente no mobile
- [ ] Substituir os `[TODO]` da seção social proof com depoimentos reais quando disponíveis

## Riscos e Rollback

- Mudanças são **exclusivamente de copy** — zero alteração em lógica, componentes, props ou APIs
- Rollback: `git revert 5a7b0513d` ou reverter os 3 arquivos manualmente

## Closes

Closes #867