### PR TITLE
test(a11y): Playwright @axe-core fixture + smoke spec (#276)

### DIFF
--- a/docs/testing/a11y-e2e.md
+++ b/docs/testing/a11y-e2e.md
@@ -1,0 +1,158 @@
+# A11y E2E — axe-core Triage Runbook
+
+**Owner:** Frontend / QA
+**Issue:** [#276 — TD-FE-027 Missing Accessibility Tests](https://github.com/tjsasakifln/SmartLic/issues/276)
+**Last updated:** 2026-05-08
+
+This runbook explains how SmartLic enforces WCAG 2.1 AA at the E2E layer via
+[`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright)
+and how to triage violations the automated audit reports.
+
+---
+
+## What runs
+
+| Spec | What it covers |
+|------|----------------|
+| `frontend/e2e-tests/accessibility-audit.spec.ts` | 10 high-traffic pages: `/`, `/login`, `/signup`, `/buscar`, `/dashboard`, `/pipeline`, `/planos`, `/historico`, `/conta`, `/ajuda` |
+| `frontend/e2e-tests/dialog-accessibility.spec.ts` | Modal / dialog focus management |
+| `frontend/e2e-tests/tour-a11y.spec.ts` | Shepherd.js onboarding tour |
+| `frontend/e2e-tests/pipeline-keyboard.spec.ts` (AC6) | Pipeline keyboard nav + axe |
+
+All four import the shared fixture at
+`frontend/e2e-tests/fixtures/axe.ts` (or use `AxeBuilder` directly with the
+same WCAG 2.1 AA tag set).
+
+CI runs them in `.github/workflows/e2e.yml` and `.github/workflows/tests.yml`
+on every PR touching `frontend/**`.
+
+## Severity policy
+
+axe-core ranks each violation with an `impact` field. SmartLic policy:
+
+| Impact | CI behaviour | Action |
+|--------|--------------|--------|
+| `critical` | **Fail PR** | Must be fixed before merge. No exceptions outside `disableRules`. |
+| `serious` | **Fail PR** | Must be fixed before merge. Use `disableRules` only with a tracking issue. |
+| `moderate` | Logged | Triaged async into a backlog issue. Does not block merge. |
+| `minor` | Logged | Tracked but not actionable unless clustered. |
+
+The fixture `assertNoSeriousViolations` enforces this gate. Raw axe output is
+attached to the Playwright HTML report as `axe-<context>.json` so reviewers
+can inspect violation details without re-running the test.
+
+## Reading axe output
+
+A violation entry in the JSON attachment looks like:
+
+```json
+{
+  "id": "color-contrast",
+  "impact": "serious",
+  "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA",
+  "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/color-contrast",
+  "nodes": [
+    {
+      "html": "<button class=\"btn-primary\">...</button>",
+      "target": ["#submit"],
+      "failureSummary": "Element has insufficient color contrast of 3.2 (foreground color: #6c757d, background color: #f8f9fa, font size: 14.0pt, font weight: normal). Expected contrast ratio of 4.5:1"
+    }
+  ]
+}
+```
+
+Key fields:
+
+- **`id`** — axe rule name. Look it up at the `helpUrl` for fix guidance.
+- **`impact`** — drives the gate (see policy above).
+- **`nodes[].target`** — CSS selector for the offending element.
+- **`nodes[].failureSummary`** — human-readable explanation.
+
+## Fixing vs disabling
+
+**Default: fix it.** Most a11y violations have low-effort fixes:
+
+| axe rule | Typical fix |
+|----------|-------------|
+| `color-contrast` | Adjust token in `frontend/styles/tokens.css` (validated WCAG AA) |
+| `label` | Add `<label htmlFor=...>` or `aria-label` |
+| `button-name` | Add visible text or `aria-label` |
+| `landmark-one-main` | Wrap page content in `<main>` |
+| `region` | Wrap top-level sections in `<section aria-label=...>` |
+| `image-alt` | Add `alt=""` (decorative) or `alt="..."` (meaningful) |
+
+**Disable only when:**
+1. The violation is in third-party code we don't control (Stripe iframe, Google widgets).
+2. There's a tracking issue committed alongside the disable.
+3. We've capped at **5 disabled rules total per spec**. More than 5 = stop and ask.
+
+To disable a rule:
+
+```ts
+const results = await makeAxeBuilder()
+  .disableRules(['color-contrast']) // tracked in #NNNN — Stripe iframe contrast
+  .analyze();
+```
+
+Always include a comment with the issue number on the same line.
+
+## Excluding selectors
+
+The fixture excludes by default:
+
+```ts
+.exclude('iframe[src*="stripe.com"]')
+.exclude('iframe[src*="google.com"]')
+.exclude('[data-clarity-mask]')
+```
+
+Add to `frontend/e2e-tests/fixtures/axe.ts` (not per-spec) when a third-party
+embed produces unactionable noise across multiple pages.
+
+## Running locally
+
+```bash
+# All a11y specs
+cd frontend
+npx playwright test accessibility-audit dialog-accessibility tour-a11y
+
+# Single page
+npx playwright test accessibility-audit -g "Login"
+
+# Headed (see what axe is auditing)
+npx playwright test accessibility-audit --headed
+```
+
+The Playwright HTML report (`playwright-report/index.html`) shows attached
+axe JSON per failing test for offline triage.
+
+## When the audit fails on a PR
+
+1. Open the Playwright report artifact uploaded by CI.
+2. Find the failing page test, expand the attachment `axe-<context>.json`.
+3. Filter to `impact: "critical"` or `"serious"` — those are blockers.
+4. For each:
+   - Match `id` against the table above for typical fixes.
+   - Inspect `nodes[].target` to find the component.
+   - Fix in `frontend/components/...` or `frontend/app/...`.
+5. Re-run locally: `npx playwright test accessibility-audit`.
+6. If you cannot fix in this PR (e.g., third-party regression):
+   - File a tracking issue with the axe JSON snippet.
+   - `disableRules([...])` with comment referencing the issue.
+   - Note the disable in the PR body under "Disabled rules".
+
+## Adding new pages to the audit
+
+1. Pick a high-traffic public or authenticated page (top 20 by analytics).
+2. Add a new test block to `accessibility-audit.spec.ts` following the
+   existing template (mock auth/data → goto → wait for hydration → audit).
+3. Set up any required mocks via `helpers/test-utils.ts`.
+4. Run locally to confirm zero serious violations before opening a PR.
+
+## References
+
+- axe-core rules: <https://dequeuniversity.com/rules/axe/4.11>
+- WCAG 2.1 AA quick reference: <https://www.w3.org/WAI/WCAG21/quickref/>
+- axe-core/playwright README: <https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright>
+- Existing component a11y units: `frontend/__tests__/a11y/`,
+  `frontend/__tests__/viability-badge-a11y.test.tsx`

--- a/frontend/e2e-tests/accessibility-audit.spec.ts
+++ b/frontend/e2e-tests/accessibility-audit.spec.ts
@@ -1,12 +1,19 @@
 /**
- * DEBT-109 AC1-AC3: Automated Accessibility Audits via @axe-core/playwright
+ * DEBT-109 AC1-AC3 + TD-FE-027 (#276): Automated Accessibility Audits.
  *
- * Runs axe-core analysis on 5 core pages to detect critical a11y violations.
- * Critical violations must be 0; serious/moderate are documented as known issues.
+ * Runs axe-core analysis on 10 core pages to detect critical/serious WCAG 2.1
+ * AA violations. Refactored on 2026-05-08 to use the shared `axe` fixture
+ * (`frontend/e2e-tests/fixtures/axe.ts`) so every spec gets a pre-configured
+ * AxeBuilder + an opinionated severity gate.
+ *
+ * Severity policy:
+ *   - critical / serious  → fail the test (blocking)
+ *   - moderate / minor    → logged for triage, non-blocking
+ *
+ * Triage runbook: docs/testing/a11y-e2e.md
  */
 
-import { test, expect } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from './fixtures/axe';
 import {
   mockAuthAPI,
   mockSearchAPI,
@@ -15,69 +22,63 @@ import {
   mockMeAPI,
 } from './helpers/test-utils';
 
-// Helper: run axe audit and assert 0 critical violations
-async function auditPage(page: any, context: string) {
-  const results = await new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-    .analyze();
-
-  const critical = results.violations.filter((v) => v.impact === 'critical');
-  const serious = results.violations.filter((v) => v.impact === 'serious');
-  const moderate = results.violations.filter((v) => v.impact === 'moderate');
-
-  // Log non-critical for documentation (AC3)
-  if (serious.length > 0 || moderate.length > 0) {
-    console.log(`\n[${context}] Known a11y issues:`);
-    for (const v of [...serious, ...moderate]) {
-      console.log(`  - [${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`);
-    }
-  }
-
-  // AC2: 0 critical violations
-  expect(critical, `Critical a11y violations on ${context}`).toHaveLength(0);
-
-  return { critical, serious, moderate, total: results.violations.length };
-}
-
 test.describe('Accessibility Audits — @axe-core/playwright', () => {
   // -----------------------------------------------------------------------
   // 1. Login page (public, no auth needed)
   // -----------------------------------------------------------------------
-  test('AC1.1: Login page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.1: Login page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await page.goto('/login');
     await page.waitForLoadState('domcontentloaded');
-    // Wait for form to render
     await page.waitForSelector('form', { timeout: 10000 }).catch(() => {});
-    await page.waitForTimeout(500); // Allow hydration
+    await page.waitForTimeout(500);
 
-    const result = await auditPage(page, 'Login');
-    console.log(`Login: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Login');
+    console.log(
+      `Login: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 2. Buscar page (core search page, needs setores mock)
   // -----------------------------------------------------------------------
-  test('AC1.2: Buscar page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.2: Buscar page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await mockSetoresAPI(page);
     await mockSearchAPI(page, 'success');
     await mockDownloadAPI(page);
 
     await page.goto('/buscar');
     await page.waitForLoadState('domcontentloaded');
-    // Wait for search form to render (UF grid, sector selector)
-    await page.waitForSelector('[data-testid="search-form"], form, .search-form, main', {
-      timeout: 10000,
-    }).catch(() => {});
+    await page
+      .waitForSelector('[data-testid="search-form"], form, .search-form, main', {
+        timeout: 10000,
+      })
+      .catch(() => {});
     await page.waitForTimeout(500);
 
-    const result = await auditPage(page, 'Buscar');
-    console.log(`Buscar: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Buscar');
+    console.log(
+      `Buscar: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 3. Dashboard page (authenticated)
   // -----------------------------------------------------------------------
-  test('AC1.3: Dashboard page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.3: Dashboard page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await mockAuthAPI(page, 'user');
     await mockMeAPI(page, {
       plan_id: 'smartlic_pro',
@@ -85,7 +86,6 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
       credits_remaining: 50,
     });
 
-    // Mock analytics endpoints
     await page.route('**/api/analytics**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -100,7 +100,6 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
       });
     });
 
-    // Mock sessions endpoint
     await page.route('**/api/sessions**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -111,16 +110,23 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
 
     await page.goto('/dashboard');
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(1000); // Allow data fetching + render
+    await page.waitForTimeout(1000);
 
-    const result = await auditPage(page, 'Dashboard');
-    console.log(`Dashboard: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Dashboard');
+    console.log(
+      `Dashboard: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 4. Pipeline page (authenticated, needs pipeline mock)
   // -----------------------------------------------------------------------
-  test('AC1.4: Pipeline page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.4: Pipeline page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await mockAuthAPI(page, 'user');
     await mockMeAPI(page, {
       plan_id: 'smartlic_pro',
@@ -128,7 +134,6 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
       credits_remaining: 50,
     });
 
-    // Mock pipeline endpoint
     await page.route('**/api/pipeline**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -154,15 +159,21 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(1000);
 
-    const result = await auditPage(page, 'Pipeline');
-    console.log(`Pipeline: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Pipeline');
+    console.log(
+      `Pipeline: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 5. Planos page (public pricing page)
   // -----------------------------------------------------------------------
-  test('AC1.5: Planos page has 0 critical a11y violations', async ({ page }) => {
-    // Mock plans endpoint
+  test('AC1.5: Planos page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await page.route('**/api/plans**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -186,8 +197,11 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(500);
 
-    const result = await auditPage(page, 'Planos');
-    console.log(`Planos: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Planos');
+    console.log(
+      `Planos: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // =======================================================================
@@ -197,32 +211,50 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
   // -----------------------------------------------------------------------
   // 6. Landing page (public)
   // -----------------------------------------------------------------------
-  test('AC1.6: Landing page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.6: Landing page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(500);
 
-    const result = await auditPage(page, 'Landing');
-    console.log(`Landing: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Landing');
+    console.log(
+      `Landing: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 7. Signup page (public)
   // -----------------------------------------------------------------------
-  test('AC1.7: Signup page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.7: Signup page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await page.goto('/signup');
     await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('form', { timeout: 10000 }).catch(() => {});
     await page.waitForTimeout(500);
 
-    const result = await auditPage(page, 'Signup');
-    console.log(`Signup: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Signup');
+    console.log(
+      `Signup: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 8. Historico page (authenticated)
   // -----------------------------------------------------------------------
-  test('AC1.8: Historico page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.8: Historico page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await mockAuthAPI(page, 'user');
     await mockMeAPI(page, {
       plan_id: 'smartlic_pro',
@@ -230,7 +262,6 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
       credits_remaining: 50,
     });
 
-    // Mock sessions/history endpoint
     await page.route('**/api/sessions**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -243,14 +274,21 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(1000);
 
-    const result = await auditPage(page, 'Historico');
-    console.log(`Historico: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Historico');
+    console.log(
+      `Historico: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 9. Conta page (authenticated — account settings)
   // -----------------------------------------------------------------------
-  test('AC1.9: Conta page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.9: Conta page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await mockAuthAPI(page, 'user');
     await mockMeAPI(page, {
       plan_id: 'smartlic_pro',
@@ -258,7 +296,6 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
       credits_remaining: 50,
     });
 
-    // Mock subscription status
     await page.route('**/api/subscription**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -276,19 +313,32 @@ test.describe('Accessibility Audits — @axe-core/playwright', () => {
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(1000);
 
-    const result = await auditPage(page, 'Conta');
-    console.log(`Conta: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Conta');
+    console.log(
+      `Conta: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 
   // -----------------------------------------------------------------------
   // 10. Ajuda page (public help center)
   // -----------------------------------------------------------------------
-  test('AC1.10: Ajuda page has 0 critical a11y violations', async ({ page }) => {
+  test('AC1.10: Ajuda page has 0 critical a11y violations', async ({
+    page,
+    makeAxeBuilder,
+    assertNoSeriousViolations,
+  }) => {
     await page.goto('/ajuda');
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(500);
 
-    const result = await auditPage(page, 'Ajuda');
-    console.log(`Ajuda: ${result.total} total violations (${result.serious.length} serious, ${result.moderate.length} moderate)`);
+    const results = await makeAxeBuilder().analyze();
+    const summary = assertNoSeriousViolations(results, 'Ajuda');
+    console.log(
+      `Ajuda: ${summary.total} total violations (${summary.serious.length} serious, ${summary.moderate.length} moderate)`,
+    );
   });
 });
+
+// Re-export so consumers can `import { expect } from this spec` if needed.
+export { expect };

--- a/frontend/e2e-tests/fixtures/axe.ts
+++ b/frontend/e2e-tests/fixtures/axe.ts
@@ -1,0 +1,140 @@
+/**
+ * TD-FE-027 (#276): Playwright axe-core fixture for WCAG 2.1 AA validation.
+ *
+ * Usage:
+ *
+ *   import { test, expect, AxeSeverity } from './fixtures/axe';
+ *
+ *   test('home is accessible', async ({ page, makeAxeBuilder, assertNoSeriousViolations }) => {
+ *     await page.goto('/');
+ *     await page.waitForLoadState('domcontentloaded');
+ *     const results = await makeAxeBuilder().analyze();
+ *     assertNoSeriousViolations(results, 'Home');
+ *   });
+ *
+ * The fixture wraps `AxeBuilder` so every spec gets a pre-configured builder
+ * (WCAG 2.1 AA tags) plus an opinionated assertion that fails the test on any
+ * violation with impact >= "serious". Critical/serious are blocking; moderate
+ * and minor are logged for triage but do not fail the test.
+ *
+ * Severity policy and triage instructions: docs/testing/a11y-e2e.md
+ */
+
+import { test as base, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import type { AxeResults, ImpactValue } from 'axe-core';
+
+/**
+ * Severity levels emitted by axe-core, ordered from highest to lowest impact.
+ * "critical" and "serious" are blocking by default per the SmartLic a11y policy.
+ */
+export const AxeSeverity = {
+  CRITICAL: 'critical' as ImpactValue,
+  SERIOUS: 'serious' as ImpactValue,
+  MODERATE: 'moderate' as ImpactValue,
+  MINOR: 'minor' as ImpactValue,
+} as const;
+
+/** WCAG 2.1 AA tag set used across the application. */
+export const WCAG_2_1_AA_TAGS = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+] as const;
+
+type AxeFixtures = {
+  /**
+   * Returns a fresh `AxeBuilder` already configured with WCAG 2.1 AA tags.
+   * Tests can chain `.exclude()`, `.disableRules()`, etc. before `.analyze()`.
+   */
+  makeAxeBuilder: () => AxeBuilder;
+
+  /**
+   * Runs axe and asserts zero violations at impact >= "serious". Logs
+   * moderate/minor findings to stdout for documentation purposes.
+   *
+   * Returns the axe results so callers can do extra assertions if needed.
+   */
+  assertNoSeriousViolations: (
+    results: AxeResults,
+    context: string,
+  ) => {
+    critical: AxeResults['violations'];
+    serious: AxeResults['violations'];
+    moderate: AxeResults['violations'];
+    minor: AxeResults['violations'];
+    total: number;
+  };
+};
+
+export const test = base.extend<AxeFixtures>({
+  makeAxeBuilder: async ({ page }, use) => {
+    const builder = () =>
+      new AxeBuilder({ page })
+        .withTags([...WCAG_2_1_AA_TAGS])
+        // Exclude common third-party widgets we don't control. Add to this
+        // list (with a comment + tracking issue) when external embeds
+        // produce unactionable noise.
+        .exclude('iframe[src*="stripe.com"]')
+        .exclude('iframe[src*="google.com"]')
+        .exclude('[data-clarity-mask]');
+    await use(builder);
+  },
+
+  assertNoSeriousViolations: async ({}, use, testInfo) => {
+    const assert = (results: AxeResults, context: string) => {
+      const byImpact = (impact: ImpactValue) =>
+        results.violations.filter((v) => v.impact === impact);
+      const critical = byImpact('critical');
+      const serious = byImpact('serious');
+      const moderate = byImpact('moderate');
+      const minor = byImpact('minor');
+
+      // Log non-blocking findings for triage. They appear in Playwright's
+      // stdout report and the JUnit log, but do not fail the test.
+      if (moderate.length > 0 || minor.length > 0) {
+        // eslint-disable-next-line no-console
+        console.log(`\n[${context}] Non-blocking a11y findings:`);
+        for (const v of [...moderate, ...minor]) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `  - [${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`,
+          );
+        }
+      }
+
+      // Attach raw axe output to the Playwright HTML report so triage is
+      // possible without re-running the test locally.
+      void testInfo.attach(`axe-${context}.json`, {
+        body: JSON.stringify(results, null, 2),
+        contentType: 'application/json',
+      });
+
+      // Blocking gate: zero serious + zero critical.
+      expect(
+        critical,
+        `Critical a11y violations on ${context}: ${critical
+          .map((v) => v.id)
+          .join(', ')}`,
+      ).toHaveLength(0);
+      expect(
+        serious,
+        `Serious a11y violations on ${context}: ${serious
+          .map((v) => v.id)
+          .join(', ')}`,
+      ).toHaveLength(0);
+
+      return {
+        critical,
+        serious,
+        moderate,
+        minor,
+        total: results.violations.length,
+      };
+    };
+    await use(assert);
+  },
+});
+
+export { expect };


### PR DESCRIPTION
## Summary
- Adds shared Playwright fixture `frontend/e2e-tests/fixtures/axe.ts` with `makeAxeBuilder()` (WCAG 2.1 AA tags + default exclusions for Stripe/Google iframes + Clarity-masked elements) and `assertNoSeriousViolations()` (severity gate + JSON attachment to HTML report).
- Refactors `accessibility-audit.spec.ts` to consume the fixture instead of the inline `auditPage()` helper. Tightens the gate from "0 critical" to "0 critical + 0 serious" — moderate/minor are logged for triage, non-blocking.
- Adds `docs/testing/a11y-e2e.md` — triage runbook (severity policy, how to read axe output, fix vs `disableRules`, how to add new pages).

## Context
Closes [#276](https://github.com/tjsasakifln/SmartLic/issues/276) — TD-FE-027 asked for a Playwright `test.fixture` that runs accessibility checks after load. `@axe-core/playwright` was already in `devDependencies` and an inline-helper spec covering 10 pages already existed (DEBT-109 / DEBT-205). The remaining gap was the fixture pattern + a triage runbook, which this PR delivers as a refactor (no net-new spec coverage; same 10 pages: `/`, `/login`, `/signup`, `/buscar`, `/dashboard`, `/pipeline`, `/planos`, `/historico`, `/conta`, `/ajuda`).

## Pages covered (unchanged)
1. `/login` (public)
2. `/buscar` (auth, mocked setores+search)
3. `/dashboard` (auth, mocked analytics+sessions)
4. `/pipeline` (auth, mocked pipeline)
5. `/planos` (public, mocked plans)
6. `/` Landing (public)
7. `/signup` (public)
8. `/historico` (auth, mocked sessions)
9. `/conta` (auth, mocked subscription)
10. `/ajuda` (public)

## Severity gate change
- **Before:** 0 critical violations enforced; serious/moderate logged-only.
- **After:** 0 critical AND 0 serious enforced; moderate/minor logged-only.

If serious violations exist on `main` for any of the 10 pages, this spec will start failing in CI for those pages. That's the intended behaviour. Mitigation if it lands hot: per-rule `disableRules([...])` with a tracking issue (capped at 5 per spec — see runbook).

## Disabled rules
None in this PR. The fixture defaults exclude common third-party widgets via `.exclude()` selectors (Stripe iframe, Google iframe, Clarity-masked elements), but no axe rules are globally disabled.

## CI integration
No workflow changes — `accessibility-audit.spec.ts` is already picked up by the existing `e2e-tests` job in `.github/workflows/e2e.yml` (runs on PRs touching `frontend/**`). No extra Playwright project added; existing CI runtime should be unchanged (same number of tests, same pages).

## Testing Plan
- [ ] CI `E2E Tests (Playwright)` job runs `accessibility-audit.spec.ts` and reports per-page violation counts in the test log
- [ ] Failing test attaches `axe-<context>.json` to the Playwright HTML report (downloadable from CI artifacts on failure)
- [ ] Manual: temporarily add an `<img>` without `alt` to one page locally, run `npx playwright test accessibility-audit -g "Login"`, confirm test fails with serious violation
- [ ] Lint clean (touched files)
- [ ] No CI runtime regression > 30s for e2e job (refactor only; no new tests)

## Out of scope (follow-up)
- Fixing any actual a11y violations the new severity gate uncovers — list in this PR's CI run; address in follow-up issues per the runbook (`docs/testing/a11y-e2e.md`).
- Component-level a11y units with `jest-axe` already exist in `frontend/__tests__/a11y/` and `frontend/__tests__/viability-badge-a11y.test.tsx` (separate scope).

## Closes
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)