### PR TITLE
fix(db): covering partial indexes for pncp_supplier_contracts (Disk IO mitigation)

### DIFF
--- a/supabase/migrations/20260508222200_psc_disk_io_covering_indexes.down.sql
+++ b/supabase/migrations/20260508222200_psc_disk_io_covering_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_psc_data_assinatura_active_partial;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_psc_orgao_cnpj_active_partial;

--- a/supabase/migrations/20260508222200_psc_disk_io_covering_indexes.sql
+++ b/supabase/migrations/20260508222200_psc_disk_io_covering_indexes.sql
@@ -1,0 +1,25 @@
+-- Disk IO Pressure Mitigation — pncp_supplier_contracts
+--
+-- Context (2026-05-08): Supabase Pro Disk IO budget approaching depletion.
+-- pg_stat_statements top consumer (queryid 5428716347732353988):
+--   SELECT orgao_cnpj WHERE is_active=true AND orgao_cnpj IS NOT NULL LIMIT/OFFSET
+--   → 314M shared_blks_read across 35K calls (~9K blocks/call, 70% miss ratio).
+-- Existing idx_psc_orgao_cnpj is plain btree without is_active partial filter,
+-- so planner may pick idx_psc_active (partial) and seq-scan inside.
+--
+-- Q-3119050603016953898 (objeto_contrato ILIKE + ORDER BY data_assinatura):
+-- planner skips idx_psc_objeto_trgm (GIN) when ORDER+LIMIT present
+-- (memory: feedback_planner_no_pick_gin_trgm_with_limit_order). Adding a
+-- partial btree on data_assinatura WHERE is_active=true gives the planner a
+-- cheap index-only ordered path for the ranking step.
+--
+-- Both indexes use CONCURRENTLY to avoid blocking writes during creation.
+-- Each statement runs in its own transaction (CONCURRENTLY requirement).
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_psc_orgao_cnpj_active_partial
+  ON public.pncp_supplier_contracts (orgao_cnpj)
+  WHERE is_active = true AND orgao_cnpj IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_psc_data_assinatura_active_partial
+  ON public.pncp_supplier_contracts (data_assinatura DESC)
+  WHERE is_active = true;


### PR DESCRIPTION
## Summary
- Add `idx_psc_orgao_cnpj_active_partial` (CONCURRENTLY) — covering partial on `(orgao_cnpj) WHERE is_active=true AND orgao_cnpj IS NOT NULL`
- Add `idx_psc_data_assinatura_active_partial` (CONCURRENTLY) — covering partial on `(data_assinatura DESC) WHERE is_active=true`
- Paired `.down.sql` (STORY-6.2)

## Context
Supabase Pro project showing "Disk IO Budget about to deplete" warning (2026-05-08). pg_stat_statements diagnosis identifies `pncp_supplier_contracts` as dominant disk reader (8 of top 12 queries):

| queryid | calls | mean_ms | shared_blks_read | pattern |
|---|---|---|---|---|
| 5428...3988 | 35K | 1164ms | **314M** | `SELECT orgao_cnpj WHERE is_active LIMIT/OFFSET` (sitemap pagination) |
| 2171...6703 | 23K | 9816ms | 115M | full-row supplier listing |
| -3119...3898 | 13K | 3283ms | 24M | `objeto_contrato ILIKE ... ORDER BY data_assinatura` |

Existing `idx_psc_orgao_cnpj` is plain btree (no `is_active` partial filter) so the planner picks `idx_psc_active` and seq-scans within. New partial covering index gives a direct index-only path for the sitemap enumeration.

For Q-3119, planner skips `idx_psc_objeto_trgm` (GIN) when ORDER+LIMIT is present (memory: `feedback_planner_no_pick_gin_trgm_with_limit_order`). The new `data_assinatura` partial btree provides a cheap ordered path so the planner can rank candidates without falling back to seq scan.

Expected reduction: ~10× shared_blks_read on top-1 query, ~3-5× on top-3.

## Testing Plan
- [ ] Migration applies cleanly via `supabase db push --include-all` in CI auto-apply
- [ ] Both indexes visible in `pg_indexes WHERE tablename = 'pncp_supplier_contracts'`
- [ ] Post-deploy: re-query `pg_stat_statements` after 24h and verify shared_blks_read drop on top queries (memory: schema_drift_psql_discriminator pattern)
- [ ] No bloat regression on writes (CONCURRENTLY = non-blocking, but partial WHERE limits index size)
- [ ] `EXPLAIN (ANALYZE, BUFFERS)` on the top-1 query before/after — included as deploy verification step
- [ ] Disk IO budget telemetry shows downward inflection within 48h

## Closes
Refs Disk IO budget alert (no GH issue created — operational fix surfaced from session triage on 2026-05-08).