### PR TITLE
chore(ci): disable E2E Playwright on main, keep PR-only (closes #968)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,18 @@
-# NOTE: E2E tests are also run in tests.yml (as a job after unit tests pass).
-# This standalone workflow exists for targeted E2E runs — e.g., path-triggered on
-# frontend/backend critical files. It includes smoke test quality gate (GTM-QUAL-001 AC13).
+# NOTE: E2E tests are also run in tests.yml (as a job on push to main, after unit
+# tests pass). This standalone workflow exists for targeted PR-gated E2E runs —
+# path-triggered on frontend/backend critical files. It includes smoke test quality
+# gate (GTM-QUAL-001 AC13).
+#
+# Issue #968 (2026-05-09): The `push: [main, develop]` trigger was removed because
+# every push to main triggered an unconditional run (no path filter), and the
+# 15-minute job timeout was insufficient for the full pipeline (npm ci + 2 browsers
+# via `--with-deps` + Next.js 16 monorepo build + tests), producing `cancelled`
+# conclusions on every merge. Coverage on main is preserved by tests.yml's E2E job.
+# E2E Tests (Playwright) is NOT a required branch-protection check (only Backend
+# Tests, Frontend Tests, Check Real Merge Conflicts are).
 name: "E2E Tests (Playwright)"
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
     # GTM-QUAL-001 AC12: Trigger when GTM-ROOT stories touch affected files
@@ -27,6 +34,11 @@ on:
       - 'backend/job_queue.py'
       - 'backend/main.py'
   workflow_dispatch: # Allow manual trigger
+
+# Cancel stale PR runs when new commits are pushed; never cancel manual runs.
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
## Summary

The standalone `E2E Tests (Playwright)` workflow was marked `cancelled` on every push to main since 2026-05-09. RCA: 15-minute job timeout was insufficient — setup (npm ci + `playwright install --with-deps chromium webkit` + Next.js 16 monorepo build) consumes ~10-11 min, leaving < 5 min for tests, so the job hits its `timeout-minutes: 15` cap mid-execution. Decision: remove `push: [main, develop]` trigger (no path filter, ran on every merge); coverage on main is already provided by `tests.yml`'s E2E job. Workflow remains available on path-filtered PRs + `workflow_dispatch`. Added concurrency block to cancel stale PR runs.

## Context

Cancelled runs (sample): https://github.com/tjsasakifln/SmartLic/actions/runs/25611757902 (Playwright E2E Tests step #10 cancelled at 21:18:41, exactly 15:16 after job start at 21:03:25 — confirms job-level timeout, not concurrency).

Memory: `feedback_concurrent_jobs_cap.md` (cap 20 GH Actions) — not the cause here; the 15-min job timeout is. The workflow had no concurrency block at all.

RCA evidence:
- Workflow steps before "Run E2E tests": Checkout + setup-python + setup-node + `pip install` + `npm ci` + `playwright install --with-deps chromium webkit` (this alone is ~3-5 min) + `npm run build` (Next.js 16 + 4000+ pages, ~3-5 min) + backend startup wait + frontend startup wait. Total ≈ 10-11 min.
- Then `npm run test:e2e` starts and is killed at 15:00 mark by `timeout-minutes: 15`.
- Push trigger had no `paths:` filter, so it fired on every commit regardless of E2E relevance.
- `tests.yml` already runs an E2E job on push to main (after unit tests pass) with proper concurrency.

Branch protection (`gh api repos/tjsasakifln/SmartLic/branches/main/protection`): required checks are `Backend Tests`, `Frontend Tests`, `Check Real Merge Conflicts`. `E2E Tests (Playwright)` is NOT required — no protection update needed.

## Testing Plan

- [x] Workflow YAML validated via `python3 yaml.safe_load` — triggers now `pull_request` + `workflow_dispatch`, jobs unchanged, concurrency block present
- [x] Branch protection required-checks list verified via `gh api` — E2E not required
- [x] Diff scoped to `.github/workflows/e2e.yml` only (17 insertions, 5 deletions)
- [ ] Post-merge: next push to main should NOT trigger this workflow (verify via `gh run list --workflow=e2e.yml --limit 5` after merge — only `tests.yml` E2E should run on main)
- [ ] Post-merge: PR-gated E2E still works for path-matching PRs (verify on next PR touching `frontend/app/buscar/**` etc.)

## Closes

Closes #968