### PR TITLE
feat(arch): response_model Pass 1 admin routes (PARITY-BE-FE-001)

### DIFF
--- a/backend/routes/admin_cron.py
+++ b/backend/routes/admin_cron.py
@@ -14,6 +14,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from admin import require_admin
+from schemas.admin import AdminCronStatusResponse, CronJobHealthRow
 from supabase_client import get_supabase, sb_execute_direct
 
 logger = logging.getLogger(__name__)
@@ -42,8 +43,8 @@ def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-@router.get("/cron-status")
-async def get_cron_status(user=Depends(require_admin)) -> dict[str, Any]:
+@router.get("/cron-status", response_model=AdminCronStatusResponse)
+async def get_cron_status(user=Depends(require_admin)) -> AdminCronStatusResponse:
     """Return the pg_cron health snapshot.
 
     Calls ``public.get_cron_health()`` (SECURITY DEFINER) via the backend's
@@ -76,19 +77,23 @@ async def get_cron_status(user=Depends(require_admin)) -> dict[str, Any]:
         sb = get_supabase()
         result = await sb_execute_direct(sb.rpc("get_cron_health"))
         rows = getattr(result, "data", None) or []
-        jobs = [_normalize_row(r) for r in rows if isinstance(r, dict)]
-        return {
-            "status": "ok",
-            "queried_at": queried_at,
-            "count": len(jobs),
-            "jobs": jobs,
-        }
+        jobs = [
+            CronJobHealthRow(**_normalize_row(r))
+            for r in rows
+            if isinstance(r, dict)
+        ]
+        return AdminCronStatusResponse(
+            status="ok",
+            queried_at=queried_at,
+            count=len(jobs),
+            jobs=jobs,
+        )
     except Exception as exc:
         logger.warning("cron-status RPC failed: %s", exc)
-        return {
-            "status": "error",
-            "queried_at": queried_at,
-            "count": 0,
-            "jobs": [],
-            "detail": str(exc),
-        }
+        return AdminCronStatusResponse(
+            status="error",
+            queried_at=queried_at,
+            count=0,
+            jobs=[],
+            detail=str(exc),
+        )

--- a/backend/routes/admin_llm_cost.py
+++ b/backend/routes/admin_llm_cost.py
@@ -12,20 +12,20 @@ GET /v1/admin/llm-cost — admin-only JSON snapshot do gasto LLM do mês:
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from fastapi import APIRouter, Depends
 
 from admin import require_admin
 from llm_budget import get_cost_snapshot
+from schemas.admin import AdminLlmCostResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
 
-@router.get("/llm-cost")
-async def admin_llm_cost(user: dict = Depends(require_admin)) -> dict[str, Any]:
+@router.get("/llm-cost", response_model=AdminLlmCostResponse)
+async def admin_llm_cost(user: dict = Depends(require_admin)) -> AdminLlmCostResponse:
     """Return LLM cost snapshot para o mês corrente (admin-only).
 
     Response shape::
@@ -41,4 +41,5 @@ async def admin_llm_cost(user: dict = Depends(require_admin)) -> dict[str, Any]:
 
     Em caso de Redis indisponível, retorna zeros (graceful degradation).
     """
-    return await get_cost_snapshot()
+    snapshot = await get_cost_snapshot()
+    return AdminLlmCostResponse(**snapshot)

--- a/backend/routes/admin_trace.py
+++ b/backend/routes/admin_trace.py
@@ -4,23 +4,40 @@ GET /v1/admin/search-trace/{search_id} — aggregates search journey data
 from multiple sources (search sessions, cache, jobs).
 POST /v1/admin/trigger-contracts-backfill — enqueue contracts full crawl to Worker.
 POST /v1/admin/trigger-bids-backfill — enqueue historical bids backfill to Worker.
+
+PARITY-BE-FE-001 (Pass 1): every route now declares ``response_model=`` so
+the OpenAPI schema is fully typed and ``frontend/app/api-types.generated.ts``
+exposes proper TypeScript shapes for the admin panel instead of
+``{[k: string]: unknown}``.
 """
 
 import logging
 from datetime import datetime, timezone
-from typing import Any
 
 from fastapi import APIRouter, Depends
 
 from admin import require_admin
