### PR TITLE
fix(reliability): admin_calibration paginate + AST audit gate (DATA-CAP-001 follow-up)

### DIFF
--- a/.github/workflows/audit-postgrest-cap.yml
+++ b/.github/workflows/audit-postgrest-cap.yml
@@ -1,0 +1,88 @@
+name: "Audit .limit(N>=1000).execute() without paginate_full (DATA-CAP-001)"
+
+# Guards against regressions of DATA-CAP-001. PostgREST silently caps SELECT
+# responses at max_rows=1000 per call, so any `.limit(N).execute()` with
+# N >= 1000 in `backend/routes/` is silently truncated and aggregations
+# downstream operate on the wrong row set. The fix is paginate_full() from
+# backend/utils/postgrest_paginate.py.
+
+on:
+  pull_request:
+    paths:
+      - 'backend/routes/**'
+      - 'backend/utils/postgrest_paginate.py'
+      - 'backend/scripts/audit_postgrest_max_rows.py'
+      - '.github/workflows/audit-postgrest-cap.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/routes/**'
+      - 'backend/utils/postgrest_paginate.py'
+      - 'backend/scripts/audit_postgrest_max_rows.py'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: audit-postgrest-cap-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit routes for unprotected .limit(>=1000).execute()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run audit
+        id: audit
+        run: |
+          set +e
+          python backend/scripts/audit_postgrest_max_rows.py --json \
+            > /tmp/postgrest-cap-violations.jsonl
+          STATUS=$?
+          set -e
+
+          # Human-readable summary in the job log.
+          python backend/scripts/audit_postgrest_max_rows.py \
+            > /tmp/postgrest-cap-violations.txt 2>&1 || true
+          cat /tmp/postgrest-cap-violations.txt
+
+          COUNT=$(wc -l < /tmp/postgrest-cap-violations.jsonl | tr -d ' ')
+          if [ -z "$COUNT" ]; then COUNT=0; fi
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "has_violations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_violations=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Emit GitHub annotations
+        if: steps.audit.outputs.has_violations == 'true'
+        run: |
+          # One ::error:: per violation so reviewers see them inline on the PR.
+          while IFS= read -r line; do
+            file=$(echo "$line" | python -c "import json,sys; d=json.loads(sys.stdin.read()); print(d['file'])")
+            ln=$(echo "$line" | python -c "import json,sys; d=json.loads(sys.stdin.read()); print(d['line'])")
+            col=$(echo "$line" | python -c "import json,sys; d=json.loads(sys.stdin.read()); print(d['col'])")
+            detail=$(echo "$line" | python -c "import json,sys; d=json.loads(sys.stdin.read()); print(d['detail'])")
+            echo "::error file=${file},line=${ln},col=${col}::DATA-CAP-001: ${detail}"
+          done < /tmp/postgrest-cap-violations.jsonl
+
+      - name: Fail on violations
+        if: steps.audit.outputs.has_violations == 'true'
+        run: |
+          echo "DATA-CAP-001 audit found ${{ steps.audit.outputs.count }} violation(s)."
+          echo "Replace .limit(N).execute() with paginate_full(query, route=..., max_total=N)"
+          echo "from backend/utils/postgrest_paginate.py."
+          exit 1

--- a/backend/routes/admin_calibration.py
+++ b/backend/routes/admin_calibration.py
@@ -282,18 +282,27 @@ async def _fetch_recent_surveys(range_days: int) -> list[dict[str, Any]]:
     cutoff = (datetime.now(timezone.utc) - timedelta(days=int(range_days))).isoformat()
     sb = get_supabase()
 
