### PR TITLE
docs(spec): SDD specs Intel Reports v0.2 (INTEL-REPORT-002-V02-SPEC-001)

### DIFF
--- a/_reversa_sdd/code-spec-matrix.md
+++ b/_reversa_sdd/code-spec-matrix.md
@@ -11,6 +11,7 @@
 | `03-auth-oauth` | auth-oauth | `backend/auth.py`, `backend/authorization.py`, `backend/oauth.py`, `backend/routes/auth_*.py`, `backend/routes/mfa.py`, `frontend/middleware.ts`, `frontend/app/{login,signup,auth,recuperar-senha}/` | ~1.700 |
 | `04-pipeline-kanban` | pipeline-kanban | `backend/routes/pipeline.py`, `backend/schemas/pipeline.py`, `frontend/app/pipeline/`, `frontend/hooks/usePipeline.ts` | ~1.200 |
 | `05-ingestion-datalake` | ingestion-datalake | `backend/ingestion/`, `backend/datalake_query.py`, `backend/jobs/queue/config.py`, `backend/jobs/cron/pncp_canary.py` | ~1.500 |
+| `07-intel-report-sector-uf` + `07b-intel-pdf-generator` | intel-report-sector-uf (v0.2 INTEL-REPORT-002 — R$147 one-time) | `supabase/migrations/20260508120000_sector_uf_intel_rpc.sql` (+ `.down.sql`), `backend/pdf_generator_sector_uf_report.py`, `backend/jobs/queue/jobs.py` (`_generate_sector_uf_report_pdf` + `generate_intel_report`), `backend/services/billing.py:create_intel_report_checkout`, `backend/schemas/intel_report.py`, `backend/routes/intel_reports.py`, `backend/email_service.py:send_intel_report_ready`, `backend/tests/test_sector_uf_intel_pdf.py` (34 tests) | ~1.400 |
 
 ## Code → Spec
 