+from schemas.admin import (
+    AdminCacheTraceState,
+    AdminCircuitBreakerResetResponse,
+    AdminClearCheckpointsResponse,
+    AdminJobTraceState,
+    AdminJobTriggerResponse,
+    AdminProgressTraceState,
+    AdminSchemaContractStatusResponse,
+    AdminSearchTraceResponse,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/admin", tags=["admin"])
 
 
-@router.post("/trigger-contracts-backfill")
-async def trigger_contracts_backfill(user=Depends(require_admin)) -> dict:
+@router.post(
+    "/trigger-contracts-backfill",
+    response_model=AdminJobTriggerResponse,
+)
+async def trigger_contracts_backfill(user=Depends(require_admin)) -> AdminJobTriggerResponse:
     """Enqueue contracts_full_crawl_job to ARQ Worker.
 
     Runs on Railway Worker (better network for PNCP).
@@ -31,21 +48,34 @@ async def trigger_contracts_backfill(user=Depends(require_admin)) -> dict:
         from ingestion.contracts_crawler import CONTRACTS_FULL_CRAWL_TIMEOUT
         pool = await get_arq_pool()
         if not pool:
-            return {"status": "error", "detail": "ARQ pool unavailable — Worker offline?"}
+            return AdminJobTriggerResponse(
+                status="error",
+                detail="ARQ pool unavailable — Worker offline?",
+            )
 
         # Timeout set via @arq_func(timeout=CONTRACTS_FULL_CRAWL_TIMEOUT) on the function.
         # Do NOT pass _timeout/_job_timeout as kwargs — ARQ forwards unknown kwargs to the function.
         job = await pool.enqueue_job("contracts_full_crawl_job")
         if job:
-            return {"status": "enqueued", "job_id": job.job_id, "timeout_s": CONTRACTS_FULL_CRAWL_TIMEOUT}
-        return {"status": "skipped", "detail": "Job already queued or duplicate"}
+            return AdminJobTriggerResponse(
+                status="enqueued",
+                job_id=job.job_id,
+                timeout_s=CONTRACTS_FULL_CRAWL_TIMEOUT,
+            )
+        return AdminJobTriggerResponse(
+            status="skipped",
+            detail="Job already queued or duplicate",
+        )
     except Exception as e:
         logger.error("trigger_contracts_backfill failed: %s", e)
-        return {"status": "error", "detail": str(e)}
+        return AdminJobTriggerResponse(status="error", detail=str(e))
 
 
-@router.post("/trigger-bids-backfill")
-async def trigger_bids_backfill(user=Depends(require_admin)) -> dict:
+@router.post(
+    "/trigger-bids-backfill",
+    response_model=AdminJobTriggerResponse,
+)
+async def trigger_bids_backfill(user=Depends(require_admin)) -> AdminJobTriggerResponse:
     """Enqueue ingestion_backfill_job to ARQ Worker.
 
     One-time historical crawl: fetches up to 365 days of PNCP bids
@@ -56,19 +86,34 @@ async def trigger_bids_backfill(user=Depends(require_admin)) -> dict:
         from job_queue import get_arq_pool
         pool = await get_arq_pool()
         if not pool:
-            return {"status": "error", "detail": "ARQ pool unavailable — Worker offline?"}
+            return AdminJobTriggerResponse(
+                status="error",
+                detail="ARQ pool unavailable — Worker offline?",
+            )
 
         job = await pool.enqueue_job("ingestion_backfill_job")
         if job:
-            return {"status": "enqueued", "job_id": job.job_id, "timeout_s": 36000}
-        return {"status": "skipped", "detail": "Job already queued or duplicate"}
+            return AdminJobTriggerResponse(
+                status="enqueued",
+                job_id=job.job_id,
+                timeout_s=36000,
+            )
+        return AdminJobTriggerResponse(
+            status="skipped",
+            detail="Job already queued or duplicate",
+        )
     except Exception as e:
         logger.error("trigger_bids_backfill failed: %s", e)
-        return {"status": "error", "detail": str(e)}
+        return AdminJobTriggerResponse(status="error", detail=str(e))
 
 
-@router.post("/clear-contracts-checkpoints")
-async def clear_contracts_checkpoints(user=Depends(require_admin)) -> dict:
+@router.post(
+    "/clear-contracts-checkpoints",
+    response_model=AdminClearCheckpointsResponse,
+)
+async def clear_contracts_checkpoints(
+    user=Depends(require_admin),
+) -> AdminClearCheckpointsResponse:
     """Clear all Redis checkpoints for contracts crawler.
 
     Use before re-triggering a full crawl when stale checkpoints
@@ -77,14 +122,23 @@ async def clear_contracts_checkpoints(user=Depends(require_admin)) -> dict:
     try:
         from ingestion.contracts_crawler import clear_all_checkpoints
         deleted = await clear_all_checkpoints()
-        return {"status": "ok", "checkpoints_deleted": deleted}
+        return AdminClearCheckpointsResponse(
+            status="ok",
+            checkpoints_deleted=deleted,
+        )
     except Exception as e:
         logger.error("clear_contracts_checkpoints failed: %s", e)
-        return {"status": "error", "detail": str(e)}
+        return AdminClearCheckpointsResponse(status="error", detail=str(e))
 
 
-@router.get("/search-trace/{search_id}")
-async def get_search_trace(search_id: str, user=Depends(require_admin)) -> dict[str, Any]:
+@router.get(
+    "/search-trace/{search_id}",
+    response_model=AdminSearchTraceResponse,
+)
+async def get_search_trace(
+    search_id: str,
+    user=Depends(require_admin),
+) -> AdminSearchTraceResponse:
     """Reconstruct complete search journey from search_id.
 
     Aggregates:
@@ -92,40 +146,36 @@ async def get_search_trace(search_id: str, user=Depends(require_admin)) -> dict[
     - Cache entries matching this search
     - Job queue results (if ARQ available)
     """
-    trace: dict[str, Any] = {
-        "search_id": search_id,
-        "queried_at": datetime.now(timezone.utc).isoformat(),
-        "progress": None,
-        "cache": None,
-        "jobs": None,
-    }
+    progress: AdminProgressTraceState | None = None
+    cache: AdminCacheTraceState | None = None
+    jobs: AdminJobTraceState | None = None
 
     # 1. Check active progress tracker
     try:
         from progress import get_tracker
         tracker = await get_tracker(search_id)
         if tracker:
-            trace["progress"] = {
-                "uf_count": tracker.uf_count,
-                "ufs_completed": tracker._ufs_completed,
-                "is_complete": tracker._is_complete,
-                "created_at": tracker.created_at,
-                "mode": "redis" if tracker._use_redis else "in-memory",
-            }
+            progress = AdminProgressTraceState(
+                uf_count=tracker.uf_count,
+                ufs_completed=tracker._ufs_completed,
+                is_complete=tracker._is_complete,
+                created_at=tracker.created_at,
+                mode="redis" if tracker._use_redis else "in-memory",
+            )
     except Exception as e:
-        trace["progress"] = {"error": str(e)}
+        progress = AdminProgressTraceState(error=str(e))
 
     # 2. Check job results in Redis
     try:
         from job_queue import get_job_result
         resumo = await get_job_result(search_id, "resumo_json")
         excel = await get_job_result(search_id, "excel_result")
-        trace["jobs"] = {
-            "llm_summary": "completed" if resumo else "not_found",
-            "excel_generation": "completed" if excel else "not_found",
-        }
+        jobs = AdminJobTraceState(
+            llm_summary="completed" if resumo else "not_found",
+            excel_generation="completed" if excel else "not_found",
+        )
     except Exception as e:
-        trace["jobs"] = {"error": str(e)}
+        jobs = AdminJobTraceState(error=str(e))
 
     # 3. Check cache for this search
     try:
@@ -135,15 +185,21 @@ async def get_search_trace(search_id: str, user=Depends(require_admin)) -> dict[
             # Look for revalidation key
             reval_key = f"revalidating:{search_id[:16]}"
             is_revalidating = await redis.exists(reval_key)
-            trace["cache"] = {
-                "is_revalidating": bool(is_revalidating),
-            }
+            cache = AdminCacheTraceState(
+                is_revalidating=bool(is_revalidating),
+            )
         else:
-            trace["cache"] = {"redis": "unavailable"}
+            cache = AdminCacheTraceState(redis="unavailable")
     except Exception as e:
-        trace["cache"] = {"error": str(e)}
+        cache = AdminCacheTraceState(error=str(e))
 
-    return trace
+    return AdminSearchTraceResponse(
+        search_id=search_id,
+        queried_at=datetime.now(timezone.utc).isoformat(),
+        progress=progress,
+        cache=cache,
+        jobs=jobs,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -151,8 +207,13 @@ async def get_search_trace(search_id: str, user=Depends(require_admin)) -> dict[
 # ---------------------------------------------------------------------------
 
 
-@router.post("/cb/reset")
-async def reset_circuit_breakers(user=Depends(require_admin)) -> dict[str, Any]:
+@router.post(
+    "/cb/reset",
+    response_model=AdminCircuitBreakerResetResponse,
+)
+async def reset_circuit_breakers(
+    user=Depends(require_admin),
+) -> AdminCircuitBreakerResetResponse:
     """STORY-416 AC5: Reset all segregated Supabase CBs to CLOSED.
 
     Intended for on-call use after an upstream incident has been mitigated
@@ -163,15 +224,20 @@ async def reset_circuit_breakers(user=Depends(require_admin)) -> dict[str, Any]:
     from supabase_client import reset_all_circuit_breakers
 
     previous = reset_all_circuit_breakers()
-    return {
-        "status": "ok",
-        "previous_states": previous,
-        "reset_by": user.get("id") if isinstance(user, dict) else str(user),
-    }
+    return AdminCircuitBreakerResetResponse(
+        status="ok",
+        previous_states=previous,
+        reset_by=user.get("id") if isinstance(user, dict) else str(user),
+    )
 
 
-@router.get("/schema-contract-status")
-async def get_schema_contract_status(user=Depends(require_admin)) -> dict[str, Any]:
+@router.get(
+    "/schema-contract-status",
+    response_model=AdminSchemaContractStatusResponse,
+)
+async def get_schema_contract_status(
+    user=Depends(require_admin),
+) -> AdminSchemaContractStatusResponse:
     """STORY-414 AC4: Expose the last schema-contract validation result.
 
     Returns the cached result from the startup check plus a ``stale``
@@ -185,10 +251,10 @@ async def get_schema_contract_status(user=Depends(require_admin)) -> dict[str, A
     status = get_last_status()
     # Never expose raw exception strings or DB internals — the cache is
     # already sanitised by enforce_schema_contract.
-    return {
-        "passed": status.get("passed"),
-        "missing": status.get("missing", []),
-        "strict_mode": status.get("strict_mode", False),
-        "checked_at": status.get("checked_at", 0.0),
-        "stale": status.get("stale", True),
-    }
+    return AdminSchemaContractStatusResponse(
+        passed=status.get("passed"),
+        missing=list(status.get("missing", []) or []),
+        strict_mode=bool(status.get("strict_mode", False)),
+        checked_at=float(status.get("checked_at", 0.0) or 0.0),
+        stale=bool(status.get("stale", True)),
+    )

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -70,3 +70,137 @@ class AdminUpdateCreditsResponse(BaseModel):
     credits: int
     previous_credits: Optional[int] = None
     subscription_created: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# PARITY-BE-FE-001 (Pass 1): admin_trace.py / admin_cron.py / admin_llm_cost.py
+# ---------------------------------------------------------------------------
+
+
+class AdminJobTriggerResponse(BaseModel):
+    """Response for POST /v1/admin/trigger-{contracts,bids}-backfill.
+
+    Routes return ``status`` in {"enqueued", "skipped", "error"} plus an
+    optional ``job_id`` (when ARQ accepts the job) and ``timeout_s``.
+    ``detail`` carries the operator-facing reason string when non-OK.
+    """
+    status: str
+    job_id: Optional[str] = None
+    timeout_s: Optional[int] = None
+    detail: Optional[str] = None
+
+
+class AdminClearCheckpointsResponse(BaseModel):
+    """Response for POST /v1/admin/clear-contracts-checkpoints."""
+    status: str
+    checkpoints_deleted: Optional[int] = None
+    detail: Optional[str] = None
+
+
+class AdminProgressTraceState(BaseModel):
+    """``progress`` field of the search-trace response when a tracker
+    is still in memory. ``mode`` is ``"redis"`` or ``"in-memory"``.
+    """
+    uf_count: Optional[int] = None
+    ufs_completed: Optional[int] = None
+    is_complete: Optional[bool] = None
+    created_at: Optional[float] = None
+    mode: Optional[str] = None
+    error: Optional[str] = None
+
+
+class AdminJobTraceState(BaseModel):
+    """``jobs`` field of the search-trace response.
+
+    Values are short status strings (``"completed"`` / ``"not_found"``)
+    so the model accepts them as ``Optional[str]``. ``error`` is present
+    when the lookup itself raised.
+    """
+    llm_summary: Optional[str] = None
+    excel_generation: Optional[str] = None
+    error: Optional[str] = None
+
+
+class AdminCacheTraceState(BaseModel):
+    """``cache`` field of the search-trace response."""
+    is_revalidating: Optional[bool] = None
+    redis: Optional[str] = None
+    error: Optional[str] = None
+
+
+class AdminSearchTraceResponse(BaseModel):
+    """Response for GET /v1/admin/search-trace/{search_id}.
+
+    Each sub-section is independently nullable: a transient Redis or ARQ
+    failure sets the corresponding key to a small ``{"error": "..."}``
+    payload instead of failing the whole response.
+    """
+    search_id: str
+    queried_at: str
+    progress: Optional[AdminProgressTraceState] = None
+    cache: Optional[AdminCacheTraceState] = None
+    jobs: Optional[AdminJobTraceState] = None
+
+
+class AdminCircuitBreakerResetResponse(BaseModel):
+    """Response for POST /v1/admin/cb/reset (STORY-416 AC5)."""
+    status: str
+    previous_states: Dict[str, Any]
+    reset_by: Optional[str] = None
+
+
+class AdminSchemaContractStatusResponse(BaseModel):
+    """Response for GET /v1/admin/schema-contract-status (STORY-414 AC4)."""
+    passed: Optional[bool] = None
+    missing: List[str] = []
+    strict_mode: bool = False
+    checked_at: float = 0.0
+    stale: bool = True
+
+
+# --- admin_cron.py ---------------------------------------------------------
+
+
+class CronJobHealthRow(BaseModel):
+    """One row of ``public.get_cron_health()`` (STORY-1.1)."""
+    jobname: Optional[str] = None
+    schedule: Optional[str] = None
+    active: Optional[bool] = None
+    last_status: Optional[str] = None
+    last_run_at: Optional[str] = None
+    runs_24h: int = 0
+    failures_24h: int = 0
+    latency_avg_ms: Optional[int] = None
+    last_return_message: Optional[str] = None
+
+
+class AdminCronStatusResponse(BaseModel):
+    """Response for GET /v1/admin/cron-status (STORY-1.1).
+
+    On transient backend failure (Supabase CB open, RPC error) the route
+    returns ``status="error"`` with ``jobs=[]`` so dashboards degrade
+    gracefully instead of 500-ing.
+    """
+    status: str
+    queried_at: str
+    count: int
+    jobs: List[CronJobHealthRow]
+    detail: Optional[str] = None
+
+
+# --- admin_llm_cost.py -----------------------------------------------------
+
+
+class AdminLlmCostResponse(BaseModel):
+    """Response for GET /v1/admin/llm-cost (STORY-2.11).
+
+    Mirrors ``llm_budget.get_cost_snapshot()``. ``month`` is the Redis
+    key shape (e.g. ``"llm_cost_month_2026_04"``); ``exceeded`` flips
+    to ``True`` when the hard-reject is active.
+    """
+    month_to_date_usd: float = 0.0
+    budget_usd: float = 0.0
+    pct_used: float = 0.0
+    projected_end_of_month_usd: float = 0.0
+    month: str
+    exceeded: bool = False

--- a/backend/scripts/audit_response_model_coverage.py
+++ b/backend/scripts/audit_response_model_coverage.py
@@ -1,0 +1,336 @@
+"""PARITY-BE-FE-001 (AC1): Audit `response_model=` coverage on FastAPI routes.
+
+Walks ``backend/routes/*.py`` and parses each module's AST to count:
+    * Total `@router.<verb>(...)` decorators (HTTP-handling routes).
+    * How many of those declare `response_model=` (truthy or None — both count
+      as explicitly typed; `response_model=None` is the documented escape
+      hatch for raw / streaming responses, see story AC2).
+    * Per-file coverage % and the list of `path` strings that are still
+      missing the kwarg.
+
+Why an AST walk and not import-the-app?
+    * The script must run in CI without env vars / DB / Redis.
+    * AST stays dependency-free and deterministic — same output across
+      Linux / macOS / Windows, regardless of feature-flag state.
+    * False negatives (e.g. routes registered via a helper) are rare
+      in this codebase: every router uses ``@router.<verb>("/path", ...)``.
+
+Usage:
+
+    # Print human-readable table to stdout.
+    python backend/scripts/audit_response_model_coverage.py
+
+    # Emit machine-readable JSON to a path (used to commit the baseline
+    # snapshot consumed by the future CI gate).
+    python backend/scripts/audit_response_model_coverage.py \
+        --json backend/scripts/audit_response_model_coverage_baseline.json
+
+    # Compare against a previously-committed baseline and exit non-zero
+    # when coverage shrinks (intended for the CI gate in AC3).
+    python backend/scripts/audit_response_model_coverage.py \
+        --check-against backend/scripts/audit_response_model_coverage_baseline.json
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+#: HTTP verbs that produce a typed response in OpenAPI. ``websocket`` and
+#: ``api_route`` are excluded — the former does not surface response_model
+#: in OpenAPI, and the latter is virtually unused in this codebase.
+HTTP_VERBS: frozenset[str] = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options"}
+)
+
+
+@dataclass
+class RouteEntry:
+    """One ``@router.<verb>(...)`` decorator we found in a route module."""
+
+    verb: str
+    path: str
+    has_response_model: bool
+    lineno: int
+
+
+@dataclass
+class FileReport:
+    """Aggregated audit data for a single route module."""
+
+    file: str
+    routes: list[RouteEntry] = field(default_factory=list)
+
+    @property
+    def router_count(self) -> int:
+        return len(self.routes)
+
+    @property
+    def response_model_count(self) -> int:
+        return sum(1 for r in self.routes if r.has_response_model)
+
+    @property
+    def coverage_pct(self) -> float:
+        if not self.routes:
+            return 100.0  # vacuously typed (helper / aggregator file)
+        return round(100.0 * self.response_model_count / self.router_count, 2)
+
+    @property
+    def missing_paths(self) -> list[str]:
+        return [r.path for r in self.routes if not r.has_response_model]
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file,
+            "router_count": self.router_count,
+            "response_model_count": self.response_model_count,
+            "coverage_pct": self.coverage_pct,
+            "missing_paths": self.missing_paths,
+        }
+
+
+def _is_router_call(node: ast.AST) -> tuple[bool, str | None]:
+    """Match ``@router.<verb>(...)`` and ``@<some_router>.<verb>(...)``.
+
+    Returns ``(matched, verb)``. We accept any attribute access on a Name
+    target ending in ``_router`` or named exactly ``router`` — covers the
+    occasional ``api_router.get(...)`` / ``public_router.get(...)`` patterns.
+    """
+    if not isinstance(node, ast.Call):
+        return False, None
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False, None
+    verb = func.attr
+    if verb not in HTTP_VERBS:
+        return False, None
+    target = func.value
+    if isinstance(target, ast.Name):
+        name = target.id
+        if name == "router" or name.endswith("_router"):
+            return True, verb
+    return False, None
+
+
+def _has_response_model_kwarg(call: ast.Call) -> bool:
+    """``response_model=`` declared explicitly (any value, incl. ``None``)."""
+    return any(kw.arg == "response_model" for kw in call.keywords)
+
+
+def _extract_path(call: ast.Call) -> str:
+    """Return the first positional string arg of the decorator, e.g. ``"/me"``.
+
+    The audit treats the path as a label only — exact normalization (leading
+    slash, trailing slash, prefix mounting) does not matter for coverage
+    counting.
+    """
+    if call.args:
+        first = call.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return first.value
+    return "<unknown>"
+
+
+def audit_file(path: Path) -> FileReport:
+    """AST-walk one route module. Never raises; reports skip via empty routes."""
+    report = FileReport(file=str(path))
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError) as exc:
+        # Surface the failure in the report file but keep the script moving:
+        # a single broken file should not abort an org-wide audit.
+        sys.stderr.write(f"[audit] skip {path}: {exc}\n")
+        return report
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for deco in node.decorator_list:
+            matched, verb = _is_router_call(deco)
+            if not matched:
+                continue
+            assert isinstance(deco, ast.Call)  # narrowed by _is_router_call
+            assert verb is not None
+            report.routes.append(
+                RouteEntry(
+                    verb=verb,
+                    path=_extract_path(deco),
+                    has_response_model=_has_response_model_kwarg(deco),
+                    lineno=node.lineno,
+                )
+            )
+    return report
+
+
+def audit_routes_dir(routes_dir: Path) -> list[FileReport]:
+    """Audit every ``*.py`` (excluding ``__pycache__``) under ``routes_dir``.
+
+    File paths are normalized to ``backend/routes/<name>.py`` so the JSON
+    baseline stays reproducible across worktrees / CI checkouts that have
+    different absolute paths.
+    """
+    files = sorted(
+        p for p in routes_dir.glob("*.py") if p.name != "__init__.py"
+    )
+    reports: list[FileReport] = []
+    for p in files:
+        report = audit_file(p)
+        # Always render as ``backend/routes/<name>.py`` regardless of CWD.
+        report.file = f"backend/routes/{p.name}"
+        reports.append(report)
+    return reports
+
+
+def aggregate(reports: Iterable[FileReport]) -> dict:
+    """Roll up totals + per-file rows into a JSON-serializable summary."""
+    rows = [r for r in reports if r.router_count > 0]
+    helpers = [r for r in reports if r.router_count == 0]
+    total_routers = sum(r.router_count for r in rows)
+    total_typed = sum(r.response_model_count for r in rows)
+    coverage_pct = (
+        round(100.0 * total_typed / total_routers, 2) if total_routers else 100.0
+    )
+    return {
+        "summary": {
+            "files_scanned": len(rows) + len(helpers),
+            "files_with_routes": len(rows),
+            "helper_files_excluded": [h.file for h in helpers],
+            "total_routes": total_routers,
+            "total_with_response_model": total_typed,
+            "coverage_pct": coverage_pct,
+        },
+        "files": [r.to_dict() for r in sorted(rows, key=lambda x: x.coverage_pct)],
+    }
+
+
+def render_table(summary: dict) -> str:
+    """Pretty-print the summary as a single ASCII table for human review."""
+    lines: list[str] = []
+    s = summary["summary"]
+    lines.append(
+        f"== response_model coverage ({s['coverage_pct']}% over "
+        f"{s['total_routes']} routes in {s['files_with_routes']} files) =="
+    )
+    lines.append(
+        f"{'file':<55}{'routes':>8}{'typed':>8}{'cov%':>8}  missing"
+    )
+    lines.append("-" * 100)
+    for row in summary["files"]:
+        missing = ", ".join(row["missing_paths"]) if row["missing_paths"] else ""
+        # Truncate to a sane terminal width but keep the leading paths.
+        if len(missing) > 60:
+            missing = missing[:57] + "..."
+        lines.append(
+            f"{row['file']:<55}{row['router_count']:>8}"
+            f"{row['response_model_count']:>8}{row['coverage_pct']:>8.2f}  {missing}"
+        )
+    if s["helper_files_excluded"]:
+        lines.append("")
+        lines.append(
+            f"# {len(s['helper_files_excluded'])} helper/aggregator files excluded "
+            "(zero @router.* decorators)"
+        )
+    return "\n".join(lines)
+
+
+def check_against_baseline(current: dict, baseline_path: Path) -> int:
+    """Compare ``current`` summary against the JSON baseline file.
+
+    Returns a Unix exit code:
+        0 — coverage stayed the same or improved (allowed)
+        1 — coverage shrank, OR a previously-typed file lost typed routes,
+            OR a brand-new route was added without response_model
+    """
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    base_pct = baseline["summary"]["coverage_pct"]
+    cur_pct = current["summary"]["coverage_pct"]
+    failures: list[str] = []
+
+    if cur_pct + 0.01 < base_pct:
+        failures.append(
+            f"coverage decreased: {base_pct}% -> {cur_pct}% "
+            "(new routes must declare response_model=)"
+        )
+
+    base_files = {row["file"]: row for row in baseline["files"]}
+    cur_files = {row["file"]: row for row in current["files"]}
+
+    for file, cur_row in cur_files.items():
+        base_row = base_files.get(file)
+        if base_row is None:
+            # New file added — every route must be typed.
+            if cur_row["missing_paths"]:
+                failures.append(
+                    f"new file {file} added with {len(cur_row['missing_paths'])} "
+                    f"untyped routes: {cur_row['missing_paths']}"
+                )
+            continue
+        # Existing file — typed-route count must not decrease.
+        if cur_row["response_model_count"] < base_row["response_model_count"]:
+            failures.append(
+                f"{file}: typed routes dropped from "
+                f"{base_row['response_model_count']} to "
+                f"{cur_row['response_model_count']}"
+            )
+
+    if failures:
+        sys.stderr.write("response_model coverage gate FAILED:\n")
+        for f in failures:
+            sys.stderr.write(f"  - {f}\n")
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--routes-dir",
+        type=Path,
+        default=None,
+        help="Override target directory (default: backend/routes/ relative to this script).",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=None,
+        help="Write JSON output to this path instead of stdout table.",
+    )
+    parser.add_argument(
+        "--check-against",
+        type=Path,
+        default=None,
+        help="Compare against an existing baseline JSON and exit 1 on regression.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.routes_dir is None:
+        # __file__ = backend/scripts/audit_response_model_coverage.py
+        args.routes_dir = Path(__file__).resolve().parent.parent / "routes"
+
+    if not args.routes_dir.is_dir():
+        sys.stderr.write(f"routes dir not found: {args.routes_dir}\n")
+        return 2
+
+    reports = audit_routes_dir(args.routes_dir)
+    summary = aggregate(reports)
+
+    if args.json is not None:
+        args.json.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    else:
+        print(render_table(summary))
+
+    if args.check_against is not None:
+        return check_against_baseline(summary, args.check_against)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/audit_response_model_coverage_baseline.json
+++ b/backend/scripts/audit_response_model_coverage_baseline.json
@@ -1,0 +1,601 @@
+{
+  "files": [
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/auth_check.py",
+      "missing_paths": [
+        "/check-email",
+        "/check-phone"
+      ],
+      "response_model_count": 0,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/auth_oauth.py",
+      "missing_paths": [
+        "/google",
+        "/google/callback",
+        "/google"
+      ],
+      "response_model_count": 0,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/export.py",
+      "missing_paths": [
+        "/pdf"
+      ],
+      "response_model_count": 0,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/health.py",
+      "missing_paths": [
+        "/health",
+        "/status",
+        "/status/incidents",
+        "/status/uptime-history",
+        "/health/tasks",
+        "/health/sources",
+        "/health/cache"
+      ],
+      "response_model_count": 0,
+      "router_count": 7
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/organizations.py",
+      "missing_paths": [
+        "/organizations/me",
+        "/organizations",
+        "/organizations/{org_id}",
+        "/organizations/{org_id}/invite",
+        "/organizations/{org_id}/accept",
+        "/organizations/{org_id}/members/{target_user_id}",
+        "/organizations/{org_id}/dashboard",
+        "/organizations/{org_id}/logo"
+      ],
+      "response_model_count": 0,
+      "router_count": 8
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/partners.py",
+      "missing_paths": [
+        "/partner/dashboard",
+        "/admin/partners",
+        "/admin/partners",
+        "/admin/partners/{partner_id}/referrals",
+        "/admin/partners/{partner_id}/revenue"
+      ],
+      "response_model_count": 0,
+      "router_count": 5
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/reports.py",
+      "missing_paths": [
+        "/reports/diagnostico"
+      ],
+      "response_model_count": 0,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/search_sse.py",
+      "missing_paths": [
+        "/buscar-progress/{search_id}"
+      ],
+      "response_model_count": 0,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/slo.py",
+      "missing_paths": [
+        "/slo",
+        "/slo/alerts"
+      ],
+      "response_model_count": 0,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/stats_public.py",
+      "missing_paths": [
+        "/stats/public"
+      ],
+      "response_model_count": 0,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 0.0,
+      "file": "backend/routes/trial_emails.py",
+      "missing_paths": [
+        "/trial-emails/unsubscribe",
+        "/trial-emails/webhook",
+        "/admin/trial-emails/preview",
+        "/admin/trial-emails/test-send"
+      ],
+      "response_model_count": 0,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 12.5,
+      "file": "backend/routes/search_status.py",
+      "missing_paths": [
+        "/search/{search_id}/timeline",
+        "/buscar-results/{search_id}",
+        "/search/{search_id}/results",
+        "/search/{search_id}/zero-match",
+        "/search/{search_id}/regenerate-excel",
+        "/search/{search_id}/retry",
+        "/search/{search_id}/cancel"
+      ],
+      "response_model_count": 1,
+      "router_count": 8
+    },
+    {
+      "coverage_pct": 25.0,
+      "file": "backend/routes/health_core.py",
+      "missing_paths": [
+        "/health/live",
+        "/health",
+        "/sources/health"
+      ],
+      "response_model_count": 1,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 33.33,
+      "file": "backend/routes/metrics_api.py",
+      "missing_paths": [
+        "/discard-rate",
+        "/sse-fallback"
+      ],
+      "response_model_count": 1,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 40.0,
+      "file": "backend/routes/pipeline.py",
+      "missing_paths": [
+        "/pipeline",
+        "/pipeline/{item_id}",
+        "/pipeline/{item_id}"
+      ],
+      "response_model_count": 2,
+      "router_count": 5
+    },
+    {
+      "coverage_pct": 42.86,
+      "file": "backend/routes/alerts.py",
+      "missing_paths": [
+        "/alerts",
+        "/alerts/{alert_id}",
+        "/alerts/{alert_id}",
+        "/alerts/{alert_id}/unsubscribe"
+      ],
+      "response_model_count": 3,
+      "router_count": 7
+    },
+    {
+      "coverage_pct": 50.0,
+      "file": "backend/routes/emails.py",
+      "missing_paths": [
+        "/emails/unsubscribe"
+      ],
+      "response_model_count": 1,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 50.0,
+      "file": "backend/routes/notifications.py",
+      "missing_paths": [
+        "/new-bids-count"
+      ],
+      "response_model_count": 1,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 50.0,
+      "file": "backend/routes/observatorio.py",
+      "missing_paths": [
+        "/observatorio/relatorio/{mes}/{ano}/csv"
+      ],
+      "response_model_count": 1,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 50.0,
+      "file": "backend/routes/onboarding.py",
+      "missing_paths": [
+        "/onboarding/tour-event"
+      ],
+      "response_model_count": 1,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 50.0,
+      "file": "backend/routes/sessions.py",
+      "missing_paths": [
+        "/sessions/{search_id}/download"
+      ],
+      "response_model_count": 1,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 50.0,
+      "file": "backend/routes/sitemap_licitacoes.py",
+      "missing_paths": [
+        "/admin/sitemap-cache/refresh"
+      ],
+      "response_model_count": 1,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 60.0,
+      "file": "backend/routes/billing.py",
+      "missing_paths": [
+        "/billing-portal",
+        "/subscription/status"
+      ],
+      "response_model_count": 3,
+      "router_count": 5
+    },
+    {
+      "coverage_pct": 66.67,
+      "file": "backend/routes/auth_email.py",
+      "missing_paths": [
+        "/validate-signup-email"
+      ],
+      "response_model_count": 2,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 75.0,
+      "file": "backend/routes/intel_reports.py",
+      "missing_paths": [
+        "/{purchase_id}/download"
+      ],
+      "response_model_count": 3,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 80.0,
+      "file": "backend/routes/feature_flags.py",
+      "missing_paths": [
+        "/experiments"
+      ],
+      "response_model_count": 4,
+      "router_count": 5
+    },
+    {
+      "coverage_pct": 83.33,
+      "file": "backend/routes/analytics.py",
+      "missing_paths": [
+        "/track-cta"
+      ],
+      "response_model_count": 5,
+      "router_count": 6
+    },
+    {
+      "coverage_pct": 84.62,
+      "file": "backend/routes/user.py",
+      "missing_paths": [
+        "/me/export",
+        "/admin/trial-exit-surveys"
+      ],
+      "response_model_count": 11,
+      "router_count": 13
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_billing_sync.py",
+      "missing_paths": [],
+      "response_model_count": 4,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_calibration.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_cron.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_founding.py",
+      "missing_paths": [],
+      "response_model_count": 4,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_llm_cost.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_trace.py",
+      "missing_paths": [],
+      "response_model_count": 6,
+      "router_count": 6
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/alertas_publicos.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/auth_signup.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/bid_analysis.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/blog_stats.py",
+      "missing_paths": [],
+      "response_model_count": 9,
+      "router_count": 9
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/calculadora.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/comparador.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/compliance_publicos.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/conta.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/contratos_publicos.py",
+      "missing_paths": [],
+      "response_model_count": 4,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/dados_publicos.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/daily_digest.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/empresa_publica.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/export_sheets.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/features.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/feedback.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/founding.py",
+      "missing_paths": [],
+      "response_model_count": 4,
+      "router_count": 4
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/indice_municipal.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/itens_publicos.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/lead_capture.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/messages.py",
+      "missing_paths": [],
+      "response_model_count": 6,
+      "router_count": 6
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/mfa.py",
+      "missing_paths": [],
+      "response_model_count": 6,
+      "router_count": 6
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/municipios_publicos.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/orgao_publico.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/plans.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/referral.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/relatorio.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/sectors_public.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/seo_admin.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/share.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/sitemap_cnpjs.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/sitemap_licitacoes_do_dia.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/sitemap_orgaos.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/subscriptions.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/survey.py",
+      "missing_paths": [],
+      "response_model_count": 1,
+      "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/trial_extension.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/weekly_digest.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    }
+  ],
+  "summary": {
+    "coverage_pct": 67.92,
+    "files_scanned": 72,
+    "files_with_routes": 70,
+    "helper_files_excluded": [
+      "backend/routes/_sitemap_cache_headers.py",
+      "backend/routes/search_state.py"
+    ],
+    "total_routes": 212,
+    "total_with_response_model": 144
+  }
+}

--- a/backend/tests/scripts/test_audit_response_model_coverage.py
+++ b/backend/tests/scripts/test_audit_response_model_coverage.py
@@ -1,0 +1,365 @@
+"""Tests for ``backend/scripts/audit_response_model_coverage.py``.
+
+The audit script is the data source for the future CI gate (AC3 of
+PARITY-BE-FE-001) so the unit tests focus on three properties:
+
+1. **Detection** — the AST walker correctly counts ``@router.<verb>(...)``
+   decorators with and without ``response_model=``.
+2. **Reproducibility** — the JSON output uses repository-relative paths
+   so the baseline file stays stable across CI checkouts and worktrees.
+3. **Gate semantics** — ``--check-against`` flips to exit code 1 only on
+   genuine regressions (decreased typed-route count, lowered global
+   coverage, or new untyped routes in a new file). Same-or-better
+   never trips the gate.
+
+The tests construct synthetic route modules in a tmp directory rather
+than importing the real backend routes — keeps the tests hermetic and
+independent of in-flight backfills.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# The audit script lives at backend/scripts/. Tests run with backend/
+# on sys.path (via conftest), so we add scripts/ explicitly here.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import audit_response_model_coverage as audit  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_TYPED = '''\
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class FooResponse(BaseModel):
+    ok: bool
+
+
+@router.get("/foo", response_model=FooResponse)
+async def get_foo() -> FooResponse:
+    return FooResponse(ok=True)
+
+
+@router.post("/bar", response_model=FooResponse)
+async def post_bar() -> FooResponse:
+    return FooResponse(ok=True)
+'''
+
+
+SAMPLE_MIXED = '''\
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/typed", response_model=dict)
+async def typed_one():
+    return {}
+
+
+@router.get("/untyped")
+async def untyped_one():
+    return {}
+
+
+@router.post("/also-untyped")
+async def untyped_two():
+    return {}
+'''
+
+
+SAMPLE_HELPER = '''\
+"""Pure helper module — no @router.* decorators."""
+
+CONSTANT = 42
+
+
+def helper(x: int) -> int:
+    return x + 1
+'''
+
+
+SAMPLE_NAMED_ROUTER = '''\
+from fastapi import APIRouter
+
+api_router = APIRouter()
+
+
+@api_router.get("/named", response_model=dict)
+async def named():
+    return {}
+
+
+@api_router.delete("/named-untyped")
+async def named_untyped():
+    return {}
+'''
+
+
+@pytest.fixture
+def routes_dir(tmp_path: Path) -> Path:
+    """Build a synthetic backend/routes/ directory."""
+    d = tmp_path / "routes"
+    d.mkdir()
+    (d / "all_typed.py").write_text(SAMPLE_TYPED)
+    (d / "mixed.py").write_text(SAMPLE_MIXED)
+    (d / "helper.py").write_text(SAMPLE_HELPER)
+    (d / "named.py").write_text(SAMPLE_NAMED_ROUTER)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def test_audit_file_counts_typed_routes(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text(SAMPLE_TYPED)
+    report = audit.audit_file(p)
+    assert report.router_count == 2
+    assert report.response_model_count == 2
+    assert report.coverage_pct == 100.0
+    assert report.missing_paths == []
+
+
+def test_audit_file_counts_mixed(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text(SAMPLE_MIXED)
+    report = audit.audit_file(p)
+    assert report.router_count == 3
+    assert report.response_model_count == 1
+    assert report.coverage_pct == pytest.approx(33.33, abs=0.01)
+    assert report.missing_paths == ["/untyped", "/also-untyped"]
+
+
+def test_audit_file_helper_excluded(tmp_path: Path) -> None:
+    p = tmp_path / "helper.py"
+    p.write_text(SAMPLE_HELPER)
+    report = audit.audit_file(p)
+    assert report.router_count == 0
+    # helper coverage is "100% vacuously" — the aggregator skips it.
+    assert report.coverage_pct == 100.0
+
+
+def test_audit_recognizes_named_router(tmp_path: Path) -> None:
+    """Names ending in ``_router`` (e.g. ``api_router``) are accepted."""
+    p = tmp_path / "named.py"
+    p.write_text(SAMPLE_NAMED_ROUTER)
+    report = audit.audit_file(p)
+    assert report.router_count == 2
+    assert report.response_model_count == 1
+
+
+def test_audit_skips_unrelated_decorators(tmp_path: Path) -> None:
+    p = tmp_path / "x.py"
+    p.write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n\n"
+        "@property\n"
+        "def foo(self): return 1\n\n"
+        "@router.get('/x', response_model=dict)\n"
+        "async def get_x(): return {}\n"
+    )
+    report = audit.audit_file(p)
+    assert report.router_count == 1
+
+
+def test_audit_skips_websocket(tmp_path: Path) -> None:
+    """``@router.websocket(...)`` is not counted (no response_model in OpenAPI)."""
+    p = tmp_path / "x.py"
+    p.write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n\n"
+        "@router.websocket('/ws')\n"
+        "async def ws(): pass\n\n"
+        "@router.get('/x', response_model=dict)\n"
+        "async def get_x(): return {}\n"
+    )
+    report = audit.audit_file(p)
+    assert report.router_count == 1
+
+
+def test_audit_response_model_none_counts_as_typed(tmp_path: Path) -> None:
+    """``response_model=None`` is the documented escape hatch (story AC2);
+    the kwarg presence — not its value — is what the audit checks for.
+    """
+    p = tmp_path / "x.py"
+    p.write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n\n"
+        "@router.get('/raw', response_model=None)\n"
+        "async def raw(): return b'...'\n"
+    )
+    report = audit.audit_file(p)
+    assert report.router_count == 1
+    assert report.response_model_count == 1
+
+
+def test_audit_skips_broken_files(tmp_path: Path) -> None:
+    """A SyntaxError must not abort the audit."""
+    p = tmp_path / "broken.py"
+    p.write_text("def (): not python\n")
+    report = audit.audit_file(p)
+    assert report.router_count == 0  # graceful empty
+
+
+# ---------------------------------------------------------------------------
+# Aggregation + JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_audit_routes_dir_uses_relative_paths(routes_dir: Path) -> None:
+    reports = audit.audit_routes_dir(routes_dir)
+    files = {r.file for r in reports}
+    # Always rendered as backend/routes/<name>.py for reproducibility.
+    assert files == {
+        "backend/routes/all_typed.py",
+        "backend/routes/mixed.py",
+        "backend/routes/helper.py",
+        "backend/routes/named.py",
+    }
+
+
+def test_aggregate_excludes_helpers(routes_dir: Path) -> None:
+    reports = audit.audit_routes_dir(routes_dir)
+    summary = audit.aggregate(reports)
+
+    assert summary["summary"]["files_with_routes"] == 3
+    # all_typed (2) + mixed (3) + named (2) = 7
+    assert summary["summary"]["total_routes"] == 7
+    # all_typed (2) + mixed (1) + named (1) = 4
+    assert summary["summary"]["total_with_response_model"] == 4
+    assert summary["summary"]["coverage_pct"] == pytest.approx(57.14, abs=0.01)
+    assert "backend/routes/helper.py" in summary["summary"]["helper_files_excluded"]
+
+
+def test_render_table_includes_coverage(routes_dir: Path) -> None:
+    summary = audit.aggregate(audit.audit_routes_dir(routes_dir))
+    out = audit.render_table(summary)
+    assert "response_model coverage" in out
+    assert "57.14" in out
+    assert "/untyped" in out
+    assert "/also-untyped" in out
+
+
+def test_main_writes_json_with_sorted_keys(
+    routes_dir: Path, tmp_path: Path
+) -> None:
+    """JSON baseline must be deterministic — sort_keys=True keeps diffs minimal."""
+    out = tmp_path / "baseline.json"
+    rc = audit.main(["--routes-dir", str(routes_dir), "--json", str(out)])
+    assert rc == 0
+    raw = out.read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    # sort_keys=True means the literal output is the canonical re-dump.
+    canonical = json.dumps(parsed, indent=2, sort_keys=True) + "\n"
+    assert raw == canonical
+
+
+# ---------------------------------------------------------------------------
+# Gate semantics (--check-against)
+# ---------------------------------------------------------------------------
+
+
+def test_check_against_self_passes(routes_dir: Path, tmp_path: Path) -> None:
+    """Re-running the audit against its own snapshot is a no-op (exit 0)."""
+    baseline = tmp_path / "baseline.json"
+    audit.main(["--routes-dir", str(routes_dir), "--json", str(baseline)])
+    rc = audit.main(
+        ["--routes-dir", str(routes_dir), "--check-against", str(baseline)]
+    )
+    assert rc == 0
+
+
+def test_check_against_detects_regression(
+    routes_dir: Path, tmp_path: Path
+) -> None:
+    """Removing ``response_model=`` from an existing route must trip the gate."""
+    baseline = tmp_path / "baseline.json"
+    audit.main(["--routes-dir", str(routes_dir), "--json", str(baseline)])
+
+    # Regression: drop response_model from the all-typed file.
+    (routes_dir / "all_typed.py").write_text(
+        SAMPLE_TYPED.replace(", response_model=FooResponse", "")
+    )
+    rc = audit.main(
+        ["--routes-dir", str(routes_dir), "--check-against", str(baseline)]
+    )
+    assert rc == 1
+
+
+def test_check_against_detects_new_untyped_file(
+    routes_dir: Path, tmp_path: Path
+) -> None:
+    """Adding a new file with untyped routes must trip the gate."""
+    baseline = tmp_path / "baseline.json"
+    audit.main(["--routes-dir", str(routes_dir), "--json", str(baseline)])
+
+    (routes_dir / "new_untyped.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n\n"
+        "@router.get('/new')\n"
+        "async def new(): return {}\n"
+    )
+    rc = audit.main(
+        ["--routes-dir", str(routes_dir), "--check-against", str(baseline)]
+    )
+    assert rc == 1
+
+
+def test_check_against_allows_improvement(
+    routes_dir: Path, tmp_path: Path
+) -> None:
+    """Adding response_model to a previously-untyped route must NOT trip."""
+    baseline = tmp_path / "baseline.json"
+    audit.main(["--routes-dir", str(routes_dir), "--json", str(baseline)])
+
+    # Improvement: type up the previously-untyped routes in mixed.py.
+    (routes_dir / "mixed.py").write_text(
+        SAMPLE_MIXED.replace(
+            "@router.get(\"/untyped\")",
+            "@router.get(\"/untyped\", response_model=dict)",
+        ).replace(
+            "@router.post(\"/also-untyped\")",
+            "@router.post(\"/also-untyped\", response_model=dict)",
+        )
+    )
+    rc = audit.main(
+        ["--routes-dir", str(routes_dir), "--check-against", str(baseline)]
+    )
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Real repository invariant — sanity check, not a coverage assertion.
+# ---------------------------------------------------------------------------
+
+
+def test_real_admin_routes_are_fully_typed_pass1() -> None:
+    """PARITY-BE-FE-001 Pass 1 lives-or-dies on these three files.
+
+    If a future PR drops response_model from an admin route the test
+    fails immediately, before the coverage gate even runs.
+    """
+    backend_routes = Path(__file__).resolve().parents[2] / "routes"
+    pass1_files = {"admin_trace.py", "admin_cron.py", "admin_llm_cost.py"}
+    for name in pass1_files:
+        report = audit.audit_file(backend_routes / name)
+        assert report.router_count > 0, f"{name} should have routes"
+        assert report.coverage_pct == 100.0, (
+            f"{name} regressed: {report.coverage_pct}%, missing={report.missing_paths}"
+        )

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -25,6 +25,113 @@
         "title": "AdminAssignPlanResponse",
         "type": "object"
       },
+      "AdminCacheTraceState": {
+        "description": "``cache`` field of the search-trace response.",
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "is_revalidating": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Revalidating"
+          },
+          "redis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redis"
+          }
+        },
+        "title": "AdminCacheTraceState",
+        "type": "object"
+      },
+      "AdminCircuitBreakerResetResponse": {
+        "description": "Response for POST /v1/admin/cb/reset (STORY-416 AC5).",
+        "properties": {
+          "previous_states": {
+            "additionalProperties": true,
+            "title": "Previous States",
+            "type": "object"
+          },
+          "reset_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reset By"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "previous_states"
+        ],
+        "title": "AdminCircuitBreakerResetResponse",
+        "type": "object"
+      },
+      "AdminClearCheckpointsResponse": {
+        "description": "Response for POST /v1/admin/clear-contracts-checkpoints.",
+        "properties": {
+          "checkpoints_deleted": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checkpoints Deleted"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "AdminClearCheckpointsResponse",
+        "type": "object"
+      },
       "AdminCreateUserResponse": {
         "description": "Response for POST /admin/users.",
         "properties": {
@@ -55,6 +162,49 @@
         "title": "AdminCreateUserResponse",
         "type": "object"
       },
+      "AdminCronStatusResponse": {
+        "description": "Response for GET /v1/admin/cron-status (STORY-1.1).\n\nOn transient backend failure (Supabase CB open, RPC error) the route\nreturns ``status=\"error\"`` with ``jobs=[]`` so dashboards degrade\ngracefully instead of 500-ing.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "jobs": {
+            "items": {
+              "$ref": "#/components/schemas/CronJobHealthRow"
+            },
+            "title": "Jobs",
+            "type": "array"
+          },
+          "queried_at": {
+            "title": "Queried At",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "queried_at",
+          "count",
+          "jobs"
+        ],
+        "title": "AdminCronStatusResponse",
+        "type": "object"
+      },
       "AdminDeleteUserResponse": {
         "description": "Response for DELETE /admin/users/{user_id}.",
         "properties": {
@@ -74,6 +224,205 @@
         "title": "AdminDeleteUserResponse",
         "type": "object"
       },
+      "AdminJobTraceState": {
+        "description": "``jobs`` field of the search-trace response.\n\nValues are short status strings (``\"completed\"`` / ``\"not_found\"``)\nso the model accepts them as ``Optional[str]``. ``error`` is present\nwhen the lookup itself raised.",
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "excel_generation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Excel Generation"
+          },
+          "llm_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Summary"
+          }
+        },
+        "title": "AdminJobTraceState",
+        "type": "object"
+      },
+      "AdminJobTriggerResponse": {
+        "description": "Response for POST /v1/admin/trigger-{contracts,bids}-backfill.\n\nRoutes return ``status`` in {\"enqueued\", \"skipped\", \"error\"} plus an\noptional ``job_id`` (when ARQ accepts the job) and ``timeout_s``.\n``detail`` carries the operator-facing reason string when non-OK.",
+        "properties": {
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Id"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "timeout_s": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeout S"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "AdminJobTriggerResponse",
+        "type": "object"
+      },
+      "AdminLlmCostResponse": {
+        "description": "Response for GET /v1/admin/llm-cost (STORY-2.11).\n\nMirrors ``llm_budget.get_cost_snapshot()``. ``month`` is the Redis\nkey shape (e.g. ``\"llm_cost_month_2026_04\"``); ``exceeded`` flips\nto ``True`` when the hard-reject is active.",
+        "properties": {
+          "budget_usd": {
+            "default": 0.0,
+            "title": "Budget Usd",
+            "type": "number"
+          },
+          "exceeded": {
+            "default": false,
+            "title": "Exceeded",
+            "type": "boolean"
+          },
+          "month": {
+            "title": "Month",
+            "type": "string"
+          },
+          "month_to_date_usd": {
+            "default": 0.0,
+            "title": "Month To Date Usd",
+            "type": "number"
+          },
+          "pct_used": {
+            "default": 0.0,
+            "title": "Pct Used",
+            "type": "number"
+          },
+          "projected_end_of_month_usd": {
+            "default": 0.0,
+            "title": "Projected End Of Month Usd",
+            "type": "number"
+          }
+        },
+        "required": [
+          "month"
+        ],
+        "title": "AdminLlmCostResponse",
+        "type": "object"
+      },
+      "AdminProgressTraceState": {
+        "description": "``progress`` field of the search-trace response when a tracker\nis still in memory. ``mode`` is ``\"redis\"`` or ``\"in-memory\"``.",
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "is_complete": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Complete"
+          },
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mode"
+          },
+          "uf_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uf Count"
+          },
+          "ufs_completed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ufs Completed"
+          }
+        },
+        "title": "AdminProgressTraceState",
+        "type": "object"
+      },
       "AdminResetPasswordResponse": {
         "description": "Response for POST /admin/users/{user_id}/reset-password.",
         "properties": {
@@ -91,6 +440,96 @@
           "user_id"
         ],
         "title": "AdminResetPasswordResponse",
+        "type": "object"
+      },
+      "AdminSchemaContractStatusResponse": {
+        "description": "Response for GET /v1/admin/schema-contract-status (STORY-414 AC4).",
+        "properties": {
+          "checked_at": {
+            "default": 0.0,
+            "title": "Checked At",
+            "type": "number"
+          },
+          "missing": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing",
+            "type": "array"
+          },
+          "passed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passed"
+          },
+          "stale": {
+            "default": true,
+            "title": "Stale",
+            "type": "boolean"
+          },
+          "strict_mode": {
+            "default": false,
+            "title": "Strict Mode",
+            "type": "boolean"
+          }
+        },
+        "title": "AdminSchemaContractStatusResponse",
+        "type": "object"
+      },
+      "AdminSearchTraceResponse": {
+        "description": "Response for GET /v1/admin/search-trace/{search_id}.\n\nEach sub-section is independently nullable: a transient Redis or ARQ\nfailure sets the corresponding key to a small ``{\"error\": \"...\"}``\npayload instead of failing the whole response.",
+        "properties": {
+          "cache": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AdminCacheTraceState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "jobs": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AdminJobTraceState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AdminProgressTraceState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "queried_at": {
+            "title": "Queried At",
+            "type": "string"
+          },
+          "search_id": {
+            "title": "Search Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "search_id",
+          "queried_at"
+        ],
+        "title": "AdminSearchTraceResponse",
         "type": "object"
       },
       "AdminUpdateCreditsResponse": {
@@ -3396,6 +3835,100 @@
           "password"
         ],
         "title": "CreateUserRequest",
+        "type": "object"
+      },
+      "CronJobHealthRow": {
+        "description": "One row of ``public.get_cron_health()`` (STORY-1.1).",
+        "properties": {
+          "active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active"
+          },
+          "failures_24h": {
+            "default": 0,
+            "title": "Failures 24H",
+            "type": "integer"
+          },
+          "jobname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Jobname"
+          },
+          "last_return_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Return Message"
+          },
+          "last_run_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Run At"
+          },
+          "last_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Status"
+          },
+          "latency_avg_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency Avg Ms"
+          },
+          "runs_24h": {
+            "default": 0,
+            "title": "Runs 24H",
+            "type": "integer"
+          },
+          "schedule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schedule"
+          }
+        },
+        "title": "CronJobHealthRow",
         "type": "object"
       },
       "DadosAgregadosResponse": {
@@ -13322,9 +13855,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Reset Circuit Breakers V1 Admin Cb Reset Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminCircuitBreakerResetResponse"
                 }
               }
             },
@@ -13351,9 +13882,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Clear Contracts Checkpoints V1 Admin Clear Contracts Checkpoints Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminClearCheckpointsResponse"
                 }
               }
             },
@@ -13439,9 +13968,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Cron Status V1 Admin Cron Status Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminCronStatusResponse"
                 }
               }
             },
@@ -13833,9 +14360,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Admin Llm Cost V1 Admin Llm Cost Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminLlmCostResponse"
                 }
               }
             },
@@ -14362,9 +14887,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Schema Contract Status V1 Admin Schema Contract Status Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminSchemaContractStatusResponse"
                 }
               }
             },
@@ -14402,9 +14925,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Search Trace V1 Admin Search Trace  Search Id  Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminSearchTraceResponse"
                 }
               }
             },
@@ -14793,9 +15314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Trigger Bids Backfill V1 Admin Trigger Bids Backfill Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminJobTriggerResponse"
                 }
               }
             },
@@ -14822,9 +15341,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Trigger Contracts Backfill V1 Admin Trigger Contracts Backfill Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminJobTriggerResponse"
                 }
               }
             },

--- a/docs/stories/2026-05/PARITY-BE-FE-001-response-model-coverage.story.md
+++ b/docs/stories/2026-05/PARITY-BE-FE-001-response-model-coverage.story.md
@@ -1,0 +1,165 @@
+# PARITY-BE-FE-001: response_model coverage 100% (Backend ↔ Frontend type parity)
+
+**Priority:** P1
+**Effort:** M (1-2d)
+**Squad:** @architect (lead) + @dev + @qa
+**Status:** InProgress (Pass 1 — admin routes; Pass 2 follow-up after DATA-CAP-001)
+**Epic:** [EPIC-TD-2026Q2](EPIC-TD-2026Q2/) — eixo architectural consistency
+**Sprint:** TBD
+**Dependências bloqueadoras:** Nenhuma
+**Reversa anchor:** `_reversa_sdd/code-spec-matrix.md` Stories Status + drift `.reversa/drift-2026-05-09.md`
+**Score Δ:** arch consistency +6 (88% → 94%) + tests/CI +2
+
+---
+
+## Contexto
+
+CLAUDE.md regra explícita: "every endpoint exposed to the frontend MUST declare `response_model=` on its route decorator so the schema ends up in the OpenAPI output — otherwise CI passes but the frontend stays loosely typed (`{[k: string]: unknown}`)".
+
+Realidade empírica 2026-05-09: 24+ routes têm zero `response_model=` declarations. CI `api-types-check.yml` passa porque schema é gerado, mas frontend recebe `unknown` em paths não-tipados → quebra parity BE/FE silenciosamente.
+
+Routes com 0 `response_model=` (high-impact):
+
+| Arquivo | @router.* count | Notes |
+|---------|-----------------|-------|
+| `backend/routes/__init__.py` | 0 | aggregator (OK) |
+| `backend/routes/_sitemap_cache_headers.py` | 0 | helper module (OK) |
+| `backend/routes/admin_cron.py` | 0 | admin-only mas frontend usa typed admin panel |
+| `backend/routes/admin_llm_cost.py` | 0 | admin-only |
+| `backend/routes/admin_trace.py` | 6 routers, 0 response_models | **HIGH IMPACT** |
+| ... | (resto da inventory na AC1) | |
+
+Stories Sprint 2 STORY-2.1 EPIC-TD-2026Q2 entregou Pydantic→TS sync com CI gate, mas response_model adoption ficou opcional → drift acumulado.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Inventory completo
+
+- [ ] `backend/scripts/audit_response_model_coverage.py`:
+  - Walk `backend/routes/*.py`
+  - Para cada `@router.(get|post|put|delete|patch)(...)` verificar presença `response_model=` kwarg
+  - Output table: file → router_count → response_model_count → coverage% → list de paths missing
+  - Excluir helpers/aggregators (heurística: zero `@router.*` decorators)
+- [ ] Commit baseline JSON `backend/scripts/audit_response_model_coverage_baseline.json` (snapshot 2026-05-10)
+
+### AC2: Backfill response_model em routes high-impact
+
+Prioridade descendente:
+1. **Admin panel paths** (frontend typed): `admin_trace.py`, `admin_cron.py`, `admin_llm_cost.py`, `admin_calibration.py`, `admin_billing_sync.py`
+2. **Public-facing pSEO** (frontend programmatic types): `contratos_publicos.py`, `orgao_publico.py`, `empresa_publica.py`, `dados_publicos.py`, `municipios_publicos.py`, `itens_publicos.py`, `compliance_publicos.py`, `alertas_publicos.py`
+3. **Conversion paths** (high traffic): `intel_reports.py`, `founding.py`, `subscriptions.py`, `mfa.py`, `organizations.py`
+4. **Internal but typed**: `analytics.py`, `messages.py`, `feedback.py`, `pipeline.py`, `onboarding.py`
+
+- [ ] Cada route com handler retornando dict/list adiciona Pydantic schema em `backend/schemas/<module>.py` (reuse existing onde aplicável)
+- [ ] Cada `@router.*(..., response_model=Schema)` declarado
+- [ ] Routes sem retorno tipável (raw response, file streams, redirects) anotam `response_model=None` explícito + docstring rationale
+
+### AC3: CI gate extension
+
+- [ ] `.github/workflows/api-types-check.yml` extended:
+  - Run audit script
+  - Fail PR se coverage decreases vs baseline
+  - Fail PR se new route adicionado sem `response_model` (compare baseline)
+- [ ] Pre-commit hook `audit_response_model_coverage.py --strict` (warn-only inicialmente)
+
+### AC4: Frontend types regen + parity validation
+
+- [ ] `npm --prefix frontend run generate:api-types` — regen `frontend/app/api-types.generated.ts`
+- [ ] Pre-commit confirma file checked-in (existing pattern)
+- [ ] Audit `frontend/app/types.ts` re-export surface:
+  - Add re-exports para schemas novos críticos
+  - Doc convenção: import via `@/app/types` quando possível, fallback `components["schemas"]["X"]`
+- [ ] `frontend/__tests__/types-parity.test.ts` — assert que tipos críticos NÃO são `{[k:string]:unknown}`:
+  ```ts
+  type AssertNotUnknown<T> = T extends { [k: string]: unknown } ? never : T;
+  type _C1 = AssertNotUnknown<components["schemas"]["IntelReport"]>;
+  type _C2 = AssertNotUnknown<components["schemas"]["AdminTraceResult"]>;
+  // ... 20+ critical types
+  ```
+
+### AC5: Doc + governance
+
+- [ ] Update `CLAUDE.md` "Pydantic -> TypeScript Type Sync" section com link audit script + coverage threshold
+- [ ] Update `_reversa_sdd/code-spec-matrix.md` "Bidirectional traceability" — passo 5 "Regen api-types" mandatory + audit pass
+- [ ] ADR `docs/adr/ADR-PARITY-BE-FE-001-response-model-mandatory.md` — política + edge cases (raw, streams)
+
+---
+
+## DoD
+
+- [ ] Audit script committed + baseline JSON
+- [ ] Coverage atual ≥ 95% (50+ routes backfilled)
+- [ ] CI gate ativo (audit + types regen check)
+- [ ] Frontend types regenerated + parity test green
+- [ ] ADR + CLAUDE.md updates
+- [ ] Memory entry: `feedback_response_model_mandatory_pattern.md`
+
+---
+
+## Dependências
+
+- STORY-2.1 EPIC-TD-2026Q2 Done (precursor — pipeline existe)
+
+---
+
+## Notes
+
+- Preferir reuse de `backend/schemas/*.py` existentes — não criar schema duplicado.
+- Edge case: routes que retornam `JSONResponse(content=...)` raw → `response_class=JSONResponse` + Pydantic schema separate.
+- File streams (PDF download, Excel export): `response_class=StreamingResponse`, `response_model=None` com docstring rationale.
+
+---
+
+## Execution log
+
+### Pass 1 — admin routes (2026-05-09)
+
+**Scope reduction rationale.** DATA-CAP-001 (#949) is rewriting the same
+public-route files (`contratos_publicos.py`, `orgao_publico.py`,
+`empresa_publica.py`, `itens_publicos.py`, `blog_stats.py`,
+`observatorio.py`, `seo_admin.py`) in parallel. Shipping the AC2 sweep
+across both groups in a single PR would force a painful rebase into
+DATA-CAP-001. Pass 1 ships the audit infrastructure (AC1) plus the
+admin-route subset of AC2 only; Pass 2 (public routes) follows once
+DATA-CAP-001 lands.
+
+**Coverage delta (AC1 baseline):** 64.15% → **67.92%** over 212 routes
+in 70 route modules. Pass 1 typed up 8 previously-untyped admin routes:
+
+- `backend/routes/admin_trace.py` (6 routes: `/trigger-contracts-backfill`,
+  `/trigger-bids-backfill`, `/clear-contracts-checkpoints`,
+  `/search-trace/{search_id}`, `/cb/reset`, `/schema-contract-status`).
+- `backend/routes/admin_cron.py` (1 route: `/cron-status`).
+- `backend/routes/admin_llm_cost.py` (1 route: `/llm-cost`).
+
+**Files added / changed in Pass 1:**
+
+- `backend/scripts/audit_response_model_coverage.py` — AST-based audit
+  + `--check-against` gate semantics (AC1 + foundation for AC3).
+- `backend/scripts/audit_response_model_coverage_baseline.json` — baseline
+  snapshot @ 67.92% post-Pass 1, used by the future CI gate.
+- `backend/schemas/admin.py` — 11 new Pydantic models for the admin
+  responses (AdminJobTriggerResponse, AdminClearCheckpointsResponse,
+  AdminSearchTraceResponse + nested progress/cache/jobs states,
+  AdminCircuitBreakerResetResponse, AdminSchemaContractStatusResponse,
+  CronJobHealthRow, AdminCronStatusResponse, AdminLlmCostResponse).
+- `backend/routes/admin_trace.py`, `backend/routes/admin_cron.py`,
+  `backend/routes/admin_llm_cost.py` — added `response_model=` on every
+  decorator + replaced `dict` returns with the typed Pydantic models.
+- `frontend/app/api-types.generated.ts` — regenerated via the same
+  pipeline CI uses (`app.openapi_schema=None; app.openapi(); npx
+  openapi-typescript /tmp/openapi.json`).
+- `backend/tests/scripts/test_audit_response_model_coverage.py` — 17
+  tests covering detection, JSON shape, gate semantics, and a real-repo
+  invariant that fails if any Pass 1 admin route loses its
+  `response_model=`.
+
+**Deferred to Pass 2 (issue #951 stays open):**
+
+- AC2 sweep across the public-route group, conversion paths, and
+  internal/typed routers (still ~68 untyped routes).
+- AC3 CI gate wiring (`api-types-check.yml` extension + pre-commit hook).
+- AC4 frontend re-export surface audit + `types-parity.test.ts`.
+- AC5 ADR + CLAUDE.md governance section.

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -5220,6 +5220,44 @@ export interface components {
             user_id: string;
         };
         /**
+         * AdminCacheTraceState
+         * @description ``cache`` field of the search-trace response.
+         */
+        AdminCacheTraceState: {
+            /** Error */
+            error?: string | null;
+            /** Is Revalidating */
+            is_revalidating?: boolean | null;
+            /** Redis */
+            redis?: string | null;
+        };
+        /**
+         * AdminCircuitBreakerResetResponse
+         * @description Response for POST /v1/admin/cb/reset (STORY-416 AC5).
+         */
+        AdminCircuitBreakerResetResponse: {
+            /** Previous States */
+            previous_states: {
+                [key: string]: unknown;
+            };
+            /** Reset By */
+            reset_by?: string | null;
+            /** Status */
+            status: string;
+        };
+        /**
+         * AdminClearCheckpointsResponse
+         * @description Response for POST /v1/admin/clear-contracts-checkpoints.
+         */
+        AdminClearCheckpointsResponse: {
+            /** Checkpoints Deleted */
+            checkpoints_deleted?: number | null;
+            /** Detail */
+            detail?: string | null;
+            /** Status */
+            status: string;
+        };
+        /**
          * AdminCreateUserResponse
          * @description Response for POST /admin/users.
          */
@@ -5232,6 +5270,26 @@ export interface components {
             user_id: string;
         };
         /**
+         * AdminCronStatusResponse
+         * @description Response for GET /v1/admin/cron-status (STORY-1.1).
+         *
+         *     On transient backend failure (Supabase CB open, RPC error) the route
+         *     returns ``status="error"`` with ``jobs=[]`` so dashboards degrade
+         *     gracefully instead of 500-ing.
+         */
+        AdminCronStatusResponse: {
+            /** Count */
+            count: number;
+            /** Detail */
+            detail?: string | null;
+            /** Jobs */
+            jobs: components["schemas"]["CronJobHealthRow"][];
+            /** Queried At */
+            queried_at: string;
+            /** Status */
+            status: string;
+        };
+        /**
          * AdminDeleteUserResponse
          * @description Response for DELETE /admin/users/{user_id}.
          */
@@ -5242,6 +5300,96 @@ export interface components {
             user_id: string;
         };
         /**
+         * AdminJobTraceState
+         * @description ``jobs`` field of the search-trace response.
+         *
+         *     Values are short status strings (``"completed"`` / ``"not_found"``)
+         *     so the model accepts them as ``Optional[str]``. ``error`` is present
+         *     when the lookup itself raised.
+         */
+        AdminJobTraceState: {
+            /** Error */
+            error?: string | null;
+            /** Excel Generation */
+            excel_generation?: string | null;
+            /** Llm Summary */
+            llm_summary?: string | null;
+        };
+        /**
+         * AdminJobTriggerResponse
+         * @description Response for POST /v1/admin/trigger-{contracts,bids}-backfill.
+         *
+         *     Routes return ``status`` in {"enqueued", "skipped", "error"} plus an
+         *     optional ``job_id`` (when ARQ accepts the job) and ``timeout_s``.
+         *     ``detail`` carries the operator-facing reason string when non-OK.
+         */
+        AdminJobTriggerResponse: {
+            /** Detail */
+            detail?: string | null;
+            /** Job Id */
+            job_id?: string | null;
+            /** Status */
+            status: string;
+            /** Timeout S */
+            timeout_s?: number | null;
+        };
+        /**
+         * AdminLlmCostResponse
+         * @description Response for GET /v1/admin/llm-cost (STORY-2.11).
+         *
+         *     Mirrors ``llm_budget.get_cost_snapshot()``. ``month`` is the Redis
+         *     key shape (e.g. ``"llm_cost_month_2026_04"``); ``exceeded`` flips
+         *     to ``True`` when the hard-reject is active.
+         */
+        AdminLlmCostResponse: {
+            /**
+             * Budget Usd
+             * @default 0
+             */
+            budget_usd: number;
+            /**
+             * Exceeded
+             * @default false
+             */
+            exceeded: boolean;
+            /** Month */
+            month: string;
+            /**
+             * Month To Date Usd
+             * @default 0
+             */
+            month_to_date_usd: number;
+            /**
+             * Pct Used
+             * @default 0
+             */
+            pct_used: number;
+            /**
+             * Projected End Of Month Usd
+             * @default 0
+             */
+            projected_end_of_month_usd: number;
+        };
+        /**
+         * AdminProgressTraceState
+         * @description ``progress`` field of the search-trace response when a tracker
+         *     is still in memory. ``mode`` is ``"redis"`` or ``"in-memory"``.
+         */
+        AdminProgressTraceState: {
+            /** Created At */
+            created_at?: number | null;
+            /** Error */
+            error?: string | null;
+            /** Is Complete */
+            is_complete?: boolean | null;
+            /** Mode */
+            mode?: string | null;
+            /** Uf Count */
+            uf_count?: number | null;
+            /** Ufs Completed */
+            ufs_completed?: number | null;
+        };
+        /**
          * AdminResetPasswordResponse
          * @description Response for POST /admin/users/{user_id}/reset-password.
          */
@@ -5250,6 +5398,51 @@ export interface components {
             success: boolean;
             /** User Id */
             user_id: string;
+        };
+        /**
+         * AdminSchemaContractStatusResponse
+         * @description Response for GET /v1/admin/schema-contract-status (STORY-414 AC4).
+         */
+        AdminSchemaContractStatusResponse: {
+            /**
+             * Checked At
+             * @default 0
+             */
+            checked_at: number;
+            /**
+             * Missing
+             * @default []
+             */
+            missing: string[];
+            /** Passed */
+            passed?: boolean | null;
+            /**
+             * Stale
+             * @default true
+             */
+            stale: boolean;
+            /**
+             * Strict Mode
+             * @default false
+             */
+            strict_mode: boolean;
+        };
+        /**
+         * AdminSearchTraceResponse
+         * @description Response for GET /v1/admin/search-trace/{search_id}.
+         *
+         *     Each sub-section is independently nullable: a transient Redis or ARQ
+         *     failure sets the corresponding key to a small ``{"error": "..."}``
+         *     payload instead of failing the whole response.
+         */
+        AdminSearchTraceResponse: {
+            cache?: components["schemas"]["AdminCacheTraceState"] | null;
+            jobs?: components["schemas"]["AdminJobTraceState"] | null;
+            progress?: components["schemas"]["AdminProgressTraceState"] | null;
+            /** Queried At */
+            queried_at: string;
+            /** Search Id */
+            search_id: string;
         };
         /**
          * AdminUpdateCreditsResponse
@@ -6805,6 +6998,36 @@ export interface components {
              * @default free_trial
              */
             plan_id: string | null;
+        };
+        /**
+         * CronJobHealthRow
+         * @description One row of ``public.get_cron_health()`` (STORY-1.1).
+         */
+        CronJobHealthRow: {
+            /** Active */
+            active?: boolean | null;
+            /**
+             * Failures 24H
+             * @default 0
+             */
+            failures_24h: number;
+            /** Jobname */
+            jobname?: string | null;
+            /** Last Return Message */
+            last_return_message?: string | null;
+            /** Last Run At */
+            last_run_at?: string | null;
+            /** Last Status */
+            last_status?: string | null;
+            /** Latency Avg Ms */
+            latency_avg_ms?: number | null;
+            /**
+             * Runs 24H
+             * @default 0
+             */
+            runs_24h: number;
+            /** Schedule */
+            schedule?: string | null;
         };
         /** DadosAgregadosResponse */
         DadosAgregadosResponse: {
@@ -11345,9 +11568,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminCircuitBreakerResetResponse"];
                 };
             };
         };
