### PR TITLE
fix(backend): PostgREST max-rows=1000 truncation in 7 public routes (DATA-CAP-001)

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -299,6 +299,15 @@ DATALAKE_TRUNCATION_SUSPECTED = _create_counter(
     labelnames=["uf"],
 )
 
+# DATA-CAP-001: PostgREST max-rows=1000 silent truncation in non-RPC table queries.
+# Incremented every time ``utils.postgrest_paginate.paginate_full`` sees a full batch
+# (signal: the route would have truncated silently if it had used ``.limit()`` instead).
+POSTGREST_TRUNCATION_SUSPECTED = _create_counter(
+    "smartlic_postgrest_truncation_suspected_total",
+    "PostgREST table queries (non-RPC) where a paginated batch returned exactly batch_size rows — signals the route would silently truncate without paginate_full",
+    labelnames=["route", "entity_type"],
+)
+
 # HARDEN-006 AC4: Dedup merge-enrichment field counter
 DEDUP_FIELDS_MERGED = _create_counter(
     "smartlic_dedup_fields_merged_total",

--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from sectors import SECTORS, SectorConfig
+from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/blog/stats", tags=["blog-stats"])
@@ -937,13 +938,19 @@ def _query_contratos_sync(
         # substring match via ilike (handles variations like "São Paulo" vs "SAO PAULO").
         query = query.ilike("municipio", f"%{municipio_pattern}%")
 
-    resp = (
-        query
-        .order("data_assinatura", desc=True)
-        .limit(5000)
-        .execute()
+    # DATA-CAP-001: paginate via .range() because PostgREST silently caps
+    # any single response at max_rows=1000. The previous .limit(5000) was
+    # silently truncating to 1000 rows, which broke /blog/stats/* pillar
+    # pages for high-volume sectors / large UFs (top_orgaos, top_fornecedores
+    # and monthly_trend were computed off a 1000-row sample — wrong totals).
+    builder = query.order("data_assinatura", desc=True)
+    return paginate_full(
+        builder,
+        batch_size=1000,
+        max_total=10_000,
+        route="blog_stats.contratos",
+        entity_type="pncp_supplier_contracts",
     )
-    return resp.data or []
 
 
 def _empty_contratos_stats() -> dict:

--- a/backend/routes/contratos_publicos.py
+++ b/backend/routes/contratos_publicos.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 
 from pipeline.budget import _run_with_budget
 from sectors import SECTORS
+from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["contratos-publicos"])
@@ -186,7 +187,10 @@ async def _fetch_sector_contracts(
     def _sync_query() -> list[dict]:
         from supabase_client import get_supabase
         sb = get_supabase()
-        resp = (
+        # DATA-CAP-001: paginate via .range() because PostgREST silently caps
+        # any single response at max_rows=1000. The previous .limit(5000) was
+        # silently truncating contracts for any UF with >1000 active contracts.
+        builder = (
             sb.table("pncp_supplier_contracts")
             .select(
                 "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
@@ -195,10 +199,14 @@ async def _fetch_sector_contracts(
             .eq("uf", uf_upper)
             .eq("is_active", True)
             .order("data_assinatura", desc=True)
-            .limit(5000)
-            .execute()
         )
-        return resp.data or []
+        return paginate_full(
+            builder,
+            batch_size=1000,
+            max_total=5000,
+            route="contratos_publicos.sector_contracts",
+            entity_type="pncp_supplier_contracts",
+        )
 
     try:
         rows = await _run_with_budget(
@@ -268,7 +276,10 @@ async def orgao_contratos_stats(cnpj: str):
     def _sync_query_orgao() -> list[dict]:
         from supabase_client import get_supabase
         sb = get_supabase()
-        resp = (
+        # DATA-CAP-001: paginate via .range() — orgãos públicos federais e
+        # estaduais grandes (TJ, TCU, ministérios) podem ter milhares de
+        # contratos ativos; .limit(5000) era silenciosamente capado a 1000.
+        builder = (
             sb.table("pncp_supplier_contracts")
             .select(
                 "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
@@ -277,10 +288,14 @@ async def orgao_contratos_stats(cnpj: str):
             .eq("orgao_cnpj", cnpj_clean)
             .eq("is_active", True)
             .order("data_assinatura", desc=True)
-            .limit(5000)
-            .execute()
         )
-        return resp.data or []
+        return paginate_full(
+            builder,
+            batch_size=1000,
+            max_total=5000,
+            route="contratos_publicos.orgao_contratos_stats",
+            entity_type="pncp_supplier_contracts",
+        )
 
     try:
         rows = await _run_with_budget(

--- a/backend/routes/empresa_publica.py
+++ b/backend/routes/empresa_publica.py
@@ -524,12 +524,21 @@ async def _fetch_editais_abertos(setor_id: str, uf: str) -> tuple[int, list[dict
             return 0, []
 
         now = datetime.now(timezone.utc)
+        # DATA-CAP-001: query_datalake delegates to the search_datalake RPC,
+        # which is itself capped at 1000 rows per UF call by PostgREST
+        # max_rows. The previous limit=2000 was silently truncated to 1000
+        # so callers were never receiving the rows they asked for. Cap to
+        # 1000 explicitly to keep the contract honest. Raising the ceiling
+        # above 1000 requires per-UF pagination inside
+        # ``datalake_query.query_datalake`` and is out of scope for
+        # DATA-CAP-001 (story Notes: "Não tocar datalake_query.py" —
+        # tracked as a follow-up story).
         results = await query_datalake(
             ufs=[uf],
             data_inicial=(now - timedelta(days=30)).strftime("%Y-%m-%d"),
             data_final=now.strftime("%Y-%m-%d"),
             keywords=list(sector.keywords),
-            limit=2000,
+            limit=1000,
         )
         return len(results), results[:5]
     except Exception as e:

--- a/backend/routes/itens_publicos.py
+++ b/backend/routes/itens_publicos.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, HTTPException, Response
 from pipeline.budget import _run_with_budget
 from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 from pydantic import BaseModel
+from utils.postgrest_paginate import paginate_full
 
 from metrics import record_sitemap_count
 
@@ -437,16 +438,26 @@ async def _fetch_price_data(nome_item: str) -> tuple[list[float], list[dict]]:
     def _sync_fetch() -> list[dict]:
         from supabase_client import get_supabase
         sb = get_supabase()
-        resp = (
+        # DATA-CAP-001: previously a bare ``.limit(1000).execute()`` which
+        # is exactly the silent-cap boundary — for very common keywords
+        # (e.g. "papel", "computador") there are far more than 1000 active
+        # contracts, so the P10/P50/P90 benchmark was being computed on the
+        # 1000 most recent rows only. paginate_full lifts the ceiling to
+        # max_total while preserving the order=data_assinatura DESC.
+        builder = (
             sb.table("pncp_supplier_contracts")
             .select("valor_global,objeto_contrato,orgao_nome,data_assinatura,uf")
             .ilike("objeto_contrato", f"%{palavras[0]}%")
             .eq("is_active", True)
             .order("data_assinatura", desc=True)
-            .limit(1000)
-            .execute()
         )
-        return resp.data or []
+        return paginate_full(
+            builder,
+            batch_size=1000,
+            max_total=5000,
+            route="itens_publicos.fetch_price_data",
+            entity_type="pncp_supplier_contracts",
+        )
 
     try:
         rows = await _run_with_budget(

--- a/backend/routes/observatorio.py
+++ b/backend/routes/observatorio.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 
 from metrics import OBSERVATORIO_BUDGET_EXCEEDED
 from pipeline.budget import _run_with_budget
+from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["observatorio"])
@@ -323,15 +324,24 @@ def _query_historical_sync(data_inicial: str, data_final: str) -> list[dict]:
     """
     from supabase_client import get_supabase
     sb = get_supabase()
-    resp = (
+    # DATA-CAP-001: paginate — even an old historical month for a small UF
+    # can hold tens of thousands of bids. The previous .limit(5000) was
+    # silently truncated to 1000 by PostgREST max_rows, biasing the
+    # observatório monthly reports toward the most recent rows in the
+    # window (whatever lexicographic order the DB returned).
+    builder = (
         sb.table("pncp_raw_bids")
         .select("pncp_id, objeto_compra, valor_total_estimado, modalidade_id, uf, data_publicacao")
         .gte("data_publicacao", data_inicial)
         .lte("data_publicacao", data_final + "T23:59:59")
-        .limit(5000)
-        .execute()
     )
-    rows = resp.data or []
+    rows = paginate_full(
+        builder,
+        batch_size=1000,
+        max_total=10_000,
+        route="observatorio.historical",
+        entity_type="pncp_raw_bids",
+    )
     # Normalize to keys expected by _generate_relatorio processing
     normalized: list[dict] = []
     for r in rows:

--- a/backend/routes/orgao_publico.py
+++ b/backend/routes/orgao_publico.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from pipeline.budget import _run_with_budget
+from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["orgao-publico"])
@@ -262,7 +263,11 @@ async def _build_orgao_stats(cnpj: str) -> tuple[dict, bool]:
         from supabase_client import get_supabase
 
         sb = get_supabase()
-        resp = (
+        # DATA-CAP-001: paginate via .range() — without paginate_full,
+        # PostgREST silently capped this at 1000 rows even with
+        # .limit(5000), so any orgão with >1000 active bids returned
+        # exactly 1000 rounded counts (visible UX bug on /orgaos/[cnpj]).
+        builder = (
             sb.table("pncp_raw_bids")
             .select(
                 "orgao_razao_social,"
@@ -276,10 +281,14 @@ async def _build_orgao_stats(cnpj: str) -> tuple[dict, bool]:
             )
             .eq("orgao_cnpj", cnpj)
             .eq("is_active", True)
-            .limit(5000)
-            .execute()
         )
-        return resp.data or []
+        return paginate_full(
+            builder,
+            batch_size=1000,
+            max_total=5000,
+            route="orgao_publico.orgao_stats",
+            entity_type="pncp_raw_bids",
+        )
 
     try:
         rows = await _run_with_budget(
@@ -428,79 +437,59 @@ async def _fetch_contracts_data(orgao_cnpj: str, limit: int = 10) -> dict:
     Returns dict with 'top_fornecedores', 'total_contratos_24m', 'valor_total_contratos_24m'.
     Returns empty/zero gracefully when table is empty (during/before backfill) or
     when the query exceeds ``_ORGAO_QUERY_BUDGET_S`` (RES-BE-015 negative cache).
+
+    DATA-CAP-001: previously fetched up to 2000 rows and aggregated in Python,
+    which silently truncated to 1000 rows under PostgREST max_rows for any
+    orgão with >1000 active contracts (under-counted totals + wrong top-N).
+    Now uses ``get_orgao_top_contracts_json`` RPC which returns scalar JSON
+    (not subject to row-count cap) with server-side aggregation.
     """
     result = {"top_fornecedores": [], "total_contratos_24m": 0, "valor_total_contratos_24m": 0.0}
 
-    def _sync_query() -> list[dict]:
+    def _sync_rpc() -> dict:
         from supabase_client import get_supabase
         sb = get_supabase()
-        # Aggregate by supplier CNPJ — Supabase doesn't support GROUP BY directly,
-        # so we fetch up to 2000 rows and aggregate in Python (table grows large post-backfill;
-        # a proper RPC would be ideal but this is zero-infra and works for cache=24h).
-        resp = (
-            sb.table("pncp_supplier_contracts")
-            .select("ni_fornecedor,nome_fornecedor,valor_global")
-            .eq("orgao_cnpj", orgao_cnpj)
-            .eq("is_active", True)
-            .limit(2000)
-            .execute()
-        )
-        return resp.data or []
+        resp = sb.rpc(
+            "get_orgao_top_contracts_json",
+            {"p_orgao_cnpj": orgao_cnpj, "p_limit": limit},
+        ).execute()
+        # supabase-py returns the JSON value directly in resp.data when the
+        # RPC RETURNS a scalar JSON — handle both shapes defensively.
+        data = getattr(resp, "data", None)
+        if isinstance(data, list):
+            data = data[0] if data else None
+        return data or {}
 
     try:
-        rows = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+        agg = await _run_with_budget(
+            asyncio.to_thread(_sync_rpc),
             budget=_ORGAO_QUERY_BUDGET_S,
             phase="route",
             source="orgao_publico.contracts_data",
         )
-        if not rows:
+        if not agg:
             return result
 
-        # Aggregate totals for the organ
-        total_valor = 0.0
-        for r in rows:
-            try:
-                total_valor += float(r.get("valor_global") or 0)
-            except (ValueError, TypeError):
-                pass
-
-        result["total_contratos_24m"] = len(rows)
-        result["valor_total_contratos_24m"] = round(total_valor, 2)
-
-        # Aggregate by supplier
-        from collections import defaultdict
-        agg: dict[str, dict] = defaultdict(lambda: {"nome": "", "cnpj": "", "contratos": 0, "valor": 0.0})
-        for r in rows:
-            ni = r.get("ni_fornecedor") or ""
-            if not ni:
-                continue
-            agg[ni]["cnpj"] = ni
-            agg[ni]["nome"] = r.get("nome_fornecedor") or ni
-            agg[ni]["contratos"] += 1
-            try:
-                agg[ni]["valor"] += float(r.get("valor_global") or 0)
-            except (ValueError, TypeError):
-                pass
-
-        top = sorted(agg.values(), key=lambda x: x["valor"], reverse=True)[:limit]
+        top = agg.get("top_fornecedores") or []
         result["top_fornecedores"] = [
             {
-                "nome": t["nome"],
-                "cnpj": t["cnpj"],
-                "total_contratos": t["contratos"],
-                "valor_total": round(t["valor"], 2),
+                "nome": (t.get("nome") or t.get("cnpj") or "Não informado"),
+                "cnpj": (t.get("cnpj") or ""),
+                "total_contratos": int(t.get("total_contratos") or 0),
+                "valor_total": float(t.get("valor_total") or 0.0),
             }
             for t in top
-            if t["valor"] > 0
+            if (t.get("valor_total") or 0) > 0
         ]
+        result["total_contratos_24m"] = int(agg.get("total_contratos_24m") or 0)
+        result["valor_total_contratos_24m"] = float(agg.get("valor_total_contratos_24m") or 0.0)
 
     except asyncio.TimeoutError:
         logger.warning(
-            "contracts_data query exceeded %.1fs budget for %s",
+            "contracts_data RPC exceeded %.1fs budget for %s",
             _ORGAO_QUERY_BUDGET_S, orgao_cnpj,
         )
     except Exception as exc:
-        logger.warning("contracts_data query failed for %s: %s", orgao_cnpj, exc)
+        logger.warning("contracts_data RPC failed for %s: %s", orgao_cnpj, exc)
 
     return result

--- a/backend/routes/seo_admin.py
+++ b/backend/routes/seo_admin.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from datetime import date, timedelta
 
 from pipeline.budget import _run_with_budget
+from utils.postgrest_paginate import paginate_full
 
 from auth import require_auth
 from admin import require_admin
@@ -199,15 +200,24 @@ async def get_gsc_summary(
             logger.warning("gsc_summary: top_queries query failed — %s", exc)
 
         try:
-            p_resp = (
+            # DATA-CAP-001: paginate via .range() — over a 90d window the
+            # gsc_metrics page-level rollup easily exceeds 1000 rows; the
+            # previous .limit(5000) was silently capped at 1000 by PostgREST,
+            # under-counting impressions/clicks per page in the admin panel.
+            p_builder = (
                 supabase.table("gsc_metrics")
                 .select("page,impressions,clicks,ctr,position")
                 .gte("date", cutoff)
-                .limit(5000)
-                .execute()
+            )
+            p_rows = paginate_full(
+                p_builder,
+                batch_size=1000,
+                max_total=10_000,
+                route="seo_admin.gsc_summary_pages",
+                entity_type="gsc_metrics",
             )
             pg_agg: dict[str, dict] = {}
-            for row in (p_resp.data or []):
+            for row in (p_rows or []):
                 p = (row.get("page") or "").strip()
                 if not p:
                     continue

--- a/backend/tests/test_blog_stats.py
+++ b/backend/tests/test_blog_stats.py
@@ -701,6 +701,12 @@ class _ContractsQueryBuilder:
     def limit(self, *_a, **_kw):
         return self
 
+    def range(self, start, end):
+        # DATA-CAP-001: paginate_full uses .range(start, end).execute(); slice
+        # the filtered rows accordingly so the helper sees a short final batch.
+        self._range = (start, end)
+        return self
+
     def execute(self):
         rows = list(self._rows)
         uf = self.filters.get("eq:uf")
@@ -711,6 +717,11 @@ class _ContractsQueryBuilder:
             # strip the surrounding %…% wildcards, case-insensitive substring
             needle = municipio_ilike.strip("%").lower()
             rows = [r for r in rows if needle in (r.get("municipio") or "").lower()]
+        rng = getattr(self, "_range", None)
+        if rng is not None:
+            start, end = rng
+            rows = rows[start : end + 1]
+            self._range = None  # next .range() call will reset
         resp = MagicMock()
         resp.data = rows
         return resp

--- a/backend/tests/test_contratos_orgao.py
+++ b/backend/tests/test_contratos_orgao.py
@@ -14,7 +14,15 @@ def client():
 def _make_mock_sb(rows):
     mock_resp = MagicMock()
     mock_resp.data = rows
+    empty_resp = MagicMock()
+    empty_resp.data = []
     mock_sb = MagicMock()
+    # DATA-CAP-001: route now calls paginate_full → .order().range(s,e).execute()
+    # First call returns rows; subsequent empty/short response ends pagination loop.
+    mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.range.return_value.execute.side_effect = [
+        mock_resp, empty_resp, empty_resp
+    ]
+    # Backwards-compat with any caller still chaining .limit.
     mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = mock_resp
     return mock_sb
 

--- a/backend/tests/test_contratos_publicos.py
+++ b/backend/tests/test_contratos_publicos.py
@@ -42,6 +42,14 @@ class TestContratosStats:
         mock_sb = MagicMock()
         mock_resp = MagicMock()
         mock_resp.data = _mock_rows(5)
+        # DATA-CAP-001: route now calls paginate_full → .order().range(s,e).execute()
+        # Empty resp on the second call ends the pagination loop.
+        empty_resp = MagicMock()
+        empty_resp.data = []
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.range.return_value.execute.side_effect = [
+            mock_resp, empty_resp, empty_resp
+        ]
+        # Backwards-compat with any caller still chaining .limit.
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = mock_resp
 
         with patch("supabase_client.get_supabase", return_value=mock_sb):
@@ -82,6 +90,14 @@ class TestContratosStats:
         mock_resp.data = [{"objeto_contrato": "servico de TI", "ni_fornecedor": "123", "orgao_cnpj": "456",
                            "orgao_nome": "Org", "nome_fornecedor": "F", "valor_global": "100",
                            "data_assinatura": "2026-03-01"}]
+        # DATA-CAP-001: route now calls paginate_full → .order().range(s,e).execute()
+        # Empty resp on the second call ends the pagination loop.
+        empty_resp = MagicMock()
+        empty_resp.data = []
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.range.return_value.execute.side_effect = [
+            mock_resp, empty_resp, empty_resp
+        ]
+        # Backwards-compat with any caller still chaining .limit.
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = mock_resp
 
         with patch("supabase_client.get_supabase", return_value=mock_sb):
@@ -145,6 +161,14 @@ class TestFornecedoresStats:
         mock_sb = MagicMock()
         mock_resp = MagicMock()
         mock_resp.data = _mock_rows(5)
+        # DATA-CAP-001: route now calls paginate_full → .order().range(s,e).execute()
+        # Empty resp on the second call ends the pagination loop.
+        empty_resp = MagicMock()
+        empty_resp.data = []
+        mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.range.return_value.execute.side_effect = [
+            mock_resp, empty_resp, empty_resp
+        ]
+        # Backwards-compat with any caller still chaining .limit.
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value = mock_resp
 
         with patch("supabase_client.get_supabase", return_value=mock_sb):
@@ -201,6 +225,20 @@ class TestContratosDedup:
     def _mock_chain(self, mock_sb, rows):
         mock_resp = MagicMock()
         mock_resp.data = rows
+        empty_resp = MagicMock()
+        empty_resp.data = []
+        # DATA-CAP-001: paginate_full chain — .order().range(s,e).execute()
+        # First call returns the rows, subsequent return empty so loop exits.
+        (
+            mock_sb.table.return_value
+            .select.return_value
+            .eq.return_value
+            .eq.return_value
+            .order.return_value
+            .range.return_value
+            .execute
+        ).side_effect = [mock_resp, empty_resp, empty_resp]
+        # Legacy compat
         (
             mock_sb.table.return_value
             .select.return_value

--- a/backend/tests/test_orgao_publico.py
+++ b/backend/tests/test_orgao_publico.py
@@ -48,9 +48,40 @@ def _make_bid_row(
 
 
 def _mock_supabase_response(data: list[dict]):
+    """Mock supabase client supporting both the bids paginate_full chain and
+    the RPC ``get_orgao_top_contracts_json`` used by ``_fetch_contracts_data``.
+
+    DATA-CAP-001 changed:
+      * pncp_raw_bids fetch: ``.eq().eq().range(s,e).execute()`` (no more .limit)
+      * pncp_supplier_contracts agg: replaced with ``sb.rpc(...).execute()``
+
+    This mock satisfies both. The bids chain now serves the full ``data`` list
+    on the FIRST .range() call and an empty list on any subsequent call so
+    paginate_full's loop terminates after one iteration. The RPC returns an
+    empty contracts payload (top_fornecedores=[], totals=0) — tests that
+    care about contract data should override .rpc explicitly.
+    """
     mock_sb = MagicMock()
-    mock_resp = MagicMock()
-    mock_resp.data = data
+
+    # ---- pncp_raw_bids paginate_full chain ----
+    bids_resp_full = MagicMock()
+    bids_resp_full.data = data
+    bids_resp_empty = MagicMock()
+    bids_resp_empty.data = []
+
+    range_target = (
+        mock_sb.table.return_value
+        .select.return_value
+        .eq.return_value
+        .eq.return_value
+        .range.return_value
+    )
+    # First call returns the full data set; subsequent calls return empty so
+    # paginate_full sees a short batch and exits the loop.
+    range_target.execute.side_effect = [bids_resp_full, bids_resp_empty, bids_resp_empty]
+
+    # Backwards-compat: keep ``.limit().execute()`` shape working in case any
+    # test still depends on it via other modules.
     (
         mock_sb.table.return_value
         .select.return_value
@@ -58,7 +89,17 @@ def _mock_supabase_response(data: list[dict]):
         .eq.return_value
         .limit.return_value
         .execute
-    ).return_value = mock_resp
+    ).return_value = bids_resp_full
+
+    # ---- get_orgao_top_contracts_json RPC (Pattern A) ----
+    rpc_resp = MagicMock()
+    rpc_resp.data = {
+        "top_fornecedores": [],
+        "total_contratos_24m": 0,
+        "valor_total_contratos_24m": 0.0,
+    }
+    mock_sb.rpc.return_value.execute.return_value = rpc_resp
+
     return mock_sb
 
 

--- a/backend/tests/test_postgrest_paginate.py
+++ b/backend/tests/test_postgrest_paginate.py
@@ -1,0 +1,211 @@
+"""DATA-CAP-001 — unit tests for ``utils.postgrest_paginate.paginate_full``.
+
+These tests do NOT require Supabase: they mock a builder that records every
+``.range(start, end).execute()`` call and serves a pre-set list of rows
+sliced by the requested range. That is enough to validate:
+
+* Empty result set → return [].
+* Result smaller than batch_size → 1 query, return all.
+* Result exactly batch_size rows → 2 queries (second returns empty / short).
+* Result larger than batch_size → N queries until short batch.
+* ``max_total`` upper bound respected.
+* Truncation suspect metric is incremented exactly when a full batch is
+  returned (non-final batch) and NOT on the short final batch.
+"""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.postgrest_paginate import (
+    POSTGREST_MAX_ROWS_CAP,
+    paginate_full,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeBuilder:
+    """Mimics the supabase-py query builder for paginate_full's purposes.
+
+    Stores ``rows`` and serves slices on each ``.range(start, end).execute()``
+    call. Keeps a log of every range call so tests can assert call shapes.
+    """
+
+    def __init__(self, rows: List[dict]):
+        self._rows = rows
+        self.range_calls: list[tuple[int, int]] = []
+        self._next_range: tuple[int, int] | None = None
+
+    def range(self, start: int, end: int) -> "FakeBuilder":
+        self.range_calls.append((start, end))
+        self._next_range = (start, end)
+        return self
+
+    def execute(self):
+        if self._next_range is None:
+            raise RuntimeError("execute() called before range()")
+        start, end = self._next_range
+        # PostgREST .range is INCLUSIVE on both ends.
+        slice_data = self._rows[start : end + 1]
+        resp = MagicMock()
+        resp.data = slice_data
+        return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_returns_empty_when_no_rows():
+    builder = FakeBuilder([])
+
+    result = paginate_full(builder, batch_size=1000, max_total=5000, route="t.empty", entity_type="t")
+
+    assert result == []
+    # Empty data returns immediately on the first batch.
+    assert builder.range_calls == [(0, 999)]
+
+
+def test_paginate_short_batch_single_query():
+    rows = [{"id": i} for i in range(42)]
+    builder = FakeBuilder(rows)
+
+    result = paginate_full(builder, batch_size=1000, max_total=5000, route="t.short", entity_type="t")
+
+    assert result == rows
+    assert builder.range_calls == [(0, 999)]
+
+
+def test_paginate_full_batch_two_queries():
+    """Exactly batch_size rows → 1 full batch + 1 empty/short batch."""
+    rows = [{"id": i} for i in range(1000)]
+    builder = FakeBuilder(rows)
+
+    result = paginate_full(builder, batch_size=1000, max_total=5000, route="t.exact", entity_type="t")
+
+    assert len(result) == 1000
+    # First range fetches 0..999 (full); second range 1000..1999 returns empty.
+    assert builder.range_calls == [(0, 999), (1000, 1999)]
+
+
+def test_paginate_multi_batch():
+    rows = [{"id": i} for i in range(2300)]
+    builder = FakeBuilder(rows)
+
+    result = paginate_full(builder, batch_size=1000, max_total=5000, route="t.multi", entity_type="t")
+
+    assert len(result) == 2300
+    assert builder.range_calls == [(0, 999), (1000, 1999), (2000, 2999)]
+    # Last batch returned 300 rows (short) → loop ends.
+
+
+def test_paginate_max_total_caps_result():
+    rows = [{"id": i} for i in range(5000)]
+    builder = FakeBuilder(rows)
+
+    result = paginate_full(builder, batch_size=1000, max_total=2000, route="t.cap", entity_type="t")
+
+    assert len(result) == 2000
+    # We stop at offset 2000 (max_total) because len(rows) >= max_total triggers break.
+    # With batch_size=1000, max_total=2000 we expect 2 calls then loop exit.
+    assert builder.range_calls[:2] == [(0, 999), (1000, 1999)]
+    assert len(builder.range_calls) == 2
+
+
+def test_paginate_clamps_batch_size_above_postgrest_cap():
+    """batch_size > 1000 must be clamped (would silently truncate otherwise)."""
+    rows = [{"id": i} for i in range(500)]
+    builder = FakeBuilder(rows)
+
+    paginate_full(
+        builder,
+        batch_size=5000,  # ridiculous; must be clamped to 1000
+        max_total=10_000,
+        route="t.clamp",
+        entity_type="t",
+    )
+
+    # The single range call must use end=999 (inclusive), confirming clamp.
+    assert builder.range_calls == [(0, 999)]
+    assert POSTGREST_MAX_ROWS_CAP == 1000
+
+
+# ---------------------------------------------------------------------------
+# Tests — input validation
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_rejects_zero_batch_size():
+    builder = FakeBuilder([])
+    with pytest.raises(ValueError):
+        paginate_full(builder, batch_size=0, max_total=10, route="t", entity_type="t")
+
+
+def test_paginate_rejects_zero_max_total():
+    builder = FakeBuilder([])
+    with pytest.raises(ValueError):
+        paginate_full(builder, batch_size=10, max_total=0, route="t", entity_type="t")
+
+
+# ---------------------------------------------------------------------------
+# Tests — instrumentation (truncation-suspect metric)
+# ---------------------------------------------------------------------------
+
+
+def test_truncation_metric_inc_on_full_batch_only():
+    """A full batch (len == batch_size) increments the metric; a short batch does not."""
+    rows = [{"id": i} for i in range(1500)]
+    builder = FakeBuilder(rows)
+
+    with patch("utils.postgrest_paginate._record_truncation_suspect") as record:
+        paginate_full(builder, batch_size=1000, max_total=5000, route="t.metric", entity_type="t")
+
+    # First batch (1000 rows) is full → metric incremented exactly once.
+    # Second batch (500 rows) is short → no increment.
+    assert record.call_count == 1
+    record.assert_called_with(route="t.metric", entity_type="t")
+
+
+def test_truncation_metric_not_inc_when_under_batch():
+    rows = [{"id": i} for i in range(50)]
+    builder = FakeBuilder(rows)
+
+    with patch("utils.postgrest_paginate._record_truncation_suspect") as record:
+        paginate_full(builder, batch_size=1000, max_total=5000, route="t", entity_type="t")
+
+    record.assert_not_called()
+
+
+def test_truncation_metric_inc_when_exact_batch_size():
+    """Exactly batch_size → first call full → metric increments once,
+    then second call returns empty → no extra metric increment."""
+    rows = [{"id": i} for i in range(1000)]
+    builder = FakeBuilder(rows)
+
+    with patch("utils.postgrest_paginate._record_truncation_suspect") as record:
+        paginate_full(builder, batch_size=1000, max_total=5000, route="t", entity_type="t")
+
+    assert record.call_count == 1
+
+
+def test_record_truncation_suspect_swallows_metric_failure(caplog):
+    """Failure inside metrics import / Sentry must NOT break the query path."""
+    from utils import postgrest_paginate
+
+    # If POSTGREST_TRUNCATION_SUSPECTED raises on .labels(...), the query keeps running.
+    with patch.object(postgrest_paginate, "logger") as fake_log, patch(
+        "metrics.POSTGREST_TRUNCATION_SUSPECTED",
+        new=MagicMock(labels=MagicMock(side_effect=RuntimeError("metric backend down"))),
+    ):
+        # Should not raise.
+        postgrest_paginate._record_truncation_suspect(route="t", entity_type="t")
+        # Logger.warning was called (the announcement line) — confirms function ran.
+        assert fake_log.warning.called

--- a/backend/utils/postgrest_paginate.py
+++ b/backend/utils/postgrest_paginate.py
@@ -1,0 +1,210 @@
+"""DATA-CAP-001 — PostgREST per-batch pagination helper.
+
+PostgREST caps every response at ``max_rows = 1000`` (Supabase platform default,
+NOT tunable). Calling ``.limit(5000).execute()`` therefore silently truncates to
+1000 rows with no error or warning. Visible symptom: any public route that lists
+contratos / fornecedores / licitações for an entity with >1000 records returns
+exactly 1000 every time, which breaks credibility on programmatic SEO pages.
+
+This module implements the canonical Pattern B fix: paginate via PostgREST
+``.range(start, end)`` in a loop, batch_size capped at 1000 (the platform max).
+
+Pattern A (RPC ``RETURNS json`` scalar) bypasses the cap entirely and is
+preferred for aggregating queries — see
+``supabase/migrations/20260408200000_sitemap_rpc_json.sql`` and the migration
+introduced alongside this helper for ``get_orgao_top_contracts_json``.
+
+Usage
+-----
+Synchronous (run inside ``asyncio.to_thread`` from async handlers):
+
+.. code-block:: python
+
+    from utils.postgrest_paginate import paginate_full
+
+    def _sync_query() -> list[dict]:
+        from supabase_client import get_supabase
+        sb = get_supabase()
+        builder = (
+            sb.table("pncp_supplier_contracts")
+            .select("ni_fornecedor,nome_fornecedor,valor_global")
+            .eq("orgao_cnpj", cnpj)
+            .eq("is_active", True)
+            .order("data_assinatura", desc=True)
+        )
+        return paginate_full(
+            builder,
+            batch_size=1000,
+            max_total=10_000,
+            route="contratos_publicos.orgao_contratos_stats",
+            entity_type="pncp_supplier_contracts",
+        )
+
+The helper deliberately does NOT call ``asyncio.to_thread`` itself: callers
+already wrap the whole sync block in ``_run_with_budget(asyncio.to_thread(...))``
+to keep the request inside the time budget waterfall.
+
+Notes
+-----
+* ``batch_size`` MUST be ``<= 1000``. Values above are silently capped at 1000
+  by PostgREST so each batch would still truncate.
+* ``max_total`` defaults to 10_000 — a runaway guard. Most public routes need
+  far less; tune per call site.
+* On truncation suspect (``len(batch) == batch_size``) the helper increments
+  ``POSTGREST_TRUNCATION_SUSPECTED{route, entity_type}`` and emits a
+  ``logger.warning`` + Sentry breadcrumb. Metric failure never blocks the
+  query path.
+* The supabase-py builder is **stateful**: chaining ``.range(a, b)`` mutates
+  the underlying request URL. We therefore call ``.range`` and ``.execute``
+  on the SAME builder reference each iteration; this matches the patterns
+  already used in ``backend/routes/sitemap_*.py`` and ``datalake_query.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# PostgREST platform cap (Supabase Cloud). NOT tunable — see story DATA-CAP-001.
+POSTGREST_MAX_ROWS_CAP = 1000
+
+
+def paginate_full(
+    query_builder: Any,
+    *,
+    batch_size: int = 1000,
+    max_total: int = 10_000,
+    route: str = "unknown",
+    entity_type: str = "unknown",
+) -> list[dict]:
+    """Paginate a supabase-py query builder in batches, returning all rows.
+
+    Iterates ``builder.range(offset, offset + batch_size - 1).execute()`` until
+    a short batch is returned (``len(batch) < batch_size``) or ``max_total`` is
+    reached.
+
+    Parameters
+    ----------
+    query_builder
+        A supabase-py query builder ready for ``.execute()`` — i.e. the result
+        of ``sb.table(...).select(...).eq(...).order(...)``. The builder MUST
+        NOT have ``.limit()`` chained on it (use this helper instead).
+    batch_size
+        Rows per ``.range`` call. Capped at 1000 (PostgREST platform cap).
+        Default 1000.
+    max_total
+        Hard upper bound on total rows fetched. Prevents runaway queries from
+        exhausting the connection pool. Default 10 000.
+    route
+        Identifier for the calling route (used as Prometheus label and in
+        Sentry breadcrumb). Convention: ``"<module>.<function>"``.
+    entity_type
+        Table or domain entity being queried (used as Prometheus label).
+        Convention: the Supabase table name, e.g. ``"pncp_supplier_contracts"``.
+
+    Returns
+    -------
+    list[dict]
+        All rows returned by the query, up to ``max_total``. Empty list if
+        the query returned no rows.
+
+    Raises
+    ------
+    Whatever ``builder.execute()`` raises — typically ``httpx`` errors. The
+    caller is responsible for wrapping in ``_run_with_budget`` to keep the
+    request inside the time budget.
+    """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be > 0")
+    if max_total <= 0:
+        raise ValueError("max_total must be > 0")
+    if batch_size > POSTGREST_MAX_ROWS_CAP:
+        logger.warning(
+            "[postgrest_paginate] batch_size=%d > PostgREST cap=%d; clamping to %d "
+            "(route=%s entity=%s)",
+            batch_size, POSTGREST_MAX_ROWS_CAP, POSTGREST_MAX_ROWS_CAP, route, entity_type,
+        )
+        batch_size = POSTGREST_MAX_ROWS_CAP
+
+    rows: list[dict] = []
+    offset = 0
+    iterations = 0
+    # Hard sanity cap on iterations — even with batch_size=1, max_total=10k
+    # gives 10k iterations; a 100k requested with batch_size=1000 gives 100.
+    # We pick a generous bound so it never fires in healthy paths but catches
+    # bugs (e.g. callers passing builder that returns the same row forever).
+    max_iterations = (max_total // batch_size) + 2
+
+    while iterations < max_iterations and len(rows) < max_total:
+        iterations += 1
+        end = offset + batch_size - 1
+        try:
+            resp = query_builder.range(offset, end).execute()
+        except Exception:
+            # Re-raise — the caller wraps this in _run_with_budget and logs.
+            raise
+
+        batch = getattr(resp, "data", None) or []
+        if not batch:
+            break
+
+        rows.extend(batch)
+
+        # Truncation suspect: a full batch means there might be more rows.
+        # We continue paginating; the metric records that this route hit the
+        # batch boundary at least once (signal: this entity has many rows
+        # and the helper is doing its job).
+        if len(batch) == batch_size:
+            _record_truncation_suspect(route=route, entity_type=entity_type)
+            offset += batch_size
+            continue
+
+        # Short batch — we have everything.
+        break
+
+    if len(rows) >= max_total:
+        logger.warning(
+            "[postgrest_paginate] max_total=%d reached for route=%s entity=%s — "
+            "returning capped result. Consider raising max_total or filtering tighter.",
+            max_total, route, entity_type,
+        )
+        # Truncate defensively in case the last batch overshot
+        rows = rows[:max_total]
+
+    return rows
+
+
+def _record_truncation_suspect(*, route: str, entity_type: str) -> None:
+    """Increment Prometheus counter + emit log + Sentry breadcrumb.
+
+    All instrumentation is best-effort: failures here NEVER block the query
+    path. This matches the convention in ``datalake_query.py:213``.
+    """
+    logger.warning(
+        "[postgrest_paginate] truncation suspect — full batch returned "
+        "(route=%s entity=%s); paginating next batch",
+        route, entity_type,
+    )
+
+    try:
+        from metrics import POSTGREST_TRUNCATION_SUSPECTED
+
+        POSTGREST_TRUNCATION_SUSPECTED.labels(route=route, entity_type=entity_type).inc()
+    except Exception:
+        # Metrics are optional — never block the flow.
+        pass
+
+    # Sentry breadcrumb (best-effort)
+    try:
+        import sentry_sdk
+
+        sentry_sdk.add_breadcrumb(
+            category="postgrest.truncation",
+            message="PostgREST batch returned full batch_size — pagination continued",
+            level="info",
+            data={"route": route, "entity_type": entity_type},
+        )
+    except Exception:
+        pass

--- a/docs/stories/2026-05/DATA-CAP-001-postgrest-max-rows-truncation-fix.story.md
+++ b/docs/stories/2026-05/DATA-CAP-001-postgrest-max-rows-truncation-fix.story.md
@@ -1,0 +1,116 @@
+# DATA-CAP-001: PostgREST max-rows=1000 silent truncation fix em 7 routes
+
+**Priority:** P0
+**Effort:** M (1-2d)
+**Squad:** @dev (lead) + @data-engineer + @qa
+**Status:** Draft
+**Epic:** [EPIC-RES-BE-2026-Q2](EPIC-RES-BE-2026-Q2/) — eixo operational reliability + UX credibilidade
+**Sprint:** TBD
+**Dependências bloqueadoras:** Nenhuma
+**Reversa anchor:** `_reversa_sdd/review-report.md §11.1` (counts realinhados) + `.reversa/drift-2026-05-09.md`
+**Score Δ:** ops reliability +6 (84% → 90%)
+
+---
+
+## Contexto
+
+PostgREST `supabase/config.toml:max_rows = 1000` cap silencioso em 7 routes públicas. Bug visível ao user: entes contratantes com 1001+ contratos retornam **sempre 1000 redondos** → degrada credibilidade dos dados públicos da plataforma.
+
+`backend/datalake_query.py:L195-218` já implementa o pattern correto (per-UF pagination + truncation suspect logging + `DATALAKE_TRUNCATION_SUSPECTED` Prometheus counter). `backend/routes/sitemap_orgaos.py` + `sitemap_cnpjs.py` usam pattern alternativo (RPC `RETURNS json scalar` que bypassa max-rows).
+
+7 routes restantes passam `.limit(2000-5000)` para PostgREST que silently caps a 1000:
+
+| Arquivo | Linha | `.limit()` | Sintoma |
+|---------|-------|-----------|---------|
+| `backend/routes/contratos_publicos.py` | 198 | `.limit(5000)` | Lista contratos do orgão truncada |
+| `backend/routes/contratos_publicos.py` | 280 | `.limit(5000)` | mesma rota outra query |
+| `backend/routes/orgao_publico.py` | 279 | `.limit(5000)` | Page orgão público |
+| `backend/routes/orgao_publico.py` | 445 | `.limit(2000)` | `_fetch_contracts_data` agg top |
+| `backend/routes/empresa_publica.py` | 532 | `limit=2000` | CNPJ supplier history |
+| `backend/routes/itens_publicos.py` | 446 | `.limit(1000)` | Already at cap (silent) |
+| `backend/routes/blog_stats.py` | 943 | `.limit(5000)` | Blog stats aggregation |
+| `backend/routes/observatorio.py` | 331 | `.limit(5000)` | Observatorio metric |
+| `backend/routes/seo_admin.py` | 206 | `.limit(5000)` | Admin SEO panel |
+
+Memory `reference_supabase_management_api_query` confirma: PostgREST max-rows não-tunável via Supabase platform (config.toml local apenas docs alignment).
+
+---
+
+## Acceptance Criteria
+
+### AC1: Pattern A — RPC RETURNS json scalar (preferencial para aggregates)
+
+Para queries agregadoras (top-N por valor, count distinct, etc.):
+
+- [ ] Criar RPC PostgreSQL `get_<route>_<query>_json()` retornando `RETURNS json` scalar (modelo: `supabase/migrations/20260408200000_sitemap_rpc_json.sql`)
+- [ ] Aplicar a:
+  - `orgao_publico:445` `_fetch_contracts_data` → `get_orgao_top_contracts_json(orgao_cnpj, limit)`
+  - `blog_stats:943` → `get_blog_stats_aggregated_json()`
+- [ ] Each RPC migration paired com `.down.sql`
+
+### AC2: Pattern B — Per-batch pagination via `.range()` em loop
+
+Para queries que precisam dos rows brutos:
+
+- [ ] Implementar helper `backend/utils/postgrest_paginate.py:paginate_full(query_builder, batch_size=1000, max_total=10000)` que:
+  - Executa `.range(offset, offset+batch_size-1).execute()` em loop
+  - Detecta truncation: se `len(batch) == batch_size`, continua; se `< batch_size`, encerra
+  - Emite log + métrica em truncation suspect (mesma de `DATALAKE_TRUNCATION_SUSPECTED`)
+  - Cap `max_total` para evitar runaway (default 10k)
+- [ ] Aplicar a:
+  - `contratos_publicos:198, 280`
+  - `orgao_publico:279`
+  - `empresa_publica:532`
+  - `itens_publicos:446`
+  - `observatorio:331`
+  - `seo_admin:206`
+
+### AC3: Telemetria + audit script
+
+- [ ] Promote `DATALAKE_TRUNCATION_SUSPECTED` counter de `metrics.py` para uso global (label=`route`, `entity_type`)
+- [ ] Sentry breadcrumb em truncation suspect
+- [ ] `backend/scripts/audit_postgrest_max_rows.py` — grep `\.limit\((1000|[2-9]\d{3,})\)` em `routes/` e fail se encontrar bare execute
+- [ ] CI gate `.github/workflows/audit-postgrest-cap.yml` — exige zero violations
+
+### AC4: Tests
+
+- [ ] `backend/tests/test_postgrest_paginate.py` — unit tests do helper:
+  - 0 rows → return []
+  - <batch_size rows → 1 query, return all
+  - Exatos batch_size rows → 2 queries (segunda vazia)
+  - >batch_size rows → N queries até completar
+  - max_total cap respeitado
+- [ ] `backend/tests/integration/test_routes_no_silent_truncation.py` — fixture orgão sintético com 1500 contratos, confirmar route retorna 1500 (não 1000)
+- [ ] Frontend: `/orgaos/[cnpj]` page snapshot test — count exibido = count real
+
+### AC5: Doc + observabilidade
+
+- [ ] Update `_reversa_sdd/review-report.md` — close gap em §11.4 (DATA-CAP-001 RESOLVED)
+- [ ] Doc `docs/architecture/postgrest-pagination-patterns.md` — pattern A vs B decision tree + exemplos
+- [ ] Sentry alert: trigger se `DATALAKE_TRUNCATION_SUSPECTED` rate > 10/h
+
+---
+
+## DoD
+
+- [ ] 9 callsites refactored (Pattern A: 2; Pattern B: 7)
+- [ ] Helper `postgrest_paginate.py` 100% covered
+- [ ] CI gate ativo (zero violations baseline)
+- [ ] Integration test orgão 1500-contratos PASS
+- [ ] Frontend page exibe count real (validação Playwright snapshot)
+- [ ] Sentry alert configurado
+- [ ] Doc patterns + review-report close-out
+- [ ] Memory entry: `feedback_postgrest_max_rows_silent_cap.md`
+
+---
+
+## Dependências
+
+- Helper `_run_with_budget` existente — paginate loop deve respeitar budget (cada batch dentro de budget remanescente)
+
+---
+
+## Notes
+
+- Memory `feedback_chief_revenue_aware_routing` Gate D: P0 reliability (n_paid não-zero, dados públicos visíveis = trust signal direto). NÃO defer.
+- Não tocar `datalake_query.py` (já correto desde STORY-437). Replicar pattern.

--- a/supabase/migrations/20260509172143_data_cap_001_orgao_top_contracts_rpc.down.sql
+++ b/supabase/migrations/20260509172143_data_cap_001_orgao_top_contracts_rpc.down.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- DOWN: DATA-CAP-001 orgao top contracts RPC — reverses
+--       20260509172143_data_cap_001_orgao_top_contracts_rpc.sql
+-- Date: 2026-05-09
+-- Author: @dev / @data-engineer
+-- ============================================================================
+-- Context:
+--   Drops the get_orgao_top_contracts_json RPC. After rollback the application
+--   code in backend/routes/orgao_publico.py will start failing with PGRST202
+--   ("function not found") because it expects this RPC to exist — therefore
+--   rolling back this migration MUST be paired with reverting the route to
+--   the previous .limit(2000) implementation.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.get_orgao_top_contracts_json(text, integer);

--- a/supabase/migrations/20260509172143_data_cap_001_orgao_top_contracts_rpc.sql
+++ b/supabase/migrations/20260509172143_data_cap_001_orgao_top_contracts_rpc.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- DATA-CAP-001 — RPC RETURNS json scalar for orgao top suppliers aggregation
+-- Date: 2026-05-09
+-- Author: @dev / @data-engineer
+-- ============================================================================
+-- Context:
+--   PostgREST max_rows=1000 silently truncates table queries. The
+--   /v1/orgaos/{cnpj} endpoint (orgao_publico.py::_fetch_contracts_data)
+--   used to fetch up to 2000 raw contract rows from pncp_supplier_contracts
+--   and aggregate in Python. With orgãos that have >1000 active contracts,
+--   that truncation produced incorrect "top fornecedores" lists and
+--   under-counted total_contratos_24m / valor_total_contratos_24m.
+--
+--   Pattern A (RETURNS json scalar) bypasses the row-cap entirely because
+--   PostgREST only enforces max_rows on TABLE / SETOF returns, not on
+--   scalar JSON. This RPC returns one JSON document with the pre-aggregated
+--   top suppliers + totals, computed server-side.
+--
+-- Reference: supabase/migrations/20260408200000_sitemap_rpc_json.sql
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_orgao_top_contracts_json(
+  p_orgao_cnpj text,
+  p_limit integer DEFAULT 10
+)
+RETURNS json
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH per_supplier AS (
+    SELECT
+      ni_fornecedor,
+      MAX(nome_fornecedor) AS nome,
+      COUNT(*)::bigint     AS contratos,
+      COALESCE(SUM(valor_global), 0)::numeric AS valor
+    FROM pncp_supplier_contracts
+    WHERE orgao_cnpj = p_orgao_cnpj
+      AND is_active  = true
+      AND ni_fornecedor IS NOT NULL
+      AND ni_fornecedor <> ''
+    GROUP BY ni_fornecedor
+  ),
+  totals AS (
+    SELECT
+      COALESCE(SUM(contratos), 0)::bigint  AS total_contratos,
+      COALESCE(SUM(valor),     0)::numeric AS valor_total
+    FROM per_supplier
+  ),
+  top_n AS (
+    SELECT
+      nome,
+      ni_fornecedor AS cnpj,
+      contratos     AS total_contratos,
+      ROUND(valor::numeric, 2)::float8 AS valor_total
+    FROM per_supplier
+    WHERE valor > 0
+    ORDER BY valor DESC
+    LIMIT GREATEST(p_limit, 0)
+  )
+  SELECT json_build_object(
+    'top_fornecedores', COALESCE(
+      (SELECT json_agg(t.* ORDER BY t.valor_total DESC) FROM top_n t),
+      '[]'::json
+    ),
+    'total_contratos_24m',       (SELECT total_contratos FROM totals),
+    'valor_total_contratos_24m', ROUND((SELECT valor_total FROM totals)::numeric, 2)::float8
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_orgao_top_contracts_json(text, integer)
+  TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_orgao_top_contracts_json(text, integer) IS
+  'DATA-CAP-001: aggregate top suppliers + totals for an orgão. Returns scalar JSON to bypass PostgREST max_rows=1000.';


### PR DESCRIPTION
## Summary

- **What:** Replace `.limit(2000-5000)` calls in 7 public SEO routes with the canonical Pattern B (`paginate_full` helper) and Pattern A (RPC `RETURNS json` scalar) so PostgREST `max_rows=1000` no longer silently truncates results.
- **Why:** Visible UX bug — every entity with >1000 contracts/bids was returning rounded counts and biased "top N" lists on `/orgaos/[cnpj]`, `/contratos/{setor}/{uf}/stats`, `/blog/stats/*`, `/observatorio` and the SEO admin panel. P0 (operational reliability + credibilidade dos dados públicos).
- **Scope:** 9 callsites in 7 files + 1 helper module + 1 metric + 1 RPC migration (paired `.down.sql`) + 12 unit tests. Mirrors the pattern already proven in `backend/datalake_query.py:L195-218` and `supabase/migrations/20260408200000_sitemap_rpc_json.sql`.

## Context

PostgREST (Supabase Cloud) hard-caps any table response at `max_rows=1000`. There is no platform setting to lift it (`supabase/config.toml:max_rows` is local-only). Three callsite shapes were affected:

| Pattern | Used for | Mechanism |
|---|---|---|
| **B — `paginate_full`** | List queries that need raw rows | Iterates `.range(offset, offset+batch_size-1).execute()` until short batch; `max_total` guard; emits `POSTGREST_TRUNCATION_SUSPECTED{route, entity_type}` on full batches + Sentry breadcrumb |
| **A — RPC `RETURNS json` scalar** | Aggregations | New `public.get_orgao_top_contracts_json(cnpj, limit)` aggregates server-side and returns a single JSON document (not subject to row-cap) |
| **Truthful cap** | Wrappers around `query_datalake` | `empresa_publica.py:532` lowered to `limit=1000` because the per-UF RPC inside `datalake_query.py` is itself capped at 1000 — the previous `limit=2000` was already silently truncated. Lifting >1000 requires touching `datalake_query.py` and is out of scope (story Notes) |

### Files changed (9 callsites)

| File | Line(s) | Pattern | Notes |
|---|---|---|---|
| `backend/routes/contratos_publicos.py` | 198, 280 | B | Sector + orgão contracts list |
| `backend/routes/orgao_publico.py` | 279 | B | Bids per orgão |
| `backend/routes/orgao_publico.py` | 445 (`_fetch_contracts_data`) | A | Replaced 2000-row Python aggregation with the new RPC |
| `backend/routes/empresa_publica.py` | 532 | Truthful cap | `limit=2000` → `limit=1000` (see deviation note below) |
| `backend/routes/itens_publicos.py` | 446 | B | CATMAT price benchmark |
| `backend/routes/blog_stats.py` | 943 | B | Pillar pages aggregation (see deviation note below) |
| `backend/routes/observatorio.py` | 331 | B | Historical monthly query |
| `backend/routes/seo_admin.py` | 206 | B | GSC pages rollup over 90d window |

### Migration

- `supabase/migrations/20260509172143_data_cap_001_orgao_top_contracts_rpc.sql` — creates `public.get_orgao_top_contracts_json`, `SECURITY DEFINER`, `STABLE`, `SET search_path = public`, granted to `anon, authenticated, service_role`.
- Paired `.down.sql` drops the function. CRIT-050 auto-apply on deploy.
- Brief safe window between code-deploy and migration-apply: the route's existing `try/except Exception` returns the empty `result` skeleton; route renders gracefully (no 500).

### Telemetry

- New metric `smartlic_postgrest_truncation_suspected_total{route, entity_type}` — fires every time `paginate_full` sees a full batch (signal: this entity has >batch_size rows in the filter set, and the route would have silently truncated without the helper).
- Sibling to existing `smartlic_datalake_truncation_suspected_total{uf}` — left untouched (different signal, different label set).
- Sentry breadcrumb `category=postgrest.truncation` for every full-batch event (best-effort; metric/Sentry failures never block the query).

### Scope decisions / deviations from story ACs

1. **`empresa_publica.py:532` set to `limit=1000`, not pagination.** Story Notes: "Não tocar `datalake_query.py` (já correto desde STORY-437). Replicar pattern." That call passes `limit` to `query_datalake()`, whose internal per-UF `search_datalake` RPC is itself row-capped at 1000. Lifting beyond 1000 needs per-UF pagination *inside* `datalake_query.py` (out of scope). The truthful 1000 cap matches what the RPC was actually returning.
2. **`blog_stats.py:943` got Pattern B (not Pattern A).** AC1 listed `blog_stats:943` as a Pattern A target, but the surrounding aggregator computes 8+ derived fields (`top_orgaos`, `top_fornecedores`, `monthly_trend`, `by_uf`, `n_unique_orgaos`, `n_unique_fornecedores`, `sample_contracts`, totals) plus optional `uf` / `municipio_pattern` (free-text `ilike`). Porting the full aggregation surface into one `RETURNS json` RPC is a 5x larger refactor with painful test surface; Pattern B with `max_total=10_000` preserves correctness without bloating the RPC API. Recommend leaving Pattern A migration for `blog_stats` as a follow-up if reviewers want the full server-side aggregation.
3. **Out-of-scope per user task (intentionally not implemented):** AC3 audit script + `audit-postgrest-cap.yml` CI gate; AC4 1500-row integration test (covered conceptually by helper unit tests + existing integration tests touching every modified route); AC5 docs (`postgrest-pagination-patterns.md`, review-report close-out, Sentry alert config). Frontend snapshot test deferred per memory `feedback_wsl_next16_build_inviavel`.

### Concurrency note (not a regression)

`paginate_full` makes up to N sequential SQL calls under one `_run_with_budget`. With `max_total=10000` and `batch_size=1000` that's up to 10 sequential `.execute()` calls. The previous `.limit(5000)` was a single call but had the same per-call pool semantics (caller `wait_for` cancels the await; the thread keeps running until Supabase `statement_timeout=15s` fires per query — pool-leak antipattern from `feedback_pool_leak_caller_timeout_vs_sql_timeout`). The `max_total` guard bounds the worst case.

## Testing Plan

- [x] **Unit:** `backend/tests/test_postgrest_paginate.py` — 12 tests covering empty / short batch / exact `batch_size` (boundary) / multi-batch / `max_total` cap / `batch_size > 1000` clamp / input validation / metric semantics (`_record_truncation_suspect` increments only on full batches) / metric-failure swallowed without breaking query path.
- [x] **Existing route tests updated** to mock the new `.range(start, end).execute()` chain (and the new RPC for `orgao_publico.contracts_data`):
  - `backend/tests/test_orgao_publico.py` — `_mock_supabase_response` now returns full data on first `.range()` then empty (loop exit), plus stub for `sb.rpc(...).execute()`.
  - `backend/tests/test_contratos_publicos.py` — chain mocks updated; `TestContratosDedup._mock_chain` mirrors the new `.order().range().execute()` shape with `side_effect=[full, empty, empty]`.
  - `backend/tests/test_blog_stats.py` — hand-rolled `_ContractsQueryBuilder` got a `range(start, end)` slice method.
- [x] **Local run:** `pytest -k "data_cap or postgrest_truncation or contratos_publicos or orgao_publico or empresa_publica or blog_stats or observatorio or seo_admin or itens_publicos" --ignore=tests/fuzz --timeout=30` → **145 passed, 6 skipped (env-gated parity tests), 0 failures.**
- [x] **Lint:** `ruff check backend/utils/postgrest_paginate.py backend/tests/test_postgrest_paginate.py backend/metrics.py` clean. (Two pre-existing lint warnings on lines I did not touch in `contratos_publicos.py` and `blog_stats.py` — confirmed not in this diff.)
- [ ] **CI to validate:** full backend suite (`backend-tests.yml`), migration gate (`migration-gate.yml` — paired `.down.sql` is present), audit-execute-without-budget gate (all `.execute()` still inside `_run_with_budget` calls), `audit-prod-env` (no env-var changes in this diff).
- [ ] **Manual post-merge sanity (out of PR scope):** hit `/orgaos/{cnpj}` for an orgão known to have >1000 active contracts (e.g. Tribunal de Justiça de SP) and confirm count > 1000 in the rendered page.

## Closes

Closes #949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed silent truncation of results at 1,000 rows in contract queries, blog statistics, item pricing, and public agency endpoints, improving data accuracy for large datasets.
  * Enhanced data retrieval with truncation detection monitoring across multiple endpoints.

* **New Features**
  * Implemented paginated queries to reliably handle large result sets without data loss.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/957)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->