### PR TITLE
fix(tests): isolate feature_flag_matrix from os.environ pollution (#971 AC1)

### DIFF
--- a/backend/tests/test_feature_flag_matrix.py
+++ b/backend/tests/test_feature_flag_matrix.py
@@ -7,15 +7,53 @@ AC: test_feature_flag_matrix.py with 10 critical flags tested on/off
     + 5 critical combinations tested.
 """
 
+import os
+
 import pytest
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import patch
 
 from config.features import (
     _FEATURE_FLAG_REGISTRY,
+    _feature_flag_cache,
+    _runtime_overrides,
     get_feature_flag,
     reload_feature_flags,
-    _feature_flag_cache,
 )
+
+
+# ---------------------------------------------------------------------------
+# 0. File-local pollution shield (#971 AC1, fixes STORY-BTS-FOLLOWUP)
+# ---------------------------------------------------------------------------
+# RCA: ``get_feature_flag`` resolution order is
+# ``_runtime_overrides`` (authoritative, bypasses cache+env) > TTL cache > env
+# > registry default. The previous ``setup_method`` only cleared the TTL cache,
+# leaving any leaked entry in ``_runtime_overrides`` (module-level dict in
+# ``config.features``) able to silently override every ``patch.dict(os.environ,
+# ...)`` in this file. Any test in the 10k-suite that exercises the admin
+# PATCH route or writes to ``_runtime_overrides`` without cleanup was a
+# candidate polluter — and ``patch.dict`` could not undo it.
+#
+# This file-local autouse fixture snapshots and restores os.environ AND clears
+# both registries (``_runtime_overrides`` and ``_feature_flag_cache``) on
+# entry+exit so pollution from prior tests cannot leak in, and our own
+# patches cannot leak out to subsequent tests in the batch.
+@pytest.fixture(autouse=True)
+def _isolate_feature_flag_state():
+    """Snapshot env + clear flag dicts before and after every test."""
+    env_snapshot = dict(os.environ)
+    _runtime_overrides.clear()
+    _feature_flag_cache.clear()
+    try:
+        yield
+    finally:
+        # Restore env to its pre-test state (drop additions, restore removals).
+        for key in list(os.environ.keys()):
+            if key not in env_snapshot:
+                del os.environ[key]
+        for key, value in env_snapshot.items():
+            os.environ[key] = value
+        _runtime_overrides.clear()
+        _feature_flag_cache.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -66,93 +104,59 @@ _CRITICAL_FLAGS = [
 ]
 
 
-# STORY-BTS-FOLLOWUP (baseline-zero PR #411): In isolation all these tests pass
-# (Docker Python 3.12 + real conftest: 9/9 local). In the 9k-test batch they fail
-# with ``env should be True/False with env=<value>`` — ``get_feature_flag`` is
-# returning the registry default, not honoring the env var set by patch.dict or
-# monkeypatch. Tried both approaches without success. Root cause likely a test
-# earlier in the alphabetical/collection order writing ``os.environ[x] = y``
-# directly (no teardown), or ``_feature_flag_cache`` being populated by a module
-# import side-effect before ``clear()`` runs.
-#
-# Marked xfail(strict=False) so CI is green while the investigation continues in
-# a dedicated follow-up story — DO NOT remove without reproducing the failure
-# and the fix in isolation first.
-_XFAIL_BATCH_POLLUTION = pytest.mark.xfail(
-    reason="STORY-BTS-FOLLOWUP: batch-only failure (passes in isolation). "
-    "get_feature_flag returns registry default instead of env var value — "
-    "polluter test writing os.environ directly without teardown suspected.",
-    strict=False,
-)
+# STORY-BTS-FOLLOWUP / #971 AC1: previously these tests were marked
+# ``xfail(strict=False)`` because in the 9k-test batch ``get_feature_flag``
+# returned the registry default instead of the env var value — the autouse
+# fixture above (``_isolate_feature_flag_state``) now snapshots os.environ and
+# clears ``_runtime_overrides`` + ``_feature_flag_cache`` on entry and exit,
+# so neither pollution from earlier tests nor leakage from our own patches
+# can cross the boundary.
 
 
 class TestCriticalFlagsOnOff:
     """Each critical flag tested in both on and off states."""
 
-    def setup_method(self):
-        _feature_flag_cache.clear()
-
-    @_XFAIL_BATCH_POLLUTION
     @pytest.mark.parametrize("flag_name", _CRITICAL_FLAGS)
     def test_flag_on(self, flag_name: str):
         """Flag returns True when env var is 'true'."""
-        _feature_flag_cache.clear()
         env_var = _FEATURE_FLAG_REGISTRY[flag_name][0]
         with patch.dict("os.environ", {env_var: "true"}):
             _feature_flag_cache.clear()
             result = get_feature_flag(flag_name)
             assert result is True, f"{flag_name} should be True with env=true"
 
-    @_XFAIL_BATCH_POLLUTION
     @pytest.mark.parametrize("flag_name", _CRITICAL_FLAGS)
     def test_flag_off(self, flag_name: str):
         """Flag returns False when env var is 'false'."""
-        _feature_flag_cache.clear()
         env_var = _FEATURE_FLAG_REGISTRY[flag_name][0]
         with patch.dict("os.environ", {env_var: "false"}):
             _feature_flag_cache.clear()
             result = get_feature_flag(flag_name)
             assert result is False, f"{flag_name} should be False with env=false"
 
-    @_XFAIL_BATCH_POLLUTION
     @pytest.mark.parametrize("flag_name", _CRITICAL_FLAGS)
     def test_flag_default(self, flag_name: str):
         """Flag returns its registry default when env var is unset."""
-        _feature_flag_cache.clear()
         env_var = _FEATURE_FLAG_REGISTRY[flag_name][0]
         _, default_str = _FEATURE_FLAG_REGISTRY[flag_name]
         expected = default_str == "true"
-        with patch.dict("os.environ", {}, clear=False):
-            import os
-            old = os.environ.pop(env_var, None)
-            try:
-                _feature_flag_cache.clear()
-                result = get_feature_flag(flag_name)
-                assert result is expected, (
-                    f"{flag_name} default should be {expected}"
-                )
-            finally:
-                if old is not None:
-                    os.environ[env_var] = old
+        # Autouse fixture restores os.environ on teardown, so popping is safe.
+        os.environ.pop(env_var, None)
+        _feature_flag_cache.clear()
+        result = get_feature_flag(flag_name)
+        assert result is expected, (
+            f"{flag_name} default should be {expected}"
+        )
 
 
 # ---------------------------------------------------------------------------
 # 3. Five critical flag combinations
 # ---------------------------------------------------------------------------
-@_XFAIL_BATCH_POLLUTION
 class TestCriticalCombinations:
-    """5 combinations of flags that interact in the search pipeline.
-
-    xfail decorator applied class-wide — same batch-pollution failure mode as
-    TestCriticalFlagsOnOff (see the _XFAIL_BATCH_POLLUTION docstring above).
-    """
-
-    def setup_method(self):
-        _feature_flag_cache.clear()
+    """5 combinations of flags that interact in the search pipeline."""
 
     def test_combo1_datalake_off_llm_zero_match_on(self):
         """DATALAKE_QUERY_ENABLED=false + LLM_ZERO_MATCH_ENABLED=true."""
-        _feature_flag_cache.clear()
         with patch.dict("os.environ", {
             "DATALAKE_QUERY_ENABLED": "false",
             "LLM_ZERO_MATCH_ENABLED": "true",
@@ -163,14 +167,12 @@ class TestCriticalCombinations:
 
     def test_combo2_search_async_on(self):
         """SEARCH_ASYNC_ENABLED=true — background processing validated."""
-        _feature_flag_cache.clear()
         with patch.dict("os.environ", {"SEARCH_ASYNC_ENABLED": "true"}):
             _feature_flag_cache.clear()
             assert get_feature_flag("SEARCH_ASYNC_ENABLED") is True
 
     def test_combo3_trial_paywall_on_rate_limiting_on(self):
         """TRIAL_PAYWALL_ENABLED=true + RATE_LIMITING_ENABLED=true."""
-        _feature_flag_cache.clear()
         with patch.dict("os.environ", {
             "TRIAL_PAYWALL_ENABLED": "true",
             "RATE_LIMITING_ENABLED": "true",
@@ -181,7 +183,6 @@ class TestCriticalCombinations:
 
     def test_combo4_all_sources_off(self):
         """COMPRASGOV_ENABLED=false + DATALAKE_ENABLED=false."""
-        _feature_flag_cache.clear()
         with patch.dict("os.environ", {
             "COMPRASGOV_ENABLED": "false",
             "DATALAKE_ENABLED": "false",
@@ -192,7 +193,6 @@ class TestCriticalCombinations:
 
     def test_combo5_llm_arbiter_off_zero_match_off(self):
         """LLM_ARBITER_ENABLED=false + LLM_ZERO_MATCH_ENABLED=false."""
-        _feature_flag_cache.clear()
         with patch.dict("os.environ", {
             "LLM_ARBITER_ENABLED": "false",
             "LLM_ZERO_MATCH_ENABLED": "false",
@@ -210,16 +210,9 @@ class TestReloadFlags:
         """reload_feature_flags() clears the TTL cache."""
         _feature_flag_cache["TEST_FLAG"] = (True, 0)
         result = reload_feature_flags()
-        # batch pollution note: failure observed in 9k-test run only — assertion
-        # says ``'TEST_FLAG' in {'TEST_FLAG': (True, 0)}``, suggesting another
-        # test (or module import side-effect) is writing to _feature_flag_cache
-        # between reload's clear() and this assert. Tracked in STORY-BTS-FOLLOWUP.
-        import pytest as _pytest
-        if "TEST_FLAG" in _feature_flag_cache:
-            _pytest.xfail(
-                "STORY-BTS-FOLLOWUP: batch-only failure — another test is repopulating "
-                "_feature_flag_cache with TEST_FLAG between reload() and this assert."
-            )
+        # The autouse ``_isolate_feature_flag_state`` fixture above clears the
+        # cache before each test, so any leftover entry would be a real bug in
+        # ``reload_feature_flags`` (not cross-test contamination).
         assert "TEST_FLAG" not in _feature_flag_cache
         assert isinstance(result, dict)
         assert len(result) >= 30

--- a/backend/tests/test_feature_flag_matrix.py
+++ b/backend/tests/test_feature_flag_matrix.py
@@ -12,10 +12,9 @@ import os
 import pytest
 from unittest.mock import patch
 
+from config import features as _features_mod
 from config.features import (
     _FEATURE_FLAG_REGISTRY,
-    _feature_flag_cache,
-    _runtime_overrides,
     get_feature_flag,
     reload_feature_flags,
 )
@@ -37,12 +36,22 @@ from config.features import (
 # both registries (``_runtime_overrides`` and ``_feature_flag_cache``) on
 # entry+exit so pollution from prior tests cannot leak in, and our own
 # patches cannot leak out to subsequent tests in the batch.
+#
+# IMPORTANT (#971 AC1 follow-up): we deliberately access the dicts via the
+# module reference (``_features_mod._runtime_overrides`` /
+# ``_features_mod._feature_flag_cache``) instead of the name-imported aliases.
+# Sibling tests (test_crit057_filter_time_budget, test_debt103_llm_search_resilience,
+# test_harden001_openai_timeout) call ``importlib.reload(features)``, which
+# rebinds those module attributes to brand-new dict objects. The name-imported
+# aliases would still point at the old dicts, leaving the new ones — which
+# ``get_feature_flag`` actually consults — untouched. Going through the module
+# attribute always resolves to the current dict.
 @pytest.fixture(autouse=True)
 def _isolate_feature_flag_state():
     """Snapshot env + clear flag dicts before and after every test."""
     env_snapshot = dict(os.environ)
-    _runtime_overrides.clear()
-    _feature_flag_cache.clear()
+    _features_mod._runtime_overrides.clear()
+    _features_mod._feature_flag_cache.clear()
     try:
         yield
     finally:
@@ -52,8 +61,8 @@ def _isolate_feature_flag_state():
                 del os.environ[key]
         for key, value in env_snapshot.items():
             os.environ[key] = value
-        _runtime_overrides.clear()
-        _feature_flag_cache.clear()
+        _features_mod._runtime_overrides.clear()
+        _features_mod._feature_flag_cache.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +130,7 @@ class TestCriticalFlagsOnOff:
         """Flag returns True when env var is 'true'."""
         env_var = _FEATURE_FLAG_REGISTRY[flag_name][0]
         with patch.dict("os.environ", {env_var: "true"}):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             result = get_feature_flag(flag_name)
             assert result is True, f"{flag_name} should be True with env=true"
 
@@ -130,7 +139,7 @@ class TestCriticalFlagsOnOff:
         """Flag returns False when env var is 'false'."""
         env_var = _FEATURE_FLAG_REGISTRY[flag_name][0]
         with patch.dict("os.environ", {env_var: "false"}):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             result = get_feature_flag(flag_name)
             assert result is False, f"{flag_name} should be False with env=false"
 
@@ -142,7 +151,7 @@ class TestCriticalFlagsOnOff:
         expected = default_str == "true"
         # Autouse fixture restores os.environ on teardown, so popping is safe.
         os.environ.pop(env_var, None)
-        _feature_flag_cache.clear()
+        _features_mod._feature_flag_cache.clear()
         result = get_feature_flag(flag_name)
         assert result is expected, (
             f"{flag_name} default should be {expected}"
@@ -161,14 +170,14 @@ class TestCriticalCombinations:
             "DATALAKE_QUERY_ENABLED": "false",
             "LLM_ZERO_MATCH_ENABLED": "true",
         }):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             assert get_feature_flag("DATALAKE_QUERY_ENABLED") is False
             assert get_feature_flag("LLM_ZERO_MATCH_ENABLED") is True
 
     def test_combo2_search_async_on(self):
         """SEARCH_ASYNC_ENABLED=true — background processing validated."""
         with patch.dict("os.environ", {"SEARCH_ASYNC_ENABLED": "true"}):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             assert get_feature_flag("SEARCH_ASYNC_ENABLED") is True
 
     def test_combo3_trial_paywall_on_rate_limiting_on(self):
@@ -177,7 +186,7 @@ class TestCriticalCombinations:
             "TRIAL_PAYWALL_ENABLED": "true",
             "RATE_LIMITING_ENABLED": "true",
         }):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             assert get_feature_flag("TRIAL_PAYWALL_ENABLED") is True
             assert get_feature_flag("RATE_LIMITING_ENABLED") is True
 
@@ -187,7 +196,7 @@ class TestCriticalCombinations:
             "COMPRASGOV_ENABLED": "false",
             "DATALAKE_ENABLED": "false",
         }):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             assert get_feature_flag("COMPRASGOV_ENABLED") is False
             assert get_feature_flag("DATALAKE_ENABLED") is False
 
@@ -197,7 +206,7 @@ class TestCriticalCombinations:
             "LLM_ARBITER_ENABLED": "false",
             "LLM_ZERO_MATCH_ENABLED": "false",
         }):
-            _feature_flag_cache.clear()
+            _features_mod._feature_flag_cache.clear()
             assert get_feature_flag("LLM_ARBITER_ENABLED") is False
             assert get_feature_flag("LLM_ZERO_MATCH_ENABLED") is False
 
@@ -208,12 +217,12 @@ class TestCriticalCombinations:
 class TestReloadFlags:
     def test_reload_clears_cache(self):
         """reload_feature_flags() clears the TTL cache."""
-        _feature_flag_cache["TEST_FLAG"] = (True, 0)
+        _features_mod._feature_flag_cache["TEST_FLAG"] = (True, 0)
         result = reload_feature_flags()
         # The autouse ``_isolate_feature_flag_state`` fixture above clears the
         # cache before each test, so any leftover entry would be a real bug in
         # ``reload_feature_flags`` (not cross-test contamination).
-        assert "TEST_FLAG" not in _feature_flag_cache
+        assert "TEST_FLAG" not in _features_mod._feature_flag_cache
         assert isinstance(result, dict)
         assert len(result) >= 30
 


### PR DESCRIPTION
## Summary

**RCA:** `get_feature_flag` (config/features.py) has resolution order `_runtime_overrides` (authoritative — bypasses cache + env) > TTL cache > env var > registry default. The previous `setup_method` in `test_feature_flag_matrix.py` only cleared `_feature_flag_cache`, **never** clearing `_runtime_overrides` (also a module-level dict in `config.features`). Any test in the 10k-suite that exercises the admin `PATCH /admin/feature-flags/{name}` endpoint or writes directly to `_runtime_overrides` without cleanup was a candidate polluter — and crucially, `patch.dict("os.environ", ...)` cannot override a runtime override, which is exactly the failure signature reported (`get_feature_flag returns registry default instead of env var value`).

**Fix mechanism:** file-local `@pytest.fixture(autouse=True)` (`_isolate_feature_flag_state`) that:
1. Snapshots `os.environ` on entry
2. Clears `_runtime_overrides` and `_feature_flag_cache`
3. Yields
4. Restores `os.environ` (drops additions, restores removals)
5. Clears both dicts again

This guarantees neither pre-existing pollution nor in-test patches leak across test boundaries, regardless of the polluter identity. Also removed the now-redundant `@_XFAIL_BATCH_POLLUTION` markers and the inline `pytest.xfail()` call in `test_reload_clears_cache`.

**Constraints respected:** scope is purely file-local (`backend/tests/test_feature_flag_matrix.py` only — no shared `conftest.py` modification, no production code change).

**Note on local reproduction:** in WSL the polluter could not be reproduced locally — every combination ran XPASS even with `test_feature_flags_admin.py`, `test_story226_track4.py`, and the full `-k feature` collection (~170 tests) prepended. The 9k-test CI batch is the only environment that exhibits the failure. Defensive autouse fixture is the safest fix because it neutralizes the whole class of polluters without depending on identifying which one.

## Testing Plan

- [x] `cd backend && python3 -m pytest tests/test_feature_flag_matrix.py -v` — `43 passed`, **0 xfail**, **0 xpass** (was `11 passed, 32 xpassed` before fix)
- [x] `cd backend && python3 -m pytest tests/test_feature_flags_admin.py tests/test_feature_flag_matrix.py -q` — both files pass cleanly together
- [x] `cd backend && python3 -m pytest tests/test_story226_track4.py tests/test_feature_flag_matrix.py -q` — pass
- [x] `cd backend && python3 -m pytest tests/ -k feature --ignore=tests/fuzz` — 169/170 pass (1 unrelated middleware flake in `test_no_quota_enforcement_when_disabled` reproduces with the same module collection pre-fix and passes alone — confirmed pre-existing, unrelated to feature flags)
- [x] `cd backend && ruff check tests/test_feature_flag_matrix.py` — `All checks passed!`
- [ ] CI runs the full 10k batch — this is the empirical gate. If batch tests still fail, the polluter writes to something other than `_runtime_overrides`/`_feature_flag_cache`/`os.environ` (e.g., monkeypatches `get_feature_flag` itself), and we re-investigate with the actual CI trace.

### Before / after counts

| State | Pass | Xfail | Xpass |
|-------|-----:|------:|------:|
| Before fix (in isolation) | 11 | 0 | 32 |
| Before fix (CI batch, per issue) | unknown | ~32 | 0 |
| **After fix** (in isolation) | **43** | **0** | **0** |

## Closes

Partial fix for #971 AC1 (TEST-XFAIL-CLEANUP-001). Does **not** close #971 — remaining ACs (other xfail clusters) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation infrastructure for feature flag tests to prevent cross-test state contamination and ensure more reliable test execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/982)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->