### PR TITLE
feat(backend+frontend): auto-invite founding buyers without account + /obrigado dual-state (#863 #864)

### DIFF
--- a/backend/tests/test_founding_webhook_lifetime.py
+++ b/backend/tests/test_founding_webhook_lifetime.py
@@ -30,6 +30,7 @@ from webhooks.handlers.founding import (  # noqa: E402
     _resolve_user_id_from_email,
     _resolve_user_display_name,
     _dispatch_founders_welcome_email,
+    _send_founding_invite,
 )
 
 
@@ -272,6 +273,10 @@ def test_lifetime_metadata_propagation():
 def test_lifetime_deferred_when_profile_not_found(caplog):
     """When user hasn't signed up yet, entitlement defers gracefully — no
     profiles.update call, log says 'deferred — user signup pending'.
+
+    _send_founding_invite is patched here because it has its own set of tests
+    (test_invite_*) and would call .update() on the shared mock, making the
+    assertion on profiles.update meaningless.
     """
     import logging
 
@@ -288,10 +293,11 @@ def test_lifetime_deferred_when_profile_not_found(caplog):
 
     session = _founding_session(email="notregistered@empresa.com")
 
-    with caplog.at_level(logging.INFO, logger="webhooks.handlers.founding"):
+    with patch("webhooks.handlers.founding._send_founding_invite"), \
+         caplog.at_level(logging.INFO, logger="webhooks.handlers.founding"):
         _activate_lifetime_founder_entitlement(direct_sb, session, _DEFAULT_LEAD_ID)
 
-    # update must NOT have been called
+    # profiles.update must NOT have been called
     assert not direct_sb.update.called, "profiles.update should not be called when user missing"
     assert "deferred" in caplog.text or "signup pending" in caplog.text
 
@@ -505,3 +511,102 @@ def test_welcome_email_not_dispatched_when_profile_missing():
         _activate_lifetime_founder_entitlement(direct_sb, session, None)
 
     mock_dispatch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _send_founding_invite — STORY-863 invite after payment
+# ---------------------------------------------------------------------------
+
+
+def _make_invite_sb(invite_sent_at: str | None = None, raise_idempotency: bool = False) -> MagicMock:
+    """Build a fake supabase client for invite tests.
+
+    ``invite_sent_at`` simulates the current DB value for idempotency.
+    ``raise_idempotency=True`` makes the idempotency select raise an exception.
+    """
+    fake_sb = MagicMock()
+
+    # Table chain
+    t = MagicMock()
+    t.select.return_value = t
+    t.update.return_value = t
+    t.eq.return_value = t
+    t.limit.return_value = t
+
+    if raise_idempotency:
+        t.execute.side_effect = RuntimeError("DB error")
+    else:
+        idempotency_result = MagicMock(data=[{"invite_sent_at": invite_sent_at}])
+        update_result = MagicMock(data=[])
+        t.execute.side_effect = [idempotency_result, update_result]
+
+    fake_sb.table.return_value = t
+
+    # auth.admin.invite_user_by_email — success by default
+    fake_sb.auth = MagicMock()
+    fake_sb.auth.admin = MagicMock()
+    fake_sb.auth.admin.invite_user_by_email = MagicMock(return_value=MagicMock())
+
+    return fake_sb
+
+
+def test_invite_sent_when_user_has_no_account():
+    """When user_id is None (no pre-existing account), invite is dispatched."""
+    fake_sb = _make_invite_sb(invite_sent_at=None)
+    session = _founding_session()
+
+    _send_founding_invite(fake_sb, _DEFAULT_EMAIL, _DEFAULT_LEAD_ID, session)
+
+    fake_sb.auth.admin.invite_user_by_email.assert_called_once()
+    call_args = fake_sb.auth.admin.invite_user_by_email.call_args
+    assert call_args.args[0] == _DEFAULT_EMAIL or call_args[0][0] == _DEFAULT_EMAIL
+    # options data must mark the user as founder
+    options = call_args.kwargs.get("options") or (call_args[1].get("options") if len(call_args) > 1 else {})
+    if options:
+        assert options.get("data", {}).get("is_founder") is True
+
+
+def test_invite_not_sent_when_invite_already_sent(caplog):
+    """Idempotency: if invite_sent_at is set, skip the invite and log."""
+    import logging
+
+    fake_sb = _make_invite_sb(invite_sent_at="2026-05-08T10:00:00+00:00")
+    session = _founding_session()
+
+    with caplog.at_level(logging.INFO, logger="webhooks.handlers.founding"):
+        _send_founding_invite(fake_sb, _DEFAULT_EMAIL, _DEFAULT_LEAD_ID, session)
+
+    # auth.admin.invite_user_by_email must NOT be called
+    fake_sb.auth.admin.invite_user_by_email.assert_not_called()
+    assert "already sent" in caplog.text or "skipping" in caplog.text
+
+
+def test_invite_supabase_error_does_not_raise():
+    """auth.admin.invite_user_by_email failure must not raise — swallowed."""
+    fake_sb = _make_invite_sb(invite_sent_at=None)
+    fake_sb.auth.admin.invite_user_by_email.side_effect = RuntimeError("Supabase admin error")
+
+    session = _founding_session()
+
+    # Must not raise
+    _send_founding_invite(fake_sb, _DEFAULT_EMAIL, _DEFAULT_LEAD_ID, session)
+
+
+def test_invite_sent_when_no_account_via_activate_entitlement():
+    """_activate_lifetime_founder_entitlement calls _send_founding_invite when user is None."""
+    session = _founding_session(email="newfounder@empresa.com")
+
+    with patch("webhooks.handlers.founding._send_founding_invite") as mock_invite:
+        direct_sb = MagicMock()
+        direct_sb.table.return_value = direct_sb
+        direct_sb.select.return_value = direct_sb
+        direct_sb.eq.return_value = direct_sb
+        direct_sb.limit.return_value = direct_sb
+        # profile lookup returns empty — user not yet signed up
+        direct_sb.execute.return_value = MagicMock(data=[])
+
+        _activate_lifetime_founder_entitlement(direct_sb, session, _DEFAULT_LEAD_ID)
+
+        mock_invite.assert_called_once()
+        call_args = mock_invite.call_args
+        assert call_args.args[1] == "newfounder@empresa.com" or call_args[0][1] == "newfounder@empresa.com"

--- a/backend/webhooks/handlers/founding.py
+++ b/backend/webhooks/handlers/founding.py
@@ -274,6 +274,71 @@ def _dispatch_founders_welcome_email(email: str, user_name: str) -> None:
     thread.start()
 
 
+def _send_founding_invite(sb, email: str, lead_id: str | None, session: Any) -> None:
+    """Send a Supabase auth invite to a founding buyer who has no account yet.
+
+    Idempotent: queries ``founding_leads.invite_sent_at`` before sending —
+    skips if the invite has already been dispatched (prevents double-emails on
+    Stripe retry / webhook replay).
+
+    Never raises — a failure here must not break the 200 response to Stripe.
+    """
+    sid = _session_id(session)
+
+    # ---- Idempotency check ----
+    try:
+        filter_col = "id" if lead_id else "email"
+        filter_val = lead_id if lead_id else email
+        res = (
+            sb.table("founding_leads")
+            .select("invite_sent_at")
+            .eq(filter_col, filter_val)
+            .limit(1)
+            .execute()
+        )
+        rows = getattr(res, "data", None) or []
+        if rows and rows[0].get("invite_sent_at") is not None:
+            logger.info(
+                f"founding invite already sent, skipping — "
+                f"email={email[:3]}*** lead_id={lead_id}"
+            )
+            return
+    except Exception as e:
+        logger.warning(
+            f"founding invite: idempotency check failed — will attempt send anyway "
+            f"(email={email[:3]}*** err={e})"
+        )
+
+    # ---- Send invite via Supabase Admin API ----
+    try:
+        sb.auth.admin.invite_user_by_email(
+            email,
+            options={"data": {"is_founder": True, "lead_id": lead_id}},
+        )
+        logger.info(
+            f"founding invite sent — email={email[:3]}*** session_id={sid}"
+        )
+    except Exception as e:
+        logger.error(
+            f"founding invite: auth.admin.invite_user_by_email failed — "
+            f"email={email[:3]}*** lead_id={lead_id} err={e}"
+        )
+        return
+
+    # ---- Record invite timestamp ----
+    try:
+        filter_col = "id" if lead_id else "email"
+        filter_val = lead_id if lead_id else email
+        sb.table("founding_leads").update(
+            {"invite_sent_at": datetime.now(timezone.utc).isoformat()}
+        ).eq(filter_col, filter_val).execute()
+    except Exception as e:
+        logger.error(
+            f"founding invite: failed to record invite_sent_at — "
+            f"lead_id={lead_id} err={e}"
+        )
+
+
 def _activate_lifetime_founder_entitlement(sb, session: Any, lead_id: str | None) -> None:
     """Upsert the lifetime founder entitlement on ``profiles``.
 
@@ -305,6 +370,7 @@ def _activate_lifetime_founder_entitlement(sb, session: Any, lead_id: str | None
             f"founding lifetime activation deferred — user signup pending "
             f"(session_id={sid} email={email} lead_id={lead_id})"
         )
+        _send_founding_invite(sb, email, lead_id, session)
         return
 
     consulting_discount_pct = _read_consulting_discount_pct(sb)

--- a/frontend/app/api/founding/session-status/route.ts
+++ b/frontend/app/api/founding/session-status/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export async function GET(request: NextRequest) {
+  if (!BACKEND_URL) {
+    return NextResponse.json({ error: 'Backend unavailable' }, { status: 503 });
+  }
+  const sessionId = request.nextUrl.searchParams.get('session_id');
+  if (!sessionId) {
+    return NextResponse.json({ error: 'session_id required' }, { status: 400 });
+  }
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/v1/founding/session-status?session_id=${encodeURIComponent(sessionId)}`,
+      { next: { revalidate: 0 } }
+    );
+    if (!res.ok) {
+      return NextResponse.json({ status: 'error' }, { status: 200 });
+    }
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json({ status: 'error' }, { status: 200 });
+  }
+}
+
+export const runtime = 'nodejs';

--- a/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
+++ b/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
@@ -3,17 +3,48 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-type Status = 'loading' | 'success' | 'pending' | 'error';
+type Status = 'loading' | 'has_account' | 'no_account' | 'session_error' | 'pending' | 'error';
+
+type SessionStatus = {
+  status: 'completed' | 'pending' | 'not_found' | 'error';
+  email?: string;
+  has_account?: boolean;
+  invite_sent?: boolean;
+};
 
 const MAX_POLLS = 20;
 const POLL_INTERVAL_MS = 3000;
+const REDIRECT_DELAY_MS = 5000;
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  const mp = (window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // no-op
+  }
+}
+
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return email;
+  const masked = local.length > 2
+    ? local[0] + '*'.repeat(Math.min(local.length - 2, 4)) + local[local.length - 1]
+    : local[0] + '*';
+  return `${masked}@${domain}`;
+}
 
 export function FundadoresObrigadoClient() {
   const searchParams = useSearchParams();
   const sessionId = searchParams.get('session_id');
   const [status, setStatus] = useState<Status>('loading');
+  const [maskedEmail, setMaskedEmail] = useState<string>('');
   const pollCountRef = useRef(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trackedRef = useRef(false);
 
   useEffect(() => {
     if (!sessionId) {
@@ -28,6 +59,46 @@ export function FundadoresObrigadoClient() {
       }
     };
 
+    const fetchSessionStatus = async (sid: string): Promise<void> => {
+      try {
+        const res = await fetch(`/api/founding/session-status?session_id=${encodeURIComponent(sid)}`);
+        if (!res.ok) {
+          setStatus('session_error');
+          return;
+        }
+        const data: SessionStatus = await res.json();
+        if (data.status === 'error' || data.status === 'not_found') {
+          setStatus('session_error');
+          return;
+        }
+        if (data.has_account === true) {
+          setStatus('has_account');
+          if (!trackedRef.current) {
+            trackedRef.current = true;
+            trackEvent('fundadores_obrigado_viewed', { has_account: true });
+          }
+          redirectTimerRef.current = setTimeout(() => {
+            window.location.href = '/dashboard';
+          }, REDIRECT_DELAY_MS);
+        } else {
+          if (data.email) {
+            setMaskedEmail(maskEmail(data.email));
+          }
+          setStatus('no_account');
+          if (!trackedRef.current) {
+            trackedRef.current = true;
+            trackEvent('fundadores_obrigado_viewed', { has_account: false });
+          }
+        }
+      } catch {
+        setStatus('session_error');
+        if (!trackedRef.current) {
+          trackedRef.current = true;
+          trackEvent('fundadores_obrigado_viewed', { state: 'error' });
+        }
+      }
+    };
+
     // Poll backend for checkout status (max MAX_POLLS × POLL_INTERVAL_MS)
     const poll = async () => {
       try {
@@ -36,7 +107,7 @@ export function FundadoresObrigadoClient() {
           const data = await res.json();
           if (data.status === 'complete' || data.payment_status === 'paid') {
             stopPolling();
-            setStatus('success');
+            await fetchSessionStatus(sessionId);
             return;
           }
         }
@@ -55,7 +126,12 @@ export function FundadoresObrigadoClient() {
     poll();
     intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
 
-    return stopPolling;
+    return () => {
+      stopPolling();
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+    };
   }, [sessionId]);
 
   if (status === 'loading') {
@@ -88,85 +164,96 @@ export function FundadoresObrigadoClient() {
     );
   }
 
-  if (status === 'success') {
+  // Estado A — has_account: true
+  if (status === 'has_account') {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950">
-        <div className="container mx-auto px-4 py-16 max-w-2xl">
-          <div className="text-center mb-12">
-            <div className="text-6xl mb-4">&#127881;</div>
-            <h1 className="text-4xl font-bold mb-3 text-gray-900 dark:text-white">
-              Você está dentro!
-            </h1>
-            <p className="text-lg text-gray-600 dark:text-gray-400">
-              Seu acesso vitalício ao SmartLic foi ativado.
-            </p>
-          </div>
-
-          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 mb-8">
-            <h2 className="text-xl font-semibold mb-6 text-gray-900 dark:text-white">
-              Próximos passos
-            </h2>
-            <ol className="space-y-4">
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-sm font-bold">&#10003;</span>
-                <div>
-                  <span className="font-medium text-gray-900 dark:text-white">Acesso vitalício ativado</span>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Seu plano self-service está ativo</p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">2</span>
-                <div>
-                  <a href="/buscar" className="font-medium text-blue-600 dark:text-blue-400 hover:underline">
-                    Faça sua primeira busca de editais →
-                  </a>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Busca multi-fonte PNCP + ComprasGov</p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">3</span>
-                <div>
-                  <span className="font-medium text-gray-900 dark:text-white">Resgate 50% de desconto em consultoria</span>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 dark:text-blue-400 hover:underline">
-                      tiago.sasaki@confenge.com.br
-                    </a>{' '}— mencione que é Fundador
-                  </p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-gray-400 text-white rounded-full flex items-center justify-center text-sm font-bold">4</span>
-                <div>
-                  <span className="font-medium text-gray-900 dark:text-white">Como você nos descobriu?</span>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    <a href="mailto:tiago.sasaki@confenge.com.br?subject=Como+descobri+o+SmartLic" className="text-blue-600 dark:text-blue-400 hover:underline">
-                      Responda em 1 frase
-                    </a>
-                  </p>
-                </div>
-              </li>
-            </ol>
-          </div>
-
-          <div className="text-center">
-            <a href="/buscar"
-               className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors">
-              Começar a buscar editais →
-            </a>
-          </div>
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">&#9989;</div>
+          <h1 className="text-3xl font-bold mb-3 text-gray-900 dark:text-white">
+            Acesso vitalício ativado!
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
+            Seu acesso Fundador está ativo. Redirecionando para o painel em 5 segundos...
+          </p>
+          <a
+            href="/dashboard"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Ir para o painel agora →
+          </a>
         </div>
       </div>
     );
   }
 
-  // error state
+  // Estado B — has_account: false
+  if (status === 'no_account') {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">&#9989;</div>
+          <h1 className="text-3xl font-bold mb-3 text-gray-900 dark:text-white">
+            Pagamento confirmado! Verifique seu email.
+          </h1>
+          {maskedEmail ? (
+            <p className="text-gray-600 dark:text-gray-400 mb-3">
+              Enviamos um link de acesso para{' '}
+              <span className="font-semibold text-gray-800 dark:text-gray-200">{maskedEmail}</span>.
+            </p>
+          ) : (
+            <p className="text-gray-600 dark:text-gray-400 mb-3">
+              Enviamos um link de acesso para o seu email.
+            </p>
+          )}
+          <p className="text-gray-600 dark:text-gray-400 mb-2">
+            Clique no link para criar sua senha e acessar a plataforma.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500 mb-6">
+            Não recebeu? Verifique a caixa de spam.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            Dúvidas?{' '}
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 dark:text-blue-400 hover:underline">
+              tiago@smartlic.tech
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Estado C — session_error (fallback) or generic error state
+  if (status === 'session_error') {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">&#9989;</div>
+          <h1 className="text-3xl font-bold mb-3 text-gray-900 dark:text-white">
+            Pagamento confirmado!
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
+            Você receberá um email com instruções de acesso em breve.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            Dúvidas? Fale conosco:{' '}
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 dark:text-blue-400 hover:underline">
+              tiago@smartlic.tech
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // error state (no session_id or other unrecoverable error)
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="max-w-md text-center">
         <p className="text-gray-600 dark:text-gray-400">
           Algo deu errado. Entre em contato:{' '}
-          <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 hover:underline">
-            tiago.sasaki@confenge.com.br
+          <a href="mailto:tiago@smartlic.tech" className="text-blue-600 hover:underline">
+            tiago@smartlic.tech
           </a>
         </p>
       </div>

--- a/supabase/migrations/20260508100000_founding_leads_invite_fields.down.sql
+++ b/supabase/migrations/20260508100000_founding_leads_invite_fields.down.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- Down Migration: 20260508100000_founding_leads_invite_fields
+-- Reverts: STORY-863 founding_leads invite tracking fields
+-- ============================================================================
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.idx_founding_leads_invite_pending;
+
+ALTER TABLE public.founding_leads
+    DROP COLUMN IF EXISTS invite_sent_at,
+    DROP COLUMN IF EXISTS invite_token_hash;
+
+COMMIT;

--- a/supabase/migrations/20260508100000_founding_leads_invite_fields.sql
+++ b/supabase/migrations/20260508100000_founding_leads_invite_fields.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- Migration: 20260508100000_founding_leads_invite_fields
+-- Story: STORY-863 — Auto-create credentials after Founders purchase
+-- Date: 2026-05-08
+--
+-- Purpose:
+--   Adds invite tracking fields to founding_leads to support:
+--     * invite_sent_at     — idempotency gate: skip re-invite if NOT NULL
+--     * invite_token_hash  — optional hash of the Supabase invite token for
+--                            audit / dedup (populated if token is available)
+--
+-- Down migration: 20260508100000_founding_leads_invite_fields.down.sql
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.founding_leads
+    ADD COLUMN IF NOT EXISTS invite_sent_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS invite_token_hash TEXT NULL;
+
+COMMENT ON COLUMN public.founding_leads.invite_sent_at IS
+    'STORY-863: Timestamp when a Supabase auth invite email was dispatched to '
+    'a founding buyer who had no pre-existing account. NULL = not yet sent. '
+    'Used as idempotency gate — webhook skips invite if NOT NULL.';
+
+COMMENT ON COLUMN public.founding_leads.invite_token_hash IS
+    'STORY-863: SHA-256 hash of the Supabase invite token returned by '
+    'auth.admin.invite_user_by_email, stored for audit purposes. '
+    'NULL if the token was unavailable or hashing was skipped.';
+
+-- Partial index for efficient idempotency queries on pending invites.
+CREATE INDEX IF NOT EXISTS idx_founding_leads_invite_pending
+    ON public.founding_leads (email)
+    WHERE checkout_status = 'completed' AND invite_sent_at IS NULL;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Context
Founders who pay R\$997 without a pre-existing account receive no credentials. `_activate_lifetime_founder_entitlement` deferred silently. This implements automatic Supabase auth invite (backend, #863) and fixes the post-purchase page to render the correct state for buyers without an account (frontend, #864).

## Changes
- `_activate_lifetime_founder_entitlement` (#863): calls `_send_founding_invite` when `user_id` not found — idempotent via `founding_leads.invite_sent_at`, swallows all errors
- Migration `20260508100000_founding_leads_invite_fields` (#863): adds `invite_sent_at`, `invite_token_hash` columns to `founding_leads`
- Tests (#863): idempotency, error-swallowing, happy path, integration via `_activate_lifetime_founder_entitlement`
- FundadoresObrigadoClient.tsx (#864): call session-status endpoint, render 3 states (has_account / no_account / error)
- New Next.js proxy (#864): `/api/founding/session-status` → backend `/v1/founding/session-status`
- Auto-redirect to /dashboard after 5s for Estado A (#864)

## Testing Plan
- [ ] Unit tests passing (15/15 in test_founding_webhook_lifetime.py)
- [ ] Invite not sent twice (idempotency test)
- [ ] Supabase error swallowed (never breaks 200 to Stripe)
- [ ] Estado A (has_account=true): shows "Acesso ativado", redirects to /dashboard after 5s
- [ ] Estado B (has_account=false): shows "Verifique seu email" with masked email
- [ ] Estado C (error): shows fallback with support email

## Risks & Rollback
Invite email sent to buyer — no financial risk. Rollback: down migration drops columns; revert webhook code.

## Closes
Closes #863
Closes #864