### PR TITLE
test(security): expand HMAC coverage (HMAC-ENFORCE-001 confirm)

### DIFF
--- a/backend/tests/test_resend_webhook_signature.py
+++ b/backend/tests/test_resend_webhook_signature.py
@@ -186,3 +186,160 @@ def test_trial_emails_webhook_secret_alias(fake_secret):
             r = c.post("/v1/trial-emails/webhook", content=body, headers=headers)
     assert r.status_code == 200
     assert r.json()["status"] in ("processed", "skipped", "ignored")
+
+
+# ---------------------------------------------------------------------------
+# HMAC-ENFORCE-001 (confirm) — coverage expansion 2026-05-09
+# Audit confirmed enforcement is already shipped (PR #534/#858/#954). These
+# additional cases close the remaining test-spec gaps without changing
+# production code: malformed signature header, future-skewed timestamp,
+# non-numeric timestamp, missing svix-id, invalidly-encoded secret, and a
+# byte-replacement tamper variant (memory feedback_jwt_base64url_flaky_test:
+# prefer full byte replacement over single-char flips for deterministic fail).
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_signature_header_rejected(client, fake_secret):
+    """Header missing the `v1,` prefix → no candidate sigs extracted → 401.
+
+    Behavior check (memory feedback_test_regex_invariant_semantic): we assert
+    the status code 401 produced by the verifier rejecting an unparseable
+    header, not the literal log string.
+    """
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    ts = int(time.time())
+    # No comma → unparseable. Verifier filters require "," + startswith("v1,")
+    headers = {
+        "svix-id": "msg_malformed",
+        "svix-timestamp": str(ts),
+        "svix-signature": "not-a-valid-svix-header-format",
+        "content-type": "application/json",
+    }
+    r = client.post("/v1/trial-emails/webhook", content=body, headers=headers)
+    assert r.status_code == 401
+
+
+def test_unsupported_scheme_rejected(client, fake_secret):
+    """Header with `v2,...` (unsupported scheme) → no candidates → 401.
+
+    Defense-in-depth: only `v1` Svix scheme must be accepted. A future v2
+    scheme would need explicit support, not silent acceptance.
+    """
+    _, raw = fake_secret
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    ts = int(time.time())
+    sig_v1 = _sign(raw, "msg_v2", ts, body)  # valid v1 signature
+    sig_v2_only = sig_v1.replace("v1,", "v2,", 1)  # rebrand as v2
+    headers = {
+        "svix-id": "msg_v2",
+        "svix-timestamp": str(ts),
+        "svix-signature": sig_v2_only,
+        "content-type": "application/json",
+    }
+    r = client.post("/v1/trial-emails/webhook", content=body, headers=headers)
+    assert r.status_code == 401
+
+
+def test_non_numeric_timestamp_rejected(client, fake_secret):
+    """Non-numeric svix-timestamp → ValueError caught → 401."""
+    _, raw = fake_secret
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    headers = {
+        "svix-id": "msg_bad_ts",
+        "svix-timestamp": "not-a-number",
+        "svix-signature": _sign(raw, "msg_bad_ts", int(time.time()), body),
+        "content-type": "application/json",
+    }
+    r = client.post("/v1/trial-emails/webhook", content=body, headers=headers)
+    assert r.status_code == 401
+
+
+def test_future_skewed_timestamp_rejected(client, fake_secret):
+    """Timestamp >5 min in the future → 401 (replay window symmetric).
+
+    Complements `test_replay_old_timestamp_rejected` — verifier uses
+    `abs(now - ts) > tolerance`, so future drift must also fail.
+    """
+    _, raw = fake_secret
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    future_ts = int(time.time()) + 600  # 10 min ahead
+    headers = {
+        "svix-id": "msg_future",
+        "svix-timestamp": str(future_ts),
+        "svix-signature": _sign(raw, "msg_future", future_ts, body),
+        "content-type": "application/json",
+    }
+    r = client.post("/v1/trial-emails/webhook", content=body, headers=headers)
+    assert r.status_code == 401
+
+
+def test_missing_svix_id_rejected(client, fake_secret):
+    """All three Svix headers required — drop svix-id → 401."""
+    _, raw = fake_secret
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    ts = int(time.time())
+    headers = {
+        # svix-id intentionally absent
+        "svix-timestamp": str(ts),
+        "svix-signature": _sign(raw, "any-id", ts, body),
+        "content-type": "application/json",
+    }
+    r = client.post("/v1/trial-emails/webhook", content=body, headers=headers)
+    assert r.status_code == 401
+
+
+def test_invalid_base64_secret_rejected(fake_secret):
+    """Secret value that is not valid base64 → exception caught → 401.
+
+    Confirms `_verify_svix_signature` swallows base64 decode errors instead of
+    bubbling them up as 500s, which would leak operational state to attackers.
+    """
+    _, raw = fake_secret
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    ts = int(time.time())
+    bad_secret = "whsec_!!!not-base64!!!"
+    with patch.dict(os.environ, {"RESEND_WEBHOOK_SECRET": bad_secret}, clear=False):
+        from main import app
+        c = TestClient(app)
+        r = c.post(
+            "/v1/trial-emails/webhook",
+            content=body,
+            headers={
+                "svix-id": "msg_bad_secret",
+                "svix-timestamp": str(ts),
+                "svix-signature": _sign(raw, "msg_bad_secret", ts, body),
+                "content-type": "application/json",
+            },
+        )
+    assert r.status_code == 401
+
+
+def test_signature_byte_replacement_rejected(client, fake_secret):
+    """Replace one base64 char in the signature → 401.
+
+    Memory `feedback_jwt_base64url_flaky_test`: single-char base64url flips
+    can land on an equivalent character (~6% false-pass risk). We replace a
+    middle char with one that is guaranteed not to be a valid base64 alphabet
+    member at that position, ensuring deterministic mismatch.
+    """
+    _, raw = fake_secret
+    body = json.dumps({"type": "email.opened", "data": {}}).encode()
+    ts = int(time.time())
+    valid = _sign(raw, "msg_tamper", ts, body)  # "v1,<base64>"
+    prefix, b64 = valid.split(",", 1)
+    # Replace 5 contiguous chars with a determinedly distinct sequence.
+    # Use chars that are valid base64 (so the parse succeeds) but
+    # statistically guaranteed not to coincide with the original 5 bytes.
+    if len(b64) >= 16:
+        replacement = "AAAAA" if not b64[8:13].startswith("A") else "BBBBB"
+        tampered_b64 = b64[:8] + replacement + b64[13:]
+    else:
+        tampered_b64 = "A" * len(b64)
+    headers = {
+        "svix-id": "msg_tamper",
+        "svix-timestamp": str(ts),
+        "svix-signature": f"{prefix},{tampered_b64}",
+        "content-type": "application/json",
+    }
+    r = client.post("/v1/trial-emails/webhook", content=body, headers=headers)
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary

