### PR TITLE
test(sectors): coverage cases for equipamentos_medicos + produtos_limpeza (#971 AC6)

### DIFF
--- a/backend/tests/test_sector_coverage_audit.py
+++ b/backend/tests/test_sector_coverage_audit.py
@@ -372,12 +372,34 @@ AUDIT_TEST_CASES = [
     ("servicos_prediais", "Contratacao de servicos de zeladoria para os predios da prefeitura", True),
     ("servicos_prediais", "Aquisicao de escavadeira hidraulica para desassoreamento da lagoa", False),
     # --- produtos_limpeza (TP) ---
+    # Positive: keyword "detergente"+"alvejante"+"desinfetante" hit; no exclusion fires (#971 AC6)
+    ("produtos_limpeza", "Aquisicao de detergente alvejante e desinfetante para escolas municipais", True),
+    # Positive: keyword "material de limpeza" (signature_term) hit; no exclusion fires (#971 AC6)
+    ("produtos_limpeza", "Registro de precos para material de limpeza de uso geral em reparticoes", True),
+    # Positive: keyword "papel higienico"+"papel toalha" hit; no exclusion fires (#971 AC6)
+    ("produtos_limpeza", "Aquisicao de papel higienico e papel toalha para banheiros publicos", True),
+    # Negative: pre-existing — exclusion "lubrificante" + "limpeza pesada para veiculos" blocks automotive context
     ("produtos_limpeza", "Aquisicao de lubrificantes e produtos de limpeza pesada para veiculos", False),
+    # Negative: exclusions "empresa de limpeza" + "zeladoria" route this to servicos_prediais (#971 AC6)
+    ("produtos_limpeza", "Contratacao de empresa de limpeza e zeladoria para predios municipais", False),
+    # Negative: exclusions "tinta" + "cimento" route construction supplies to engenharia (#971 AC6)
+    ("produtos_limpeza", "Aquisicao de tinta e cimento para reforma da escola municipal", False),
     # --- medicamentos (TP) ---
     ("medicamentos", "Aquisicao de medicamentos para a rede municipal de saude", True),
     ("medicamentos", "Registro de preco para medicamentos da farmacia basica", True),
     ("medicamentos", "Contratacao de plano de saude para servidores municipais", False),
     ("medicamentos", "Aquisicao de agulhas de costura e linhas para oficina de costura", False),
+    # --- equipamentos_medicos (TP) ---
+    # Positive: keyword "tomografo" (signature_term) hit; no exclusion fires (#971 AC6)
+    ("equipamentos_medicos", "Aquisicao de tomografo computadorizado para o hospital regional", True),
+    # Positive: keyword "ventilador pulmonar" (signature_term) hit; no exclusion fires (#971 AC6)
+    ("equipamentos_medicos", "Aquisicao de ventilador pulmonar para UTI neonatal", True),
+    # Positive: keyword "autoclave" (signature_term) hit; no exclusion fires (#971 AC6)
+    ("equipamentos_medicos", "Aquisicao de autoclave horizontal para central de esterilizacao", True),
+    # Negative: exclusions "seringa" + "agulha" route descartaveis to insumos_hospitalares (#971 AC6)
+    ("equipamentos_medicos", "Aquisicao de seringas e agulhas descartaveis para sala de vacinacao", False),
+    # Negative: exclusions "notebook" + "impressora" route IT goods to informatica (#971 AC6)
+    ("equipamentos_medicos", "Aquisicao de notebooks e impressoras para a secretaria de saude", False),
     # --- insumos_hospitalares (TP) ---
     ("insumos_hospitalares", "Aquisicao de seringas e agulhas descartaveis", True),
     # --- vigilancia (TP) ---


### PR DESCRIPTION
## Summary

Adds 5 audit cases per sector (3 positive + 2 negative) to `AUDIT_TEST_CASES` in `backend/tests/test_sector_coverage_audit.py`, eliminating the implicit `pytest.skip(\"No test cases for ...\")` paths in `TestPrecisionRecallPerSector` for these two sectors.

**`equipamentos_medicos` rules exercised:**
- Positive (keyword match, no exclusion fires):
  - `tomografo` (signature_term) — "Aquisicao de tomografo computadorizado para o hospital regional"
  - `ventilador pulmonar` (signature_term) — "Aquisicao de ventilador pulmonar para UTI neonatal"
  - `autoclave` (signature_term) — "Aquisicao de autoclave horizontal para central de esterilizacao"
- Negative (exclusion-driven routing):
  - `seringa` + `agulha` exclusions route descartaveis to `insumos_hospitalares`
  - `notebook` + `impressora` exclusions route IT goods to `informatica`

**`produtos_limpeza` rules exercised:**
- Positive (keyword match, no exclusion fires):
  - `detergente` + `alvejante` + `desinfetante` — "Aquisicao de detergente alvejante e desinfetante para escolas municipais"
  - `material de limpeza` (signature_term) — "Registro de precos para material de limpeza de uso geral em reparticoes"
  - `papel higienico` + `papel toalha` — "Aquisicao de papel higienico e papel toalha para banheiros publicos"
- Negative (exclusion-driven routing):
  - `empresa de limpeza` + `zeladoria` exclusions route to `servicos_prediais`
  - `tinta` + `cimento` exclusions route construction supplies to `engenharia`
  - (Pre-existing) `lubrificante` + `limpeza pesada para veiculos` exclusions

All cases were empirically validated against `match_keywords(texto, s.keywords, s.exclusions)` before commit — predicted outcome matches actual matcher behavior for all 10 cases. Note that `_match` does not pass `context_required` or co-occurrence rules, so negatives rely on explicit exclusion hits (with word-boundary + plural expansion semantics).

## Testing Plan

```
$ cd backend && python -m pytest tests/test_sector_coverage_audit.py -v
...
tests/test_sector_coverage_audit.py::TestPrecisionRecallPerSector::test_sector_precision[equipamentos_medicos] PASSED
tests/test_sector_coverage_audit.py::TestPrecisionRecallPerSector::test_sector_precision[produtos_limpeza] PASSED
tests/test_sector_coverage_audit.py::TestPrecisionRecallPerSector::test_sector_recall[equipamentos_medicos] PASSED
tests/test_sector_coverage_audit.py::TestPrecisionRecallPerSector::test_sector_recall[produtos_limpeza] PASSED
...
============================= 346 passed in 4.75s ==============================

$ ruff check tests/test_sector_coverage_audit.py
All checks passed!
```

Before this PR: 342 passed + 4 skipped (precision/recall for the two sectors had no cases, hit the `pytest.skip` early-return).
After this PR: 346 passed + 0 skipped.

- [x] `pytest tests/test_sector_coverage_audit.py -v` — 346 passed
- [x] `ruff check tests/test_sector_coverage_audit.py` — clean
- [x] All 10 new cases empirically validated (3 TP + 2 TN per sector)
- [x] Precision = 100% / Recall = 100% for both sectors (well above 85% / 70% gates)

## Closes

Partial fix for #971 AC6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for sector classification to improve precision/recall: refined cleaning-products cases (removed an ambiguous negative, added clearer positive and negative examples) and introduced new medical-equipment test cases (positive matches and negatives that route to related sectors) to better validate categorization behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/980)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->