### PR TITLE
feat(backend): founders welcome email — template + trigger pós-ativação

### DIFF
--- a/backend/tests/test_founding_webhook_lifetime.py
+++ b/backend/tests/test_founding_webhook_lifetime.py
@@ -28,6 +28,8 @@ from webhooks.handlers.founding import (  # noqa: E402
     _activate_lifetime_founder_entitlement,
     _read_consulting_discount_pct,
     _resolve_user_id_from_email,
+    _resolve_user_display_name,
+    _dispatch_founders_welcome_email,
 )
 
 
@@ -356,3 +358,150 @@ def test_lifetime_no_email_in_session_does_not_raise():
     _activate_lifetime_founder_entitlement(direct_sb, session, None)
 
     assert not direct_sb.table.called
+
+
+# ---------------------------------------------------------------------------
+# _resolve_user_display_name
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_user_display_name_returns_full_name():
+    """Returns full_name when the profile has one."""
+    fake_sb = MagicMock()
+    fake_sb.table.return_value = fake_sb
+    fake_sb.select.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.limit.return_value = fake_sb
+    fake_sb.execute.return_value = MagicMock(data=[{"full_name": "Carlos Silva"}])
+
+    result = _resolve_user_display_name(fake_sb, "user-1", "carlos@empresa.com")
+    assert result == "Carlos Silva"
+
+
+def test_resolve_user_display_name_falls_back_to_email_prefix():
+    """Returns email prefix when no full_name in profile."""
+    fake_sb = MagicMock()
+    fake_sb.table.return_value = fake_sb
+    fake_sb.select.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.limit.return_value = fake_sb
+    fake_sb.execute.return_value = MagicMock(data=[{"full_name": None}])
+
+    result = _resolve_user_display_name(fake_sb, "user-2", "maria@empresa.com")
+    assert result == "maria"
+
+
+def test_resolve_user_display_name_falls_back_on_db_error():
+    """Returns email prefix when DB raises."""
+    fake_sb = MagicMock()
+    fake_sb.table.return_value = fake_sb
+    fake_sb.select.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.limit.return_value = fake_sb
+    fake_sb.execute.side_effect = RuntimeError("DB down")
+
+    result = _resolve_user_display_name(fake_sb, "user-3", "joao@empresa.com")
+    assert result == "joao"
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_founders_welcome_email — thread dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_founders_welcome_email_calls_send_function():
+    """Dispatches send_founders_welcome_email in a background thread."""
+    import time
+
+    with patch("email_service.send_founders_welcome_email", return_value="email-id-ok") as mock_send:
+        _dispatch_founders_welcome_email(email="founder@empresa.com", user_name="Fundador")
+        # Give the daemon thread time to run
+        time.sleep(0.1)
+
+    mock_send.assert_called_once_with(user_email="founder@empresa.com", user_name="Fundador")
+
+
+def test_dispatch_founders_welcome_email_never_raises_on_exception():
+    """Fire-and-forget: never raises even if send function throws."""
+    import time
+
+    with patch("email_service.send_founders_welcome_email", side_effect=RuntimeError("SMTP down")):
+        # Must not raise
+        _dispatch_founders_welcome_email(email="err@empresa.com", user_name="Erro")
+        time.sleep(0.1)
+
+
+# ---------------------------------------------------------------------------
+# Welcome email dispatched on successful entitlement activation
+# ---------------------------------------------------------------------------
+
+
+def test_welcome_email_dispatched_after_successful_activation():
+    """_activate_lifetime_founder_entitlement dispatches welcome email on success."""
+    direct_sb = MagicMock()
+    direct_sb.table.return_value = direct_sb
+    direct_sb.select.return_value = direct_sb
+    direct_sb.update.return_value = direct_sb
+    direct_sb.eq.return_value = direct_sb
+    direct_sb.limit.return_value = direct_sb
+
+    # profile lookup → user_id; policy lookup → discount pct; update → ok;
+    # display name lookup → full_name
+    profile_result = MagicMock(data=[{"id": _DEFAULT_USER_ID}])
+    policy_result = MagicMock(data=[{"consulting_discount_pct": 50}])
+    update_result = MagicMock(data=[])
+    name_result = MagicMock(data=[{"full_name": "Ana Fundadora"}])
+    direct_sb.execute.side_effect = [profile_result, policy_result, update_result, name_result]
+
+    session = _founding_session()
+
+    with patch(
+        "webhooks.handlers.founding._dispatch_founders_welcome_email"
+    ) as mock_dispatch:
+        _activate_lifetime_founder_entitlement(direct_sb, session, _DEFAULT_LEAD_ID)
+
+    mock_dispatch.assert_called_once_with(email=_DEFAULT_EMAIL, user_name="Ana Fundadora")
+
+
+def test_welcome_email_not_dispatched_when_profiles_update_fails():
+    """Welcome email must NOT be dispatched when the profiles upsert raises."""
+    direct_sb = MagicMock()
+    direct_sb.table.return_value = direct_sb
+    direct_sb.select.return_value = direct_sb
+    direct_sb.update.return_value = direct_sb
+    direct_sb.eq.return_value = direct_sb
+    direct_sb.limit.return_value = direct_sb
+
+    profile_result = MagicMock(data=[{"id": _DEFAULT_USER_ID}])
+    policy_result = MagicMock(data=[{"consulting_discount_pct": 50}])
+    direct_sb.execute.side_effect = [profile_result, policy_result, RuntimeError("DB down")]
+
+    session = _founding_session()
+
+    with patch(
+        "webhooks.handlers.founding._dispatch_founders_welcome_email"
+    ) as mock_dispatch:
+        # Must not raise
+        _activate_lifetime_founder_entitlement(direct_sb, session, _DEFAULT_LEAD_ID)
+
+    mock_dispatch.assert_not_called()
+
+
+def test_welcome_email_not_dispatched_when_profile_missing():
+    """Welcome email not dispatched when user hasn't signed up yet (deferred path)."""
+    direct_sb = MagicMock()
+    direct_sb.table.return_value = direct_sb
+    direct_sb.select.return_value = direct_sb
+    direct_sb.update.return_value = direct_sb
+    direct_sb.eq.return_value = direct_sb
+    direct_sb.limit.return_value = direct_sb
+    direct_sb.execute.return_value = MagicMock(data=[])  # no profile
+
+    session = _founding_session(email="unknown@empresa.com")
+
+    with patch(
+        "webhooks.handlers.founding._dispatch_founders_welcome_email"
+    ) as mock_dispatch:
+        _activate_lifetime_founder_entitlement(direct_sb, session, None)
+
+    mock_dispatch.assert_not_called()

