### PR TITLE
fix(a11y): WCAG AA contrast for muted text tokens (#197)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -6,30 +6,30 @@
 :root {
   /* Canvas & Ink - WCAG Contrast Documentation */
   --canvas: #ffffff;  /* Base background */
-  --ink: #1e2d3b;     /* Primary text - vs canvas: 12.6:1 (AAA ✅) */
-  --ink-secondary: #3d5975;  /* Secondary text - vs canvas: 5.5:1 (AA ✅) */
-  --ink-muted: #6b7a8a;  /* Muted text - vs canvas: 5.1:1 (AA ✅) - Bug fix P2-6: Improved from #808f9f (4.48:1) */
+  --ink: #1e2d3b;     /* Primary text - vs canvas: 14.06:1 (AAA ✅) */
+  --ink-secondary: #3d5975;  /* Secondary text - vs canvas: 7.28:1 (AAA ✅) */
+  --ink-muted: #5a6573;  /* Muted text - vs canvas: 5.93:1, vs surface-1: 5.58:1, vs surface-2: 5.28:1 (AA ✅ all backgrounds) - Issue #197: Darkened from #6b7a8a (was actually 4.14:1 vs surface-1, FAILED AA despite earlier P2-6 comment) */
   --ink-faint: #c0d2e5;  /* Faint text/borders - vs canvas: 1.9:1 (decorative only) */
 
   /* Brand Colors */
-  --brand-navy: #0a1e3f;  /* Primary brand - vs canvas: 14.8:1 (AAA ✅) */
-  --brand-blue: #116dff;  /* Accent color - vs canvas: 4.8:1 (AA ✅) */
-  --brand-blue-hover: #0d5ad4;  /* Hover state - vs canvas: 6.2:1 (AA+ ✅) */
+  --brand-navy: #0a1e3f;  /* Primary brand - vs canvas: 17.4:1 (AAA ✅) */
+  --brand-blue: #116dff;  /* Accent color - vs canvas: 4.51:1 (AA text ✅), vs surface-1: 4.25:1 (UI 3:1 ✅, text use should prefer brand-blue-hover on tinted bg) */
+  --brand-blue-hover: #0d5ad4;  /* Hover state - vs canvas: 6.12:1, vs surface-1: 5.76:1 (AA ✅) */
   --brand-blue-subtle: #e8f0ff;  /* Subtle background - vs ink: 1.1:1 (decorative only) */
 
   /* Surface Hierarchy */
   --surface-0: #ffffff;  /* Base surface */
-  --surface-1: #f7f8fa;  /* Elevated surface - vs ink: 12.3:1 (AAA ✅) */
-  --surface-2: #f0f2f5;  /* Card backgrounds - vs ink: 11.8:1 (AAA ✅) */
+  --surface-1: #f7f8fa;  /* Elevated surface - vs ink: 13.2:1 (AAA ✅) */
+  --surface-2: #f0f2f5;  /* Card backgrounds - vs ink: 12.5:1 (AAA ✅) */
   --surface-elevated: #ffffff;  /* Modals/dropdowns */
 
-  /* Semantic Colors */
-  --success: #16a34a;  /* Success state - vs canvas: 4.7:1 (AA ✅) */
-  --success-subtle: #f0fdf4;  /* Success bg - vs success: 1.2:1 (decorative) */
-  --error: #dc2626;  /* Error state - vs canvas: 5.9:1 (AA ✅) */
-  --error-subtle: #fef2f2;  /* Error bg - vs error: 1.1:1 (decorative) */
-  --warning: #ca8a04;  /* Warning state - vs canvas: 5.2:1 (AA ✅) */
-  --warning-subtle: #fefce8;  /* Warning bg - vs warning: 1.1:1 (decorative) */
+  /* Semantic Colors — Issue #197: retuned to AA-pass on all surfaces (canvas/surface-1/surface-2) and on their *-subtle banners */
+  --success: #107533;  /* Success text - vs canvas: 5.81:1, surface-1: 5.47:1, surface-2: 5.18:1, success-subtle: 5.55:1 (AA ✅) - was #16a34a (3.30:1, FAILED) */
+  --success-subtle: #f0fdf4;  /* Success bg - decorative; pair text uses --success */
+  --error: #b91c1c;  /* Error text - vs canvas: 6.47:1, surface-1: 6.09:1, surface-2: 5.77:1, error-subtle: 5.91:1 (AA ✅) - was #dc2626 (4.41:1 vs error-subtle, FAILED banner pattern) */
+  --error-subtle: #fef2f2;  /* Error bg - decorative; pair text uses --error */
+  --warning: #92580a;  /* Warning text - vs canvas: 5.80:1, surface-1: 5.46:1, surface-2: 5.17:1, warning-subtle: 5.60:1 (AA ✅) - was #ca8a04 (2.94:1 vs canvas, FAILED) */
+  --warning-subtle: #fefce8;  /* Warning bg - decorative; pair text uses --warning */
 
   /* Borders */
   --border: rgba(0, 0, 0, 0.08);  /* Subtle borders */
@@ -42,7 +42,7 @@
   --text-tertiary: var(--ink-muted);
 
   /* Focus Ring */
-  --ring: #116dff;  /* Focus indicator - vs canvas: 4.8:1 (AA ✅) */
+  --ring: #116dff;  /* Focus indicator - vs canvas: 4.51:1 (UI component WCAG 1.4.11 ≥3:1 ✅) */
 
   /* ========================================
      STORY-174: Premium SaaS Design System
@@ -107,11 +107,12 @@
   /* DEBT-012: Third-party brand colors */
   --whatsapp: #25D366;
 
-  /* STORY-2.5: Disabled state tokens — WCAG AA compliant
-     ink-disabled: #6B7280 vs #F3F4F6 surface → 4.6:1 (AA ✅ text)
+  /* STORY-2.5 + Issue #197: Disabled state tokens — WCAG AA compliant
+     ink-disabled: #5F6770 vs #F3F4F6 surface → 5.21:1 (AA ✅ text)
      surface-disabled: #F3F4F6 vs #FFFFFF canvas → UI component, not text
+     Was #6B7280 (4.39:1, FAILED).
   */
-  --ink-disabled: #6B7280;      /* 4.6:1 vs surface-disabled (#F3F4F6) — AA ✅ */
+  --ink-disabled: #5F6770;      /* 5.21:1 vs surface-disabled (#F3F4F6), 5.74:1 vs canvas — AA ✅ */
   --surface-disabled: #F3F4F6;  /* Disabled input/button background */
 }
 
@@ -143,11 +144,12 @@
 
   --ring: #3b8bff;  /* Focus indicator - vs canvas: 6.2:1 (AA ✅) */
 
-  /* STORY-2.5: Dark mode disabled tokens — WCAG AA compliant
-     ink-disabled: #9CA3AF vs #374151 surface → 4.5:1 (AA ✅ text)
+  /* STORY-2.5 + Issue #197: Dark mode disabled tokens — WCAG AA compliant
+     ink-disabled: #a8b0bb vs #374151 surface → 4.71:1 (AA ✅ text)
      surface-disabled: #374151 vs #121212 canvas → UI component
+     Was #9CA3AF (4.06:1, FAILED).
   */
-  --ink-disabled: #9CA3AF;      /* 4.5:1 vs surface-disabled (#374151) — AA ✅ */
+  --ink-disabled: #a8b0bb;      /* 4.71:1 vs surface-disabled (#374151), 8.56:1 vs canvas — AA ✅ */
   --surface-disabled: #374151;  /* Disabled input/button background dark mode */
 
   /* STORY-174: Dark mode premium variables */

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -53,9 +53,9 @@ const config: Config = {
         "chart-10": "var(--chart-10)",
         /* DEBT-012: Third-party brand colors */
         whatsapp: "var(--whatsapp)",
-        /* STORY-2.5: Disabled state tokens — WCAG AA 4.5:1 (text), 3:1 (large)
-           Light: ink-disabled (#6B7280) vs surface-disabled (#F3F4F6) → 4.6:1 ✅
-           Dark:  ink-disabled (#9CA3AF) vs surface-disabled (#374151) → 4.5:1 ✅
+        /* STORY-2.5 + Issue #197: Disabled state tokens — WCAG AA 4.5:1 (text), 3:1 (large)
+           Light: ink-disabled (#5F6770) vs surface-disabled (#F3F4F6) → 5.21:1 ✅
+           Dark:  ink-disabled (#a8b0bb) vs surface-disabled (#374151) → 4.71:1 ✅
         */
         "ink-disabled": "var(--ink-disabled)",
         "surface-disabled": "var(--surface-disabled)",


### PR DESCRIPTION
## Summary
- Retune 6 design tokens in `frontend/app/globals.css` whose actual contrast ratios failed WCAG 2.1 AA (4.5:1 small text). The CSS comments claimed AA pass but computed luminance ratios said otherwise.
- No new tokens, no hue family changes, no component edits — minimal hex retunes only.
- Sync the disabled-state ratio comments in `frontend/tailwind.config.ts`.

## Context
Closes [#197](https://github.com/tjsasakifln/SmartLic/issues/197). The issue flagged `--ink-muted #808f9f` on `--surface-1` as low contrast. Investigation showed:

1. `--ink-muted` had already been retuned to `#6b7a8a` in an earlier P2-6 fix, **but the new value still failed** (4.14:1 vs `surface-1`, comment incorrectly stated 5.1:1).
2. Several other tokens claimed AA pass in their comments but were actually below 4.5:1 — semantic colors (`success`, `warning`, `error` on `error-subtle`) and `ink-disabled` in both light and dark mode.

Ratios were computed using the standard relative-luminance formula (WCAG 2.1 SC 1.4.3 / 1.4.11). Background candidates checked: `canvas`, `surface-1`, `surface-2`, plus the matching `*-subtle` banner backgrounds for semantic colors (per the banner pattern `bg-error-subtle text-error` already used in `app/admin/cache/page.tsx`, `app/buscar/components/BuscarModals.tsx`, etc).

### Contrast table (before -> after, light mode)

| Token | Background | Before | After | WCAG AA (4.5:1 text) |
|-------|-----------|--------|-------|----------------------|
| `--ink-muted` (#6b7a8a -> #5a6573) | `surface-1` #f7f8fa | 4.14:1 FAIL | **5.58:1** | PASS |
| `--ink-muted` | `surface-2` #f0f2f5 | 3.92:1 FAIL | **5.28:1** | PASS |
| `--ink-muted` | `canvas` #ffffff | 4.40:1 FAIL | **5.93:1** | PASS |
| `--ink-disabled` (#6B7280 -> #5F6770) | `surface-disabled` #F3F4F6 | 4.39:1 FAIL | **5.21:1** | PASS |
| `--success` (#16a34a -> #107533) | `canvas` | 3.30:1 FAIL | **5.81:1** | PASS |
| `--success` | `surface-1` | 3.10:1 FAIL | **5.47:1** | PASS |
| `--success` | `success-subtle` #f0fdf4 | n/a | **5.55:1** | PASS |
| `--warning` (#ca8a04 -> #92580a) | `canvas` | 2.94:1 FAIL | **5.80:1** | PASS |
| `--warning` | `surface-1` | 2.76:1 FAIL | **5.46:1** | PASS |
| `--warning` | `warning-subtle` #fefce8 | n/a | **5.60:1** | PASS |
| `--error` (#dc2626 -> #b91c1c) | `error-subtle` #fef2f2 | 4.41:1 FAIL | **5.91:1** | PASS |
| `--error` | `canvas` | 4.83:1 PASS | **6.47:1** | PASS |
| `--error` | `surface-1` | 4.54:1 PASS | **6.09:1** | PASS |
| `--ink` | `canvas` | 14.06:1 | unchanged | PASS (AAA) |
| `--ink-secondary` | `canvas` | 7.28:1 | unchanged | PASS |
| `--brand-blue` | `canvas` | 4.51:1 | unchanged | PASS |

### Contrast table (dark mode)

| Token | Background | Before | After | WCAG AA |
|-------|-----------|--------|-------|---------|
| `--ink-disabled` (#9CA3AF -> #a8b0bb) | `surface-disabled` #374151 | 4.06:1 FAIL | **4.71:1** | PASS |
| `--ink-muted` #8494a7 | `surface-1` #1a1d22 | 5.45:1 | unchanged | PASS |
| `--error` #f87171 | `error-subtle` #450a0a | 5.84:1 | unchanged | PASS |

### Out of scope (intentionally not changed)
- `--brand-blue #116dff`: passes AA (4.51:1) on `canvas`. Borderline (4.25:1) on `surface-1`, but it is a brand-identity color used primarily on white CTAs; existing `--brand-blue-hover #0d5ad4` (5.76:1 on surface-1) should be preferred for body text on tinted surfaces. Changing the brand color is a design decision, not a token retune.
- `--ink-faint`, `*-subtle` background tokens, `--border` rgba values, focus `--ring`: decorative or UI-component (3:1 gate), already pass.
- Chart palette (`--chart-1`...`--chart-10`): data-viz colors, 3:1 UI gate, not text.

## Testing Plan
- [ ] Visual diff on `/buscar`, `/dashboard`, `/admin/cache`, `/conta` after deploy: muted text remains visibly subordinate to primary ink (still cooler/lighter), no over-darkening.
- [ ] Run Chrome DevTools Lighthouse / axe-core on `/` and `/buscar` after deploy: zero contrast violations on previously failing token pairs.
- [ ] Spot-check banner pattern (`bg-error-subtle text-error`) renders with sufficient contrast — exists on `app/admin/{cache,feature-flags,metrics,partners,slo}/page.tsx`, `app/admin/components/AdminUserTable.tsx`, `app/buscar/components/BuscarModals.tsx`.
- [ ] Verify dark mode `text-ink-disabled` on disabled inputs/buttons.
- [ ] No build errors (verified in CI; WSL local build skipped per repo memory note on Next.js 16 + WSL OOM).

## Closes
Closes #197