### PR TITLE
feat(backend): GET /v1/founding/session-status — enricher para página /fundadores/obrigado (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added — Backend / Founders
+- **`GET /v1/founding/session-status` — enricher para /fundadores/obrigado (#865)** — Endpoint público com rate limit (10 req/min/IP) que retorna `status`, `email` mascarado (2 chars + ****@domínio), `has_account` e `invite_sent` para o frontend renderizar CTA pós-compra correto sem expor PII. Expiry guard: leads não-`completed` com age > 24h retornam `status=pending` para evitar polling infinito. `_run_with_budget(5.0s)` protege o event loop. 8 testes unitários.
 - **Founders welcome email template + ARQ job + founding_leads tracking fields (#791)** — `templates/emails/founders_welcome.py` com HTML + plain text, tom pessoal direto de Tiago. `send_founders_welcome_email()` em `email_service.py` com gate de idempotência via `founding_leads.welcome_sent_at`. `send_founders_welcome` ARQ job (despacha email + Mixpanel people.set). Migration `20260507130000_founding_leads_tracking_fields.sql`: adiciona `welcome_sent_at`, `checkout_source`, `offer_version` à tabela `founding_leads`. Índice parcial `idx_founding_leads_welcome_pending` para queries de idempotência. 19 testes unitários. Rollback: `20260507130000_founding_leads_tracking_fields.down.sql`.
 
 ### Fixed — SEO / Structured Data

--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -157,7 +157,10 @@ def _mask_email(email: str) -> str:
     """Return a masked email exposing only the first 2 chars of the local part.
 
     Example: ``mariaalvabaron@gmail.com`` -> ``ma****@gmail.com``
+    Returns the input unchanged if it does not contain ``@`` (malformed).
     """
+    if "@" not in email:
+        return email
     local, domain = email.split("@", 1)
     return f"{local[:2]}****@{domain}"
 

--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -112,6 +112,19 @@ class FoundingAvailabilityResponse(BaseModel):
     price_brl_cents: int = Field(default=99700, description="Price in BRL cents")
 
 
+class FoundingSessionStatusResponse(BaseModel):
+    """Enriched session status for the /fundadores/obrigado page (#865).
+
+    Returns masked email, has_account, and invite_sent so the frontend can
+    render the correct post-purchase CTA without exposing full PII.
+    """
+
+    status: str = Field(description="'completed' | 'pending' | 'not_found'")
+    email: str = Field(description="Masked email (2 chars before @ + **** + domain).")
+    has_account: bool = Field(description="True if a profiles row exists for this email.")
+    invite_sent: bool = Field(description="True if magic_link_sent_at IS NOT NULL.")
+
+
 def _is_valid_cnpj_check_digits(cnpj: str) -> bool:
     """Validate Brazilian CNPJ check digits. `cnpj` must be 14 digits already."""
     if len(cnpj) != 14 or not cnpj.isdigit():
@@ -140,6 +153,15 @@ def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
+def _mask_email(email: str) -> str:
+    """Return a masked email exposing only the first 2 chars of the local part.
+
+    Example: ``mariaalvabaron@gmail.com`` -> ``ma****@gmail.com``
+    """
+    local, domain = email.split("@", 1)
+    return f"{local[:2]}****@{domain}"
+
+
 def _already_registered(sb, email: str) -> bool:
     """Return True if the email already owns a profile. Best-effort, non-blocking."""
     try:
@@ -148,6 +170,22 @@ def _already_registered(sb, email: str) -> bool:
     except Exception as e:
         logger.warning(f"founding: profile lookup failed (non-blocking): {e}")
         return False
+
+
+def _get_session_lead(sb, session_id: str) -> dict | None:
+    """Return founding_leads row for the given Stripe checkout session ID.
+
+    Returns ``None`` when not found. Raises on unexpected DB errors.
+    """
+    res = (
+        sb.table("founding_leads")
+        .select("email, checkout_status, magic_link_sent_at, created_at")
+        .eq("checkout_session_id", session_id)
+        .limit(1)
+        .execute()
+    )
+    rows = res.data or []
+    return rows[0] if rows else None
 
 
 def _check_availability(sb) -> dict[str, Any]:
@@ -316,6 +354,104 @@ async def founding_checkout_status(
     except Exception as exc:
         logger.warning(f"founding: checkout/status retrieval failed — session_id_prefix={session_id[:8]} err={exc}")
         return FoundingCheckoutStatusResponse(status="unknown", payment_status="unpaid")
+
+
+@router.get("/session-status", response_model=FoundingSessionStatusResponse)
+async def founding_session_status(
+    session_id: str = Query(..., min_length=8),
+    _rl=Depends(require_rate_limit(10, 60)),
+) -> Any:
+    """Enriched session status for the /fundadores/obrigado confirmation page (#865).
+
+    No auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.
+    Returns masked email, ``has_account``, and ``invite_sent`` so the frontend
+    can render the right post-purchase CTA without polling Stripe directly.
+
+    Expiry guard: sessions with checkout_status != 'completed' that are older
+    than 24 h return ``status='pending'`` to prevent infinite polling.
+    """
+    from datetime import datetime, timezone
+
+    sb = get_supabase()
+
+    def _fetch():
+        return _get_session_lead(sb, session_id)
+
+    try:
+        lead = await _run_with_budget(
+            asyncio.to_thread(_fetch),
+            budget=5.0,
+            phase="route",
+            source="founding.session_status",
+        )
+    except Exception as exc:
+        logger.warning(
+            f"founding: session-status DB error — session_id_prefix={session_id[:8]} err={exc}"
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Erro temporário ao consultar status. Tente novamente.",
+        )
+
+    if lead is None:
+        return FoundingSessionStatusResponse(
+            status="not_found",
+            email="",
+            has_account=False,
+            invite_sent=False,
+        )
+
+    email: str = lead.get("email", "") or ""
+    checkout_status: str = lead.get("checkout_status", "") or ""
+    magic_link_sent_at = lead.get("magic_link_sent_at")
+    created_at_raw = lead.get("created_at")
+
+    # Status resolution — completed is always returned as-is.
+    # Non-completed leads older than 24 h are capped at "pending" to stop polling.
+    status: str
+    if checkout_status == "completed":
+        status = "completed"
+    else:
+        age_expired = False
+        if created_at_raw:
+            try:
+                created_dt = (
+                    datetime.fromisoformat(created_at_raw.replace("Z", "+00:00"))
+                    if isinstance(created_at_raw, str)
+                    else created_at_raw
+                )
+                if created_dt.tzinfo is None:
+                    created_dt = created_dt.replace(tzinfo=timezone.utc)
+                if (datetime.now(tz=timezone.utc) - created_dt).total_seconds() > 86400:
+                    age_expired = True
+            except Exception:
+                pass  # unparseable date — leave age_expired=False (safe)
+        status = "pending" if age_expired else (checkout_status or "pending")
+
+    # has_account — non-blocking profile lookup
+    has_account = False
+    if email:
+        try:
+            has_account = await asyncio.to_thread(_already_registered, sb, email)
+        except Exception as exc:
+            logger.warning(
+                f"founding: session-status profile check failed (non-blocking): {exc}"
+            )
+
+    invite_sent = bool(magic_link_sent_at)
+    masked = _mask_email(email) if email else ""
+
+    logger.info(
+        f"founding: session-status — session_id_prefix={session_id[:8]} "
+        f"status={status} has_account={has_account} invite_sent={invite_sent}"
+    )
+
+    return FoundingSessionStatusResponse(
+        status=status,
+        email=masked,
+        has_account=has_account,
+        invite_sent=invite_sent,
+    )
 
 
 @router.post("/checkout", response_model=FoundingCheckoutResponse)

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -5412,6 +5412,39 @@
         "title": "FoundingCheckoutStatusResponse",
         "type": "object"
       },
+      "FoundingSessionStatusResponse": {
+        "description": "Enriched session status for the /fundadores/obrigado page (#865).\n\nReturns masked email, has_account, and invite_sent so the frontend can\nrender the correct post-purchase CTA without exposing full PII.",
+        "properties": {
+          "email": {
+            "description": "Masked email (2 chars before @ + **** + domain).",
+            "title": "Email",
+            "type": "string"
+          },
+          "has_account": {
+            "description": "True if a profiles row exists for this email.",
+            "title": "Has Account",
+            "type": "boolean"
+          },
+          "invite_sent": {
+            "description": "True if magic_link_sent_at IS NOT NULL.",
+            "title": "Invite Sent",
+            "type": "boolean"
+          },
+          "status": {
+            "description": "'completed' | 'pending' | 'not_found'",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "email",
+          "has_account",
+          "invite_sent"
+        ],
+        "title": "FoundingSessionStatusResponse",
+        "type": "object"
+      },
       "FoundingLeadEntry": {
         "properties": {
           "checkout_status": {
@@ -18775,6 +18808,50 @@
           }
         },
         "summary": "Founding Checkout Status",
+        "tags": [
+          "founding"
+        ]
+      }
+    },
+    "/v1/founding/session-status": {
+      "get": {
+        "description": "Enriched session status for the /fundadores/obrigado confirmation page (#865).\n\nNo auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.\nReturns masked email, ``has_account``, and ``invite_sent`` so the frontend\ncan render the right post-purchase CTA without polling Stripe directly.\n\nExpiry guard: sessions with checkout_status != 'completed' that are older\nthan 24 h return ``status='pending'`` to prevent infinite polling.",
+        "operationId": "founding_session_status_v1_founding_session_status_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "minLength": 8,
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoundingSessionStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Founding Session Status",
         "tags": [
           "founding"
         ]

--- a/backend/tests/test_founding_checkout.py
+++ b/backend/tests/test_founding_checkout.py
@@ -487,3 +487,136 @@ def test_checkout_v2_checkout_source_from_query_param(
 
     call_kwargs = stripe_create_mock.call_args.kwargs
     assert call_kwargs["metadata"]["checkout_source"] == "email_campaign"
+
+
+# ---------------------------------------------------------------------------
+# _mask_email helper (#865)
+# ---------------------------------------------------------------------------
+
+
+def test_mask_email_basic():
+    from routes.founding import _mask_email
+
+    assert _mask_email("mariaalvabaron@gmail.com") == "ma****@gmail.com"
+
+
+def test_mask_email_preserves_domain():
+    from routes.founding import _mask_email
+
+    masked = _mask_email("founder@smartlic.tech")
+    assert masked.endswith("@smartlic.tech")
+    assert masked.startswith("fo****")
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/founding/session-status (#865)
+# ---------------------------------------------------------------------------
+
+
+def _make_lead_row(
+    *,
+    email="maria@example.com",
+    checkout_status="completed",
+    magic_link_sent_at=None,
+    created_at="2026-05-08T10:00:00+00:00",
+):
+    return {
+        "email": email,
+        "checkout_status": checkout_status,
+        "magic_link_sent_at": magic_link_sent_at,
+        "created_at": created_at,
+    }
+
+
+def _make_sb_for_session(lead_row, *, has_profile=False):
+    """Build a minimal Supabase mock for session-status queries."""
+    sb = MagicMock()
+    tbl = MagicMock()
+    sb.table.return_value = tbl
+    tbl.select.return_value = tbl
+    tbl.eq.return_value = tbl
+    tbl.limit.return_value = tbl
+    lead_result = MagicMock(data=[lead_row] if lead_row else [])
+    profile_result = MagicMock(data=[{"id": "profile-1"}] if has_profile else [])
+    tbl.execute.side_effect = [lead_result, profile_result]
+    return sb
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_returns_completed(mock_get_supabase, app_with_founding):
+    sb = _make_sb_for_session(_make_lead_row(checkout_status="completed"))
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_12345678")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "completed"
+    assert body["email"] == "ma****@example.com"
+    assert body["has_account"] is False
+    assert body["invite_sent"] is False
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_not_found_when_no_lead(mock_get_supabase, app_with_founding):
+    sb = _make_sb_for_session(None)
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_nonexistent_1234")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "not_found"
+    assert body["email"] == ""
+    assert body["has_account"] is False
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_invite_sent_true_when_magic_link_set(
+    mock_get_supabase, app_with_founding
+):
+    lead = _make_lead_row(
+        checkout_status="completed",
+        magic_link_sent_at="2026-05-08T11:00:00+00:00",
+    )
+    sb = _make_sb_for_session(lead)
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_magic_link")
+    assert r.status_code == 200
+    assert r.json()["invite_sent"] is True
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_has_account_true_when_profile_exists(
+    mock_get_supabase, app_with_founding
+):
+    sb = _make_sb_for_session(_make_lead_row(checkout_status="completed"), has_profile=True)
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_has_acct_1")
+    assert r.status_code == 200
+    assert r.json()["has_account"] is True
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_expired_lead_returns_pending(mock_get_supabase, app_with_founding):
+    """A non-completed lead older than 24 h must return status='pending'."""
+    old_created_at = "2026-05-06T08:00:00+00:00"  # > 24 h before 2026-05-08
+    lead = _make_lead_row(checkout_status="pending", created_at=old_created_at)
+    sb = _make_sb_for_session(lead)
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_expired_lead")
+    assert r.status_code == 200
+    assert r.json()["status"] == "pending"
+
+
+def test_session_status_rejects_short_session_id(app_with_founding):
+    """session_id shorter than 8 chars must return 422."""
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=short")
+    assert r.status_code == 422

--- a/backend/tests/test_founding_session_status.py
+++ b/backend/tests/test_founding_session_status.py
@@ -1,0 +1,249 @@
+"""Tests for GET /v1/founding/session-status (#865).
+
+Verifies the enriched session-status endpoint used by /fundadores/obrigado
+to determine post-purchase copy (has account vs. "check your email").
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_fake")
+os.environ.setdefault("FOUNDING_ONE_TIME_PRICE_ID", "price_test_founding_lifetime")
+
+from routes.founding import _mask_email, router as founding_router  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _mask_email unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_mask_email_standard():
+    assert _mask_email("mariaalvabaron@gmail.com") == "ma****@gmail.com"
+
+
+def test_mask_email_short_local_part():
+    assert _mask_email("ab@example.com") == "ab****@example.com"
+
+
+def test_mask_email_one_char_local_part():
+    # Only 1 char before @: local[:2] still returns 1 char
+    assert _mask_email("a@example.com") == "a****@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_founding():
+    app = FastAPI()
+    app.include_router(founding_router, prefix="/v1")
+    return app
+
+
+def _mk_sb(lead_row=None, profile_row=None):
+    """Build a minimal Supabase mock that returns deterministic data."""
+    sb = MagicMock()
+
+    class _Chain:
+        def __init__(self):
+            self._table = None
+            self._lead_row = lead_row
+            self._profile_row = profile_row
+
+        def table(self, name):
+            self._table = name
+            return self
+
+        def select(self, *a, **kw):
+            return self
+
+        def eq(self, *a, **kw):
+            return self
+
+        def limit(self, *a, **kw):
+            return self
+
+        def execute(self):
+            if self._table == "founding_leads":
+                return MagicMock(data=[self._lead_row] if self._lead_row else [])
+            if self._table == "profiles":
+                return MagicMock(data=[self._profile_row] if self._profile_row else [])
+            return MagicMock(data=[])
+
+    chain = _Chain()
+    sb.table.side_effect = lambda name: chain.table(name)
+    return sb
+
+
+# ---------------------------------------------------------------------------
+# Happy path: completed session, user HAS an account
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_completed_with_account(mock_get_supabase, app_with_founding):
+    lead = {
+        "email": "founder@empresa.com.br",
+        "checkout_status": "completed",
+        "magic_link_sent_at": None,
+        "created_at": "2026-05-08T10:00:00+00:00",
+    }
+    profile = {"id": "some-uuid"}
+
+    # Build a mock that returns the lead row for founding_leads and a profile
+    sb = MagicMock()
+    call_count = {"n": 0}
+
+    def table_side_effect(name):
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        if name == "founding_leads":
+            chain.execute.return_value = MagicMock(data=[lead])
+        elif name == "profiles":
+            chain.execute.return_value = MagicMock(data=[profile])
+        else:
+            chain.execute.return_value = MagicMock(data=[])
+        return chain
+
+    sb.table.side_effect = table_side_effect
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_12345678")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "completed"
+    assert body["has_account"] is True
+    assert body["invite_sent"] is False
+    # Email must be masked
+    assert "@" in body["email"]
+    assert "fo****@" in body["email"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path: completed, no account, invite sent
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_completed_no_account_invite_sent(
+    mock_get_supabase, app_with_founding
+):
+    lead = {
+        "email": "newuser@gmail.com",
+        "checkout_status": "completed",
+        "magic_link_sent_at": "2026-05-08T11:00:00+00:00",
+        "created_at": "2026-05-08T10:00:00+00:00",
+    }
+
+    sb = MagicMock()
+
+    def table_side_effect(name):
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        if name == "founding_leads":
+            chain.execute.return_value = MagicMock(data=[lead])
+        elif name == "profiles":
+            chain.execute.return_value = MagicMock(data=[])  # no profile
+        else:
+            chain.execute.return_value = MagicMock(data=[])
+        return chain
+
+    sb.table.side_effect = table_side_effect
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_12345678")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "completed"
+    assert body["has_account"] is False
+    assert body["invite_sent"] is True
+    assert "ne****@gmail.com" == body["email"]
+
+
+# ---------------------------------------------------------------------------
+# Lead not found in DB → status='not_found'
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_not_found(mock_get_supabase, app_with_founding):
+    sb = MagicMock()
+
+    def table_side_effect(name):
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = MagicMock(data=[])
+        return chain
+
+    sb.table.side_effect = table_side_effect
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_notexist")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "not_found"
+    assert body["email"] == ""
+    assert body["has_account"] is False
+    assert body["invite_sent"] is False
+
+
+# ---------------------------------------------------------------------------
+# session_id too short → 422 validation error
+# ---------------------------------------------------------------------------
+
+
+def test_session_status_short_session_id_rejected(app_with_founding):
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=short")
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit header is present in response
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.founding.get_supabase")
+def test_session_status_rate_limit_headers_present(
+    mock_get_supabase, app_with_founding
+):
+    sb = MagicMock()
+
+    def table_side_effect(name):
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = MagicMock(data=[])
+        return chain
+
+    sb.table.side_effect = table_side_effect
+    mock_get_supabase.return_value = sb
+
+    client = TestClient(app_with_founding)
+    r = client.get("/v1/founding/session-status?session_id=cs_test_12345678")
+    # Rate limiter injects X-RateLimit-* headers when Redis is available.
+    # In unit tests Redis is absent, so the endpoint still returns 200
+    # (require_rate_limit is a soft limiter with Redis fallback).
+    assert r.status_code == 200

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -3116,6 +3116,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/founding/session-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Session Status
+         * @description Enriched session status for the /fundadores/obrigado confirmation page (#865).
+         *
+         *     No auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.
+         *     Returns masked email, ``has_account``, and ``invite_sent`` so the frontend
+         *     can render the right post-purchase CTA without polling Stripe directly.
+         *
+         *     Expiry guard: sessions with checkout_status != 'completed' that are older
+         *     than 24 h return ``status='pending'`` to prevent infinite polling.
+         */
+        get: operations["founding_session_status_v1_founding_session_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -7805,6 +7832,35 @@ export interface components {
             seats_remaining: number;
             /** Seats Taken */
             seats_taken: number;
+        };
+        /**
+         * FoundingSessionStatusResponse
+         * @description Enriched session status for the /fundadores/obrigado page (#865).
+         *
+         *     Returns masked email, has_account, and invite_sent so the frontend can
+         *     render the correct post-purchase CTA without exposing full PII.
+         */
+        FoundingSessionStatusResponse: {
+            /**
+             * Email
+             * @description Masked email (2 chars before @ + **** + domain).
+             */
+            email: string;
+            /**
+             * Has Account
+             * @description True if a profiles row exists for this email.
+             */
+            has_account: boolean;
+            /**
+             * Invite Sent
+             * @description True if magic_link_sent_at IS NOT NULL.
+             */
+            invite_sent: boolean;
+            /**
+             * Status
+             * @description 'completed' | 'pending' | 'not_found'
+             */
+            status: string;
         };
         /** GSCLowCTROpportunity */
         GSCLowCTROpportunity: {
@@ -14900,6 +14956,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FoundingCheckoutStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_session_status_v1_founding_session_status_get: {
+        parameters: {
+            query: {
+                session_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingSessionStatusResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Contexto

A página `/fundadores/obrigado` precisa saber se o comprador já tem conta no SmartLic e se o convite foi enviado, para renderizar o CTA correto pós-compra. O endpoint existente `/v1/founding/checkout/status` só retorna `status` e `payment_status` do Stripe, sem informações de conta.

## Mudanças

**`backend/routes/founding.py`**
- Novo response model `FoundingSessionStatusResponse` com campos `status`, `email` (mascarado), `has_account`, `invite_sent`
- Helper `_mask_email(email)`: expõe apenas 2 chars do local part + `****` + domínio (ex: `ma****@gmail.com`)
- Helper `_get_session_lead(sb, session_id)`: busca o lead em `founding_leads` por `checkout_session_id`
- Endpoint `GET /v1/founding/session-status?session_id={cs_*}`:
  - Público, sem auth — session_id do Stripe é suficientemente opaco
  - Rate limit 10 req/min por IP via `require_rate_limit`
  - Retorna `not_found` se session_id não existe em `founding_leads`
  - Expiry guard: leads não-`completed` com age > 24 h retornam `status='pending'` para evitar polling infinito
  - `has_account`: lookup em `profiles` por email (best-effort, não bloqueia)
  - `invite_sent`: `magic_link_sent_at IS NOT NULL` em `founding_leads`

**`backend/tests/test_founding_checkout.py`**
- `test_mask_email_basic` e `test_mask_email_preserves_domain`
- `test_session_status_returns_completed`
- `test_session_status_not_found_when_no_lead`
- `test_session_status_invite_sent_true_when_magic_link_set`
- `test_session_status_has_account_true_when_profile_exists`
- `test_session_status_expired_lead_returns_pending`
- `test_session_status_rejects_short_session_id`

## Testing Plan

- [x] `python3 -m pytest tests/test_founding_checkout.py -q --timeout=30` → **37 passed**
- [x] `python3 -m pytest tests/ -k "founding" --ignore=tests/fuzz -q --timeout=30` → **79 passed**
- [ ] Testar manualmente em staging: `GET /v1/founding/session-status?session_id=cs_test_*` com session válida e inválida
- [ ] Verificar response mascaramento de email na resposta

## Riscos e Rollback

- **Risco baixo**: endpoint aditivo — nenhum endpoint existente foi alterado
- **Rollback**: reverter o commit ou remover o endpoint do router sem impacto em produção
- Endpoint público com rate limit protege contra scraping. session_id do Stripe é `cs_live_*` com entropia suficiente para não ser adivinhado por força bruta

## Closes

Closes #865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint for checking founding session status after checkout, returning session status, masked email, account status, and invitation information.

* **Tests**
  * Added comprehensive unit and integration test coverage for the new session status endpoint, including validation and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->