### PR TITLE
feat(ci): pip-audit + npm-audit + dependabot (#193)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     reviewers:
       - "tjsasakifln"
     labels:
@@ -16,6 +16,12 @@ updates:
     commit-message:
       prefix: "chore(backend)"
       include: "scope"
+    # TD-GTM-004 (#193): group minor + patch into one PR per ecosystem to reduce churn.
+    groups:
+      backend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # Ignore major version updates for now (POC phase)
       - dependency-name: "*"
@@ -28,7 +34,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     reviewers:
       - "tjsasakifln"
     labels:
@@ -37,6 +43,12 @@ updates:
     commit-message:
       prefix: "chore(frontend)"
       include: "scope"
+    # TD-GTM-004 (#193): group minor + patch into one PR per ecosystem to reduce churn.
+    groups:
+      frontend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # Ignore major version updates for now (POC phase)
       - dependency-name: "*"
@@ -49,9 +61,15 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "ci"
     commit-message:
       prefix: "chore(ci)"
+    # TD-GTM-004 (#193): group minor + patch into one PR per ecosystem to reduce churn.
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,136 @@
+# TD-GTM-004 (#193): Dependency security scanning via pip-audit + npm audit.
+#
+# Complementary to dep-scan.yml (DEBT-08, PyPI advisories): this workflow uses
+# the OSV vulnerability service for broader/recent CVE coverage and runs on a
+# daily schedule so newly disclosed CVEs in already-merged dependencies surface
+# within 24h instead of waiting for the next dep-changing PR.
+name: "Dependency Audit (OSV)"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/requirements.txt'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - '.github/workflows/dependency-audit.yml'
+  schedule:
+    # Daily at 07:00 UTC (04:00 BRT) — surfaces newly disclosed CVEs within 24h.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-audit-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # ─────────────────────────────────────────────────
+  # Backend: pip-audit against the OSV database
+  # ─────────────────────────────────────────────────
+  pip-audit:
+    name: "Backend — pip-audit (OSV)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install pip-audit
+        run: pip install 'pip-audit==2.9.0'
+
+      - name: Run pip-audit (OSV, strict)
+        # --strict: fail on any vulnerability (not just HIGH/CRITICAL); pairs with
+        # documented --ignore-vuln entries in docs/security/dependency-scanning.md.
+        # --vulnerability-service osv: free OSV.dev advisories with broad coverage.
+        run: |
+          set -euo pipefail
+          mkdir -p audit-reports
+          pip-audit \
+            -r backend/requirements.txt \
+            --strict \
+            --vulnerability-service osv \
+            --desc on \
+            --format json \
+            --output audit-reports/pip-audit.json
+          echo "pip-audit (OSV): clean"
+
+      - name: Upload pip-audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-osv-report
+          path: audit-reports/pip-audit.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ─────────────────────────────────────────────────
+  # Frontend: npm audit (production deps, HIGH+)
+  # ─────────────────────────────────────────────────
+  npm-audit:
+    name: "Frontend — npm audit (prod, HIGH+)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          # Honors frontend/package.json engines (>=18). Pinned to 20 LTS to match
+          # other workflows (dep-scan.yml, frontend-tests.yml).
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies (no scripts)
+        run: |
+          cd frontend
+          npm ci --ignore-scripts
+
+      - name: Run npm audit (prod, HIGH+)
+        run: |
+          cd frontend
+          mkdir -p ../audit-reports
+          # Capture JSON for artifact, then re-run with human-readable output for
+          # the action log. --omit=dev focuses the gate on prod runtime.
+          npm audit --audit-level=high --omit=dev --json > ../audit-reports/npm-audit.json || NPM_AUDIT_EXIT=$?
+          npm audit --audit-level=high --omit=dev
+          if [ -n "${NPM_AUDIT_EXIT:-}" ] && [ "${NPM_AUDIT_EXIT}" -ne 0 ]; then
+            echo "npm audit reported HIGH/CRITICAL vulnerabilities — see report artifact"
+            exit "${NPM_AUDIT_EXIT}"
+          fi
+          echo "npm audit (prod): clean"
+
+      - name: Upload npm-audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: audit-reports/npm-audit.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ─────────────────────────────────────────────────
+  # Gate summary — both jobs must pass to unblock PRs
+  # ─────────────────────────────────────────────────
+  dependency-audit-gate:
+    name: "Dependency Audit Gate"
+    runs-on: ubuntu-latest
+    needs: [pip-audit, npm-audit]
+    if: always()
+    steps:
+      - name: Verify all audits passed
+        run: |
+          if [ "${{ needs.pip-audit.result }}" != "success" ] || [ "${{ needs.npm-audit.result }}" != "success" ]; then
+            echo "Dependency audit failed — see job logs and artifacts"
+            exit 1
+          fi
+          echo "Dependency audit gate: passed"

--- a/docs/security/dependency-scanning.md
+++ b/docs/security/dependency-scanning.md
@@ -1,0 +1,70 @@
+# Dependency Security Scanning
+
+Runbook for the dependency CVE gates. Closes [#193](https://github.com/tjsasakifln/SmartLic/issues/193) (TD-GTM-004).
+
+## Overview
+
+Two complementary CI workflows protect production from vulnerable dependencies:
+
+| Workflow | File | Vuln source | Schedule | Scope |
+|----------|------|-------------|----------|-------|
+| **Dep Scan** (DEBT-08) | `.github/workflows/dep-scan.yml` | PyPI advisories + npm registry | Weekly (Mon 08:00 UTC) + on dep PRs + push to `main` | HIGH/CRITICAL gate |
+| **Dependency Audit (OSV)** | `.github/workflows/dependency-audit.yml` | OSV.dev + npm registry | **Daily (07:00 UTC)** + on dep PRs | Strict (any severity for backend, HIGH+ for frontend) |
+
+The OSV workflow runs daily so a CVE disclosed against an already-merged dependency surfaces within 24 hours instead of waiting for the next dep-changing PR.
+
+Dependabot (`.github/dependabot.yml`) opens grouped weekly PRs (minor + patch combined) for `pip` (`/backend`), `npm` (`/frontend`), and `github-actions` (`/`).
+
+## How the OSV workflow runs
+
+1. **Backend (`pip-audit`):** installs `pip-audit==2.9.0`, runs `pip-audit -r backend/requirements.txt --strict --vulnerability-service osv --format json`. JSON report uploaded as artifact `pip-audit-osv-report` (30d retention).
+2. **Frontend (`npm-audit`):** `npm ci --ignore-scripts` then `npm audit --audit-level=high --omit=dev`. JSON uploaded as `npm-audit-report`.
+3. **Gate (`dependency-audit-gate`):** fails if either job fails. Required for PR merge once the workflow has run on the PR.
+
+## Triage: pip-audit failure
+
+When `pip-audit` blocks a PR:
+
+1. **Read the JSON artifact** from the failed run (`Actions → Dependency Audit (OSV) → run → artifacts → pip-audit-osv-report`). Each entry has `id` (e.g. `GHSA-xxxx-xxxx-xxxx` or `PYSEC-2024-NN`), `description`, `fix_versions`, and the affected package.
+2. **Check fix availability:**
+   - **Fix available:** bump the pinned version in `backend/requirements.txt`. If it's a transitive dependency, bump the parent or pin the transitive dep directly.
+   - **No fix yet:** confirm exploitability against our actual usage. If non-applicable (CVE in a code path we don't call), proceed to whitelist.
+3. **Whitelist (temporary):** add `--ignore-vuln <ID>` to the `pip-audit` step in `.github/workflows/dependency-audit.yml`, with an inline comment containing the rationale, link to upstream advisory, and a follow-up issue number. **Cap at 3 simultaneous ignores** — if more accumulate, open a security debt epic.
+4. **Track:** open a follow-up issue tagged `security` + `dependencies` listing the ignored CVE, expected fix ETA, and review date.
+
+Example ignore syntax:
+
+```yaml
+- name: Run pip-audit (OSV, strict)
+  run: |
+    pip-audit \
+      -r backend/requirements.txt \
+      --strict \
+      --vulnerability-service osv \
+      --ignore-vuln GHSA-xxxx-xxxx-xxxx \  # Issue #NNN — non-exploitable, awaiting upstream fix (review YYYY-MM)
+      --desc on \
+      --format json \
+      --output audit-reports/pip-audit.json
+```
+
+## Triage: npm audit failure
+
+1. **Read the JSON artifact** (`npm-audit-report`). For each `vulnerabilities` entry check `severity`, `via`, `fixAvailable`.
+2. **`fixAvailable: true` and non-breaking:** run `cd frontend && npm audit fix`, commit `package-lock.json`.
+3. **`fixAvailable` requires major bump:** evaluate breaking changes; if blocked, file an issue and add a per-package allow-list via `npm audit --audit-level=critical` (raise the gate temporarily) **only with code-owner approval**. Document in `CHANGELOG.md`.
+4. **Dev-only deps:** the gate already excludes them via `--omit=dev`. The legacy `dep-scan.yml` runs an advisory dev-deps pass.
+
+## How to update the workflow
+
+- **Bump pip-audit:** edit `pip install 'pip-audit==X.Y.Z'` in `dependency-audit.yml`. Pin to specific patch — pip-audit's CLI/JSON shape changed between minor versions historically.
+- **Bump Node:** edit `node-version: '20'`. Keep aligned with `dep-scan.yml` and `frontend-tests.yml` to avoid version skew across audits.
+- **Change cron:** the `0 7 * * *` daily UTC schedule was chosen to land before the team's working hours (BRT). Adjust in the `on.schedule.cron` field if disclosure→fix latency becomes a problem.
+- **Disable temporarily:** comment the `paths:` and `schedule:` triggers (do **not** delete the workflow) and open a tracking issue. Never bypass via branch protection without code-owner sign-off.
+
+## Where things live
+
+- Workflow: `.github/workflows/dependency-audit.yml`
+- Legacy / sibling workflow: `.github/workflows/dep-scan.yml`
+- Dependabot config: `.github/dependabot.yml`
+- Auto-merge config (Dependabot): `.github/workflows/dependabot-auto-merge.yml`
+- This runbook: `docs/security/dependency-scanning.md`


### PR DESCRIPTION
## Summary
- New `dependency-audit.yml` workflow runs `pip-audit` (OSV) and `npm audit` on PRs touching deps + daily schedule (07:00 UTC) so CVEs disclosed against already-merged dependencies surface within 24h.
- Updated `.github/dependabot.yml`: raised `pip` and `npm` limits to 10, added minor+patch grouping for all three ecosystems (`pip` `/backend`, `npm` `/frontend`, `github-actions` `/`) to reduce PR churn.
- Added `docs/security/dependency-scanning.md` triage runbook (pip-audit / npm audit failure flow, `--ignore-vuln` whitelist policy capped at 3, workflow update guide).

## Context
Closes [#193](https://github.com/tjsasakifln/SmartLic/issues/193) (TD-GTM-004). Production previously had only `dep-scan.yml` (DEBT-08, weekly Mon, PyPI advisories). This PR adds a complementary daily OSV-backed scan so CVEs surface within 24h instead of waiting for the next dep-changing PR. CI now blocks PRs that introduce known vulnerabilities; Dependabot opens grouped weekly PRs to keep transitive deps current.

## Testing Plan
- [ ] Workflow YAML parses (`yaml.safe_load`) — verified locally
- [ ] First run on this PR completes — `pip-audit` (OSV) + `npm audit` (HIGH+, prod-only) both green or with documented `--ignore-vuln` rationale
- [ ] Dependabot config validates server-side after merge (next Mon run renders grouped PRs)
- [ ] Daily schedule cron fires at 07:00 UTC after merge

## Closes
Closes #193