### PR TITLE
feat(tracking): email confirmation lifecycle Mixpanel events [CONV-INST-003] (#901)

### DIFF
--- a/backend/routes/auth_email.py
+++ b/backend/routes/auth_email.py
@@ -201,6 +201,13 @@ async def resend_confirmation(
     except Exception:
         _resend_timestamps[email_lower] = now
 
+    # CONV-INST-003: Track resend event (fire-and-forget, never raises)
+    try:
+        from analytics_events import track_event
+        track_event("email_confirmation_resent", {"source": "resend_endpoint"})
+    except Exception:
+        pass
+
     logger.info(f"Confirmation email resent for {email_lower[:4]}***")
 
     return ResendResponse(
@@ -241,17 +248,29 @@ async def auth_status(email: str = Query(..., description="Email to check")):
                         if is_first_confirm:
                             from analytics_events import track_event
                             user_id = getattr(user, "id", None)
+                            uid_str = str(user_id) if user_id else "unknown"
+                            # email_confirmation_clicked: canonical CONV-INST-003 event
+                            track_event(
+                                "email_confirmation_clicked",
+                                {
+                                    "user_id": uid_str,
+                                    "email_domain": email_lower.split("@")[1],
+                                    "source": "server_side",
+                                },
+                            )
+                            # email_verification_completed: legacy alias kept for
+                            # backward-compat with existing Mixpanel funnels
                             track_event(
                                 "email_verification_completed",
                                 {
-                                    "user_id": str(user_id) if user_id else "unknown",
+                                    "user_id": uid_str,
                                     "email_domain": email_lower.split("@")[1],
                                     "source": "server_side",
                                 },
                             )
                     except Exception as e:
                         logger.debug(
-                            f"Server-side email_verification_completed emit failed: {type(e).__name__}"
+                            f"Server-side email confirmation analytics emit failed: {type(e).__name__}"
                         )
 
                     # CRIT-SEC: Do NOT expose user_id — prevents enumeration

--- a/backend/routes/auth_signup.py
+++ b/backend/routes/auth_signup.py
@@ -195,6 +195,13 @@ async def signup(
     except Exception:  # noqa: BLE001
         logger.debug("Audit log failed for signup", exc_info=True)
 
+    # CONV-INST-003: Track confirmation email sent event (fire-and-forget, never raises)
+    try:
+        from analytics_events import track_event
+        track_event("email_confirmation_sent", {"user_id": user_id, "source": "signup"})
+    except Exception:  # noqa: BLE001
+        pass
+
     # 2. No card → legacy trial path. Compute local trial_end and return.
     if not body.stripe_payment_method_id:
         _update_profile_with_stripe(

--- a/backend/tests/test_auth_email_resend_cooldown.py
+++ b/backend/tests/test_auth_email_resend_cooldown.py
@@ -286,10 +286,15 @@ class TestAuthStatusServerSideEvent:
 
         assert response.status_code == 200
         assert response.json()["confirmed"] is True
-        mock_track_event.assert_called_once()
-        call_args = mock_track_event.call_args
-        assert call_args[0][0] == "email_verification_completed"
-        props = call_args[0][1]
+        # CONV-INST-003: now fires 2 events (email_confirmation_clicked + email_verification_completed)
+        assert mock_track_event.call_count >= 1
+        event_names = [c.args[0] for c in mock_track_event.call_args_list if c.args]
+        assert "email_verification_completed" in event_names
+        assert "email_confirmation_clicked" in event_names
+        # Verify email_verification_completed props
+        verification_call = next(c for c in mock_track_event.call_args_list
+                                 if c.args and c.args[0] == "email_verification_completed")
+        props = verification_call.args[1]
         assert props["email_domain"] == "example.com"
         assert props["source"] == "server_side"
 

--- a/backend/tests/test_email_lifecycle_tracking.py
+++ b/backend/tests/test_email_lifecycle_tracking.py
@@ -1,0 +1,209 @@
+"""
+Tests for CONV-INST-003: Email confirmation lifecycle Mixpanel events.
+
+Verifies that:
+- email_confirmation_sent fires after signup (routes/auth_signup.py)
+- email_confirmation_resent fires after resend (routes/auth_email.py)
+- email_confirmation_clicked fires on first confirmation (routes/auth_email.py)
+- All events are fire-and-forget (never raise even if analytics fails)
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# email_confirmation_sent — fires on signup
+# ---------------------------------------------------------------------------
+
+class TestEmailConfirmationSentOnSignup:
+    """track_event('email_confirmation_sent') is called after user creation."""
+
+    def _make_mock_user(self, user_id="uid-abc-123"):
+        user = MagicMock()
+        user.id = user_id
+        return user
+
+    def _make_mock_auth_result(self, user_id="uid-abc-123"):
+        result = MagicMock()
+        result.user = self._make_mock_user(user_id)
+        return result
+
+    def test_email_confirmation_sent_fires_after_signup(self):
+        """track_event('email_confirmation_sent') is called with user_id after create_user."""
+        mock_sb = MagicMock()
+        auth_result = self._make_mock_auth_result("uid-abc-123")
+        mock_sb.auth.admin.create_user.return_value = auth_result
+        mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+
+        with patch("routes.auth_signup._get_supabase", return_value=mock_sb), \
+             patch("analytics_events.track_event") as mock_track, \
+             patch("routes.auth_signup.is_disposable_email", return_value=False), \
+             patch("routes.auth_signup.validate_password", return_value=(True, None)), \
+             patch("routes.auth_signup.require_rate_limit", return_value=lambda: None), \
+             patch.dict("sys.modules", {"audit": MagicMock(log_audit_event=MagicMock())}):
+
+            from routes.auth_signup import signup
+            from schemas.user import SignupRequest
+            import asyncio
+
+            request = MagicMock()
+            body = SignupRequest(email="test@example.com", password="StrongPass123!")
+
+            asyncio.run(signup(request, body, _rl=None))
+
+            # Verify email_confirmation_sent was tracked
+            sent_calls = [c for c in mock_track.call_args_list
+                          if c.args and c.args[0] == "email_confirmation_sent"]
+            assert len(sent_calls) >= 1, "email_confirmation_sent was not tracked"
+            props = sent_calls[0].args[1] if len(sent_calls[0].args) > 1 else sent_calls[0].kwargs.get("properties", {})
+            assert props.get("user_id") == "uid-abc-123"
+
+    def test_email_confirmation_sent_never_raises_if_analytics_fails(self):
+        """If track_event raises, signup still completes without error."""
+        mock_sb = MagicMock()
+        auth_result = self._make_mock_auth_result("uid-xyz-999")
+        mock_sb.auth.admin.create_user.return_value = auth_result
+        mock_sb.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock()
+
+        with patch("routes.auth_signup._get_supabase", return_value=mock_sb), \
+             patch("analytics_events.track_event", side_effect=RuntimeError("Mixpanel down")), \
+             patch("routes.auth_signup.is_disposable_email", return_value=False), \
+             patch("routes.auth_signup.validate_password", return_value=(True, None)), \
+             patch("routes.auth_signup.require_rate_limit", return_value=lambda: None), \
+             patch.dict("sys.modules", {"audit": MagicMock(log_audit_event=MagicMock())}):
+
+            from routes.auth_signup import signup
+            from schemas.user import SignupRequest
+            import asyncio
+
+            request = MagicMock()
+            body = SignupRequest(email="test@example.com", password="StrongPass123!")
+
+            # Should not raise even though analytics fails
+            response = asyncio.run(signup(request, body, _rl=None))
+            assert response is not None
+
+
+# ---------------------------------------------------------------------------
+# email_confirmation_resent — fires on resend endpoint
+# ---------------------------------------------------------------------------
+
+class TestEmailConfirmationResentEndpoint:
+    """track_event('email_confirmation_resent') is called after resend succeeds."""
+
+    @pytest.fixture
+    def client(self):
+        """Create test client with auth_email router."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from routes.auth_email import router, _resend_timestamps
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+        _resend_timestamps.clear()
+        yield TestClient(app)
+        _resend_timestamps.clear()
+
+    def test_resent_event_fires_on_success(self, client):
+        """email_confirmation_resent is tracked when resend succeeds."""
+        mock_sb = MagicMock()
+        # No cooldown active
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = []
+        # Resend succeeds silently
+        mock_sb.auth.resend.return_value = MagicMock()
+        # Record resend succeeds
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("analytics_events.track_event") as mock_track:
+
+            resp = client.post("/v1/auth/resend-confirmation", json={"email": "user@test.com"})
+
+            assert resp.status_code == 200
+            resent_calls = [c for c in mock_track.call_args_list
+                            if c.args and c.args[0] == "email_confirmation_resent"]
+            assert len(resent_calls) >= 1, "email_confirmation_resent was not tracked"
+
+    def test_resent_event_never_raises_if_analytics_fails(self, client):
+        """Resend endpoint still returns 200 even if analytics raises."""
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value.data = []
+        mock_sb.auth.resend.return_value = MagicMock()
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("analytics_events.track_event", side_effect=RuntimeError("boom")):
+
+            resp = client.post("/v1/auth/resend-confirmation", json={"email": "user@test.com"})
+            assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# email_confirmation_clicked — fires on first confirmation in /auth/status
+# ---------------------------------------------------------------------------
+
+class TestEmailConfirmationClickedOnStatus:
+    """email_confirmation_clicked is tracked on first confirmed status check."""
+
+    @pytest.fixture
+    def client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from routes.auth_email import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+        yield TestClient(app)
+
+    def _build_confirmed_user(self, email: str):
+        user = MagicMock()
+        user.email = email
+        user.id = "user-confirmed-id"
+        user.email_confirmed_at = "2026-05-08T10:00:00+00:00"
+        return user
+
+    def test_clicked_event_fires_on_first_confirm(self, client):
+        """email_confirmation_clicked fires when status endpoint detects first confirm."""
+        confirmed_user = self._build_confirmed_user("confirmed@test.com")
+
+        mock_sb = MagicMock()
+        mock_sb.auth.admin.list_users.return_value = [confirmed_user]
+        # _record_confirm_db returns True (first time)
+        # Select: empty rows (not yet confirmed in DB)
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value.data = []
+        # Insert succeeds
+        mock_sb.table.return_value.insert.return_value.execute.return_value = MagicMock()
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("analytics_events.track_event") as mock_track:
+
+            resp = client.get("/v1/auth/status?email=confirmed@test.com")
+
+            assert resp.status_code == 200
+            assert resp.json()["confirmed"] is True
+
+            clicked_calls = [c for c in mock_track.call_args_list
+                             if c.args and c.args[0] == "email_confirmation_clicked"]
+            assert len(clicked_calls) >= 1, "email_confirmation_clicked was not tracked"
+
+    def test_clicked_event_not_fired_on_repeated_confirm(self, client):
+        """email_confirmation_clicked is NOT fired again if already recorded."""
+        confirmed_user = self._build_confirmed_user("confirmed@test.com")
+
+        mock_sb = MagicMock()
+        mock_sb.auth.admin.list_users.return_value = [confirmed_user]
+        # _record_confirm_db returns False (already confirmed in DB)
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value.data = [
+            {"id": "existing-confirm-row"}
+        ]
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("analytics_events.track_event") as mock_track:
+
+            resp = client.get("/v1/auth/status?email=confirmed@test.com")
+
+            assert resp.status_code == 200
+            clicked_calls = [c for c in mock_track.call_args_list
+                             if c.args and c.args[0] == "email_confirmation_clicked"]
+            assert len(clicked_calls) == 0, "email_confirmation_clicked fired on repeat (should be idempotent)"

--- a/docs/analytics/event-dictionary.md
+++ b/docs/analytics/event-dictionary.md
@@ -739,7 +739,86 @@ Every event automatically includes these properties:
 
 ---
 
+## 7. Email Confirmation Lifecycle Events (CONV-INST-003)
+
+These events track the complete email confirmation funnel from signup through activation.
+
+**Source:** `frontend/lib/analytics/email_lifecycle.ts` (frontend) + `backend/routes/auth_signup.py` + `backend/routes/auth_email.py` (backend server-side).
+
+### `email_confirmation_sent`
+
+**Description:** Triggered server-side immediately after a new user account is created (Supabase sends the confirmation email automatically).
+
+**When Triggered:** `POST /auth/signup` — after `create_user` succeeds.
+
+**Properties:**
+
+| Property | Type | Required | Description | Example |
+|----------|------|----------|-------------|---------|
+| `user_id` | String | ✅ | Supabase user UUID | `uid-abc-123` |
+| `source` | String | ✅ | Trigger origin | `signup` |
+
+---
+
+### `email_confirmation_clicked`
+
+**Description:** Triggered server-side on the first time `GET /auth/status` detects the email as confirmed. Idempotent — fires only once per user.
+
+**When Triggered:** First successful `GET /auth/status` polling cycle after email link click.
+
+**Properties:**
+
+| Property | Type | Required | Description | Example |
+|----------|------|----------|-------------|---------|
+| `user_id` | String | ✅ | Supabase user UUID | `uid-abc-123` |
+| `email_domain` | String | ✅ | Domain of the confirmed email | `example.com` |
+| `source` | String | ✅ | Always `server_side` | `server_side` |
+
+---
+
+### `email_confirmation_expired`
+
+**Description:** Fired client-side when the confirmation link has expired before the user clicks it.
+
+**When Triggered:** Frontend detects confirmation link expiry.
+
+**Properties:**
+
+| Property | Type | Required | Description | Example |
+|----------|------|----------|-------------|---------|
+| `user_id` | String | ✅ | Supabase user UUID | `uid-abc-123` |
+
+---
+
+### `email_confirmation_resent`
+
+**Description:** Triggered server-side when the user requests a resend of the confirmation email.
+
+**When Triggered:** `POST /auth/resend-confirmation` — after resend call succeeds.
+
+**Properties:**
+
+| Property | Type | Required | Description | Example |
+|----------|------|----------|-------------|---------|
+| `source` | String | ✅ | Trigger origin | `resend_endpoint` |
+
+---
+
+### `email_verification_completed`
+
+**Description:** Legacy alias for `email_confirmation_clicked`. Kept for backward-compatibility with existing Mixpanel funnels. Both events fire together on first confirmation.
+
+**Note:** Use `email_confirmation_clicked` for new funnels; `email_verification_completed` is retained for historical continuity.
+
+---
+
 ## Changelog
+
+### Version 1.1 (2026-05-08)
+- Added Email Confirmation Lifecycle Events section (CONV-INST-003)
+- 4 new events: `email_confirmation_sent`, `email_confirmation_clicked`, `email_confirmation_expired`, `email_confirmation_resent`
+- Backend server-side triggers in `auth_signup.py` and `auth_email.py`
+- Frontend typed wrappers in `frontend/lib/analytics/email_lifecycle.ts`
 
 ### Version 1.0 (2026-01-30)
 - Initial event dictionary

--- a/frontend/lib/analytics/__tests__/email_lifecycle.test.ts
+++ b/frontend/lib/analytics/__tests__/email_lifecycle.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for email lifecycle analytics wrappers (lib/analytics/email_lifecycle.ts).
+ *
+ * Verifies:
+ * - safeTrack swallows errors from Mixpanel (never throws)
+ * - Each exported event wrapper calls mixpanel.track with the correct event
+ *   name and {user_id} property
+ */
+
+import mixpanel from 'mixpanel-browser';
+
+jest.mock('mixpanel-browser', () => ({
+  __esModule: true,
+  default: { track: jest.fn() },
+}));
+
+import {
+  trackEmailConfirmationSent,
+  trackEmailConfirmationClicked,
+  trackEmailConfirmationExpired,
+  trackEmailConfirmationResent,
+} from '../email_lifecycle';
+
+const mockTrack = mixpanel.track as jest.Mock;
+
+beforeEach(() => {
+  mockTrack.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// safeTrack — error swallowing
+// ---------------------------------------------------------------------------
+
+describe('safeTrack error swallowing', () => {
+  it('does not throw when mixpanel.track throws', () => {
+    mockTrack.mockImplementationOnce(() => {
+      throw new Error('Mixpanel not initialized');
+    });
+
+    expect(() => trackEmailConfirmationSent('user-123')).not.toThrow();
+  });
+
+  it('does not throw when mixpanel.track throws a non-Error value', () => {
+    mockTrack.mockImplementationOnce(() => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw 'consent not given';
+    });
+
+    expect(() => trackEmailConfirmationClicked('user-123')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Individual event wrappers
+// ---------------------------------------------------------------------------
+
+describe('trackEmailConfirmationSent', () => {
+  it('calls mixpanel.track with email_confirmation_sent and user_id', () => {
+    trackEmailConfirmationSent('user-abc-123');
+    expect(mockTrack).toHaveBeenCalledWith('email_confirmation_sent', {
+      user_id: 'user-abc-123',
+    });
+  });
+
+  it('calls track exactly once', () => {
+    trackEmailConfirmationSent('user-abc-123');
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('trackEmailConfirmationClicked', () => {
+  it('calls mixpanel.track with email_confirmation_clicked and user_id', () => {
+    trackEmailConfirmationClicked('user-def-456');
+    expect(mockTrack).toHaveBeenCalledWith('email_confirmation_clicked', {
+      user_id: 'user-def-456',
+    });
+  });
+
+  it('calls track exactly once', () => {
+    trackEmailConfirmationClicked('user-def-456');
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('trackEmailConfirmationExpired', () => {
+  it('calls mixpanel.track with email_confirmation_expired and user_id', () => {
+    trackEmailConfirmationExpired('user-ghi-789');
+    expect(mockTrack).toHaveBeenCalledWith('email_confirmation_expired', {
+      user_id: 'user-ghi-789',
+    });
+  });
+
+  it('calls track exactly once', () => {
+    trackEmailConfirmationExpired('user-ghi-789');
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('trackEmailConfirmationResent', () => {
+  it('calls mixpanel.track with email_confirmation_resent and user_id', () => {
+    trackEmailConfirmationResent('user-jkl-012');
+    expect(mockTrack).toHaveBeenCalledWith('email_confirmation_resent', {
+      user_id: 'user-jkl-012',
+    });
+  });
+
+  it('calls track exactly once', () => {
+    trackEmailConfirmationResent('user-jkl-012');
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/analytics/email_lifecycle.ts
+++ b/frontend/lib/analytics/email_lifecycle.ts
@@ -1,0 +1,58 @@
+/**
+ * Typed Mixpanel analytics wrappers for email confirmation lifecycle events.
+ *
+ * All functions are safe to call unconditionally — they never throw even if
+ * Mixpanel is not initialized (SSR, consent not given, token missing).
+ *
+ * Import pattern:
+ *   import { trackEmailConfirmationSent } from '@/lib/analytics/email_lifecycle';
+ *
+ * Events covered (CONV-INST-003):
+ *   - email_confirmation_sent
+ *   - email_confirmation_clicked
+ *   - email_confirmation_expired
+ *   - email_confirmation_resent
+ */
+
+import mixpanel from 'mixpanel-browser';
+
+// Safe wrapper — never throws even if Mixpanel not initialized
+function safeTrack(event: string, props?: Record<string, unknown>): void {
+  try {
+    mixpanel.track(event, props);
+  } catch {
+    // Mixpanel not initialized (SSR or consent not given)
+  }
+}
+
+// ============================================================
+// Email Confirmation Lifecycle Events
+// ============================================================
+
+/**
+ * Fire when a confirmation email is sent to the user after signup.
+ */
+export function trackEmailConfirmationSent(userId: string): void {
+  safeTrack('email_confirmation_sent', { user_id: userId });
+}
+
+/**
+ * Fire when the user clicks the confirmation link in the email.
+ */
+export function trackEmailConfirmationClicked(userId: string): void {
+  safeTrack('email_confirmation_clicked', { user_id: userId });
+}
+
+/**
+ * Fire when an unconfirmed email confirmation link expires.
+ */
+export function trackEmailConfirmationExpired(userId: string): void {
+  safeTrack('email_confirmation_expired', { user_id: userId });
+}
+
+/**
+ * Fire when the user requests a resend of the confirmation email.
+ */
+export function trackEmailConfirmationResent(userId: string): void {
+  safeTrack('email_confirmation_resent', { user_id: userId });
+}


### PR DESCRIPTION
## Summary

- Add `frontend/lib/analytics/email_lifecycle.ts` with typed `safeTrack` wrappers for all four email lifecycle events (`email_confirmation_sent`, `email_confirmation_clicked`, `email_confirmation_expired`, `email_confirmation_resent`)
- Backend server-side triggers: `email_confirmation_sent` fires in `auth_signup.py` after `create_user`; `email_confirmation_resent` fires in `auth_email.py` after successful resend; `email_confirmation_clicked` fires in `auth_email.py` on first-ever confirmation (idempotent via `user_email_actions` table)
- All analytics calls are fire-and-forget (wrapped in `try/except`, never raise)
- Legacy `email_verification_completed` event retained alongside `email_confirmation_clicked` for backward-compat with existing Mixpanel funnels

## Testing Plan

- [x] 10 frontend unit tests in `frontend/lib/analytics/__tests__/email_lifecycle.test.ts` — all pass
- [x] 6 backend unit tests in `backend/tests/test_email_lifecycle_tracking.py` — all pass
- [x] Existing `test_auth_email_resend_cooldown.py` (15 tests) — all pass after assertion update for dual-event emission
- [x] `ruff check` on all modified/new backend files — no errors
- [x] `next lint` on frontend files — no errors
- [ ] Manual smoke: sign up with a new email, confirm, resend — verify events appear in Mixpanel Live View

## Closes #901