--- a/backend/webhooks/handlers/founding.py
+++ b/backend/webhooks/handlers/founding.py
@@ -29,6 +29,7 @@ BIZ-FOUND-002 race guard:
 from __future__ import annotations
 
 import os
+import threading
 from datetime import datetime, timezone
 from typing import Any
 
@@ -223,12 +224,65 @@ def _read_consulting_discount_pct(sb) -> int:
     return 50
 
 
+def _resolve_user_display_name(sb, user_id: str, fallback_email: str) -> str:
+    """Return profiles.full_name for user_id, falling back to email prefix.
+
+    Never raises — returns fallback_email on any DB error.
+    """
+    try:
+        res = (
+            sb.table("profiles")
+            .select("full_name")
+            .eq("id", user_id)
+            .limit(1)
+            .execute()
+        )
+        rows = getattr(res, "data", None) or []
+        if rows and rows[0].get("full_name"):
+            return rows[0]["full_name"]
+    except Exception as e:
+        logger.warning(f"founding lifetime: could not resolve display name for user_id={user_id} — {e}")
+    return fallback_email.split("@")[0]
+
+
+def _dispatch_founders_welcome_email(email: str, user_name: str) -> None:
+    """Fire-and-forget dispatch of the founders welcome email.
+
+    Runs in a background daemon thread so it never blocks the webhook handler.
+    Uses send_founders_welcome_email which enforces idempotency via
+    founding_leads.welcome_sent_at — safe to call multiple times.
+
+    Never raises.
+    """
+    def _send() -> None:
+        try:
+            from email_service import send_founders_welcome_email
+
+            email_id = send_founders_welcome_email(user_email=email, user_name=user_name)
+            if email_id:
+                logger.info(
+                    f"founding welcome email sent — email={email} email_id={email_id}"
+                )
+            else:
+                logger.info(
+                    f"founding welcome email skipped (already sent or no lead) — email={email}"
+                )
+        except Exception as exc:
+            logger.error(f"founding welcome email dispatch failed — email={email} err={exc}")
+
+    thread = threading.Thread(target=_send, daemon=True)
+    thread.start()
+
+
 def _activate_lifetime_founder_entitlement(sb, session: Any, lead_id: str | None) -> None:
     """Upsert the lifetime founder entitlement on ``profiles``.
 
     Sets is_founder=True, founder_since, founder_offer_version,
     founder_checkout_source, consulting_discount_pct, plan_type,
     and clears trial_expires_at.
+
+    On success, dispatches the founders welcome email (fire-and-forget via
+    background thread, idempotency enforced inside send_founders_welcome_email).
 
     Gracefully defers if the user profile does not exist yet (founding is
     sold to unauthenticated visitors who sign up after payment).
@@ -275,6 +329,10 @@ def _activate_lifetime_founder_entitlement(sb, session: Any, lead_id: str | None
             f"session_id={sid} offer_version={offer_version} "
             f"consulting_discount_pct={consulting_discount_pct}"
         )
+        # Dispatch founders welcome email after successful entitlement activation.
+        # Fire-and-forget via background thread — never blocks the webhook response.
+        user_name = _resolve_user_display_name(sb, user_id, email)
+        _dispatch_founders_welcome_email(email=email, user_name=user_name)
     except Exception as e:
         logger.error(
             f"founding lifetime: profiles upsert failed — user_id={user_id} "


### PR DESCRIPTION
## Contexto

Issue #868 — O plano Fundadores é vitalício (R\$997 pagamento único), mas após a ativação do entitlement no Stripe webhook, nenhum email de boas-vindas era disparado para o founder. O template `founders_welcome.py` e a função `send_founders_welcome_email` já existiam completos, mas nunca eram chamados pela função `_activate_lifetime_founder_entitlement` em `webhooks/handlers/founding.py`.

## Mudanças

### `backend/webhooks/handlers/founding.py`
- Adicionado `import threading` ao cabeçalho
- Novo helper `_resolve_user_display_name(sb, user_id, fallback_email)` — busca `profiles.full_name`, fallback para prefixo do email; nunca levanta exceção
- Novo helper `_dispatch_founders_welcome_email(email, user_name)` — fire-and-forget via `threading.Thread(daemon=True)`, chama `send_founders_welcome_email` (que já tem idempotência por `founding_leads.welcome_sent_at`)
- `_activate_lifetime_founder_entitlement`: após upsert bem-sucedido em `profiles`, resolve o display name e dispara o email de boas-vindas; falha no upsert → sem disparo (garante que email só sai após entitlement confirmado)

### `backend/tests/test_founding_webhook_lifetime.py`
- Import dos dois novos helpers no topo do arquivo
- 8 novos testes:
  - `test_resolve_user_display_name_returns_full_name`
  - `test_resolve_user_display_name_falls_back_to_email_prefix`
  - `test_resolve_user_display_name_falls_back_on_db_error`
  - `test_dispatch_founders_welcome_email_calls_send_function`
  - `test_dispatch_founders_welcome_email_never_raises_on_exception`
  - `test_welcome_email_dispatched_after_successful_activation`
  - `test_welcome_email_not_dispatched_when_profiles_update_fails`
  - `test_welcome_email_not_dispatched_when_profile_missing`

## Testing Plan

- [x] `pytest tests/test_founding_webhook_lifetime.py tests/test_founders_welcome_email.py` — 38 passed
- [x] `pytest tests/ -k "founding or email" --ignore=tests/fuzz` — 614 passed, 0 failures
- [ ] Smoke test manual: processar um checkout founding em staging e verificar se o email chega na caixa com remetente `tiago@smartlic.tech`, reply-to `tiago.sasaki@gmail.com`, e conteúdo de acesso vitalício (sem menção a mensalidade/assinatura)

## Riscos e Rollback

- **Risco baixo**: o disparo é fire-and-forget via thread daemon. Falha no envio do email não afeta o webhook (sempre retorna 200 para o Stripe). Idempotência garantida por `founding_leads.welcome_sent_at` — sem risco de double-send mesmo em replay de webhook.
- **Rollback**: revert deste commit remove os dois helpers e a chamada; o entitlement continua funcionando sem o email.

## Closes

Closes #868