-    def _sync_query():
-        return (
+    def _sync_query() -> list[dict]:
+        from utils.postgrest_paginate import paginate_full
+        # DATA-CAP-001: paginate past PostgREST max_rows=1000. Previously
+        # .limit(10_000) was silently capped at 1000; calibration sample
+        # statistics were therefore biased toward the most recent 1000
+        # surveys regardless of the requested range_days window.
+        query = (
             sb.table("export_time_saved_survey")
             .select("estimated_manual_hours, bid_count, submitted_at, export_type")
             .gte("submitted_at", cutoff)
             .order("submitted_at", desc=True)
-            .limit(10_000)
-            .execute()
+        )
+        return paginate_full(
+            query,
+            route="admin_calibration.fetch_recent_surveys",
+            entity_type="surveys",
+            max_total=10_000,
         )
 
     try:
-        result = await _run_with_budget(
+        rows = await _run_with_budget(
             asyncio.to_thread(_sync_query),
             budget=5.0,
             phase="route",
@@ -308,7 +317,7 @@ async def _fetch_recent_surveys(range_days: int) -> list[dict[str, Any]]:
     except Exception as exc:
         logger.warning("admin_calibration: survey fetch failed: %s", exc)
         return []
-    return list(getattr(result, "data", None) or [])
+    return list(rows or [])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/scripts/audit_postgrest_max_rows.py
+++ b/backend/scripts/audit_postgrest_max_rows.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""DATA-CAP-001: Audit raw ``.limit(N).execute()`` patterns in ``backend/routes/``
+where ``N >= 1000`` and the call is not wrapped in ``paginate_full``.
+
+Background
+----------
+PostgREST silently caps every SELECT response at ``max_rows=1000`` per call.
+A ``.limit(5000).execute()`` therefore returns at most 1000 rows with no
+warning. DATA-CAP-001 introduced ``backend/utils/postgrest_paginate.py`` —
+``paginate_full(query, route=..., entity_type=..., max_total=N)`` — to loop
+``.range(...).execute()`` past the cap. This script keeps callsites from
+regressing.
+
+Detection
+---------
+This is an AST-based audit (deterministic, no false-positive lexical
+matches). It reports each ``.limit(N).execute()`` call inside ``backend/routes/``
+where:
+
+  * ``N`` is an integer literal ``>= MIN_LIMIT`` (default 1000), AND
+  * the enclosing chain is not under a ``paginate_full(...)`` invocation.
+
+The intent is to flag any new ``.limit(big_N).execute()`` that would silently
+truncate. Routes still use ``.limit(N)`` legitimately for *small* N (e.g.
+``.limit(20)`` for a top-N query that fits trivially in a single page) —
+those are excluded by the threshold.
+
+Exit codes
+----------
+
+  0 — no violations
+  1 — one or more violations
+  2 — invalid invocation / IO error
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+# Threshold below which ``.limit(N)`` is considered "obviously fine" — small
+# top-N queries (e.g. ``.limit(20)``) trivially fit in a single PostgREST
+# page and never trip the cap. Bump this if a route legitimately uses
+# ``.limit(900)`` for cosmetic pagination.
+MIN_LIMIT = 1000
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    col: int
+    limit_value: int
+    detail: str
+
+    def format_human(self) -> str:
+        return f"{self.file}:{self.line}:{self.col}: .limit({self.limit_value}).execute() without paginate_full — {self.detail}"
+
+
+def _attr_name(node: ast.AST) -> Optional[str]:
+    """Return the attribute name for an ``Attribute`` node (e.g. ``execute``)."""
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _is_call_named(node: ast.AST, name: str) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == name
+    if isinstance(func, ast.Name):
+        return func.id == name
+    return False
+
+
+def _walk_chain(node: ast.AST):
+    """Yield each ``Call``/``Attribute`` along a chained call expression."""
+    cur = node
+    while True:
+        yield cur
+        if isinstance(cur, ast.Call):
+            cur = cur.func
+        elif isinstance(cur, ast.Attribute):
+            cur = cur.value
+        else:
+            return
+
+
+def _find_limit_value(call_node: ast.Call) -> Optional[int]:
+    """If this ``Call`` is ``.limit(<int>)``, return the int literal."""
+    func = call_node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "limit":
+        return None
+    if not call_node.args:
+        return None
+    arg = call_node.args[0]
+    # Constant int literal — Python 3.8+
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, int):
+        return arg.value
+    return None
+
+
+class LimitExecuteVisitor(ast.NodeVisitor):
+    """Walk the module looking for ``.limit(big_N).execute()`` patterns
+    that are not under a ``paginate_full`` call.
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        self.violations: list[Violation] = []
+        # Stack of paginate_full guards — when truthy, .limit().execute()
+        # callsites inside are ignored (they may be passed as the query
+        # builder argument, but the helper itself loops .range()).
+        self._guard_stack: list[bool] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Track entering/leaving a ``paginate_full(...)`` call so anything
+        # nested inside is exempt. (The helper takes the query builder
+        # without a terminal .execute(); if the caller mistakenly passed
+        # one we still want to flag it, but the realistic shape is
+        # ``paginate_full(sb.table(...).select(...).eq(...))``.)
+        is_paginate = _is_call_named(node, "paginate_full")
+        self._guard_stack.append(is_paginate)
+        try:
+            # Pattern: <chain>.limit(N).execute()
+            if (
+                _attr_name(node.func) == "execute"
+                and not any(self._guard_stack[:-1])  # caller is not paginate_full
+            ):
+                # Walk back along the chain looking for a .limit(N) call
+                # immediately upstream.
+                chain_iter = _walk_chain(node.func.value if isinstance(node.func, ast.Attribute) else node)
+                for ancestor in chain_iter:
+                    if isinstance(ancestor, ast.Call):
+                        limit_val = _find_limit_value(ancestor)
+                        if limit_val is not None and limit_val >= MIN_LIMIT:
+                            self.violations.append(
+                                Violation(
+                                    file=self.file_path,
+                                    line=node.lineno,
+                                    col=node.col_offset,
+                                    limit_value=limit_val,
+                                    detail=(
+                                        f".limit({limit_val}) followed by .execute() — "
+                                        "PostgREST will silently truncate at 1000 rows. "
+                                        "Use paginate_full(query, route=..., max_total=N) "
+                                        "from utils.postgrest_paginate."
+                                    ),
+                                )
+                            )
+                            break
+            self.generic_visit(node)
+        finally:
+            self._guard_stack.pop()
+
+
+def _audit_file(path: Path) -> list[Violation]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except Exception as exc:  # pragma: no cover
+        print(f"[audit] could not read {path}: {exc}", file=sys.stderr)
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:  # pragma: no cover
+        print(f"[audit] syntax error in {path}: {exc}", file=sys.stderr)
+        return []
+    visitor = LimitExecuteVisitor(file_path=str(path))
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def _iter_route_files(root: Path) -> Iterable[Path]:
+    routes_dir = root / "backend" / "routes"
+    if not routes_dir.is_dir():
+        return []
+    return sorted(p for p in routes_dir.glob("*.py") if p.name != "__init__.py")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit .limit(N >= 1000).execute() callsites in backend/routes/."
+    )
+    parser.add_argument(
+        "--file",
+        help="Audit a single file instead of the full backend/routes/ tree.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit one JSON object per violation (for CI annotations).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[2]
+
+    files: Iterable[Path]
+    if args.file:
+        files = [Path(args.file)]
+    else:
+        files = list(_iter_route_files(repo_root))
+
+    all_violations: list[Violation] = []
+    for f in files:
+        all_violations.extend(_audit_file(f))
+
+    if args.json:
+        for v in all_violations:
+            print(json.dumps(asdict(v)))
+    else:
+        if not all_violations:
+            print(f"[audit] OK — no .limit(>= {MIN_LIMIT}).execute() patterns found.")
+        for v in all_violations:
+            print(v.format_human())
+
+    return 1 if all_violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_admin_calibration.py
+++ b/backend/tests/test_admin_calibration.py
@@ -50,6 +50,10 @@ def client(admin_user):
 
 
 def _make_chain(rows: list[dict]) -> MagicMock:
+    """DATA-CAP-001: paginate_full uses .range(start, end).execute(); the
+    helper now accepts that path too. side_effect cycles full→empty so the
+    paginate_full loop exits cleanly on the second iteration.
+    """
     chain = MagicMock()
     chain.select.return_value = chain
     chain.gte.return_value = chain
@@ -60,7 +64,12 @@ def _make_chain(rows: list[dict]) -> MagicMock:
     chain.insert.return_value = chain
     result = MagicMock()
     result.data = rows
+    empty = MagicMock(data=[])
+    # Default .execute() (legacy paths) returns the canned result.
     chain.execute.return_value = result
+    # paginate_full path: .range().execute() — first page full, then empty.
+    chain.range.return_value = chain  # keeps fluent API
+    chain.execute.side_effect = [result, empty, empty]
     return chain
 
 


### PR DESCRIPTION
## Summary

Follow-up enxuto ao PR #957 (DATA-CAP-001 já merged em `1104646fc`). Substitui o PR #961 que ficou DIRTY com 13 conflitos semânticos vs main pós-#957.

## Context

PR #961 era duplicata substancial de #957:
- Mesmo helper `paginate_full()` (impls divergentes funcionalmente equivalentes)
- Mesmas 7 rotas refatoradas
- Mesmo counter Prometheus `POSTGREST_TRUNCATION_SUSPECTED`

Resolução manual dos 13 conflitos = risco alto (double-instrumentation Prometheus quebra com `Duplicated timeseries`, duplicação de pagination em rotas com Pattern A vs Pattern B divergentes, collision em `schema_migrations` por timestamp próximo).

Este PR carrega APENAS os 3 deltas value-add que NÃO estavam em #957.

## Changes

1. **`backend/routes/admin_calibration.py`** — `_fetch_recent_surveys` ainda usava `.limit(10_000).execute()`. Silenciosamente truncado em 1000 surveys pelo `max_rows` cap do PostgREST → calibration sample stats com viés para o top 1000 mais recente, independente de `range_days`. Migrado para `paginate_full(query, route="admin_calibration.fetch_recent_surveys", entity_type="surveys", max_total=10_000)`.

2. **`.github/workflows/audit-postgrest-cap.yml`** — CI gate de regressão. Roda em PR + push to main quando `backend/routes/**`, `backend/utils/postgrest_paginate.py` ou o próprio script muda. Falha o build se `.limit(N>=1000).execute()` aparecer fora de `paginate_full()`. Emite `::error file=...,line=...,col=...::` annotations inline no PR.

3. **`backend/scripts/audit_postgrest_max_rows.py`** — AST audit determinístico (sem false-positive lexical). Walk recursivo procurando padrão `<chain>.limit(int_literal>=1000).execute()` que não esteja sob `paginate_full(...)`. Exit 0 em main hoje (helper já cobre os 7 callsites de #957).

## Testing Plan

- [x] AST audit roda local: `python3 backend/scripts/audit_postgrest_max_rows.py` → exit 0, "OK — no .limit(>= 1000).execute() patterns found"
- [x] `test_admin_calibration._make_chain` atualizado para suportar `paginate_full` path: `chain.range().execute()` com `side_effect=[result, empty, empty]` para sair do loop limpo
- [ ] CI: Backend Tests + audit-postgrest-cap workflow verde
- [ ] Post-merge: confirmar `admin_calibration` não regrediu em produção (logs Sentry sem PostgRESTPaginationError)

## Risks

- **Baixo.** 1 callsite migrado (não 7 como #957). Helper `paginate_full` já em main e battle-tested via #957.
- Test fixture `_make_chain` agora cicla full→empty no `.execute()` — testes legados que esperam um único `.execute()` poderiam quebrar; o `side_effect` lista contempla esse caso (primeiro item é o resultado canônico legado).

## Closes

#961 (substitui — original DIRTY com 13 conflitos semânticos vs main pós-#957)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed data retrieval for large survey datasets by implementing proper pagination to prevent silent data loss from system limits.

* **Tests**
  * Updated pagination tests to support the new database query pattern.

* **Chores**
  * Added automated audit tooling to enforce database query capacity constraints and prevent future violations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/962)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->