HMAC-ENFORCE-001 audit (2026-05-09) confirmed signature enforcement on `/v1/trial-emails/webhook` is **already shipped** (PR #534, PR #858 canonical alias, PR #954 closeout commit `159ca2e8`). Story is already marked **Done** and issue #953 is closed. This PR only **expands test coverage** for the existing verifier — no production code changes.

## Context

Per the story directive: "Se AC1 audit revelar HMAC já completo + tests existentes adequados: marcar story RESOLVED no PR description, fechar com commit `test(security): expand HMAC coverage (HMAC-ENFORCE-001 confirm)` + apenas adicionar tests que faltarem."

### Audit findings (`backend/routes/trial_emails.py`)

| Aspect | State | Lines |
|--------|-------|-------|
| Header check (Svix triplet: `svix-id` / `svix-timestamp` / `svix-signature`) | ✅ Shipped | 141-143 |
| Raw body read **before** JSON parse | ✅ | 163 |
| Constant-time compare (`secrets.compare_digest`) | ✅ | 135 |
| Reject (401) **before** any DB write | ✅ | 165-170 |
| Canonical secret env var (`TRIAL_EMAILS_WEBHOOK_SECRET` + legacy `RESEND_WEBHOOK_SECRET` fallback) | ✅ | 102 |
| 5-min replay protection (Svix-recommended) | ✅ Bonus | 86, 120 |
| Logging without secret leakage | ✅ | 166-169 |

**Intentional spec deltas** documented in the PR #954 closeout commit:
- Returns **401** (not 403) — semantically correct for auth failure + required for Resend retry behavior on transient secret rotation.
- Uses **Svix triplet headers** (Resend uses Svix protocol internally), not a plain `Resend-Signature` header.

### Coverage gaps closed by this PR

7 new test cases in `backend/tests/test_resend_webhook_signature.py`:

1. **Malformed signature header** — missing `v1,` prefix → 401
2. **Unsupported scheme rejected** — `v2,...` must not be silently accepted → 401
3. **Non-numeric `svix-timestamp`** → 401 (not 500)
4. **Future-skewed timestamp** (>5 min ahead) → 401 (replay window is symmetric)
5. **Missing `svix-id`** header → 401
6. **Invalid base64 secret** → exception swallowed → 401 (no operational state leak via 500)
7. **Byte-replacement signature tamper** — replaces 5 contiguous base64 chars instead of single-char flip, avoiding the JWT base64url antipattern documented in memory `feedback_jwt_base64url_flaky_test` (~6% false-pass risk on single-char flips).

Tests assert behavior (status codes), not log strings — per memory `feedback_test_regex_invariant_semantic`.

## Testing Plan

- [x] `pytest backend/tests/test_resend_webhook_signature.py -v --timeout=30` → **15/15 PASS** (8 pre-existing + 7 new)
- [x] `pytest backend/tests/test_trial_emails.py backend/tests/test_trial_email_sequence.py backend/tests/test_trial_email_extensions.py backend/tests/test_story418_trial_email_dlq.py --timeout=30` → **153/153 PASS** (zero regression)
- [ ] CI backend-tests + frontend-tests + Check Real Merge Conflicts pass
- [ ] No production code modified — only `backend/tests/test_resend_webhook_signature.py` (+157/-0)

## Out of Scope (deferred per PR #954)

- AC4 telemetry (Prometheus `webhook_signature_failures_total`) — separate story
- AC5 docs (`docs/security/webhook-signature-policy.md`, runbook, `review-report.md §11.2`) — folded into DOC-COVERAGE-001

## Closes

Closes-Story: HMAC-ENFORCE-001 (Gap-5 RBAC/Security) — confirmation
Refs: #953, PR #534, PR #858, PR #954