### PR TITLE
feat(security): RLS coverage audit + ADR + CI gate (closes #969)

### DIFF
--- a/.github/workflows/audit-rls-coverage.yml
+++ b/.github/workflows/audit-rls-coverage.yml
@@ -1,0 +1,57 @@
+name: "Audit RLS coverage (RLS-AUDIT-001)"
+
+# Operationalises ADR-RLS-MANDATORY-001 (`docs/adr/ADR-RLS-MANDATORY-001-policy.md`):
+# every public-schema table on Supabase must have ROW LEVEL SECURITY enabled
+# with at least one policy, OR carry a `-- rls-exempt: <reason>` marker in
+# its migration. The audit script (`backend/scripts/audit_rls_coverage.py`)
+# pulls live coverage via the Supabase Management API and exits 1 on gaps.
+#
+# Triggers:
+#   - Push to main → fail fast if a merged migration drops RLS coverage.
+#   - Weekly Monday 06:00 UTC → drift detection independent of PRs.
+#   - Manual dispatch → on-demand re-run after fixing a gap.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/scripts/audit_rls_coverage.py'
+      - '.github/workflows/audit-rls-coverage.yml'
+      - 'supabase/migrations/**'
+  schedule:
+    # 06:00 UTC = 03:00 BRT Monday morning, before business hours.
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-rls-coverage-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit pg_policy coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install httpx
+        run: pip install --quiet httpx
+      - name: Run audit
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: python backend/scripts/audit_rls_coverage.py
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rls-coverage-report
+          path: _reversa_sdd/rls-coverage-*.md
+          if-no-files-found: ignore
+          retention-days: 30

--- a/_reversa_sdd/data-master.md
+++ b/_reversa_sdd/data-master.md
@@ -148,6 +148,22 @@
 
 ## 5. RLS Policies
 
+### 5.1 RLS Coverage (RLS-AUDIT-001 / #969)
+
+Coverage empírica do schema `public` via `pg_tables` ⨝ `pg_policies` (export Management API):
+
+- **Última auditoria:** 2026-05-09 — `_reversa_sdd/rls-coverage-2026-05-09.md`
+- **Tables totais (`public`):** 60
+- **Compliant (RLS on + ≥1 policy):** 59 (98.3%)
+- **Documented exempt (`-- rls-exempt:`):** 0
+- **Gap:** 1 (`auth_attempts` — RLS on, 0 policies; service-role-only por intent, mas precisa policy explícita ou marker `-- rls-exempt:` para passar o gate)
+
+**Política formal:** ADR-RLS-MANDATORY-001 (`docs/adr/ADR-RLS-MANDATORY-001-policy.md`) — toda table em `public` deve ter RLS habilitado com ≥1 policy, ou carregar comentário `-- rls-exempt: <reason>` na migration.
+
+**Audit script:** `backend/scripts/audit_rls_coverage.py` (httpx + Management API; exit 1 em gap, 0 em coverage 100% ou exempt). CI gate: `.github/workflows/audit-rls-coverage.yml` (push to main + weekly Mon 06:00 UTC + manual dispatch).
+
+### 5.2 Policy patterns
+
 Todas tables com `user_id` têm RLS ativo:
 - SELECT: `user_id = auth.uid()`
 - INSERT: `user_id = auth.uid()` (defesa via service-role bypass + `.eq("user_id")` defense-in-depth)
@@ -194,7 +210,7 @@ Monitor: `cron_job_health` view + `get_cron_health()` RPC + ARQ hourly `cron_mon
 
 ## 9. Lacunas
 
-- 🔴 RLS policies não-documentadas exhaustively (precisa export `SELECT polname, polrelid::regclass FROM pg_policy`)
+- 🟢 RLS policies exportadas em `_reversa_sdd/rls-coverage-2026-05-09.md` (RLS-AUDIT-001 / #969); CI gate live; gap residual: `auth_attempts` precisa policy explícita ou `-- rls-exempt:` marker
 - 🟡 `service_role` sem statement_timeout (memory) — risco identificado mas não-fixed
 - 🔴 `psc_municipio_trgm` index criado mas planner não-pick com ORDER+LIMIT (memory) — query rewrite pendente
 - 🟡 Foreign keys: investigar CASCADE vs RESTRICT consistency (e.g., `pipeline_items.user_id` ON DELETE CASCADE?)

--- a/_reversa_sdd/rls-coverage-2026-05-09.md
+++ b/_reversa_sdd/rls-coverage-2026-05-09.md
@@ -1,0 +1,90 @@
+# RLS Coverage Audit — `public` schema
+
+- **Generated:** 2026-05-10 00:04 UTC
+- **Project ref:** `fqqyovlzdzimiwfofdjk`
+- **Total tables:** 60
+- **Compliant (RLS on + ≥1 policy):** 59
+- **Documented exempt (`-- rls-exempt:`):** 0
+- **Failing:** 1
+- **Coverage:** 98.3%
+
+Source: ADR-RLS-MANDATORY-001 (`docs/adr/ADR-RLS-MANDATORY-001-policy.md`).
+Generator: `backend/scripts/audit_rls_coverage.py` (RLS-AUDIT-001 / #969).
+
+## ❌ RLS disabled (failing)
+
+_None._
+
+## ❌ RLS enabled but no policies (failing — effectively closed to non-bypass roles, gap on intent)
+
+| Table | RLS | Policies | Detail |
+|-------|-----|---------:|--------|
+| `auth_attempts` | on | 0 | — |
+
+## ⚠️ Documented exemptions (`-- rls-exempt:` in migrations)
+
+_None._
+
+## ✅ Compliant (RLS on + ≥1 policy)
+
+| Table | RLS | Policies | Detail |
+|-------|-----|---------:|--------|
+| `admin_billing_audit_log` | on | 2 | `admin_billing_audit_log_service_all` (ALL → service_role); `admin_billing_audit_log_no_public_read` (SELECT → anon,authenticated) |
+| `alert_preferences` | on | 4 | `update_alert_preferences_owner` (UPDATE → public); `all_alert_preferences_service` (ALL → service_role); `select_alert_preferences_owner` (SELECT → public); `insert_alert_preferences_owner` (INSERT → public) |
+| `alert_runs` | on | 2 | `all_alert_runs_service` (ALL → service_role); `select_alert_runs_owner` (SELECT → public) |
+| `alert_sent_items` | on | 2 | `select_alert_sent_items_owner` (SELECT → public); `all_alert_sent_items_service` (ALL → service_role) |
+| `alerts` | on | 5 | `update_alerts_owner` (UPDATE → public); `all_alerts_service` (ALL → service_role); `select_alerts_owner` (SELECT → public); `delete_alerts_owner` (DELETE → public); `insert_alerts_owner` (INSERT → public) |
+| `app_config` | on | 1 | `Service role full access on app_config` (ALL → public) |
+| `audit_events` | on | 2 | `select_audit_events_admin` (SELECT → public); `all_audit_events_service` (ALL → service_role) |
+| `billing_reconciliation_runs` | on | 2 | `billing_reconciliation_runs_service_all` (ALL → service_role); `billing_reconciliation_runs_no_public_read` (SELECT → anon,authenticated) |
+| `classification_feedback` | on | 5 | `delete_classification_feedback_owner` (DELETE → public); `select_classification_feedback_owner` (SELECT → public); `insert_classification_feedback_owner` (INSERT → public); `all_classification_feedback_service` (ALL → service_role); `update_classification_feedback_owner` (UPDATE → public) |
+| `cnae_setores` | on | 1 | `cnae_setores_read_authenticated` (SELECT → authenticated) |
+| `conversations` | on | 4 | `select_conversations_owner` (SELECT → public); `update_conversations_admin` (UPDATE → public); `insert_conversations_owner` (INSERT → public); `all_conversations_service` (ALL → service_role) |
+| `enriched_entities` | on | 2 | `enriched_entities_service_write` (ALL → public); `enriched_entities_read_all` (SELECT → public) |
+| `export_time_saved_survey` | on | 3 | `Service role full access on export surveys` (ALL → public); `User can insert own surveys` (INSERT → public); `User can read own surveys` (SELECT → public) |
+| `founding_leads` | on | 2 | `founding_leads_service_write` (ALL → public); `founding_leads_admin_read` (SELECT → public) |
+| `founding_policy` | on | 2 | `founding_policy_service_write` (ALL → public); `founding_policy_public_read` (SELECT → public) |
+| `founding_policy_audit_log` | on | 1 | `founding_policy_audit_service_write` (ALL → public) |
+| `google_sheets_exports` | on | 4 | `select_google_sheets_exports_owner` (SELECT → public); `all_google_sheets_exports_service` (ALL → service_role); `insert_google_sheets_exports_owner` (INSERT → public); `update_google_sheets_exports_owner` (UPDATE → public) |
+| `gsc_metrics` | on | 2 | `admin_read_gsc_metrics` (SELECT → public); `service_write_gsc_metrics` (ALL → public) |
+| `health_checks` | on | 1 | `all_health_checks_service` (ALL → service_role) |
+| `incidents` | on | 1 | `all_incidents_service` (ALL → service_role) |
+| `indice_municipal` | on | 2 | `indice_municipal_service_write` (ALL → service_role); `indice_municipal_public_read` (SELECT → public) |
+| `ingestion_checkpoints` | on | 2 | `select_ingestion_checkpoints_authenticated` (SELECT → authenticated); `all_ingestion_checkpoints_service` (ALL → service_role) |
+| `ingestion_runs` | on | 2 | `select_ingestion_runs_authenticated` (SELECT → authenticated); `all_ingestion_runs_service` (ALL → service_role) |
+| `intel_report_purchases` | on | 4 | `irp_service_select` (SELECT → service_role); `irp_owner_select` (SELECT → authenticated); `irp_service_insert` (INSERT → service_role); `irp_service_update` (UPDATE → service_role) |
+| `leads` | on | 2 | `leads_service_all` (ALL → public); `leads_anon_insert` (INSERT → public) |
+| `messages` | on | 4 | `all_messages_service` (ALL → service_role); `insert_messages_authenticated` (INSERT → public); `select_messages_authenticated` (SELECT → public); `update_messages_owner` (UPDATE → public) |
+| `mfa_recovery_attempts` | on | 1 | `all_mfa_recovery_attempts_service` (ALL → service_role) |
+| `mfa_recovery_codes` | on | 2 | `all_mfa_recovery_codes_service` (ALL → service_role); `select_mfa_recovery_codes_owner` (SELECT → authenticated) |
+| `monthly_quota` | on | 2 | `select_monthly_quota_owner` (SELECT → public); `all_monthly_quota_service` (ALL → service_role) |
+| `organization_members` | on | 8 | `Org owner can delete members` (DELETE → public); `Org owner can insert members` (INSERT → public); `Org members can view all members` (SELECT → public); `select_organization_members_self` (SELECT → public); `select_organization_members_admin` (SELECT → public); `insert_organization_members_admin` (INSERT → public); `delete_organization_members_admin` (DELETE → public); `all_organization_members_service` (ALL → service_role) |
+| `organizations` | on | 6 | `select_organizations_owner` (SELECT → public); `update_organizations_owner` (UPDATE → public); `select_organizations_admin` (SELECT → public); `Org members can view organization` (SELECT → public); `all_organizations_service` (ALL → service_role); `insert_organizations_owner` (INSERT → public) |
+| `partner_referrals` | on | 3 | `all_partner_referrals_admin` (ALL → public); `all_partner_referrals_service` (ALL → service_role); `select_partner_referrals_partner` (SELECT → public) |
+| `partners` | on | 3 | `all_partners_service` (ALL → service_role); `all_partners_admin` (ALL → public); `select_partners_self` (SELECT → public) |
+| `pipeline_items` | on | 5 | `insert_pipeline_items_owner` (INSERT → public); `update_pipeline_items_owner` (UPDATE → public); `delete_pipeline_items_owner` (DELETE → public); `all_pipeline_items_service` (ALL → service_role); `select_pipeline_items_owner` (SELECT → public) |
+| `plan_billing_periods` | on | 2 | `all_plan_billing_periods_service` (ALL → service_role); `select_plan_billing_periods_public` (SELECT → anon,authenticated) |
+| `plan_features` | on | 1 | `select_plan_features_public` (SELECT → public) |
+| `plans` | on | 2 | `plans_select_all` (SELECT → public); `plans_service_write` (ALL → service_role) |
+| `plans_audit` | on | 1 | `plans_audit_service_all` (ALL → service_role) |
+| `pncp_raw_bids` | on | 4 | `insert_pncp_raw_bids_service` (INSERT → service_role); `delete_pncp_raw_bids_service` (DELETE → service_role); `update_pncp_raw_bids_service` (UPDATE → service_role); `select_pncp_raw_bids_authenticated` (SELECT → authenticated) |
+| `pncp_supplier_contracts` | on | 2 | `psc_public_read` (SELECT → public); `psc_service_write` (ALL → public) |
+| `profiles` | on | 5 | `all_profiles_service` (ALL → service_role); `insert_profiles_service` (INSERT → service_role); `insert_profiles_owner` (INSERT → authenticated); `profiles_update_own` (UPDATE → public); `profiles_select_own` (SELECT → public) |
+| `reconciliation_log` | on | 2 | `all_reconciliation_log_service` (ALL → service_role); `select_reconciliation_log_admin` (SELECT → public) |
+| `referrals` | on | 3 | `referrals_service_all` (ALL → service_role); `referrals_insert_own` (INSERT → authenticated); `referrals_select_own` (SELECT → authenticated) |
+| `report_leads` | on | 1 | `report_leads_service_all` (ALL → service_role) |
+| `saved_filter_presets` | on | 4 | `Users can read own presets` (SELECT → public); `Users can insert own presets` (INSERT → public); `Users can update own presets` (UPDATE → public); `Users can delete own presets` (DELETE → public) |
+| `search_results_cache` | on | 2 | `Service role full access on search_results_cache` (ALL → service_role); `select_search_results_cache_owner` (SELECT → public) |
+| `search_results_store` | on | 2 | `all_search_results_store_service` (ALL → service_role); `select_search_results_store_owner` (SELECT → public) |
+| `search_sessions` | on | 3 | `all_search_sessions_service` (ALL → service_role); `sessions_insert_own` (INSERT → public); `sessions_select_own` (SELECT → public) |
+| `search_state_transitions` | on | 2 | `all_search_state_transitions_service` (ALL → service_role); `Users can read own transitions` (SELECT → public) |
+| `seo_metrics` | on | 2 | `seo_metrics_select` (SELECT → authenticated); `seo_metrics_service_write` (ALL → service_role) |
+| `shared_analyses` | on | 2 | `users_insert_own_shares` (INSERT → public); `anyone_can_read_shares` (SELECT → public) |
+| `stripe_webhook_events` | on | 4 | `select_stripe_webhook_events_admin` (SELECT → authenticated); `insert_stripe_webhook_events_service` (INSERT → service_role); `select_stripe_webhook_events_service` (SELECT → service_role); `webhook_events_select_admin` (SELECT → authenticated) |
+| `trial_email_dlq` | on | 1 | `trial_email_dlq_service_only` (ALL → public) |
+| `trial_email_log` | on | 1 | `select_trial_email_log_owner` (SELECT → public) |
+| `trial_exit_surveys` | on | 2 | `admin_read_surveys` (SELECT → public); `users_insert_own_survey` (INSERT → public) |
+| `trial_extensions` | on | 2 | `Service role full access` (ALL → public); `Users read own extensions` (SELECT → public) |
+| `user_email_actions` | on | 2 | `service_role_insert` (INSERT → service_role); `service_role_select` (SELECT → service_role) |
+| `user_oauth_tokens` | on | 4 | `select_user_oauth_tokens_owner` (SELECT → public); `delete_user_oauth_tokens_owner` (DELETE → public); `all_user_oauth_tokens_service` (ALL → service_role); `update_user_oauth_tokens_owner` (UPDATE → public) |
+| `user_subscriptions` | on | 2 | `Service role can manage subscriptions` (ALL → service_role); `subscriptions_select_own` (SELECT → public) |

--- a/backend/scripts/audit_rls_coverage.py
+++ b/backend/scripts/audit_rls_coverage.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Audit RLS coverage on the Supabase ``public`` schema (RLS-AUDIT-001 / #969).
+
+Connects to Supabase via the Management API single-query endpoint
+(``POST /v1/projects/{ref}/database/query``) using ``SUPABASE_ACCESS_TOKEN``
+and ``SUPABASE_PROJECT_REF``. Exports per-table:
+
+* ``rowsecurity`` flag (RLS enabled or not)
+* policy count
+* per-policy ``{name, roles, cmd}`` triples
+
+Output:
+    * ``_reversa_sdd/rls-coverage-<DATE>.md`` — markdown report grouped by
+      coverage status (compliant / RLS-on no-policy / RLS-off / exempt).
+    * Exit code ``0`` if every public table has either RLS enabled with
+      ≥1 policy, or carries a ``-- rls-exempt: <reason>`` comment in
+      ``supabase/migrations/`` (best-effort grep for the table name on the
+      same line as the marker).
+    * Exit code ``1`` otherwise.
+    * Exit code ``2`` for usage / connectivity errors.
+
+Policy reference: ``docs/adr/ADR-RLS-MANDATORY-001-policy.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+DEFAULT_REPORT_PATH = "_reversa_sdd/rls-coverage-{date}.md"
+MANAGEMENT_API_BASE = "https://api.supabase.com/v1/projects"
+EXEMPT_MARKER = "rls-exempt:"
+RLS_AUDIT_QUERY = """
+SELECT t.tablename,
+       t.rowsecurity,
+       COALESCE(p.policy_count, 0) AS policy_count,
+       COALESCE(p.policies, '[]'::jsonb) AS policies
+FROM pg_tables t
+LEFT JOIN (
+  SELECT tablename,
+         COUNT(*) AS policy_count,
+         jsonb_agg(jsonb_build_object('name', policyname, 'roles', roles, 'cmd', cmd)) AS policies
+  FROM pg_policies
+  WHERE schemaname = 'public'
+  GROUP BY tablename
+) p USING (tablename)
+WHERE t.schemaname = 'public'
+ORDER BY t.tablename;
+""".strip()
+
+
+def _management_query(token: str, project_ref: str, sql: str) -> list[dict[str, Any]]:
+    """Run ``sql`` via the Supabase Management API and return the row list."""
+    url = f"{MANAGEMENT_API_BASE}/{project_ref}/database/query"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.post(url, headers=headers, json={"query": sql})
+    if resp.status_code not in (200, 201):
+        raise RuntimeError(
+            f"Management API HTTP {resp.status_code}: {resp.text[:500]}"
+        )
+    payload = resp.json()
+    # API returns either a list of rows directly or {"result": [...]} depending on version
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("result"), list):
+        return payload["result"]
+    raise RuntimeError(f"Unexpected Management API payload shape: {payload!r}")
+
+
+def _scan_exemptions(repo_root: Path) -> dict[str, str]:
+    """Best-effort scan of ``supabase/migrations/*.sql`` for ``-- rls-exempt: <reason>``.
+
+    Returns a mapping ``{table_name: reason}``. We pair the marker with a
+    table name found on the same line (after the marker) or on the next
+    non-empty line that mentions ``CREATE TABLE`` / ``ALTER TABLE``. This
+    is intentionally permissive — the goal is grace, not enforcement.
+    """
+    exemptions: dict[str, str] = {}
+    migrations_dir = repo_root / "supabase" / "migrations"
+    if not migrations_dir.exists():
+        return exemptions
+    table_pat = re.compile(
+        r"(?:CREATE\s+TABLE|ALTER\s+TABLE)\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        r"(?:public\.)?\"?([A-Za-z_][A-Za-z0-9_]*)\"?",
+        re.IGNORECASE,
+    )
+    for sql_file in migrations_dir.glob("*.sql"):
+        try:
+            text = sql_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            if EXEMPT_MARKER not in line.lower():
+                continue
+            reason = line.split(EXEMPT_MARKER, 1)[1].strip(" -:\t")
+            # Look for an explicit table after the marker (same line) first.
+            match = table_pat.search(line)
+            if not match:
+                # Fall back to the next 5 non-empty lines.
+                for follow in lines[idx + 1 : idx + 6]:
+                    match = table_pat.search(follow)
+                    if match:
+                        break
+            if match:
+                exemptions.setdefault(match.group(1).lower(), reason or "exempt")
+    return exemptions
+
+
+def _classify(rows: list[dict[str, Any]], exemptions: dict[str, str]) -> dict[str, list[dict[str, Any]]]:
+    buckets: dict[str, list[dict[str, Any]]] = {
+        "compliant": [],
+        "rls_on_no_policy": [],
+        "rls_off": [],
+        "exempt": [],
+    }
+    for row in rows:
+        table = row.get("tablename")
+        rls_on = bool(row.get("rowsecurity"))
+        policy_count = int(row.get("policy_count") or 0)
+        policies = row.get("policies") or []
+        # `policies` may arrive as a JSON string depending on the API path.
+        if isinstance(policies, str):
+            try:
+                policies = json.loads(policies)
+            except json.JSONDecodeError:
+                policies = []
+        record = {
+            "tablename": table,
+            "rowsecurity": rls_on,
+            "policy_count": policy_count,
+            "policies": policies,
+            "exempt_reason": exemptions.get((table or "").lower()),
+        }
+        if rls_on and policy_count > 0:
+            buckets["compliant"].append(record)
+        elif record["exempt_reason"]:
+            buckets["exempt"].append(record)
+        elif rls_on and policy_count == 0:
+            buckets["rls_on_no_policy"].append(record)
+        else:
+            buckets["rls_off"].append(record)
+    return buckets
+
+
+def _format_policies(policies: list[dict[str, Any]]) -> str:
+    if not policies:
+        return "—"
+    parts = []
+    for pol in policies:
+        name = pol.get("name", "?")
+        cmd = pol.get("cmd", "?")
+        roles = pol.get("roles") or []
+        if isinstance(roles, str):
+            roles_str = roles
+        else:
+            roles_str = ",".join(str(r) for r in roles)
+        parts.append(f"`{name}` ({cmd} → {roles_str or '∅'})")
+    return "; ".join(parts)
+
+
+def _render_report(buckets: dict[str, list[dict[str, Any]]], generated_at: str, project_ref: str) -> str:
+    total = sum(len(v) for v in buckets.values())
+    compliant = len(buckets["compliant"])
+    exempt = len(buckets["exempt"])
+    failing = len(buckets["rls_on_no_policy"]) + len(buckets["rls_off"])
+    coverage_pct = round(((compliant + exempt) / total) * 100, 1) if total else 0.0
+    lines: list[str] = []
+    lines.append("# RLS Coverage Audit — `public` schema")
+    lines.append("")
+    lines.append(f"- **Generated:** {generated_at}")
+    lines.append(f"- **Project ref:** `{project_ref}`")
+    lines.append(f"- **Total tables:** {total}")
+    lines.append(f"- **Compliant (RLS on + ≥1 policy):** {compliant}")
+    lines.append(f"- **Documented exempt (`-- rls-exempt:`):** {exempt}")
+    lines.append(f"- **Failing:** {failing}")
+    lines.append(f"- **Coverage:** {coverage_pct}%")
+    lines.append("")
+    lines.append("Source: ADR-RLS-MANDATORY-001 (`docs/adr/ADR-RLS-MANDATORY-001-policy.md`).")
+    lines.append("Generator: `backend/scripts/audit_rls_coverage.py` (RLS-AUDIT-001 / #969).")
+    lines.append("")
+
+    section_titles = {
+        "rls_off": "## ❌ RLS disabled (failing)",
+        "rls_on_no_policy": "## ❌ RLS enabled but no policies (failing — effectively closed to non-bypass roles, gap on intent)",
+        "compliant": "## ✅ Compliant (RLS on + ≥1 policy)",
+        "exempt": "## ⚠️ Documented exemptions (`-- rls-exempt:` in migrations)",
+    }
+    order = ["rls_off", "rls_on_no_policy", "exempt", "compliant"]
+    for key in order:
+        rows = buckets[key]
+        lines.append(section_titles[key])
+        lines.append("")
+        if not rows:
+            lines.append("_None._")
+            lines.append("")
+            continue
+        lines.append("| Table | RLS | Policies | Detail |")
+        lines.append("|-------|-----|---------:|--------|")
+        for row in sorted(rows, key=lambda r: r["tablename"] or ""):
+            detail = (
+                row["exempt_reason"]
+                if key == "exempt"
+                else _format_policies(row["policies"])
+            )
+            lines.append(
+                f"| `{row['tablename']}` | {'on' if row['rowsecurity'] else 'off'} | "
+                f"{row['policy_count']} | {detail} |"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="RLS coverage audit (RLS-AUDIT-001 / #969).")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Override report path (default: _reversa_sdd/rls-coverage-<UTC date>.md).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root used to scan ``supabase/migrations/`` for "
+        "exemption markers (default: cwd).",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Skip writing the report file (still prints summary to stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("SUPABASE_ACCESS_TOKEN")
+    project_ref = os.environ.get("SUPABASE_PROJECT_REF")
+    if not token or not project_ref:
+        print(
+            "ERROR: SUPABASE_ACCESS_TOKEN and SUPABASE_PROJECT_REF env vars are required.",
+            file=sys.stderr,
+        )
+        return 2
+
+    repo_root = Path(args.repo_root) if args.repo_root else Path.cwd()
+    try:
+        rows = _management_query(token, project_ref, RLS_AUDIT_QUERY)
+    except (httpx.HTTPError, RuntimeError) as exc:
+        print(f"ERROR: Management API call failed: {exc}", file=sys.stderr)
+        return 2
+
+    exemptions = _scan_exemptions(repo_root)
+    buckets = _classify(rows, exemptions)
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    report_path = (
+        Path(args.output)
+        if args.output
+        else repo_root / DEFAULT_REPORT_PATH.format(date=datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    )
+    report = _render_report(buckets, generated_at, project_ref)
+
+    if not args.no_write:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report, encoding="utf-8")
+        print(f"Report written: {report_path}")
+
+    failing = len(buckets["rls_on_no_policy"]) + len(buckets["rls_off"])
+    print(
+        f"Tables: {sum(len(v) for v in buckets.values())} | "
+        f"compliant={len(buckets['compliant'])} "
+        f"exempt={len(buckets['exempt'])} "
+        f"failing={failing}"
+    )
+    if failing:
+        print("FAIL: tables without RLS coverage and no exemption marker.", file=sys.stderr)
+        for row in buckets["rls_off"] + buckets["rls_on_no_policy"]:
+            print(f"  - {row['tablename']} (rls={'on' if row['rowsecurity'] else 'off'}, "
+                  f"policies={row['policy_count']})", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/adr/ADR-RLS-MANDATORY-001-policy.md
+++ b/docs/adr/ADR-RLS-MANDATORY-001-policy.md
@@ -1,0 +1,87 @@
+# ADR-RLS-MANDATORY-001: RLS is Mandatory on Every `public` Schema Table
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted (2026-05-09) |
+| Issue | [#969](https://github.com/tjsasakifln/SmartLic/issues/969) — RLS-AUDIT-001 |
+| Stakeholders | @dev (lead), @architect, @qa |
+| Supersedes | — |
+| Superseded by | — |
+
+## Context
+
+`CLAUDE.md` § Security Notes claims "Supabase Auth with RLS on all
+tables", but `_reversa_sdd/data-master.md` § 9 Lacunas flagged the
+absence of an empirical export of `pg_policies`. The 2026-05-09 review
+(`_reversa_sdd/review-report.md` § 15.3) scored RBAC/Security at 94 %
+with the explicit driver:
+
+> Closure of `feedback_secdef_search_path_trap` family + audit
+> `pg_policy` export → RBAC/Security +5
+
+Supabase's `service_role` bypasses RLS unconditionally, so a table that
+ships without RLS enabled looks healthy from the backend's perspective
+while exposing the same data to `anon` and `authenticated` clients via
+PostgREST. The 2026-05-09 SECURITY DEFINER view downgrade (PR #955)
+already absorbed one such gap; without a coverage gate, the next
+omission lands silently.
+
+The repo lacks a single source of truth for the live policy state and
+no CI gate exists to catch a new table that ships without policies.
+
+## Decision
+
+1. **RLS-mandatory.** Every table in the `public` schema must have
+   `ROW LEVEL SECURITY ENABLED` and at least one policy from
+   `pg_policies` attached.
+2. **Exemption path.** A table that is intentionally public (e.g.
+   programmatic-SEO read-only tables, plan catalog) may opt out by
+   carrying a comment of the form
+   `-- rls-exempt: <one-line reason>`
+   on or just above the `CREATE TABLE` / `ALTER TABLE` statement
+   in `supabase/migrations/`. The reason must be specific enough to be
+   re-evaluated 6 months later.
+3. **Empirical audit.** `backend/scripts/audit_rls_coverage.py` is the
+   source of truth. It queries `pg_tables` joined with `pg_policies`
+   via the Supabase Management API
+   (`POST /v1/projects/{ref}/database/query`) and writes
+   `_reversa_sdd/rls-coverage-<UTC date>.md`. Exit code is `0` if all
+   tables are compliant or exempt, `1` otherwise.
+4. **CI gate.** `.github/workflows/audit-rls-coverage.yml` runs the
+   script on push to `main`, weekly (Monday 06:00 UTC), and on manual
+   dispatch. Failures block via the workflow status (no advisory
+   bypass — RLS is non-negotiable).
+
+## Consequences
+
+- New tables that ship without an explicit policy or exemption marker
+  fail CI on the first push to `main`, instead of being discovered via
+  incident.
+- The generated report is committed monthly (or on demand) and serves
+  as the audit trail referenced by `_reversa_sdd/data-master.md`
+  § "RLS Coverage".
+- Exemptions are auditable in `git log` because the marker lives next
+  to the DDL and follows the migration's `.down.sql` pairing rule
+  (STORY-6.2).
+- The Management API path is resilient under Disk-IO degraded mode
+  (memory `reference_supabase_management_api_query`), so the gate
+  remains usable during incident response.
+
+## Alternatives Considered
+
+1. **`supabase db pull` + grep.** Rejected: the dump output groups
+   policies by command/role and is brittle to format drift between CLI
+   versions. The Management API returns structured JSON that maps
+   directly to `pg_policies`.
+2. **Backend-side audit endpoint.** Rejected: would require live
+   backend availability, which contradicts the requirement to keep the
+   audit usable during outages, and adds a new admin surface that itself
+   needs RLS reasoning.
+3. **Static grep over `supabase/migrations/`.** Rejected: false
+   negatives whenever a policy is added in a follow-up migration and
+   false positives whenever a table is dropped. The live database is
+   the only honest source.
+4. **Soft warning instead of hard fail.** Rejected: the
+   `audit-prod-env.yml` advisory pattern fits emergency env-var changes,
+   but RLS gaps cannot be "emergency-shipped" — they always need a
+   policy or an exemption marker, both of which are cheap to add.


### PR DESCRIPTION
## Summary

Implements RLS-AUDIT-001 — pg_policy coverage audit:
- `backend/scripts/audit_rls_coverage.py` exports RLS state via Supabase Management API
- New CI gate `audit-rls-coverage.yml` (push main + weekly Monday 06:00 UTC + manual dispatch)
- ADR `ADR-RLS-MANDATORY-001-policy.md` formalizes RLS-mandatory policy + `-- rls-exempt: <reason>` exemption path
- `_reversa_sdd/data-master.md` §5.1 updated with RLS Coverage section + live numbers

Initial run: **60 tables in `public`, 59 compliant (98.3%), 1 residual gap** (`auth_attempts` — RLS on but 0 policies; service-role-only by intent, but needs explicit policy or `-- rls-exempt:` marker to pass the gate).

## Context

`review-report.md` §15.3 RBAC/Security 94 % → +5 driver:
> Closure de `feedback_secdef_search_path_trap` family + audit `pg_policy` export → RBAC/Security +5

Memory: `reference_supabase_management_api_query.md` (single-query pattern survives Disk-IO degraded mode).
Closure parcial de PR #960 SEC-VIEW-001 (SECURITY DEFINER view downgrade).

## Testing Plan

- [x] Script compiles: `python -m py_compile backend/scripts/audit_rls_coverage.py`
- [x] Ruff clean: `ruff check backend/scripts/audit_rls_coverage.py`
- [x] Workflow YAML syntactically valid (`yaml.safe_load`)
- [x] Live run against prod Supabase produced report file + correct exit codes (exit 1 with `auth_attempts` flagged; would be exit 0 once policy or exemption added)
- [ ] Post-merge: workflow run on push to main produces report file + matches local run

## Closes

Closes #969