### PR TITLE
feat(frontend): MS Clarity onboarding step tagging CONV-INST-005

### DIFF
--- a/frontend/app/buscar/page.tsx
+++ b/frontend/app/buscar/page.tsx
@@ -35,6 +35,7 @@ import { ReferralToast, shouldShowReferralToast } from "./components/ReferralToa
 import { RestoredResultsBanner } from "./components/RestoredResultsBanner";
 import { clearNewBidsBadge } from "../../components/NewBidsNotificationBadge";
 import { setClarityTag } from "../components/ClarityAnalytics";
+import { tagOnboardingStep } from "../../lib/analytics/clarity_onboarding";
 
 function HomePageContent() {
   const orch = useSearchOrchestration();
@@ -97,11 +98,13 @@ function HomePageContent() {
   }, [orch.planInfo?.plan_id]);
 
   // CONV-INST-005 AC4: tag first_analysis_done once when results arrive
+  // Also tag onboarding_step=first_search for funnel filtering in Clarity dashboard
   useEffect(() => {
     if (firstAnalysisDoneRef.current) return;
     if (!orch.search.result || orch.search.loading) return;
     firstAnalysisDoneRef.current = true;
     setClarityTag("first_analysis_done", "true");
+    tagOnboardingStep('first_search');
   }, [orch.search.result, orch.search.loading]);
 
   if (orch.authLoading) {

--- a/frontend/app/signup/components/SignupSuccess.tsx
+++ b/frontend/app/signup/components/SignupSuccess.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useAnalytics } from "../../../hooks/useAnalytics";
 import { EmailDeadEndModal } from "./EmailDeadEndModal";
+import { tagOnboardingStep } from "../../../lib/analytics/clarity_onboarding";
 
 interface SignupSuccessProps {
   email: string;
@@ -53,6 +54,8 @@ export function SignupSuccess({
       rollout_branch: rolloutBranch ?? "unknown",
       signup_method: "email", // Google OAuth goes through /auth/callback — never reaches this screen
     });
+    // CONV-INST-005: Tag Clarity session with email_pending step
+    tagOnboardingStep('email_pending');
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // AC3: After 5min without confirmation, fire timeout event + show dead-end modal.

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -21,6 +21,7 @@ import { SignupOAuth } from "./components/SignupOAuth";
 import { SignupForm } from "./components/SignupForm";
 import CardCollect from "./components/CardCollect";
 import { computeRolloutBranch, readRolloutPctFromEnv, type RolloutBranch } from "./hooks/useRolloutBranch";
+import { tagOnboardingStep } from "../../lib/analytics/clarity_onboarding";
 
 // STORY-323: Partner name type
 type PartnerInfo = { name: string; slug: string } | null;
@@ -65,6 +66,11 @@ export default function SignupPage() {
       setTimeout(() => { router.push("/buscar"); }, 1500);
     }
   }, [authLoading, authSession, router]);
+
+  // CONV-INST-005: Tag Clarity session with signup_form step on mount
+  useEffect(() => {
+    tagOnboardingStep('signup_form');
+  }, []);
 
   // STORY-323 AC16: Partner tracking
   const [partnerInfo, setPartnerInfo] = useState<PartnerInfo>(null);
@@ -122,6 +128,8 @@ export default function SignupPage() {
             email_domain: email.split("@")[1] ?? "",
             polling_iterations: pollingIterationsRef.current,
           });
+          // CONV-INST-005: Tag Clarity session as email confirmed
+          tagOnboardingStep('email_confirmed');
           setIsConfirmed(true);
           clearInterval(interval);
           toast.success("Email confirmado! Redirecionando...");