--- a/_reversa_sdd/specs/07-intel-report-sector-uf.md
+++ b/_reversa_sdd/specs/07-intel-report-sector-uf.md
@@ -1,0 +1,141 @@
+# Spec: Intel Report — RPC `sector_uf_intel`
+
+> Spec executável (SDD) para INTEL-REPORT-002 v0.2 — Panorama Setorial × UF.
+> Confiança: 🟢 CONFIRMADO (código shipped via PR #826).
+> Story: `INTEL-REPORT-002-V02-SPEC-001` · Reversa anchor: `review-report.md §10.1`.
+
+## Component
+
+- **ID**: `intel-report-sector-uf-rpc`
+- **Tipo**: PostgreSQL function (RPC) — `SECURITY DEFINER`, `service_role` only.
+- **Path**: `supabase/migrations/20260508120000_sector_uf_intel_rpc.sql` (migration UP) + `.down.sql` (rollback STORY-6.2).
+- **Função**: `public.sector_uf_intel(p_sector TEXT, p_keywords TEXT[], p_uf TEXT, p_window_months INTEGER DEFAULT 24) RETURNS JSONB`.
+
+## Purpose
+
+Agrega `pncp_supplier_contracts` (~2M+ linhas, 400d) por **setor (via keywords no `objeto_contrato`) × UF × janela temporal**, retornando JSONB único pronto para alimentar `pdf_generator_sector_uf_report.py` (`generate_sector_uf_report`). Backbone do produto one-time **R$147,00** Stripe Checkout — pagamento → ARQ job → PDF → Storage signed URL → email Resend.
+
+Como `pncp_supplier_contracts` **não possui coluna `setor`**, a filtragem é feita por `objeto_contrato ILIKE '%keyword%'` sobre o array `p_keywords` (mesma abordagem de `count_contracts_by_setor_uf` SEO-471 — ver migration linhas 13-15).
+
+## Inputs
+
+| Parâmetro | Tipo | Default | Validação |
+|-----------|------|---------|-----------|
+| `p_sector` | `TEXT` | (none) | Label do setor — incluído no payload final como `sector`. Não usado para filtro. |
+| `p_keywords` | `TEXT[]` | (none) | **Obrigatório**, não-vazio. `RAISE EXCEPTION 'p_keywords must be a non-empty array'` se nulo/vazio. Resolvido em Python via `sectors.get_sector(sector_id).keywords` em `pdf_generator_sector_uf_report.py:670-671`. |
+| `p_uf` | `TEXT` | (none) | Normalizado para 2 letras maiúsculas via `upper(regexp_replace(..., '[^A-Za-z]', '', 'g'))`. `RAISE EXCEPTION 'invalid uf: must be 2-letter state code after normalization'` se length ≠ 2. |
+| `p_window_months` | `INTEGER` | `24` | Range `[1, 240]`. `RAISE EXCEPTION 'invalid window: p_window_months must be between 1 and 240'`. |
+
+## Output Schema (JSONB)
+
+Retorna single JSONB object — PostgREST embrulha em lista de 1 elemento (handle em `_fetch_rpc_data` linhas 617-623):
+
+| Campo | Tipo | Origem |
+|-------|------|--------|
+| `sector` | `string` | `COALESCE(p_sector, '')` |
+| `uf` | `string` | UF normalizada (2 letras upper) |
+| `window_months` | `integer` | `p_window_months` echo |
+| `window_start` | `date` | `CURRENT_DATE - (p_window_months \|\| ' months')::INTERVAL` |
+| `total_contracts` | `bigint` | `COUNT(*)` em `pncp_supplier_contracts WHERE is_active=TRUE AND uf = v_uf_clean AND data_assinatura >= v_window_start AND EXISTS keyword match` |
+| `total_value` | `numeric` | `COALESCE(SUM(valor_global), 0)` |
+| `avg_ticket` | `numeric` | `COALESCE(AVG(valor_global), 0)` |
+| `median_ticket` | `numeric` | `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY valor_global)` |
+| `p90_ticket` | `numeric` | `PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY valor_global)` |
+| `data_primeiro_contrato` | `date` | `MIN(data_assinatura)` |
+| `data_ultimo_contrato` | `date` | `MAX(data_assinatura)` |
+| `top_fornecedores` | `array[20]` | `[{ni_fornecedor, nome_fornecedor, count, valor_total, avg_ticket}]` ordenado por `valor_total DESC NULLS LAST`, agrupado por `ni_fornecedor`. |
+| `distribuicao_esfera` | `array` | `[{esfera, count, valor_total}]` agrupado por `COALESCE(esfera, '?')`. **Nota** (linha 137-138): `pncp_supplier_contracts` não tem coluna `modalidade` — `esfera` (F/E/M/D) é proxy. |
+| `serie_temporal` | `array` | `[{mes 'YYYY-MM', count, valor_total}]` zero-fill via `generate_series` mês a mês. |
+| `top_orgaos` | `array[10]` | `[{orgao_cnpj, orgao_nome, count, valor_total}]` ordenado por valor. |
+| `top_objetos` | `array[10]` | `[{objeto_resumo, count, valor_total}]` — `objeto_resumo = LEFT(COALESCE(NULLIF(TRIM(objeto_contrato), ''), '(sem objeto)'), 80)`. |
+| `generated_at` | `timestamptz` | `NOW()` |
+
+## SQL Definition Reference
+
+Source-of-truth: [`supabase/migrations/20260508120000_sector_uf_intel_rpc.sql`](../../supabase/migrations/20260508120000_sector_uf_intel_rpc.sql) (linhas 33-274). Rollback: `.down.sql` paired (STORY-6.2 mandatory).
+
+## Performance Characteristics
+
+- **Statement timeout local**: `SET LOCAL statement_timeout = '15s'` (linha 64) — defesa em profundidade vs `statement_timeout` Supabase-wide (15s service_role floor — ver `reference_supabase_service_role_no_timeout_default`).
+- **Single-pass headline metrics**: contagem + soma + avg + percentis + min/max em uma única SELECT (linhas 83-106). Demais agregações (top_fornecedores, top_orgaos etc.) são SELECTs separados — todas filtradas pelo mesmo predicate compound `(is_active, uf, data_assinatura, EXISTS keyword)`.
+- **Zero-fill temporal**: `generate_series(date_trunc('month', window_start), date_trunc('month', CURRENT_DATE), '1 month')` LEFT JOIN agg — garante todos os meses no intervalo, mesmo sem contratos.
+- **Índices relevantes em `pncp_supplier_contracts`**: `is_active`, `uf`, `data_assinatura`, `ni_fornecedor`, `orgao_cnpj`. Filtro `EXISTS (SELECT 1 FROM unnest(p_keywords) WHERE objeto_contrato ILIKE '%kw%')` é seq scan sobre subset filtrado por UF+window — aceitável p/ janela 24m default.
+- **p95 latency target**: <15s (statement_timeout floor). Job ARQ tem `asyncio.wait_for(timeout=90)` em `jobs/queue/jobs.py:147` — folga 6× para PDF + upload + email.
+- **Throughput esperado**: <1 chamada/min em produção (gated por Stripe webhook `checkout.session.completed`).
+
+## Permission Boundary
+
+```sql
+REVOKE ALL ON FUNCTION public.sector_uf_intel(TEXT, TEXT[], TEXT, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.sector_uf_intel(TEXT, TEXT[], TEXT, INTEGER) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sector_uf_intel(TEXT, TEXT[], TEXT, INTEGER) TO service_role;
+```
+
+- **`SECURITY DEFINER` + `SET search_path = public, pg_temp`** (linhas 41-42) — mandatory por SEC-SECDEF-001/002 (memory `feedback_secdef_search_path_trap`).
+- **`service_role` only** — payload liberado apenas pós-pagamento, via backend ARQ worker (`backend/jobs/queue/jobs.py:_generate_sector_uf_report_pdf`).
+- **Ownership check** acontece upstream em `routes/intel_reports.py` (`/v1/intel-reports/{purchase_id}/download` — RLS storage path `{user_id}/{purchase_id}.pdf`, ver `migration 20260507110000_create_intel_reports_bucket.sql`).
+
+## Invariants
+
+1. **No invention** — apenas campos retornados existem na tabela `pncp_supplier_contracts`. Modalidade ausente é declarada explicitamente (linha 137: "`pncp_supplier_contracts não possui coluna modalidade`").
+2. **Idempotente** — mesmos inputs em `t1` e `t2` (com `t2 - t1 < 1d`) produzem deltas só nos contratos novos do dia (data crawl 3×/sem em `mon/wed/fri 06 UTC`).
+3. **Sem mutação** — função read-only (`LANGUAGE plpgsql SECURITY DEFINER` mas sem `INSERT/UPDATE/DELETE`).
+4. **UF normalization deterministic** — `upper(regexp_replace(p_uf, '[^A-Za-z]', '', 'g'))` strip de tudo non-alpha; `'sp'`, `'SP'`, `'S.P.'`, `'sP '` todos convergem para `'SP'`.
+
+## Functional Requirements
+
+- **FR-1**: `sector_uf_intel('limpeza', ARRAY['limpeza','higienizacao','conservacao'], 'SP', 24)` retorna JSONB com 16 campos top-level.
+- **FR-2**: `top_fornecedores` ordenado por `valor_total DESC NULLS LAST`, máximo 20 entries.
+- **FR-3**: `top_orgaos` ordenado por `valor_total DESC NULLS LAST`, máximo 10 entries.
+- **FR-4**: `top_objetos` ordenado por `count DESC, valor_total DESC NULLS LAST`, máximo 10 entries.
+- **FR-5**: `serie_temporal` cobre todos os meses entre `window_start` e mês corrente — zero-fill garantido.
+- **FR-6**: Empty result (zero contratos no recorte) → todos os agregados retornam `0` ou `[]`, sem RAISE.
+
+## Non-Functional Requirements
+
+- **NFR-1**: Latência p95 <15s (statement_timeout local).
+- **NFR-2**: Permission gate — somente `service_role` executa.
+- **NFR-3**: `SET search_path = public, pg_temp` — anti-trap SEC-SECDEF.
+- **NFR-4**: Validação eager dos 3 inputs antes de scan da tabela (fail-fast).
+
+## Constraints
+
+- **CON-1**: `p_keywords` é mandatory non-empty — sem keywords, EXISTS subquery degenera para sempre `FALSE`, causando contagem zero (proteção via RAISE).
+- **CON-2**: `p_uf` precisa colapsar para 2 letras alpha — RAISE em UFs inválidas.
+- **CON-3**: `p_window_months` `[1, 240]` — janela 240m = 20 anos, supera retention 400d mas não falha (apenas amplia `window_start`).
+- **CON-4**: PostgREST embrulha JSONB scalar em lista — handler Python deve unwrap (`_fetch_rpc_data` linhas 617-623).
+
+## Acceptance Criteria
+
+- **AC-1**: RPC instalada em produção pós-`supabase db push` (CRIT-050 auto-apply em `deploy.yml`).
+- **AC-2**: Chamada autenticada como `service_role` retorna `{sector, uf, total_contracts, ...}` em <15s.
+- **AC-3**: Chamada como `anon`/`authenticated` retorna `permission denied for function sector_uf_intel`.
+- **AC-4**: Inputs inválidos (UF length ≠ 2, keywords vazio, window fora `[1,240]`) → RAISE EXCEPTION com mensagem específica.
+- **AC-5**: PostgREST schema cache reload (`NOTIFY pgrst, 'reload schema'`) após push — ver migration auto-apply em `deploy.yml`.
+
+## Errors
+
+| Mensagem | Trigger |
+|----------|---------|
+| `p_keywords must be a non-empty array` | `p_keywords IS NULL OR array_length(p_keywords, 1) IS NULL` |
+| `invalid uf: must be 2-letter state code after normalization` | `length(v_uf_clean) <> 2` |
+| `invalid window: p_window_months must be between 1 and 240` | `p_window_months NULL OR <1 OR >240` |
+| `permission denied for function sector_uf_intel` | Caller is anon/authenticated (sem GRANT) |
+| `canceling statement due to statement timeout` | Query >15s (statement_timeout local) |
+
+## Code Traceability
+
+- **Migration UP**: `supabase/migrations/20260508120000_sector_uf_intel_rpc.sql` (284 LOC)
+- **Migration DOWN**: `supabase/migrations/20260508120000_sector_uf_intel_rpc.down.sql`
+- **Caller Python**: `backend/pdf_generator_sector_uf_report.py:_fetch_rpc_data` (linhas 599-630)
+- **ARQ orchestrator**: `backend/jobs/queue/jobs.py:_generate_sector_uf_report_pdf` (linhas 125-134)
+- **Sub-spec PDF generator**: [`07b-intel-pdf-generator.md`](./07b-intel-pdf-generator.md)
+- **Companion spec product surface**: [`13-intel-reports.spec.md`](./13-intel-reports.spec.md)
+- **Tests indireto**: `backend/tests/test_sector_uf_intel_pdf.py` (34 testes — `TestGenerateSectorUfReport::test_rpc_called_with_correct_params` linha 337 valida assinatura).
+
+## Dependencies
+
+- `pncp_supplier_contracts` (ingestão por `backend/ingestion/contracts_crawler.py` 3×/semana mon/wed/fri).
+- `backend/sectors_data.yaml` — keywords resolvidas em Python via `sectors.get_sector(sector_id).keywords` antes da chamada RPC.
+- `service_role` Supabase JWT — backend `supabase_client.get_supabase()` com env `SUPABASE_SERVICE_ROLE_KEY`.
+- `statement_timeout=15s` Supabase floor para service_role (memory `reference_supabase_service_role_no_timeout_default`).

--- a/_reversa_sdd/specs/07b-intel-pdf-generator.md
+++ b/_reversa_sdd/specs/07b-intel-pdf-generator.md
@@ -1,0 +1,163 @@
+# Spec: Intel Report — PDF Generator `pdf_generator_sector_uf_report`
+
+> Sub-spec do contrato PDF executável do INTEL-REPORT-002 v0.2.
+> Confiança: 🟢 CONFIRMADO (código shipped via PR #826/#825 + 34 unit tests).
+> Story: `INTEL-REPORT-002-V02-SPEC-001`. Companion: [`07-intel-report-sector-uf.md`](./07-intel-report-sector-uf.md), [`13-intel-reports.spec.md`](./13-intel-reports.spec.md).
+
+## Component
+
+- **ID**: `intel-report-sector-uf-pdf-generator`
+- **Tipo**: Python function — síncrona, retorna `BytesIO` posicionado em `seek(0)`.
+- **Path**: `backend/pdf_generator_sector_uf_report.py` (732 LOC).
+- **Função pública**: `generate_sector_uf_report(db: Any, entity_key: str) -> BytesIO`.
+
+## Purpose
+
+Gera PDF A4 multi-seção a partir do payload retornado pela RPC `sector_uf_intel`. Output é **byte stream** — não escreve em disco, deixa o caller (ARQ job `generate_intel_report` em `jobs/queue/jobs.py`) fazer upload para Supabase Storage no path `{user_id}/{purchase_id}.pdf`.
+
+ReportLab `SimpleDocTemplate` com paleta brand `#1B3A5C` (BRAND_DARK_BLUE) — alinhada a `pdf_generator_intel_report.py` (Raio-X Concorrente v0.1).
+
+## Input Contract
+
+| Parâmetro | Tipo | Schema |
+|-----------|------|--------|
+| `db` | `Any` | Cliente Supabase service-role (`supabase_client.get_supabase()`). Usado apenas em `_fetch_rpc_data` para chamar `db.rpc("sector_uf_intel", {...}).execute()`. |
+| `entity_key` | `str` | Formato `"sector_id:UF"` — e.g. `"limpeza:SP"`, `"construcao:RJ"`. `sector_id` deve ser key válida em `backend/sectors_data.yaml`; UF é 2 letras. |
+
+### Resolução interna
+
+```
+entity_key = "limpeza:SP"
+  → sector_id="limpeza", uf="SP"
+  → keywords = sectors.get_sector("limpeza").keywords        # backend/sectors.py
+  → sector_label = sector.name (e.g. "Limpeza e Conservação")
+  → db.rpc("sector_uf_intel", {p_sector, p_keywords, p_uf, p_window_months: 24})
+  → data dict ← _fetch_rpc_data unwrap
+  → data["sector_label"] = sector_label  (enrich for cover)
+```
+
+## Output Contract
+
+| Característica | Valor |
+|----------------|-------|
+| Tipo | `BytesIO` |
+| Position | `seek(0)` (validado em `test_returned_bytesio_seeked_to_start`) |
+| MIME | `application/pdf` |
+| Tamanho típico | ~30-200 KB (depende top_fornecedores/orgaos populated) |
+| Page size | A4 (210×297 mm) |
+| Margins | 2 cm L/R, 1.5 cm top, 2.5 cm bottom |
+| PDF metadata | `title="SmartLic Intelligence — Panorama {sector_label} × {uf}"`, `author="SmartLic"` |
+| Footer | `"SmartLic Intelligence — smartlic.tech \| Dados: PNCP \| Atualizado em {DD/MM/YYYY}"` + página atual |
+
+## Section Builders
+
+PDF assembly via `doc.build([cover, exec_summary, top_fornecedores, top_orgaos, temporal, top_objetos, esfera])`:
+
+| Função | Saída |
+|--------|-------|
+| `_build_cover` (linhas 236-291) | Page 1 — logo SmartLic Intelligence + HRFlowable BRAND_ACCENT, título "Panorama Setorial", subtítulo `{sector_label} — {uf}`, janela 24m, geração date. PageBreak final. |
+| `_build_executive_summary` (linhas 292-354) | Metric boxes (METRIC_BOX_BG `#EFF6FF`): total_contracts, total_value, avg_ticket, median_ticket, p90_ticket, data_primeiro/ultimo. |
+| `_build_top_fornecedores` (linhas 374-423) | Table até 20 rows: ni_fornecedor, nome_fornecedor, count, valor_total, avg_ticket. |
+| `_build_top_orgaos` (linhas 424-470) | Table até 10 rows: orgao_cnpj, orgao_nome, count, valor_total. |
+| `_build_temporal_evolution` (linhas 471-512) | Série mensal `serie_temporal` (zero-fill RPC-side). |
+| `_build_top_objetos` (linhas 513-547) | Table até 10 rows: objeto_resumo (LEFT 80 chars), count, valor_total. |
+| `_build_esfera_distribution` (linhas 548-594) | Distribuição F/E/M/D (`ESFERA_LABELS` dict linhas 65-70). |
+
+## Helper Contract
+
+| Helper | Contrato | Test coverage |
+|--------|----------|---------------|
+| `_sanitize(value)` | `None → ""`, strip `\x00-\x1f` exc. tab/LF, `html.escape`. | `test_sanitize_none_returns_empty/strips_control_chars/escapes_html` |
+| `_fmt_currency(v)` | `None → "—"`, `0 → "R$ 0,00"`, `1234.56 → "R$ 1.234,56"`, invalid → `"—"`. | `test_fmt_currency_none/zero/positive/invalid` |
+| `_fmt_int(v)` | `1234 → "1.234"`, invalid → `"—"`. | `test_fmt_int_valid/invalid` |
+| `_fmt_pct(v)` | `12.345 → "12.3%"`, None → `"—"`. | `test_fmt_pct_valid/none` |
+| `_format_date("2024-05-08")` | `"08/05/2024"`. ISO 8601 com `T` sufixo OK. | `test_format_date_valid_iso/none/with_time_component` |
+| `_trunc(s, max=80)` | Strings ≤80 inalteradas; >80 truncadas com `…`. | `test_trunc_short_string_unchanged/long_string_truncated` |
+
+## Error Modes
+
+| Trigger | Exception | Site |
+|---------|-----------|------|
+| `entity_key` sem `:` | `ValueError("Invalid entity_key {!r}. Expected format 'sector_id:UF'")` | linha 654-656 |
+| `sector_id` vazio ou UF length ≠ 2 | `ValueError("Invalid entity_key {!r}. sector_id must be non-empty and UF must be 2 letters.")` | linha 661-665 |
+| `sector_id` não existe em `sectors_data.yaml` | `ValueError("Cannot resolve keywords for sector {!r}: {exc}")` | linha 673-676 |
+| RPC retorna `[]` ou `None` | `ValueError("sector_uf_intel returned no data for sector={!r} uf={!r}")` | linha 612-615 |
+| RPC retorna shape inesperado (não list/dict) | `ValueError("sector_uf_intel returned unexpected shape: {type}")` | linha 628-630 |
+| ReportLab `doc.build` exception | propagada (caller ARQ job marca `failed` + refund auto + email apologetic — `jobs.py:_send_intel_report_failed_email` linhas 223-256) |
+
+## Caller Flow (ARQ)
+
+```python
+# backend/jobs/queue/jobs.py:125-150
+async def _generate_sector_uf_report_pdf(db, entity_key) -> bytes:
+    from pdf_generator_sector_uf_report import generate_sector_uf_report
+    buffer = generate_sector_uf_report(db=db, entity_key=entity_key)
+    return buffer.getvalue()
+
+async def _generate_intel_report_pdf(db, purchase) -> bytes:
+    if purchase["product_type"] == "sector_uf":
+        return await asyncio.wait_for(
+            _generate_sector_uf_report_pdf(db, purchase["entity_key"]),
+            timeout=90,  # 6× folga sobre RPC statement_timeout 15s
+        )
+```
+
+## Test Coverage
+
+`backend/tests/test_sector_uf_intel_pdf.py` — **34 testes** distribuídos:
+
+| Classe | Quantidade | Foco |
+|--------|-----------|------|
+| `TestHelpers` | 16 | `_sanitize`, `_fmt_currency`, `_fmt_int`, `_fmt_pct`, `_format_date`, `_trunc` |
+| `TestSectionBuilders` | 7 | `_build_cover` (com/sem UF, page break), `_build_executive_summary`, `_build_top_fornecedores` (with/empty/None) |
+| `TestGenerateSectorUfReport` | 11 | E2E PDF generation, BytesIO seek, empty sections, entity_key validation (no colon, empty sector, invalid UF), RPC error modes (empty list, None, sector not found, wrong params, dict payload direct) |
+
+Run: `pytest backend/tests/test_sector_uf_intel_pdf.py -v`. Status atual: 34 passing (PR #825 fix).
+
+## Invariants
+
+1. **Output BytesIO sempre posicionado em `seek(0)`** (linha 731). Garantia para upload `bucket.upload(file=pdf_bytes)`.
+2. **Sem dependência de filesystem** — entrada e saída em memória apenas.
+3. **Sem requests externos** além do `db.rpc(...).execute()` único.
+4. **Brand colors hardcoded** (linhas 43-55) — sincronizadas com `pdf_generator_intel_report.py` (Raio-X v0.1).
+5. **Helpers duplicados intencionalmente** (linhas 73-74 docstring) — mantém modules independentes (não importa de `pdf_generator_intel_report`).
+
+## Functional Requirements
+
+- **FR-1**: `generate_sector_uf_report(db, "limpeza:SP")` retorna `BytesIO` com PDF A4 válido.
+- **FR-2**: PDF inclui 7 seções (cover, executive_summary, top_fornecedores, top_orgaos, temporal, top_objetos, esfera).
+- **FR-3**: Empty agregados (zero contratos no recorte) ainda geram PDF (cover + sections com `(sem dados)` placeholders) — `test_empty_sections_still_generates_pdf`.
+- **FR-4**: PDF metadata `title` populado com `sector_label × uf`.
+- **FR-5**: Footer em todas as páginas (`onFirstPage=_footer, onLaterPages=_footer`).
+
+## Non-Functional Requirements
+
+- **NFR-1**: Synchronous function — caller faz `asyncio.to_thread` se necessário (ARQ job já é I/O-bound concorrente).
+- **NFR-2**: Memória peak <50MB para PDF típico.
+- **NFR-3**: Wall-clock <30s para payload típico (RPC 15s + ReportLab build ~1-3s).
+- **NFR-4**: Texto sanitizado contra XML injection (`html.escape` + strip control chars).
+
+## Acceptance Criteria
+
+- **AC-1**: 34 testes em `test_sector_uf_intel_pdf.py` passam green.
+- **AC-2**: ARQ job `generate_intel_report` para `product_type='sector_uf'` upload PDF para Storage path `{user_id}/{purchase_id}.pdf` e marca `intel_report_purchases.status='ready'`.
+- **AC-3**: Email Resend (`send_intel_report_ready` em `backend/email_service.py`) entregue com signed URL 30d TTL.
+- **AC-4**: Erro de geração → refund Stripe automático + email apologetic (`_refund_intel_report_purchase` + `_send_intel_report_failed_email` em `jobs.py:199-256`).
+
+## Code Traceability
+
+- **Module**: `backend/pdf_generator_sector_uf_report.py` (732 LOC)
+- **Tests**: `backend/tests/test_sector_uf_intel_pdf.py` (366 LOC, 34 tests)
+- **ARQ adapter**: `backend/jobs/queue/jobs.py:_generate_sector_uf_report_pdf` (linhas 125-134) + `_generate_intel_report_pdf` despatch (linhas 137-150)
+- **Storage upload**: `backend/jobs/queue/jobs.py:_upload_intel_report_pdf` (linhas 158-190) — bucket `intel-reports`, signed URL TTL `INTEL_REPORT_SIGNED_URL_TTL_SECONDS`
+- **Email delivery**: `backend/email_service.py:send_intel_report_ready` + template `panorama_t1_delivery.py`
+- **RPC backing**: [`07-intel-report-sector-uf.md`](./07-intel-report-sector-uf.md)
+- **Product surface**: [`13-intel-reports.spec.md`](./13-intel-reports.spec.md) §Endpoints + §Status State Machine
+
+## Dependencies
+
+- `reportlab` (SimpleDocTemplate, Platypus, Paragraph, Table, TableStyle, HRFlowable, PageBreak, Spacer)
+- `backend/sectors.py:get_sector` (resolve keywords + label) — ver `backend/sectors_data.yaml`
+- RPC `sector_uf_intel` (gating de dados — ver companion spec)
+- `supabase_client.get_supabase()` (service_role) — passado via parâmetro `db`
+- Caller orchestrator: ARQ worker `PROCESS_TYPE=worker` (Railway worker service)

--- a/_reversa_sdd/user-stories.md
+++ b/_reversa_sdd/user-stories.md
@@ -396,6 +396,33 @@
 
 ---
 
+## Persona — Comprador one-time Intel Report
+
+### US-027 — Compra Intel Report v0.2 (Panorama Setorial × UF) 🟢
+
+**Como** usuário (autenticado, qualquer plano — incluindo trial)
+**Quero** comprar um PDF "Panorama Setorial × UF" por R$147,00 sem assinatura
+**Para que** eu obtenha um diagnóstico imediato do mercado de licitações naquele recorte (top fornecedores, órgãos, séries temporais) sem upgrade de plano.
+
+**Aceitação (fluxo end-to-end):**
+- **(1) Stripe Checkout** — `POST /v1/intel-reports/checkout` com `{product_type:"sector_uf", entity_key:"limpeza:SP"}` → `services/billing.py:create_intel_report_checkout` cria Stripe session com `unit_amount=14700` (centavos), `mode=payment` (one-time), metadata `{user_id, product_type, entity_key}`. INSERT `intel_report_purchases(status='pending', stripe_session_id)`. Retorna `{checkout_url, session_id}`.
+- **(2) Webhook `checkout.session.completed`** — `webhooks/handlers/checkout.py` verifica assinatura Stripe + dedup via `events_processed`, atualiza `intel_report_purchases.status='pending'` (mantém para o worker pegar) e enqueue ARQ `generate_intel_report(purchase_id)`.
+- **(3) ARQ job `generate_intel_report`** (`backend/jobs/queue/jobs.py:259-...`) — fetch purchase, despatch para `_generate_sector_uf_report_pdf` que chama `pdf_generator_sector_uf_report.generate_sector_uf_report(db, entity_key)`. Internamente:
+  - `sectors.get_sector("limpeza")` → keywords + label
+  - `db.rpc("sector_uf_intel", {p_sector, p_keywords, p_uf, p_window_months:24})` → JSONB payload (RPC `SECURITY DEFINER`, `service_role` only — ver spec `07-intel-report-sector-uf.md`)
+  - ReportLab assembly em `BytesIO` (7 seções A4)
+- **(4) Upload Supabase Storage** — `_upload_intel_report_pdf(db, purchase_id, user_id, pdf_bytes)` em path `{user_id}/{purchase_id}.pdf` no bucket `intel-reports` (RLS: user só lê próprio prefix). Cria signed URL TTL 30d via `bucket.create_signed_url`.
+- **(5) UPDATE `intel_report_purchases SET status='ready', pdf_url=signed_url`**.
+- **(6) Email Resend** — `email_service.send_intel_report_ready(user_email, name, pdf_url, product_name, purchase_id)` com template `templates/emails/panorama_t1_delivery.py`. Domain `smartlic.tech` from `tiago@smartlic.tech` + reply-to `tiago.sasaki@gmail.com`.
+- **(7) Frontend polling** — `GET /v1/intel-reports/{purchase_id}` (poll até `status='ready'`) → `GET /v1/intel-reports/{purchase_id}/download` faz ownership check (404 vs 403) e streams PDF.
+- **Erro de geração** — RPC `RAISE` ou `ReportLab` exception → `status='failed'` + `_refund_intel_report_purchase` (Stripe Refund automático via `payment_intent`) + `_send_intel_report_failed_email` (apologetic email Resend).
+
+**Trial?** Sim — não há `plan_check` em `/v1/intel-reports/checkout`; qualquer usuário autenticado pode comprar (one-time, fora da quota).
+
+**Mapeamento código:** `backend/routes/intel_reports.py`, `backend/services/billing.py:create_intel_report_checkout`, `backend/schemas/intel_report.py` (`INTEL_REPORT_PRICES.sector_uf=14700`), `backend/webhooks/handlers/checkout.py`, `backend/jobs/queue/jobs.py:generate_intel_report` (linhas 259-...) + `_generate_sector_uf_report_pdf` (linhas 125-134), `backend/pdf_generator_sector_uf_report.py`, `supabase/migrations/20260508120000_sector_uf_intel_rpc.sql`, `backend/email_service.py:send_intel_report_ready`, `backend/templates/emails/panorama_t1_delivery.py`. Specs: `07-intel-report-sector-uf.md` (RPC), `07b-intel-pdf-generator.md` (PDF contract), `13-intel-reports.spec.md` (product surface + endpoints + state machine).
+
+---
+
 ## Lacunas identificadas
 
 - 🔴 **Founding plan** — pricing, deadline, cap not clear

--- a/docs/stories/2026-05/INTEL-REPORT-002-V02-SPEC-001-spec-sdd.story.md
+++ b/docs/stories/2026-05/INTEL-REPORT-002-V02-SPEC-001-spec-sdd.story.md
@@ -1,0 +1,113 @@
+# INTEL-REPORT-002-V02-SPEC-001: Spec SDD para Intel Reports v0.2 (RPC sector_uf_intel + PDF generator)
+
+**Priority:** P2
+**Effort:** XS (2-4h)
+**Squad:** @architect (lead) + @dev
+**Status:** InProgress
+**Epic:** [INTEL-001](../2026-04/EPIC-RES-BE-2026-Q2.md) (epic Intel Reports one-time products)
+**Sprint:** TBD
+**Dependências bloqueadoras:** Nenhuma — INTEL-REPORT-002 RPC + PDF shipped (#826, #825 smoke tests)
+**Reversa anchor:** `_reversa_sdd/review-report.md §10.1` Intel Reports v0.1 + `state.json refresh_2026_05_08` `INTEL-REPORT-002 RPC sector_uf_intel`
+
+---
+
+## Contexto
+
+INTEL-REPORT-002 (Mapa Setorial UF — produto one-time R$497 Stripe) shipped:
+- RPC Postgres `sector_uf_intel` (#826) — agrega contratos por setor × UF × período
+- PDF generator (`backend/services/pdf_generator_sector_uf_report.py` + 34 unit tests)
+- Smoke tests + 403 ownership fix (#825)
+
+Spec SDD ainda não criada em `_reversa_sdd/specs/`. Doc coverage gap (89% atual). Esta story formaliza contrato RPC + PDF generator output schema.
+
+Memory `project_pmf_blind_spots_2026_05_04`: Intel Reports T0 — DataLake 2M contratos não monetizado historicamente; v0.1 Raio-X Concorrente já shipped, v0.2 é Mapa Setorial.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Spec SDD RPC sector_uf_intel
+
+- [x] `_reversa_sdd/specs/07-intel-report-sector-uf.md` seguindo template specs/01-05
+- [x] Seções: Inputs (setor_id, uf, periodo_inicio, periodo_fim) · Output schema (JSONB array agregado) · SQL definition referência (link migration `supabase/migrations/...sector_uf_intel.sql`) · Performance characteristics (p95 latency target, índices used) · Permission boundary (autenticado + ownership check)
+
+### AC2: PDF generator contract
+
+- [x] `_reversa_sdd/specs/07b-intel-pdf-generator.md` (sub-spec) — input dict schema, output PDF byte stream, error modes (RPC empty / ReportLab failure)
+- [x] Cross-ref test coverage (`test_pdf_generator_sector_uf_report.py` 34 tests)
+
+### AC3: User flow doc
+
+- [x] `_reversa_sdd/user-stories.md` — adicionar fluxo "Compra Intel Report v0.2" (Stripe checkout → webhook payment → RPC trigger → PDF gen → email delivery → presigned download URL)
+
+### AC4: Code-Spec matrix update
+
+- [x] `_reversa_sdd/code-spec-matrix.md` entry confirmação spec criada
+
+---
+
+## Files
+
+| Arquivo | Ação |
+|---------|------|
+| `_reversa_sdd/specs/07-intel-report-sector-uf.md` | Create |
+| `_reversa_sdd/specs/07b-intel-pdf-generator.md` | Create |
+| `_reversa_sdd/user-stories.md` | Edit (1 fluxo novo) |
+| `_reversa_sdd/code-spec-matrix.md` | Edit (1 linha) |
+
+---
+
+## Definition of Done
+
+- [x] 2 specs criadas sem invenção (fonte: código + migration + tests)
+- [x] Confiança 🟢 CONFIRMADO em todas seções (código existe e shipped)
+- [x] User-stories.md novo fluxo cross-ref Stripe + RPC + PDF
+- [x] Validate `wc -l` post-write (anti-vapor) — `07-intel-report-sector-uf.md`=141 LOC, `07b-intel-pdf-generator.md`=163 LOC
+
+---
+
+## File List
+
+- **Created:** `_reversa_sdd/specs/07-intel-report-sector-uf.md` (RPC spec, 141 LOC, 🟢 CONFIRMADO)
+- **Created:** `_reversa_sdd/specs/07b-intel-pdf-generator.md` (PDF generator sub-spec, 163 LOC, 🟢 CONFIRMADO)
+- **Edited:** `_reversa_sdd/user-stories.md` (+US-027 Compra Intel Report v0.2 fluxo end-to-end Stripe→Webhook→ARQ→Storage→Resend)
+- **Edited:** `_reversa_sdd/code-spec-matrix.md` (+row spec→code intel-report-sector-uf)
+- **Edited:** `docs/stories/2026-05/INTEL-REPORT-002-V02-SPEC-001-spec-sdd.story.md` (Status Ready→InProgress, ACs/DoD checkboxes, File List)
+
+## Dev Notes
+
+- Pricing real do código: **R$147,00** (`backend/schemas/intel_report.py:INTEL_REPORT_PRICES["sector_uf"]=14700` centavos). Story original mencionou R$497 — corrigido nas specs para fonte de verdade (No Invention).
+- RPC assinatura real: `sector_uf_intel(p_sector TEXT, p_keywords TEXT[], p_uf TEXT, p_window_months INTEGER DEFAULT 24) RETURNS JSONB` — não `(setor_id, uf, periodo_inicio, periodo_fim)` como hipotetizado na AC1; alinhado ao SQL real.
+- PDF generator localização real: `backend/pdf_generator_sector_uf_report.py` (top-level, não `backend/services/`). Tests: `backend/tests/test_sector_uf_intel_pdf.py` (366 LOC, 34 tests confirmados).
+
+---
+
+## PO Validation
+
+**Validated by:** @po (Sarah)
+**Date:** 2026-05-09
+**Verdict:** GO
+**Score:** 10/10
+**Status transition:** Draft → Ready
+
+### 10-Point Checklist
+
+| # | Criterion | ✓/✗ | Notes |
+|---|-----------|-----|-------|
+| 1 | Clear and objective title | ✓ | Spec SDD para Intel Reports v0.2 — produto + escopo doc |
+| 2 | Complete description | ✓ | Cita RPC #826 + PDF #825 + 34 unit tests; doc gap identificada |
+| 3 | Testable acceptance criteria | ✓ | 4 ACs file-deliverable based |
+| 4 | Well-defined scope | ✓ | Doc-only; código shipped |
+| 5 | Dependencies mapped | ✓ | Nenhuma (#826, #825 merged) |
+| 6 | Complexity estimate | ✓ | XS (2-4h) realista |
+| 7 | Business value | ✓ | Doc coverage +2 (gap composite 100%) + monetização one-time documentada |
+| 8 | Risks documented | ✓ | Anti-vapor `wc -l` validate; sem invenção (fonte código) |
+| 9 | Criteria of Done | ✓ | 3 itens explícitos |
+| 10 | Alignment with PRD/Epic | ✓ | Epic #634 intel-reports + Reversa anchor §10.1 |
+
+### Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-05-08 | 1.0 | Story criada (SM) | @sm |
+| 2026-05-09 | 1.1 | PO validation GO 10/10 — Draft → Ready | @po |


### PR DESCRIPTION
## Summary

Cria especificações executáveis para INTEL-REPORT-002 v0.2 (Panorama Setorial × UF — produto one-time **R\$147** Stripe Checkout) cobrindo RPC PostgreSQL + PDF generator shipped via PRs #826/#825 + 34 unit tests.

- **`_reversa_sdd/specs/07-intel-report-sector-uf.md`** (141 LOC, 🟢 CONFIRMADO) — contrato RPC `sector_uf_intel` (inputs, output JSONB schema 16 campos, perf chars `statement_timeout=15s` + single-pass aggregation, permission boundary `SECURITY DEFINER` + `service_role`-only + `search_path` SEC-SECDEF-001/002).
- **`_reversa_sdd/specs/07b-intel-pdf-generator.md`** (163 LOC, 🟢 CONFIRMADO) — sub-spec `pdf_generator_sector_uf_report.generate_sector_uf_report(db, entity_key)`: input contract `"sector:UF"`, output `BytesIO seek(0)`, 7 section builders, 34 test references, error modes (entity_key inválido, RPC empty, ReportLab exception → refund auto + apologetic email).
- **`_reversa_sdd/user-stories.md`** — `US-027 Compra Intel Report v0.2` end-to-end: Stripe Checkout (`unit_amount=14700`) → webhook `checkout.session.completed` → ARQ `generate_intel_report` → RPC `sector_uf_intel` → ReportLab → Supabase Storage signed URL 30d → Resend `send_intel_report_ready`.
- **`_reversa_sdd/code-spec-matrix.md`** — row Spec→Code para `intel-report-sector-uf` (~1.400 LOC).
- **Story file** — Status Ready→InProgress, ACs/DoD checkboxes, File List + Dev Notes (correção **R\$147** vs R\$497 mencionado no story original; assinatura RPC real `(p_sector, p_keywords, p_uf, p_window_months)` vs hipótese AC1 `(setor_id, uf, periodo_inicio, periodo_fim)`; test path real `backend/tests/test_sector_uf_intel_pdf.py`).

Confiança 🟢 CONFIRMADO — todas afirmações trace para código shipped em produção (No Invention, Article IV).

## Testing Plan

Doc-only PR — sem mudanças de runtime.

- [x] `wc -l _reversa_sdd/specs/07-intel-report-sector-uf.md` ≥ 50 → **141 LOC**
- [x] `wc -l _reversa_sdd/specs/07b-intel-pdf-generator.md` ≥ 50 → **163 LOC**
- [x] Cross-ref para `supabase/migrations/20260508120000_sector_uf_intel_rpc.sql` (linha + LOC range)
- [x] Cross-ref para `backend/pdf_generator_sector_uf_report.py:generate_sector_uf_report` (linhas)
- [x] Cross-ref 34 tests em `backend/tests/test_sector_uf_intel_pdf.py`
- [x] `git diff --stat` — 5 arquivos, +445 linhas, sem deletes em código

## Closes

Story: `docs/stories/2026-05/INTEL-REPORT-002-V02-SPEC-001-spec-sdd.story.md`
Reversa anchor: `_reversa_sdd/review-report.md §10.1` (Intel Reports v0.1) + `state.json refresh_2026_05_08` (`INTEL-REPORT-002 RPC sector_uf_intel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)