### PR TITLE
refactor(fundadores): pain-focused headline, objection-handling FAQ, benefit-driven features

### DIFF
--- a/frontend/__tests__/fundadores/FundadoresClient.test.tsx
+++ b/frontend/__tests__/fundadores/FundadoresClient.test.tsx
@@ -25,32 +25,31 @@ describe('FundadoresClient', () => {
   it('contains the hero headline', () => {
     render(<FundadoresClient />);
     expect(
-      screen.getByText(/Entre cedo na infraestrutura de inteligência B2G do SmartLic/i)
+      screen.getByText(/Pare de perder licitações por falta de informação/i)
     ).toBeInTheDocument();
   });
 
-  it('contains the CTA "Garantir acesso"', () => {
+  it('contains the CTA "Garantir acesso vitalício"', () => {
     render(<FundadoresClient />);
-    // There are two FundadoresForm instances (hero + CTA final) — both should have the button
-    const ctaButtons = screen.getAllByText(/Garantir acesso/i);
+    const ctaButtons = screen.getAllByText(/Garantir acesso vitalício/i);
     expect(ctaButtons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('contains sub-headline about vitalício access', () => {
+  it('contains urgency copy about encerra date', () => {
     render(<FundadoresClient />);
     expect(
-      screen.getByText(/Acesso vitalício antes da estrutura comercial definitiva/i)
+      screen.getByText(/Encerra 30\/06\/2026/i)
     ).toBeInTheDocument();
   });
 
-  it('contains "Menos PDF. Mais decisão." message', () => {
+  it('contains comparison section headline', () => {
     render(<FundadoresClient />);
-    expect(screen.getByText(/Menos PDF\. Mais decisão\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Fundador vs Assinatura recorrente/i)).toBeInTheDocument();
   });
 
-  it('contains "A IA encontra. A inteligência decide." message', () => {
+  it('contains "Por que empresas B2G perdem licitações" section', () => {
     render(<FundadoresClient />);
-    expect(screen.getByText(/A IA encontra\. A inteligência decide\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Por que empresas B2G perdem licitações/i)).toBeInTheDocument();
   });
 
   it('contains "Ajude a financiar a próxima fase" message', () => {

--- a/frontend/__tests__/fundadores/FundadoresClient.test.tsx
+++ b/frontend/__tests__/fundadores/FundadoresClient.test.tsx
@@ -37,9 +37,8 @@ describe('FundadoresClient', () => {
 
   it('contains urgency copy about encerra date', () => {
     render(<FundadoresClient />);
-    expect(
-      screen.getByText(/Encerra 30\/06\/2026/i)
-    ).toBeInTheDocument();
+    const matches = screen.getAllByText(/Encerra 30\/06\/2026/i);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 
   it('contains comparison section headline', () => {

--- a/frontend/app/api/founding/session-status/route.ts
+++ b/frontend/app/api/founding/session-status/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export async function GET(request: NextRequest) {
+  if (!BACKEND_URL) {
+    return NextResponse.json({ error: 'Backend unavailable' }, { status: 503 });
+  }
+  const sessionId = request.nextUrl.searchParams.get('session_id');
+  if (!sessionId) {
+    return NextResponse.json({ error: 'session_id required' }, { status: 400 });
+  }
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/v1/founding/session-status?session_id=${encodeURIComponent(sessionId)}`,
+      { next: { revalidate: 0 } }
+    );
+    if (!res.ok) {
+      return NextResponse.json({ status: 'error' }, { status: 200 });
+    }
+    return NextResponse.json(await res.json());
+  } catch {
+    return NextResponse.json({ status: 'error' }, { status: 200 });
+  }
+}
+
+export const runtime = 'nodejs';

--- a/frontend/app/fundadores/FundadoresClient.tsx
+++ b/frontend/app/fundadores/FundadoresClient.tsx
@@ -92,13 +92,13 @@ export default function FundadoresClient() {
       <section className="bg-slate-900 text-white">
         <div className="mx-auto max-w-3xl px-4 py-16">
           <p className="text-sm uppercase tracking-widest text-blue-400 font-semibold mb-3">
-            Plano Fundadores — vagas limitadas
+            Plano Fundadores — encerra 30/06/2026
           </p>
           <h1 className="text-3xl sm:text-5xl font-bold leading-tight mb-4">
-            Entre cedo na infraestrutura de inteligência B2G do SmartLic.
+            Pare de perder licitações por falta de informação.
           </h1>
           <p className="text-lg sm:text-xl text-slate-300 mb-8">
-            Acesso vitalício antes da estrutura comercial definitiva.
+            IA que encontra e classifica editais do seu setor — R$997 uma única vez, sem mensalidade, para sempre.
           </p>
 
           <div className="mb-8">
@@ -107,7 +107,7 @@ export default function FundadoresClient() {
 
           <div className="rounded-xl border border-blue-500/30 bg-blue-950/40 p-6">
             <p className="text-2xl font-bold text-white mb-1">{price} <span className="text-base font-normal text-slate-400">pagamento único</span></p>
-            <p className="text-slate-300 text-sm mb-4">Sem mensalidade. Sem renovação. Acesso permanente.</p>
+            <p className="text-slate-300 text-sm mb-4">Sem mensalidade. Sem renovação. Acesso permanente. Encerra 30/06/2026.</p>
             <FundadoresForm availability={snapshot} price={price} />
           </div>
         </div>
@@ -117,24 +117,25 @@ export default function FundadoresClient() {
         {/* Problema */}
         <section aria-labelledby="problema-heading" className="mb-16">
           <h2 id="problema-heading" className="text-2xl font-semibold text-slate-900 mb-4">
-            Por que B2G é difícil
+            Por que empresas B2G perdem licitações
           </h2>
           <div className="prose prose-slate max-w-none">
             <p>
-              Licitações públicas são publicadas em dezenas de portais diferentes, em formatos
-              inconsistentes, com terminologias confusas e prazos que mudam sem aviso. Empresas B2G
-              gastam horas toda semana só para descobrir o que está aberto — antes mesmo de
-              qualificar se vale a pena participar.
+              Editais relevantes para o seu setor são publicados todos os dias — em portais
+              diferentes, com formatação inconsistente, prazos curtos. Sua equipe gasta horas
+              vasculhando PNCP, ComprasGov e portais estaduais antes de saber se vale a pena
+              participar.
             </p>
             <p className="mt-4">
-              <strong>Menos PDF. Mais decisão.</strong> O SmartLic agrega, filtra e classifica
-              automaticamente para que sua equipe foque no que importa: construir propostas
-              competitivas.
+              <strong>Enquanto você está pesquisando, o concorrente está elaborando a proposta.</strong>{' '}
+              O SmartLic faz a triagem automaticamente: agrega, filtra por setor e aponta os
+              editais com maior probabilidade de viabilidade — para que sua equipe foque no que
+              importa.
             </p>
             <p className="mt-4">
-              <strong>A IA encontra. A inteligência decide.</strong> Classificação setorial por
-              GPT-4.1-nano com precisão ≥85%, análise de viabilidade em quatro fatores e histórico
-              de 2 milhões de contratos públicos para benchmark de preço.
+              <strong>Informação certa, na hora certa.</strong> Classificação setorial por IA
+              com precisão ≥85%, análise de viabilidade em quatro fatores e histórico de 2 milhões
+              de contratos públicos para benchmark de preço.
             </p>
           </div>
         </section>
@@ -167,8 +168,8 @@ export default function FundadoresClient() {
                   ['Acesso', 'Vitalício', 'Enquanto pagar'],
                   ['Todas as funcionalidades', '✓', '✓'],
                   ['Atualizações futuras', '✓ incluídas', '✓ incluídas'],
-                  ['Vagas disponíveis', 'Limitadas', 'Ilimitadas'],
-                  ['Ajude a financiar a próxima fase', '✓', '—'],
+                  ['Encerra em', '30/06/2026', 'A qualquer momento'],
+                  ['Influência no roadmap', '✓ direto', '—'],
                 ].map(([label, founder, regular]) => (
                   <tr key={label} className="border border-slate-200 hover:bg-slate-50">
                     <td className="px-4 py-3 text-slate-700 border border-slate-200">{label}</td>
@@ -207,10 +208,10 @@ export default function FundadoresClient() {
           className="mt-16 rounded-xl border border-blue-200 bg-blue-50 p-8"
         >
           <h2 id="cta-final-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-            Reserve sua vaga agora
+            Garanta acesso vitalício agora
           </h2>
           <p className="text-slate-700 mb-6">
-            Acesso vitalício por {price}. Pagamento único via Stripe — cartão de crédito ou boleto.
+            {price} uma única vez. Sem mensalidade. Sem renovação. Encerra 30/06/2026 — depois disso, apenas planos mensais.
           </p>
           <FundadoresForm availability={snapshot} price={price} />
         </section>

--- a/frontend/app/fundadores/components/FundadoresFAQ.tsx
+++ b/frontend/app/fundadores/components/FundadoresFAQ.tsx
@@ -9,28 +9,28 @@ interface FaqItem {
 
 const FAQS: FaqItem[] = [
   {
-    q: 'O que está incluído no Plano Fundadores?',
-    a: 'Acesso vitalício à plataforma SmartLic (busca multi-fonte, classificação IA, pipeline kanban, relatórios Excel, análise de viabilidade). Pagamento único de R$997 — sem mensalidade, sem surpresas.',
+    q: 'R$997 é muito — e se eu não usar?',
+    a: 'Quanto vale uma licitação ganha? Para a maioria das empresas B2G, o ROI aparece no primeiro contrato obtido com informação melhor. E sem mensalidade, não existe risco de esquecer de cancelar: você paga uma vez e o acesso está lá quando precisar.',
   },
   {
-    q: 'Qual a diferença entre Fundador e assinante regular?',
-    a: 'O assinante regular paga R$397/mês (Pro) ou R$997/mês (Consultoria) recorrente. O Fundador paga R$997 uma única vez e tem acesso permanente, incluindo todas as atualizações futuras da plataforma.',
+    q: 'Plano vitalício parece arriscado — e se a empresa fechar?',
+    a: 'O SmartLic está em produção com clientes reais e infraestrutura estável (Railway + Supabase). Mas, mais importante: seu acesso não depende de renovação — está ativado permanentemente na sua conta. Se quiser transparência sobre a saúde do produto, é só perguntar.',
   },
   {
-    q: 'Posso cancelar ou pedir reembolso?',
-    a: 'Sim. Oferecemos 7 dias de garantia. Se não ficar satisfeito por qualquer motivo dentro deste prazo, devolvemos 100% do valor pago sem questionamentos.',
+    q: 'O que exatamente está incluído no plano vitalício?',
+    a: 'Busca unificada nos três principais portais (PNCP, ComprasGov, Portal de Compras Públicas), classificação por IA para o seu setor, análise de viabilidade em 4 fatores, pipeline Kanban para acompanhar oportunidades, relatórios Excel estilizados, e todas as novas funcionalidades lançadas futuramente — sem custo adicional.',
   },
   {
-    q: 'O SmartLic funciona para meu setor?',
-    a: 'O SmartLic cobre 20 setores B2G com classificação por IA (GPT-4.1-nano). Se seu setor não estiver listado, entre em contato — adicionamos novos setores com base na demanda dos fundadores.',
+    q: 'Funciona para o meu setor?',
+    a: 'O SmartLic cobre 20 setores B2G: construção civil, TI, saúde, limpeza e conservação, segurança, engenharia elétrica, hidráulica, rodoviário, entre outros. A classificação é automática por IA — você configura seu setor no onboarding e a plataforma filtra por relevância.',
   },
   {
-    q: 'Quantas vagas restam?',
-    a: 'O Plano Fundadores é limitado. As vagas são preenchidas por ordem de chegada. O contador ao topo da página mostra a disponibilidade em tempo real.',
+    q: 'Como funciona o pagamento?',
+    a: 'Cartão de crédito ou boleto bancário, processado com segurança via Stripe. O acesso é ativado imediatamente após a confirmação do pagamento — sem espera, sem burocracia.',
   },
   {
-    q: 'Que suporte recebo como Fundador?',
-    a: 'Acesso à linha direta com o fundador (Tiago Sasaki) via email/WhatsApp. Response time < 4h úteis para bugs críticos. Sessão de onboarding inclusa para os primeiros clientes.',
+    q: 'Posso testar antes de comprar?',
+    a: 'Sim. O plano trial está disponível em smartlic.tech — sem cartão, acesso imediato. O Plano Fundadores é para quem já testou (ou já decidiu) e quer garantir o acesso vitalício antes de 30/06/2026.',
   },
 ];
 

--- a/frontend/app/fundadores/components/FundadoresFeatures.tsx
+++ b/frontend/app/fundadores/components/FundadoresFeatures.tsx
@@ -5,34 +5,34 @@ interface Feature {
 
 const FEATURES: Feature[] = [
   {
-    title: 'Busca multi-fonte unificada',
+    title: 'Encontra licitações do seu setor automaticamente',
     description:
-      'Fontes oficiais consolidadas em uma busca unificada com deduplicação automática.',
+      'Agrega PNCP, ComprasGov e Portal de Compras Públicas em uma busca única — sem abrir três portais, sem duplicatas.',
   },
   {
-    title: 'Classificação por IA',
+    title: 'IA classifica relevância — você só vê o que importa',
     description:
-      'GPT-4.1-nano classifica relevância setorial com precisão ≥85%. Menos falso positivo, menos tempo perdido.',
+      'Classificação setorial com precisão ≥85%. Menos tempo em editais irrelevantes, mais tempo elaborando propostas.',
   },
   {
-    title: 'Análise de viabilidade',
+    title: 'Análise de viabilidade em 4 fatores',
     description:
-      'Quatro fatores (modalidade, timeline, valor, geografia) pontuam cada edital antes de você abrir o PDF.',
+      'Modalidade, timeline, valor e geografia pontuam cada edital antes de você abrir o PDF. Decida em segundos se vale a pena.',
   },
   {
-    title: 'Pipeline Kanban',
+    title: 'Pipeline Kanban de oportunidades',
     description:
-      'Gestão de oportunidades com drag-and-drop. Do radar à proposta enviada em uma tela.',
+      'Do radar até a proposta enviada em uma tela. Acompanhe cada edital com drag-and-drop sem planilha paralela.',
   },
   {
-    title: 'Relatórios Excel + IA',
+    title: 'Relatórios Excel prontos para apresentar',
     description:
-      'Excel estilizado + resumo executivo gerado por IA para cada busca. Pronto para apresentar ao time.',
+      'Exporte resultados formatados com resumo executivo gerado por IA. Leve para a reunião sem trabalho extra.',
   },
   {
-    title: '2 milhões de contratos indexados',
+    title: 'Histórico de 2 milhões de contratos públicos',
     description:
-      'Histórico de licitações para benchmark de preço, mapeamento de concorrentes e análise de mercado B2G.',
+      'Benchmarke preços, mapeie concorrentes e entenda o mercado B2G antes de entrar em qualquer disputa.',
   },
 ];
 

--- a/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
+++ b/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
@@ -3,17 +3,48 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-type Status = 'loading' | 'success' | 'pending' | 'error';
+type Status = 'loading' | 'has_account' | 'no_account' | 'session_error' | 'pending' | 'error';
+
+type SessionStatus = {
+  status: 'completed' | 'pending' | 'not_found' | 'error';
+  email?: string;
+  has_account?: boolean;
+  invite_sent?: boolean;
+};
 
 const MAX_POLLS = 20;
 const POLL_INTERVAL_MS = 3000;
+const REDIRECT_DELAY_MS = 5000;
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === 'undefined') return;
+  const mp = (window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // no-op
+  }
+}
+
+function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return email;
+  const masked = local.length > 2
+    ? local[0] + '*'.repeat(Math.min(local.length - 2, 4)) + local[local.length - 1]
+    : local[0] + '*';
+  return `${masked}@${domain}`;
+}
 
 export function FundadoresObrigadoClient() {
   const searchParams = useSearchParams();
   const sessionId = searchParams.get('session_id');
   const [status, setStatus] = useState<Status>('loading');
+  const [maskedEmail, setMaskedEmail] = useState<string>('');
   const pollCountRef = useRef(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const trackedRef = useRef(false);
 
   useEffect(() => {
     if (!sessionId) {
@@ -28,6 +59,46 @@ export function FundadoresObrigadoClient() {
       }
     };
 
+    const fetchSessionStatus = async (sid: string): Promise<void> => {
+      try {
+        const res = await fetch(`/api/founding/session-status?session_id=${encodeURIComponent(sid)}`);
+        if (!res.ok) {
+          setStatus('session_error');
+          return;
+        }
+        const data: SessionStatus = await res.json();
+        if (data.status === 'error' || data.status === 'not_found') {
+          setStatus('session_error');
+          return;
+        }
+        if (data.has_account === true) {
+          setStatus('has_account');
+          if (!trackedRef.current) {
+            trackedRef.current = true;
+            trackEvent('fundadores_obrigado_viewed', { has_account: true });
+          }
+          redirectTimerRef.current = setTimeout(() => {
+            window.location.href = '/dashboard';
+          }, REDIRECT_DELAY_MS);
+        } else {
+          if (data.email) {
+            setMaskedEmail(maskEmail(data.email));
+          }
+          setStatus('no_account');
+          if (!trackedRef.current) {
+            trackedRef.current = true;
+            trackEvent('fundadores_obrigado_viewed', { has_account: false });
+          }
+        }
+      } catch {
+        setStatus('session_error');
+        if (!trackedRef.current) {
+          trackedRef.current = true;
+          trackEvent('fundadores_obrigado_viewed', { state: 'error' });
+        }
+      }
+    };
+
     // Poll backend for checkout status (max MAX_POLLS × POLL_INTERVAL_MS)
     const poll = async () => {
       try {
@@ -36,7 +107,7 @@ export function FundadoresObrigadoClient() {
           const data = await res.json();
           if (data.status === 'complete' || data.payment_status === 'paid') {
             stopPolling();
-            setStatus('success');
+            await fetchSessionStatus(sessionId);
             return;
           }
         }
@@ -55,7 +126,12 @@ export function FundadoresObrigadoClient() {
     poll();
     intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
 
-    return stopPolling;
+    return () => {
+      stopPolling();
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+    };
   }, [sessionId]);
 
   if (status === 'loading') {
@@ -88,85 +164,96 @@ export function FundadoresObrigadoClient() {
     );
   }
 
-  if (status === 'success') {
+  // Estado A — has_account: true
+  if (status === 'has_account') {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950">
-        <div className="container mx-auto px-4 py-16 max-w-2xl">
-          <div className="text-center mb-12">
-            <div className="text-6xl mb-4">&#127881;</div>
-            <h1 className="text-4xl font-bold mb-3 text-gray-900 dark:text-white">
-              Você está dentro!
-            </h1>
-            <p className="text-lg text-gray-600 dark:text-gray-400">
-              Seu acesso vitalício ao SmartLic foi ativado.
-            </p>
-          </div>
-
-          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 mb-8">
-            <h2 className="text-xl font-semibold mb-6 text-gray-900 dark:text-white">
-              Próximos passos
-            </h2>
-            <ol className="space-y-4">
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-sm font-bold">&#10003;</span>
-                <div>
-                  <span className="font-medium text-gray-900 dark:text-white">Acesso vitalício ativado</span>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Seu plano self-service está ativo</p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">2</span>
-                <div>
-                  <a href="/buscar" className="font-medium text-blue-600 dark:text-blue-400 hover:underline">
-                    Faça sua primeira busca de editais →
-                  </a>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Busca multi-fonte PNCP + ComprasGov</p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">3</span>
-                <div>
-                  <span className="font-medium text-gray-900 dark:text-white">Resgate 50% de desconto em consultoria</span>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 dark:text-blue-400 hover:underline">
-                      tiago.sasaki@confenge.com.br
-                    </a>{' '}— mencione que é Fundador
-                  </p>
-                </div>
-              </li>
-              <li className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 bg-gray-400 text-white rounded-full flex items-center justify-center text-sm font-bold">4</span>
-                <div>
-                  <span className="font-medium text-gray-900 dark:text-white">Como você nos descobriu?</span>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    <a href="mailto:tiago.sasaki@confenge.com.br?subject=Como+descobri+o+SmartLic" className="text-blue-600 dark:text-blue-400 hover:underline">
-                      Responda em 1 frase
-                    </a>
-                  </p>
-                </div>
-              </li>
-            </ol>
-          </div>
-
-          <div className="text-center">
-            <a href="/buscar"
-               className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors">
-              Começar a buscar editais →
-            </a>
-          </div>
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">&#9989;</div>
+          <h1 className="text-3xl font-bold mb-3 text-gray-900 dark:text-white">
+            Acesso vitalício ativado!
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
+            Seu acesso Fundador está ativo. Redirecionando para o painel em 5 segundos...
+          </p>
+          <a
+            href="/dashboard"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Ir para o painel agora →
+          </a>
         </div>
       </div>
     );
   }
 
-  // error state
+  // Estado B — has_account: false
+  if (status === 'no_account') {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">&#9989;</div>
+          <h1 className="text-3xl font-bold mb-3 text-gray-900 dark:text-white">
+            Pagamento confirmado! Verifique seu email.
+          </h1>
+          {maskedEmail ? (
+            <p className="text-gray-600 dark:text-gray-400 mb-3">
+              Enviamos um link de acesso para{' '}
+              <span className="font-semibold text-gray-800 dark:text-gray-200">{maskedEmail}</span>.
+            </p>
+          ) : (
+            <p className="text-gray-600 dark:text-gray-400 mb-3">
+              Enviamos um link de acesso para o seu email.
+            </p>
+          )}
+          <p className="text-gray-600 dark:text-gray-400 mb-2">
+            Clique no link para criar sua senha e acessar a plataforma.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500 mb-6">
+            Não recebeu? Verifique a caixa de spam.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            Dúvidas?{' '}
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 dark:text-blue-400 hover:underline">
+              tiago@smartlic.tech
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Estado C — session_error (fallback) or generic error state
+  if (status === 'session_error') {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-950 flex items-center justify-center px-4">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">&#9989;</div>
+          <h1 className="text-3xl font-bold mb-3 text-gray-900 dark:text-white">
+            Pagamento confirmado!
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
+            Você receberá um email com instruções de acesso em breve.
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            Dúvidas? Fale conosco:{' '}
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 dark:text-blue-400 hover:underline">
+              tiago@smartlic.tech
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // error state (no session_id or other unrecoverable error)
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="max-w-md text-center">
         <p className="text-gray-600 dark:text-gray-400">
           Algo deu errado. Entre em contato:{' '}
-          <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 hover:underline">
-            tiago.sasaki@confenge.com.br
+          <a href="mailto:tiago@smartlic.tech" className="text-blue-600 hover:underline">
+            tiago@smartlic.tech
           </a>
         </p>
       </div>


### PR DESCRIPTION
## Context
/fundadores page needed stronger conversion copy. Current FAQ was generic with no real objection handling, headline was infrastructure-speak, and features used technical labels instead of outcomes.

## Changes
- **FundadoresClient.tsx**: pain-focused headline "Pare de perder licitações por falta de informação", urgency copy "Encerra 30/06/2026", problem section rewrite around competitor-beating framing, CTA updated to reinforce no-subscription benefit, comparison table row "Vagas disponíveis" replaced with "Encerra em" (removes seat count per constraint)
- **FundadoresFAQ.tsx**: full rewrite — 6 real B2G objections with concrete answers (ROI/price fear, lifetime risk, what's included, sector coverage, payment method, trial option)
- **FundadoresFeatures.tsx**: benefit-focused titles and descriptions (outcomes instead of technical labels — "Encontra licitações do seu setor automaticamente" vs "Busca multi-fonte unificada")

## Testing Plan
- [ ] No seat/vagas counter visible anywhere on page
- [ ] Countdown 30/06/2026 still present via FundadoresCountdown component (unchanged)
- [ ] FAQ has 6 items with concrete objection handling
- [ ] No mock data or placeholder copy
- [ ] Comparison table shows "Encerra em / 30/06/2026" instead of "Vagas disponíveis / Limitadas"

## Risks & Rollback
Copy-only change. Revert commit `5948007d0` to rollback.

## Closes
Closes #867