--- a/frontend/lib/analytics/__tests__/clarity_onboarding.test.ts
+++ b/frontend/lib/analytics/__tests__/clarity_onboarding.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for MS Clarity onboarding step tagging (lib/analytics/clarity_onboarding.ts).
+ *
+ * Verifies:
+ * - tagOnboardingStep does not throw when window.clarity is undefined
+ * - tagOnboardingStep calls window.clarity('set', 'onboarding_step', step) when available
+ * - All OnboardingStep literal values are type-safe and exercised
+ *
+ * Strategy: mock setClarityTag (the underlying primitive) so tests don't depend
+ * on LGPD consent or ClarityAnalytics internals.
+ */
+
+// Mock the ClarityAnalytics module before importing the module under test
+jest.mock('../../../app/components/ClarityAnalytics', () => ({
+  setClarityTag: jest.fn(),
+  getCookieConsent: jest.fn(() => ({ analytics: true })),
+}));
+
+import { setClarityTag } from '../../../app/components/ClarityAnalytics';
+import { tagOnboardingStep, type OnboardingStep } from '../clarity_onboarding';
+
+const mockSetClarityTag = setClarityTag as jest.Mock;
+
+beforeEach(() => {
+  mockSetClarityTag.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Safety — never throws
+// ---------------------------------------------------------------------------
+
+describe('tagOnboardingStep safety', () => {
+  it('does not throw when setClarityTag is called', () => {
+    expect(() => tagOnboardingStep('signup_form')).not.toThrow();
+  });
+
+  it('does not throw for any valid OnboardingStep', () => {
+    const steps: OnboardingStep[] = [
+      'signup_form',
+      'email_pending',
+      'email_confirmed',
+      'profile_setup',
+      'first_search',
+      'trial_activated',
+      'churned',
+    ];
+    steps.forEach(step => {
+      expect(() => tagOnboardingStep(step)).not.toThrow();
+    });
+  });
+
+  it('does not throw when setClarityTag throws internally', () => {
+    mockSetClarityTag.mockImplementationOnce(() => {
+      throw new Error('Clarity not loaded');
+    });
+    expect(() => tagOnboardingStep('signup_form')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Correct delegation — calls setClarityTag with the right key/value
+// ---------------------------------------------------------------------------
+
+describe('tagOnboardingStep delegation', () => {
+  it('calls setClarityTag with key "onboarding_step" and the step value', () => {
+    tagOnboardingStep('signup_form');
+    expect(mockSetClarityTag).toHaveBeenCalledWith('onboarding_step', 'signup_form');
+  });
+
+  it('calls setClarityTag exactly once per invocation', () => {
+    tagOnboardingStep('email_pending');
+    expect(mockSetClarityTag).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// All step values delegate correctly
+// ---------------------------------------------------------------------------
+
+describe('OnboardingStep — all values delegate to setClarityTag', () => {
+  const steps: OnboardingStep[] = [
+    'signup_form',
+    'email_pending',
+    'email_confirmed',
+    'profile_setup',
+    'first_search',
+    'trial_activated',
+    'churned',
+  ];
+
+  steps.forEach(step => {
+    it(`delegates step "${step}" correctly`, () => {
+      tagOnboardingStep(step);
+      expect(mockSetClarityTag).toHaveBeenCalledWith('onboarding_step', step);
+    });
+  });
+});

--- a/frontend/lib/analytics/clarity_onboarding.ts
+++ b/frontend/lib/analytics/clarity_onboarding.ts
@@ -1,0 +1,43 @@
+/**
+ * Onboarding step tagging for MS Clarity (CONV-INST-005)
+ *
+ * Delegates to setClarityTag which already handles:
+ *   - SSR safety (typeof window check)
+ *   - LGPD consent gate (analytics consent required)
+ *   - Queue-before-load pattern (clarity.q)
+ *
+ * Never throws — safe to call unconditionally.
+ *
+ * Usage:
+ *   import { tagOnboardingStep } from '@/lib/analytics/clarity_onboarding';
+ *   tagOnboardingStep('signup_form');
+ */
+
+import { setClarityTag } from '../../app/components/ClarityAnalytics';
+
+export type OnboardingStep =
+  | 'signup_form'
+  | 'email_pending'
+  | 'email_confirmed'
+  | 'profile_setup'
+  | 'first_search'
+  | 'trial_activated'
+  | 'churned';
+
+/**
+ * Tag the current MS Clarity session recording with the user's onboarding step.
+ * Recordings can then be filtered in the Clarity dashboard by
+ * custom tag: onboarding_step = <step>.
+ *
+ * Never throws — safe to call unconditionally.
+ *
+ * AC4 note: 'churned' step detection via ARQ cron is out of scope for this PR.
+ */
+export function tagOnboardingStep(step: OnboardingStep): void {
+  try {
+    setClarityTag('onboarding_step', step);
+  } catch {
+    // setClarityTag is already safe but we guard here too in case of
+    // unexpected issues (e.g. test mocks throwing, future refactors).
+  }
+}


### PR DESCRIPTION
## Context

Implements CONV-INST-005: granular per-step tagging for MS Clarity session recordings so the funnel can be filtered in the Clarity dashboard by `onboarding_step` custom tag. Clarity base integration (project ID `voop54cv1p`) was already instrumented; this PR adds semantic step labels.

## Changes

- **New** `frontend/lib/analytics/clarity_onboarding.ts` — `tagOnboardingStep(step: OnboardingStep)` utility that delegates to the existing `setClarityTag` (which owns SSR safety and LGPD consent gate). Adds a secondary try/catch to guarantee it never throws even if mocks or future refactors make `setClarityTag` throw.
- **New** `frontend/lib/analytics/__tests__/clarity_onboarding.test.ts` — 12 tests covering: no-throw when clarity unavailable, no-throw when setClarityTag throws internally, correct key/value delegation for all 7 step values.
- **Wired** `frontend/app/signup/page.tsx` — fires `signup_form` on mount (step 1) and `email_confirmed` on polling-success confirmation.
- **Wired** `frontend/app/signup/components/SignupSuccess.tsx` — fires `email_pending` alongside the existing `email_verification_pending` Mixpanel event (same `useRef` gate prevents StrictMode double-fire).
- **Wired** `frontend/app/buscar/page.tsx` — fires `first_search` alongside the existing `first_analysis_done` tag when first results arrive.

### Out of scope (noted in code)
- **AC4 (churned)**: Churn detection via ARQ cron job is too complex for this PR. `churned` step type is defined and exported for future use.
- **AC5 (dashboard validation)**: Manual verification — see Testing Plan below.

## Testing Plan

- [ ] `npm test -- --testPathPattern="clarity_onboarding"` → 12 tests pass (verified locally)
- [ ] Manual: Sign up with a new account → open Clarity dashboard → filter sessions by custom tag `onboarding_step = signup_form` → confirm session appears
- [ ] Manual: Complete email confirmation → filter by `onboarding_step = email_confirmed` → confirm session appears
- [ ] Manual: Run first search in `/buscar` → filter by `onboarding_step = first_search` → confirm session appears
- [ ] Verify no JS errors in browser console on signup page, email pending screen, and buscar page
- [ ] Verify LGPD gate respected: disable analytics consent → confirm no Clarity calls are made

## Risks & Rollback

- **Low risk**: All calls are fire-and-forget, wrapped in try/catch, gated by LGPD consent. No backend changes.
- **Rollback**: Revert the 3 component edits (`signup/page.tsx`, `SignupSuccess.tsx`, `buscar/page.tsx`) — the utility file can stay.

## Closes #902