### PR TITLE
fix(security): downgrade 3 SECDEF views to INVOKER (SEC-VIEW-001)

### DIFF
--- a/backend/tests/test_secdef_views_invoker.py
+++ b/backend/tests/test_secdef_views_invoker.py
@@ -1,0 +1,197 @@
+"""
+SEC-VIEW-001: Static SQL analysis tests for the SECURITY INVOKER downgrade
+of 3 public views flagged by the Supabase Database Linter.
+
+Tests verify the migration SQL structure (UP + DOWN) — full RLS regression
+against a live database is captured in `scripts/manual_test_secdef_views.sql`
+and validated post-deploy via the Supabase advisor.
+
+Memory `feedback_test_regex_invariant_semantic`: assertions check semantic
+invariants (presence of ALTER VIEW SET, correct GRANT/REVOKE pattern per
+view) rather than exact line text — resistant to whitespace/cosmetic edits.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "supabase" / "migrations"
+UP_FILE = MIGRATIONS_DIR / "20260509120000_sec_view_001_invoker_downgrade.sql"
+DOWN_FILE = MIGRATIONS_DIR / "20260509120000_sec_view_001_invoker_downgrade.down.sql"
+
+VIEWS = (
+    "ingestion_orphan_checkpoints",
+    "pncp_raw_bids_bloat_stats",
+    "cron_job_health",
+)
+
+
+@pytest.fixture(scope="module")
+def up_sql() -> str:
+    assert UP_FILE.exists(), f"UP migration missing: {UP_FILE}"
+    return UP_FILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def down_sql() -> str:
+    assert DOWN_FILE.exists(), f"DOWN migration missing: {DOWN_FILE}"
+    return DOWN_FILE.read_text(encoding="utf-8")
+
+
+def _normalize(sql: str) -> str:
+    """Collapse whitespace for tolerant matching."""
+    return re.sub(r"\s+", " ", sql).strip()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AC1: UP migration — ALTER VIEW ... SET (security_invoker = true)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestUpMigrationInvokerDowngrade:
+    """Each of the 3 views must be downgraded to SECURITY INVOKER."""
+
+    @pytest.mark.parametrize("view", VIEWS)
+    def test_view_set_security_invoker_true(self, up_sql: str, view: str) -> None:
+        normalized = _normalize(up_sql)
+        # Tolerant pattern: optional whitespace around `=`.
+        pattern = rf"ALTER VIEW public\.{re.escape(view)} SET \( ?security_invoker ?= ?true ?\)"
+        assert re.search(pattern, normalized, re.IGNORECASE), (
+            f"UP migration must contain `ALTER VIEW public.{view} SET (security_invoker = true)`"
+        )
+
+    def test_no_create_or_replace_view(self, up_sql: str) -> None:
+        """Sanity: do not redefine the views — only ALTER their reloptions."""
+        assert "CREATE OR REPLACE VIEW" not in up_sql.upper(), (
+            "UP migration should ONLY ALTER existing views, not redefine them. "
+            "Redefining loses the original column list / comments."
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AC2: GRANT alignment per view
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGrantAlignment:
+    """Per-view privilege posture after downgrade."""
+
+    def test_bloat_stats_revoked_from_authenticated(self, up_sql: str) -> None:
+        assert re.search(
+            r"REVOKE\s+ALL\s+ON\s+public\.pncp_raw_bids_bloat_stats\s+FROM\s+authenticated",
+            up_sql,
+            re.IGNORECASE,
+        ), "bloat_stats must REVOKE ALL FROM authenticated (admin diagnostic only)"
+
+    def test_bloat_stats_revoked_from_anon(self, up_sql: str) -> None:
+        assert re.search(
+            r"REVOKE\s+ALL\s+ON\s+public\.pncp_raw_bids_bloat_stats\s+FROM\s+anon",
+            up_sql,
+            re.IGNORECASE,
+        ), "bloat_stats must REVOKE ALL FROM anon"
+
+    def test_bloat_stats_granted_to_service_role(self, up_sql: str) -> None:
+        assert re.search(
+            r"GRANT\s+SELECT\s+ON\s+public\.pncp_raw_bids_bloat_stats\s+TO\s+service_role",
+            up_sql,
+            re.IGNORECASE,
+        ), "bloat_stats must remain readable by service_role"
+
+    def test_cron_job_health_revoked_from_authenticated(self, up_sql: str) -> None:
+        assert re.search(
+            r"REVOKE\s+ALL\s+ON\s+public\.cron_job_health\s+FROM\s+authenticated",
+            up_sql,
+            re.IGNORECASE,
+        ), "cron_job_health must REVOKE ALL FROM authenticated"
+
+    def test_cron_job_health_revoked_from_anon(self, up_sql: str) -> None:
+        assert re.search(
+            r"REVOKE\s+ALL\s+ON\s+public\.cron_job_health\s+FROM\s+anon",
+            up_sql,
+            re.IGNORECASE,
+        ), "cron_job_health must REVOKE ALL FROM anon"
+
+    def test_cron_job_health_granted_to_service_role(self, up_sql: str) -> None:
+        assert re.search(
+            r"GRANT\s+SELECT\s+ON\s+public\.cron_job_health\s+TO\s+service_role",
+            up_sql,
+            re.IGNORECASE,
+        ), "cron_job_health must remain readable by service_role"
+
+    def test_orphan_checkpoints_keeps_authenticated_path(self, up_sql: str) -> None:
+        """
+        ingestion_orphan_checkpoints relies on RLS of underlying app tables.
+        UP must NOT REVOKE FROM authenticated — RLS remains the gate.
+        """
+        # Look at all REVOKE statements in the migration
+        revokes_against_view = re.findall(
+            r"REVOKE\s+\w+\s+ON\s+public\.ingestion_orphan_checkpoints",
+            up_sql,
+            re.IGNORECASE,
+        )
+        assert not revokes_against_view, (
+            "ingestion_orphan_checkpoints must keep its existing GRANT; RLS on "
+            "ingestion_checkpoints/ingestion_runs is the access gate."
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AC1 (cont): DOWN migration restores prior posture
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestDownMigrationRollback:
+    """DOWN migration must reverse the UP changes (STORY-6.2 mandatory)."""
+
+    @pytest.mark.parametrize("view", VIEWS)
+    def test_view_reverted_to_security_invoker_false(
+        self, down_sql: str, view: str
+    ) -> None:
+        normalized = _normalize(down_sql)
+        pattern = rf"ALTER VIEW public\.{re.escape(view)} SET \( ?security_invoker ?= ?false ?\)"
+        assert re.search(pattern, normalized, re.IGNORECASE), (
+            f"DOWN migration must contain `ALTER VIEW public.{view} SET (security_invoker = false)`"
+        )
+
+    def test_down_restores_bloat_stats_authenticated_grant(
+        self, down_sql: str
+    ) -> None:
+        assert re.search(
+            r"GRANT\s+SELECT\s+ON\s+public\.pncp_raw_bids_bloat_stats\s+TO\s+authenticated",
+            down_sql,
+            re.IGNORECASE,
+        ), "DOWN must restore the original authenticated GRANT on bloat_stats"
+
+    def test_down_restores_cron_job_health_authenticated_grant(
+        self, down_sql: str
+    ) -> None:
+        # Original migration had no explicit GRANT, but rollback to "broader"
+        # state is intentional (lets future advisor lint re-flag clearly).
+        assert re.search(
+            r"GRANT\s+SELECT\s+ON\s+public\.cron_job_health\s+TO\s+authenticated",
+            down_sql,
+            re.IGNORECASE,
+        ), "DOWN must restore broader access on cron_job_health"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Sanity: pair of files exists with matching basename (STORY-6.2)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestMigrationPairing:
+    def test_up_and_down_files_exist(self) -> None:
+        assert UP_FILE.exists(), f"UP file missing: {UP_FILE}"
+        assert DOWN_FILE.exists(), f"DOWN file missing: {DOWN_FILE}"
+
+    def test_paired_basename(self) -> None:
+        """UP and DOWN must share the same timestamp+slug prefix."""
+        up_stem = UP_FILE.name.replace(".sql", "")
+        down_stem = DOWN_FILE.name.replace(".down.sql", "")
+        assert up_stem == down_stem, (
+            f"UP/DOWN basename mismatch: {up_stem!r} vs {down_stem!r}"
+        )

--- a/supabase/migrations/20260509120000_sec_view_001_invoker_downgrade.down.sql
+++ b/supabase/migrations/20260509120000_sec_view_001_invoker_downgrade.down.sql
@@ -1,0 +1,27 @@
+-- SEC-VIEW-001 ROLLBACK: revert security_invoker downgrade and GRANT changes.
+--
+-- WARNING: re-enabling SECURITY DEFINER on these views will re-introduce the
+-- Supabase advisor "Security Definer View" lints. Only run this if you need to
+-- restore the prior posture for an incident.
+
+-- Revert security_invoker = true → false (DEFINER behavior).
+ALTER VIEW public.ingestion_orphan_checkpoints SET (security_invoker = false);
+ALTER VIEW public.pncp_raw_bids_bloat_stats   SET (security_invoker = false);
+ALTER VIEW public.cron_job_health             SET (security_invoker = false);
+
+-- Restore prior GRANTs.
+-- pncp_raw_bids_bloat_stats was granted to authenticated + service_role originally
+-- (see 20260331000000_debt203_bloat_monitoring.sql section 3).
+GRANT SELECT ON public.pncp_raw_bids_bloat_stats TO authenticated;
+GRANT SELECT ON public.pncp_raw_bids_bloat_stats TO service_role;
+
+-- cron_job_health had no explicit GRANTs in the source migration
+-- (20260414120000_cron_job_health.sql) — only the get_cron_health() RPC was
+-- restricted. Granting authenticated SELECT here is intentional rollback to
+-- "broader" pre-SEC-VIEW-001 posture.
+GRANT SELECT ON public.cron_job_health TO authenticated;
+GRANT SELECT ON public.cron_job_health TO service_role;
+
+-- ingestion_orphan_checkpoints: no change to GRANTs (we did not REVOKE in UP).
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260509120000_sec_view_001_invoker_downgrade.sql
+++ b/supabase/migrations/20260509120000_sec_view_001_invoker_downgrade.sql
@@ -1,0 +1,98 @@
+-- SEC-VIEW-001: Downgrade 3 SECURITY DEFINER views to SECURITY INVOKER.
+--
+-- Supabase Database Linter flags any view in `public` that runs with the
+-- creator's privileges (default Postgres behavior pre-15) as a "Security
+-- Definer View" lint. Postgres 15+ supports `security_invoker = true` on
+-- views, which makes the view evaluate row access using the *invoker's*
+-- role and policies — the safer default for application schemas.
+--
+-- Affected views:
+--   1. public.ingestion_orphan_checkpoints
+--      Source: 20260331300000_debt207_checkpoint_orphan_monitoring.sql
+--      Reads:  public.ingestion_checkpoints LEFT JOIN public.ingestion_runs.
+--              These are app tables guarded by RLS — INVOKER is the correct
+--              behavior so RLS is enforced for the calling role.
+--      GRANT:  Keep authenticated SELECT (RLS path).
+--
+--   2. public.pncp_raw_bids_bloat_stats
+--      Source: 20260331000000_debt203_bloat_monitoring.sql
+--      Reads:  pg_stat_user_tables / pg_total_relation_size /
+--              pg_relation_size / pg_indexes_size — system catalogs that
+--              are world-readable. INVOKER is fine; restrict GRANT to
+--              service_role only because this is admin diagnostic data
+--              and shouldn't bleed to authenticated dashboards.
+--
+--   3. public.cron_job_health
+--      Source: 20260414120000_cron_job_health.sql
+--      Reads:  cron.job + cron.job_run_details — cron schema is owned by
+--              the supabase_admin/postgres role and not granted to
+--              authenticated/anon. INVOKER guarantees access flows through
+--              service_role's grants on cron.*; ANON/AUTHENTICATED would
+--              receive permission_denied (which is the desired posture).
+--      GRANT:  service_role only.
+--
+-- Rollback: see paired 20260509120000_sec_view_001_invoker_downgrade.down.sql
+
+-- ════════════════════════════════════════════════════════════════════════
+-- SECTION 1: Downgrade SECURITY DEFINER → SECURITY INVOKER (Postgres 15+)
+-- ════════════════════════════════════════════════════════════════════════
+
+ALTER VIEW public.ingestion_orphan_checkpoints SET (security_invoker = true);
+ALTER VIEW public.pncp_raw_bids_bloat_stats   SET (security_invoker = true);
+ALTER VIEW public.cron_job_health             SET (security_invoker = true);
+
+-- ════════════════════════════════════════════════════════════════════════
+-- SECTION 2: GRANT alignment
+-- ════════════════════════════════════════════════════════════════════════
+-- ingestion_orphan_checkpoints:
+--   Keep authenticated GRANT — RLS on ingestion_checkpoints/ingestion_runs
+--   already gates per-role access. INVOKER + RLS is the correct path.
+
+-- pncp_raw_bids_bloat_stats: restrict to service_role only.
+REVOKE ALL ON public.pncp_raw_bids_bloat_stats FROM authenticated;
+REVOKE ALL ON public.pncp_raw_bids_bloat_stats FROM anon;
+GRANT  SELECT ON public.pncp_raw_bids_bloat_stats TO service_role;
+
+-- cron_job_health: restrict to service_role only.
+REVOKE ALL ON public.cron_job_health FROM authenticated;
+REVOKE ALL ON public.cron_job_health FROM anon;
+GRANT  SELECT ON public.cron_job_health TO service_role;
+
+-- ════════════════════════════════════════════════════════════════════════
+-- SECTION 3: Verification
+-- ════════════════════════════════════════════════════════════════════════
+
+DO $$
+DECLARE
+    v_view RECORD;
+    v_invoker_count INT := 0;
+BEGIN
+    FOR v_view IN
+        SELECT c.relname, c.reloptions
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname IN (
+              'ingestion_orphan_checkpoints',
+              'pncp_raw_bids_bloat_stats',
+              'cron_job_health'
+          )
+          AND c.relkind = 'v'
+    LOOP
+        IF v_view.reloptions IS NOT NULL
+           AND 'security_invoker=true' = ANY(v_view.reloptions) THEN
+            v_invoker_count := v_invoker_count + 1;
+        ELSE
+            RAISE WARNING 'SEC-VIEW-001: view % NOT downgraded to INVOKER (reloptions=%)',
+                v_view.relname, v_view.reloptions;
+        END IF;
+    END LOOP;
+
+    IF v_invoker_count <> 3 THEN
+        RAISE WARNING 'SEC-VIEW-001: expected 3 INVOKER views, found %', v_invoker_count;
+    ELSE
+        RAISE NOTICE 'SEC-VIEW-001: 3/3 views downgraded to security_invoker=true';
+    END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary / Context

**Story:** SEC-VIEW-001 (P1, Effort S 4-8h, RBAC/Security 84→88)

Supabase Database Linter flagged 3 views in `public` schema as "Security Definer View" lints. This PR downgrades them to `SECURITY INVOKER` (Postgres 15+ syntax) and aligns GRANTs per data-source classification.

| View | Source migration | Underlying data | GRANT posture (post) |
|------|------------------|------------------|----------------------|
| `public.ingestion_orphan_checkpoints` | 20260331300000_debt207 | App tables (ingestion_checkpoints + ingestion_runs) — RLS-guarded | Keep `authenticated` (RLS path) |
| `public.pncp_raw_bids_bloat_stats` | 20260331000000_debt203 | System catalogs (pg_stat_user_tables) | `service_role` only — admin diagnostic |
| `public.cron_job_health` | 20260414120000_cron_job_health | `cron.*` schema (extension) | `service_role` only — cron schema isn't granted to authenticated/anon |

Closes the 3 Supabase advisor "Security Definer View" lints once applied.

## Files

- `supabase/migrations/20260509120000_sec_view_001_invoker_downgrade.sql` (UP — ALTER VIEW SET security_invoker=true + REVOKE/GRANT alignment)
- `supabase/migrations/20260509120000_sec_view_001_invoker_downgrade.down.sql` (DOWN — paired rollback per STORY-6.2)
- `backend/tests/test_secdef_views_invoker.py` (18 static SQL analysis tests)

## Testing Plan

- [x] `pytest backend/tests/test_secdef_views_invoker.py -v --timeout=30` — 18/18 passed locally (verifies UP migration shape, GRANT alignment per view, DOWN rollback symmetry, paired-basename invariant)
- [x] Static SQL pattern matches project convention (mirrors `test_td001_rls_security.py`)
- [ ] **Manual post-deploy** (not blocking PR): run Supabase advisor → confirm 3 "Security Definer View" lints clear
- [ ] **Manual post-deploy** (not blocking PR): connect via psql / Supabase Management API and run:
  ```sql
  SELECT relname, reloptions FROM pg_class
  WHERE relname IN ('ingestion_orphan_checkpoints','pncp_raw_bids_bloat_stats','cron_job_health')
    AND relkind = 'v';
  -- expect security_invoker=true on all 3
  ```
- [ ] **Manual post-deploy** (not blocking PR): query `information_schema.role_table_grants` to confirm authenticated/anon have 0 SELECT rows on `pncp_raw_bids_bloat_stats` and `cron_job_health`

## Migration Apply Notes

- Per memory `reference_supabase_down_sql_schema_conflict`: Supabase CLI 2.x treats paired `.sql` + `.down.sql` as two migrations and may error on local `db push`. **Apply path is via `deploy.yml` auto-apply (CRIT-050)** which uses `supabase db push --include-all` and only consumes UP migrations.
- Migration is idempotent on `ALTER VIEW SET (security_invoker = ...)` — safe to re-run.
- Verification DO-block at end of UP migration logs `NOTICE: SEC-VIEW-001: 3/3 views downgraded to security_invoker=true` if successful.

## Closes

- Story: SEC-VIEW-001 (RBAC/Security 84→88)
- Supabase advisor lints: 3 × "Security Definer View" (post-deploy verification)

## Defer (not blocking)

- DOC-COVERAGE-001: data-master.md update (separate story)
- review-report §11.10 update (separate story)