### PR TITLE
feat(frontend): structured data JSON-LD pSEO pages [PSEO-MOBILE-001]

### DIFF
--- a/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
+++ b/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
@@ -215,6 +215,7 @@ export default function CnpjPerfilClient({ perfil }: { perfil: PerfilB2G }) {
         </p>
         <Link
           href={`/signup?ref=cnpj-mid&setor=${perfil.setor_detectado}&uf=${empresa.uf}`}
+          data-testid="pseo-cta-primary"
           className="text-sm font-bold text-white bg-green-600 hover:bg-green-700 px-4 py-2 rounded-md whitespace-nowrap w-full sm:w-auto text-center"
           onClick={() => {
             if (typeof window !== 'undefined' && window.mixpanel) {

--- a/frontend/app/contratos/orgao/[cnpj]/page.tsx
+++ b/frontend/app/contratos/orgao/[cnpj]/page.tsx
@@ -178,6 +178,7 @@ export default async function OrgaoContratosPage({ params }: Props) {
                 href={`/signup?utm_source=programmatic&utm_medium=cta&utm_campaign=conv-cta-001&utm_content=contratos-orgao&page_cnpj=${cnpj}`}
                 eventName="cta_clicked"
                 eventProps={{ cta_name: 'contratos_orgao_hero', destination: '/signup', page_type: 'contratos_orgao', page_cnpj: cnpj, orgao_nome: stats.orgao_nome }}
+                data-testid="pseo-cta-primary"
                 className="inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors min-h-[44px]"
               >
                 Teste grátis por 14 dias

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -135,6 +135,11 @@ export default async function FornecedorCnpjPage({ params }: Props) {
     (f) => f.answer.replace(/<[^>]*>/g, '').length >= 300
   );
 
+  // PSEO-MOBILE-001 #886: valorFmt for Dataset JSON-LD description
+  const valorFmtLd = profile.valor_total >= 1_000_000
+    ? `R$ ${(profile.valor_total / 1_000_000).toFixed(1)} mi`
+    : `R$ ${(profile.valor_total / 1_000).toFixed(0)} mil`;
+
   const jsonLd = [
     {
       '@context': 'https://schema.org',
@@ -171,6 +176,25 @@ export default async function FornecedorCnpjPage({ params }: Props) {
             })),
           }
         : {}),
+    },
+    // PSEO-MOBILE-001 #886: Dataset schema for Google Dataset Search rich results
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Dataset',
+      name: `Contratos públicos — ${profile.razao_social}`,
+      description: `Histórico de contratos públicos de ${profile.razao_social} (CNPJ ${cnpj}) no Portal Nacional de Contratações Públicas. ${profile.total_contratos} contratos, totalizando ${valorFmtLd}, em ${profile.ufs_atuantes.length} estado(s).`,
+      publisher: {
+        '@type': 'Organization',
+        name: 'SmartLic',
+        url: 'https://smartlic.tech',
+      },
+      creator: { '@type': 'Organization', name: 'SmartLic', url: 'https://smartlic.tech' },
+      license: 'https://dados.gov.br/dados/conteudo/sobre-dados-abertos',
+      distribution: {
+        '@type': 'DataDownload',
+        contentUrl: `https://smartlic.tech/fornecedores/${cnpj}`,
+        encodingFormat: 'text/html',
+      },
     },
     {
       '@context': 'https://schema.org',
@@ -231,10 +255,24 @@ export default async function FornecedorCnpjPage({ params }: Props) {
             CNPJ {cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5')}
             {profile.cnae_descricao && <> &middot; {profile.cnae_descricao}</>}
           </p>
-          <p className="text-sm text-gray-400 mb-6">
+          <p className="text-sm text-gray-400 mb-4">
             {profile.last_updated ? getFreshnessLabel(profile.last_updated) : 'Dados das fontes oficiais'}
             {' · Fonte: Portal Nacional de Contratacoes Publicas'}
           </p>
+
+          {/* PSEO-MOBILE-001 #886: Primary CTA above the fold — visible on mobile 375px without scroll */}
+          <div className="mb-6 rounded-lg bg-blue-600 px-4 py-4 text-center sm:text-left sm:flex sm:items-center sm:justify-between sm:gap-4">
+            <p className="text-sm text-blue-100 mb-3 sm:mb-0">
+              Monitore editais do setor de <span className="font-semibold text-white">{profile.razao_social}</span> e receba alertas automáticos.
+            </p>
+            <Link
+              href={`/signup?ref=fornecedor&cnpj=${cnpj}`}
+              data-testid="pseo-cta-primary"
+              className="inline-block whitespace-nowrap rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-blue-700 hover:bg-blue-50 transition-colors min-h-[44px] leading-[44px] sm:leading-normal sm:py-2.5"
+            >
+              Testar 14 dias grátis →
+            </Link>
+          </div>
 
           {/* KPI Cards */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">

--- a/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
+++ b/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
@@ -179,6 +179,7 @@ export default function OrgaoPerfilClient({ stats }: { stats: OrgaoStats }) {
         </p>
         <Link
           href={`/signup?ref=orgao-mid&uf=${uf}`}
+          data-testid="pseo-cta-primary"
           className="text-sm font-bold text-white bg-green-600 hover:bg-green-700 px-4 py-2 rounded-md whitespace-nowrap w-full sm:w-auto text-center"
           onClick={() => {
             if (typeof window !== 'undefined' && window.mixpanel) {

--- a/frontend/components/TrackingLink.tsx
+++ b/frontend/components/TrackingLink.tsx
@@ -9,15 +9,17 @@ interface TrackingLinkProps {
   eventProps?: Record<string, unknown>;
   children: React.ReactNode;
   className?: string;
+  'data-testid'?: string;
 }
 
-export default function TrackingLink({ href, eventName, eventProps, children, className }: TrackingLinkProps) {
+export default function TrackingLink({ href, eventName, eventProps, children, className, 'data-testid': dataTestId }: TrackingLinkProps) {
   const { trackEvent } = useAnalytics();
 
   return (
     <Link
       href={href}
       className={className}
+      data-testid={dataTestId}
       onClick={() => trackEvent(eventName, eventProps ?? {})}
     >
       {children}


### PR DESCRIPTION
## Context

Issue #886 (PSEO-MOBILE-001) — partial scope for this agent. The `/perguntas/[slug]` page is handled by a parallel agent and is NOT touched here.

## Changes

### Structured Data JSON-LD (Dataset schema)

**Audit findings:**
- `/orgaos/[slug]` — Dataset schema already present ✓
- `/contratos/orgao/[cnpj]` — Dataset schema already present ✓
- `/cnpj/[cnpj]` — Dataset schema already present ✓
- `/fornecedores/[cnpj]` — **Missing** — Dataset schema added in this PR

**Added to `/fornecedores/[cnpj]/page.tsx`:**
- `@type: Dataset` with dynamic `name` (`Contratos públicos — {razao_social}`) and `description` (includes total_contratos, valor_total, num estados)
- `publisher: { SmartLic }` + `creator`, `license`, `distribution` fields consistent with other pSEO pages

### Mobile CTA Audit (375px)

- `/fornecedores/[cnpj]` — CTA was at bottom of page only. Added blue banner CTA **above KPI cards** (above the fold on 375px). `data-testid="pseo-cta-primary"` applied.
- `/orgaos/[slug]` — Inline mid-page CTA (`OrgaoPerfilClient`) is within ~200px of viewport top on mobile; `StickyTrialCTA` only shows after 600px scroll. Added `data-testid="pseo-cta-primary"` to inline CTA.
- `/contratos/orgao/[cnpj]` — Hero CTA already above the fold ✓. Added `data-testid="pseo-cta-primary"`.
- `/cnpj/[cnpj]` — Inline mid-page CTA at similar position to orgaos. Added `data-testid="pseo-cta-primary"`.

### `TrackingLink` component

Extended `TrackingLinkProps` interface to accept `data-testid` prop and forward it to the underlying `<Link>` element. Backward compatible (optional prop).

## Files Modified

- `frontend/app/fornecedores/[cnpj]/page.tsx` — Dataset JSON-LD + above-fold CTA banner
- `frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx` — `data-testid` on inline CTA
- `frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx` — `data-testid` on inline CTA
- `frontend/app/contratos/orgao/[cnpj]/page.tsx` — `data-testid` on hero CTA
- `frontend/components/TrackingLink.tsx` — forward `data-testid` prop

## Testing Plan

- [ ] Navigate to `/fornecedores/12345678000190` (any valid CNPJ) — verify `<script type="application/ld+json">` with `@type: Dataset` is present in page source
- [ ] Validate JSON-LD using Google Rich Results Test: dataset name/description should be dynamic (not placeholder)
- [ ] On mobile 375px (Chrome DevTools): verify CTA `Testar 14 dias grátis →` is visible without scroll on `/fornecedores/[cnpj]`
- [ ] Check `data-testid="pseo-cta-primary"` present in DOM for all 4 pages
- [ ] Verify no TypeScript errors in TrackingLink component (data-testid is optional, backward compatible)
- [ ] Check `/orgaos/[slug]`, `/contratos/orgao/[cnpj]`, `/cnpj/[cnpj]` pages — confirm Dataset JSON-LD was already present (no regression)
- [ ] `/perguntas/[slug]` NOT touched — verify no changes there

## Risks & Rollback

**Risk:** Low. JSON-LD is inert HTML — invalid markup would be silently ignored by browsers. Only Google parsers consume it.

**Rollback:** `git revert HEAD` — single commit, all changes in one reversible unit.

## Closes #886 (partial — `/perguntas/[slug]` scope handled by parallel agent)