### PR TITLE
fix(tests): force cache miss + assert fallback path (closes #966)

### DIFF
--- a/backend/tests/integration/test_full_pipeline_cascade.py
+++ b/backend/tests/integration/test_full_pipeline_cascade.py
@@ -250,11 +250,17 @@ def test_llm_timeout_returns_fallback_resumo(
         new_callable=AsyncMock,
         return_value=pncp_success,
     ), patch(
-        # Patch the direct import reference in pipeline.stages.generate (where
-        # stage_generate actually calls gerar_resumo post-DEBT-110 refactor).
-        # Patching "llm.gerar_resumo" only affects the llm module namespace,
-        # not the submodule's own reference from `from llm import gerar_resumo`.
-        "pipeline.stages.generate.gerar_resumo",
+        # Issue #966: Patch the actual call site in stage_generate. PR #160
+        # introduced `get_or_generate_resumo_cached` (Redis-backed wrapper) as
+        # the inline LLM entry point — `gerar_resumo` is now only called
+        # *inside* that wrapper, so patching it here was a dead target and
+        # the real OpenAI path executed (returning llm_source='ai').
+        # Patching the cached wrapper with an AsyncMock that raises ensures
+        # the timeout reaches the `except Exception` branch in generate.py
+        # (sets ctx.llm_source = "fallback"). Redis is not involved because
+        # the wrapper itself is replaced — no cache layer to absorb the error.
+        "pipeline.stages.generate.get_or_generate_resumo_cached",
+        new_callable=AsyncMock,
         side_effect=TimeoutError("OpenAI request timed out after 30s"),
     ):
         payload = make_busca_request(ufs=_DEFAULT_UFS)


### PR DESCRIPTION
## Summary

Test `test_llm_timeout_returns_fallback_resumo` patched `pipeline.stages.generate.gerar_resumo`, but PR #160 changed stage_generate's inline LLM entry point to `get_or_generate_resumo_cached` (Redis-backed wrapper). The mock targeted a dead symbol — the real OpenAI path executed and returned `llm_source='ai'`. Fix patches the cached wrapper directly with `AsyncMock(side_effect=TimeoutError)`, which forces the timeout into the `except Exception` branch in `generate.py:282-294` (sets `ctx.llm_source='fallback'`). Replacing the wrapper also bypasses Redis entirely, so no cache layer can absorb the error.

## Context

- CI failure: https://github.com/tjsasakifln/SmartLic/actions/runs/25611757891
- RCA: `generate.py:273` calls `get_or_generate_resumo_cached(...)`, which in turn calls `gerar_resumo()` resolved against the `llm` module — patching `pipeline.stages.generate.gerar_resumo` does NOT affect that resolution. Mock fires zero times → OpenAI runs for real → `llm_source='ai'`.
- Touched files: `backend/tests/integration/test_full_pipeline_cascade.py` only (no production code change — RCA evidence pointed cleanly at the test mock target, not at `llm.py`).

## Testing Plan

- [x] `pytest backend/tests/integration/test_full_pipeline_cascade.py::test_llm_timeout_returns_fallback_resumo -v` passes locally
- [x] `pytest backend/tests/integration/test_full_pipeline_cascade.py -v` full file passes (4/4, no regression on sibling cascade tests)
- [x] `pytest backend/tests/test_llm_cache.py backend/tests/test_crit033_enqueue_fix.py -v` passes (29/29 — sanity on cached wrapper + enqueue fallback path)
- [x] `ruff check backend/tests/integration/test_full_pipeline_cascade.py` clean
- [ ] CI Tests Full Matrix green (verified post-merge)

## Closes

Closes #966


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced timeout error handling validation to ensure the system gracefully falls back when LLM services experience delays, maintaining service availability with fallback content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/974)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->