### PR TITLE
feat(frontend): SEO técnico — lang, canonical, noindex em páginas legais/operacionais [PSEO-INDEX-001] (#883)

### DIFF
--- a/frontend/app/fundadores/page.tsx
+++ b/frontend/app/fundadores/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   description:
     'Entre cedo na infraestrutura de inteligência B2G do SmartLic. Acesso vitalício por R$997 — pagamento único, sem mensalidade. Vagas limitadas.',
   robots: { index: true, follow: true },
+  alternates: { canonical: 'https://smartlic.tech/fundadores' },
   openGraph: {
     title: 'SmartLic Plano Fundadores — Acesso vitalício à inteligência B2G',
     description:

--- a/frontend/app/privacidade/page.tsx
+++ b/frontend/app/privacidade/page.tsx
@@ -3,6 +3,8 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Política de Privacidade',
   description: 'Política de Privacidade do SmartLic - Como coletamos, usamos e protegemos seus dados',
+  alternates: { canonical: 'https://smartlic.tech/privacidade' },
+  robots: { index: false, follow: true },
 };
 
 export default function PrivacidadePage() {

--- a/frontend/app/status/page.tsx
+++ b/frontend/app/status/page.tsx
@@ -11,6 +11,8 @@ import StatusContent from "./components/StatusContent";
 export const metadata: Metadata = {
   title: { absolute: "Status do Sistema | SmartLic" },
   description: "Acompanhe o status em tempo real dos sistemas e fontes de dados do SmartLic.",
+  alternates: { canonical: 'https://smartlic.tech/status' },
+  robots: { index: false, follow: true },
 };
 
 export default function StatusPage() {

--- a/frontend/app/termos/page.tsx
+++ b/frontend/app/termos/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Termos de Serviço',
   description: 'Termos de Serviço do SmartLic - Condições de uso da plataforma',
+  alternates: { canonical: 'https://smartlic.tech/termos' },
   robots: {
     index: false,
     follow: false,


### PR DESCRIPTION
## Context

GSC mostra 7.459 impressões dos EUA com apenas 2 cliques — ruído que distorce métricas de indexação. Esta PR conclui a auditoria PSEO-INDEX-001 verificando e corrigindo `lang`, `og:locale`, canonical tags e noindex em páginas problemáticas.

## Findings (auditoria pré-implementação)

**Já corretos — sem mudança necessária:**
- `layout.tsx`: `lang="pt-BR"` (linha 139) e `og:locale: 'pt_BR'` (linha 88) ✅
- `/blog/licitacoes/[setor]/[uf]`: canonical strips `?modalidade=`, noindex quando 0 bids E 0 contratos ✅
- `/calculadora`: canonical sempre `/calculadora`, ignora `?setor=&uf=` ✅
- `/indice-municipal/[municipio-uf]`: canonical strips `?periodo=` ✅
- `/blog/programmatic/`, `/alertas-publicos/`, `/contratos/[setor]/[uf]`: todos com canonical + noindex logic ✅

**Gaps corrigidos nesta PR:**
- `/fundadores`: página indexável (`index: true`) sem canonical → herda root `canonical: "https://smartlic.tech"` incorretamente
- `/privacidade`: sem canonical nem robots → herdava global `index: true` + canonical errado
- `/status`: sem canonical nem robots → página operacional indexada indevidamente
- `/termos`: tinha noindex mas sem canonical self-referential

## Changes

| Arquivo | Mudança |
|---------|---------|
| `frontend/app/fundadores/page.tsx` | Adiciona `alternates: { canonical: 'https://smartlic.tech/fundadores' }` |
| `frontend/app/privacidade/page.tsx` | Adiciona canonical + `robots: { index: false, follow: true }` |
| `frontend/app/status/page.tsx` | Adiciona canonical + `robots: { index: false, follow: true }` |
| `frontend/app/termos/page.tsx` | Adiciona `alternates: { canonical: 'https://smartlic.tech/termos' }` |

## Acceptance Criteria

- [x] `<html lang="pt-BR">` presente no layout raiz (já estava — verificado)
- [x] `og:locale = pt_BR` presente no defaultMetadata (já estava — verificado)
- [x] Páginas de listagem com parâmetros de filtro têm canonical para URL base (já correto — verificado)
- [x] Páginas programáticas com 0 resultados retornam `robots: { index: false }` (já correto — verificado)
- [x] Não há canonical apontando para URL incorreta (corrigido: fundadores, privacidade, status, termos)
- [ ] Build/lint sem regressão (validar em CI — node_modules não instalado no worktree WSL)

## Testing Plan

- [ ] Verificar GSC em 30 dias: impressões EUA devem reduzir (privacidade/status não serão mais indexadas)
- [ ] Inspecionar URL `/fundadores` no GSC: canonical deve apontar para `https://smartlic.tech/fundadores`
- [ ] Validar com Google Rich Results Test ou `curl -s https://smartlic.tech/fundadores | grep canonical`
- [ ] CI frontend-tests deve passar (mudanças são metadata-only, sem lógica)

## Risks

- Baixo: mudanças são puramente declarativas no objeto `Metadata` do Next.js. Nenhuma lógica de renderização foi alterada.
- `/privacidade` agora com noindex — alinhado com prática padrão (LGPD compliance pages raramente indexadas).
- `/status` noindex — correto; páginas de status operacional não são conteúdo SEO.

## Closes
Closes #883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added canonical URL references to the founders, privacy, status, and terms pages.
  * Applied search engine indexing directives to privacy, status, and terms pages to control discovery and link crawling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
