### PR TITLE
fix(tests): rebind PARTNERS_ENABLED in routes.partners before TestPartnerRoutes (#971 AC2)

### DIFF
--- a/backend/tests/test_partners.py
+++ b/backend/tests/test_partners.py
@@ -15,6 +15,57 @@ from fastapi.testclient import TestClient
 
 
 # ============================================================================
+# File-local autouse fixture — TEST-XFAIL-CLEANUP-001 (#971 AC2)
+# ============================================================================
+
+@pytest.fixture(autouse=True)
+def _force_partners_enabled_in_routes(monkeypatch):
+    """Re-bind ``PARTNERS_ENABLED`` inside ``routes.partners`` for every test.
+
+    Root cause of the historical batch-only failures:
+    ``routes/partners.py`` does ``from config import PARTNERS_ENABLED`` at
+    import time, which creates a module-local copy of the flag. The global
+    autouse fixture in ``tests/conftest.py`` (``_enable_feature_gated_routes``)
+    only patches ``config.PARTNERS_ENABLED``; the bound copy in
+    ``routes.partners`` keeps whatever value it had at import time. When
+    ``routes.partners`` is imported before ``setup_test_env`` runs (which
+    happens in batch mode via ``from main import app`` chains in other tests),
+    the bound copy stays at the production default of ``False``, and every
+    partner endpoint returns 404 "Feature not available".
+
+    Defensive resets for ``shutting_down`` + circuit-breaker state are
+    included as belt-and-suspenders — they were the original hypothesis in
+    issue #971 but turned out not to be the actual cause (failures were 404,
+    not 503 from drain middleware).
+    """
+    # Primary fix: rebind the import-time-copied flag in routes.partners.
+    import routes.partners as _partners_routes
+    monkeypatch.setattr(_partners_routes, "PARTNERS_ENABLED", True)
+
+    # Defense-in-depth: reset graceful-shutdown drain flag.
+    try:
+        import startup.state as _state
+        _original_shutting_down = _state.shutting_down
+        _state.shutting_down = False
+    except Exception:
+        _original_shutting_down = None
+        _state = None
+
+    # Defense-in-depth: reset Supabase circuit breakers to CLOSED.
+    try:
+        from supabase_client import _CB_REGISTRY, supabase_cb
+        for _cb in list(_CB_REGISTRY.values()) + [supabase_cb]:
+            _cb.reset()
+    except Exception:
+        pass
+
+    yield
+
+    if _state is not None and _original_shutting_down is not None:
+        _state.shutting_down = _original_shutting_down
+
+
+# ============================================================================
 # Helpers
 # ============================================================================
 
@@ -263,16 +314,6 @@ class TestPartnerReferralChurn:
 # Routes: Admin partner endpoints (AC10-AC14)
 # ============================================================================
 
-@pytest.mark.xfail(
-    reason="STORY-BTS-FOLLOWUP: batch-only failure — ``from main import app`` picks "
-    "up a polluted process state (``shutting_down=True`` leaked from lifespan tests, "
-    "or CB OPEN state) that no autouse fixture has been able to stabilise without "
-    "introducing regressions elsewhere. Helper/non-route tests in this file pass "
-    "(TestPartnerSignupAttribution, TestPartnerReferralChurn, TestRevenueShareCronJob); "
-    "only the 5 tests that instantiate TestClient(app) fail. Tracked as batch-pollution "
-    "follow-up — do not remove without reproducing in isolation first.",
-    strict=False,
-)
 class TestPartnerRoutes:
     """Test partner admin routes."""
 


### PR DESCRIPTION
## Summary

Fixes the 5 batch-only failures in ``tests/test_partners.py::TestPartnerRoutes``
that have been masked by a class-level ``@pytest.mark.xfail`` since
STORY-BTS-FOLLOWUP.

**RCA — issue hypothesis was wrong.** Issue #971 attributed the failure
to a polluted ``shutting_down`` flag or stuck Circuit Breaker. The
actual cause is mundane: ``routes/partners.py`` does ``from config import
PARTNERS_ENABLED`` at import time, which creates a module-local copy of
the flag. The global autouse fixture in ``tests/conftest.py``
(``_enable_feature_gated_routes``) only patches ``config.PARTNERS_ENABLED``
and never rebinds the copy already captured by ``routes.partners``. In
batch mode, ``routes.partners`` is imported (transitively, via
``from main import app`` in some earlier test) before
``_enable_feature_gated_routes`` runs, so its bound copy stays at the
production default of ``False``. Every partner endpoint then short-circuits
with ``HTTPException(404, "Feature not available")``.

Confirming evidence:
- failing tests assert ``200`` / ``201`` / ``403`` and get ``404`` (not 503)
- ``test_partner_dashboard_not_partner`` XPASSes in batch — because that
  test asserts ``404``, which the disabled-flag path also returns

**Fix:** file-local autouse fixture ``_force_partners_enabled_in_routes``
that ``monkeypatch.setattr(routes.partners, "PARTNERS_ENABLED", True)``
on every test in the file. Defensive resets of ``startup.state.shutting_down``
and the Supabase CB registry are kept as belt-and-suspenders since they
were the original hypothesis, but they are not the cause.

Removed the class-level ``@pytest.mark.xfail`` from ``TestPartnerRoutes``.

**Out-of-scope follow-up.** The same import-time-binding pattern exists
in ``routes/messages.py``, ``routes/alerts.py``, ``routes/organizations.py``.
The same fixture-only-patches-config bug should be reproducible in their
test files in batch mode. Not fixed here to keep this PR scoped — flagging
for #971 follow-up.

## Testing Plan

- [x] Isolation: ``python3 -m pytest tests/test_partners.py -v``
      -> **19 passed** (was 13 passed + 6 xpassed)
- [x] Batch with potential polluters:
      ``python3 -m pytest tests/ --ignore=tests/integration --ignore=tests/fuzz \
       -k "TestPartnerRoutes or schema_validation or shutdown or circuit_breaker or lifespan"``
      - **before**: 227 passed, 5 xfailed, 1 xpassed
      - **after**:  233 passed, 0 xfailed, 0 xpassed
- [x] Focused regression on related files
      (test_partners + harden_022 + schema_validation + 4 CB test files):
      **173 passed** in 10s
- [x] ``ruff check tests/test_partners.py`` -> All checks passed

## Closes

Partial fix for #971 AC2 (does not auto-close; remaining ACs handled in
parallel PRs).