@@ -11367,9 +11588,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminClearCheckpointsResponse"];
                 };
             };
         };
@@ -11424,9 +11643,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminCronStatusResponse"];
                 };
             };
         };
@@ -11661,9 +11878,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminLlmCostResponse"];
                 };
             };
         };
@@ -12003,9 +12218,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminSchemaContractStatusResponse"];
                 };
             };
         };
@@ -12027,9 +12240,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminSearchTraceResponse"];
                 };
             };
             /** @description Validation Error */
@@ -12315,9 +12526,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
                 };
             };
         };
@@ -12337,9 +12546,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Ship the **audit infrastructure** (AC1) plus the **admin-route subset of AC2** of PARITY-BE-FE-001 — strict scope cap to avoid rebase hell with DATA-CAP-001 (#949), which is rewriting the public-route group in parallel.

- Coverage moved from **64.15% → 67.92%** over 212 routes in 70 route modules.
- 8 previously-untyped admin routes now declare `response_model=` and return Pydantic models:
  - `admin_trace.py` (6 routes — `/trigger-contracts-backfill`, `/trigger-bids-backfill`, `/clear-contracts-checkpoints`, `/search-trace/{search_id}`, `/cb/reset`, `/schema-contract-status`)
  - `admin_cron.py` (1 route — `/cron-status`)
  - `admin_llm_cost.py` (1 route — `/llm-cost`)
- Frontend `api-types.generated.ts` regenerated via the **same pipeline CI uses** (`app.openapi_schema=None; app.openapi(); openapi-typescript`) — diff is exactly the new admin schemas.

## Context

CLAUDE.md is explicit: *"every endpoint exposed to the frontend MUST declare `response_model=` on its route decorator so the schema ends up in the OpenAPI output — otherwise CI passes but the frontend stays loosely typed (`{[k: string]: unknown}`)"*. Audit on 2026-05-09 surfaced 24+ routes with zero `response_model=` declarations — admin panel was hitting the silent `unknown` failure mode. STORY-2.1 (EPIC-TD-2026Q2) shipped the codegen pipeline but `response_model` adoption stayed optional and drifted.

**Scope cap rationale.** DATA-CAP-001 (#949) rewrites the public-route group (`contratos_publicos.py`, `orgao_publico.py`, `empresa_publica.py`, `itens_publicos.py`, `blog_stats.py`, `observatorio.py`, `seo_admin.py`). Sweeping both groups in one PR forces a rebase tug-of-war. **Pass 1 = admin routes only**; Pass 2 (public routes + AC3 CI gate + AC4 frontend re-export + AC5 ADR) follows once DATA-CAP-001 lands — that's why this PR uses `Refs #951`, not `Closes`.

**What's deferred to Pass 2:**
- AC2 sweep across public-route group, conversion paths, internal/typed routers (~68 untyped routes remain).
- AC3 CI gate wiring (`api-types-check.yml` extension + pre-commit hook). The audit script already supports `--check-against baseline.json` and exits 1 on regression — wiring is the remaining piece.
- AC4 `frontend/app/types.ts` re-export surface audit + `types-parity.test.ts`.
- AC5 ADR + CLAUDE.md governance section.

## Files changed

- `backend/scripts/audit_response_model_coverage.py` (NEW) — AST-based audit. Walks `backend/routes/*.py`, counts `@router.<verb>(...)` vs ones with `response_model=`, supports `--json`, `--check-against`. Hermetic: needs no env vars, DB, or running app — picks up named routers (`api_router`/`*_router`) and treats `response_model=None` as the documented escape hatch for streams.
- `backend/scripts/audit_response_model_coverage_baseline.json` (NEW) — committed baseline at 67.92% post-Pass 1. Repository-relative paths + `sort_keys=True` for stable diffs.
- `backend/schemas/admin.py` — 11 new Pydantic models (`AdminJobTriggerResponse`, `AdminClearCheckpointsResponse`, `AdminSearchTraceResponse` + nested `AdminProgressTraceState`/`AdminCacheTraceState`/`AdminJobTraceState`, `AdminCircuitBreakerResetResponse`, `AdminSchemaContractStatusResponse`, `CronJobHealthRow`, `AdminCronStatusResponse`, `AdminLlmCostResponse`).
- `backend/routes/admin_trace.py`, `backend/routes/admin_cron.py`, `backend/routes/admin_llm_cost.py` — `response_model=` on every decorator + return-type annotations swapped from `dict`/`dict[str, Any]` to the new typed models. Behavior preserved (status strings, error fall-throughs, graceful-degradation on Redis/Supabase failure).
- `frontend/app/api-types.generated.ts` — regenerated; diff is the new admin schemas (no other drift).
- `backend/tests/scripts/test_audit_response_model_coverage.py` (NEW) — 17 tests covering detection (typed, mixed, helpers, named routers, websocket-ignored, `response_model=None`-as-typed, broken-files-graceful), aggregation (relative paths, helper exclusion, JSON shape with `sort_keys=True`), and gate semantics (self-passes, regression detected, new untyped file detected, improvement allowed). Plus a real-repo invariant test that fails immediately if any Pass 1 admin route loses its `response_model=`.
- `docs/stories/2026-05/PARITY-BE-FE-001-response-model-coverage.story.md` — copied + status set to `InProgress (Pass 1)` + execution-log section appended.

## Testing Plan

- [x] `pytest backend/tests/scripts/ --timeout=30` — 17 passed in 3.97s
- [x] `ruff check backend/routes/admin_*.py backend/schemas/admin.py backend/scripts/audit_response_model_coverage.py backend/tests/scripts/` — All checks passed
- [x] `python3 -c "from routes import admin_trace, admin_cron, admin_llm_cost"` — clean import
- [x] CI-style OpenAPI extraction reproduced locally (220 paths, 292 schemas) → `openapi-typescript` regen → diff against committed file = 0
- [x] Audit gate self-check: `audit_response_model_coverage.py --check-against backend/scripts/audit_response_model_coverage_baseline.json` exits 0
- [x] Pre-push verification: no public-route file in the diff (`grep` against the DATA-CAP-001 file list returns empty)
- [ ] CI `api-types-check.yml` passes (validates the regenerated TS file matches what CI would produce)
- [ ] CI `audit-execute-without-budget.yml` passes (no `.execute()` added — admin routes don't query DB directly)
- [ ] Backend test suite green (Pass 1 routes don't change runtime semantics — Pydantic validation is additive)

## Closes

Refs #951 (Pass 2 follow-up will close — public routes + AC3 CI gate wiring + AC4 frontend re-export audit + AC5 ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)