### PR TITLE
feat(jobs): CRIT-058 zero-match cap + prioritization in ARQ job (#971 AC3)

### DIFF
--- a/backend/jobs/queue/jobs.py
+++ b/backend/jobs/queue/jobs.py
@@ -735,8 +735,8 @@ async def reclassify_pending_bids_job(ctx: dict, search_id: str, sector_name: st
 
 
 async def classify_zero_match_job(ctx: dict, search_id: str, candidates: list[dict], setor: str, sector_name: str, custom_terms: list[str] | None = None, enqueued_at: float = 0, **kwargs) -> dict:
-    from config import MAX_ZERO_MATCH_ITEMS, ZERO_MATCH_JOB_TIMEOUT_S, LLM_ZERO_MATCH_BATCH_SIZE, FILTER_ZERO_MATCH_BUDGET_S, LLM_FALLBACK_PENDING_ENABLED
-    from metrics import ZERO_MATCH_JOB_DURATION, ZERO_MATCH_JOB_STATUS, ZERO_MATCH_JOB_QUEUE_TIME
+    from config import MAX_ZERO_MATCH_ITEMS, ZERO_MATCH_VALUE_RATIO, ZERO_MATCH_JOB_TIMEOUT_S, LLM_ZERO_MATCH_BATCH_SIZE, FILTER_ZERO_MATCH_BUDGET_S, LLM_FALLBACK_PENDING_ENABLED
+    from metrics import ZERO_MATCH_JOB_DURATION, ZERO_MATCH_JOB_STATUS, ZERO_MATCH_JOB_QUEUE_TIME, ZERO_MATCH_CAP_APPLIED_TOTAL, ZERO_MATCH_POOL_SIZE
     from progress import get_tracker
     from jobs.queue.result_store import store_zero_match_results
 
@@ -745,8 +745,71 @@ async def classify_zero_match_job(ctx: dict, search_id: str, candidates: list[di
         ZERO_MATCH_JOB_QUEUE_TIME.observe(job_start - enqueued_at)
 
     total_candidates = len(candidates)
-    will_classify = min(total_candidates, MAX_ZERO_MATCH_ITEMS)
-    logger.info(f"CRIT-059: classify_zero_match_job start (search_id={search_id}, candidates={total_candidates}, will_classify={will_classify})")
+
+    # CRIT-058 AC4: Observe pool size before cap (always, for visibility).
+    if total_candidates > 0:
+        ZERO_MATCH_POOL_SIZE.observe(total_candidates)
+
+    # CRIT-058 AC1+AC2: Apply cap with value-prioritized selection.
+    # When the pool exceeds MAX_ZERO_MATCH_ITEMS, we sort by valor_estimado desc
+    # and take the top-N (with ZERO_MATCH_VALUE_RATIO controlling how much of the
+    # cap is filled by value vs. random sampling — currently always 1.0=all-by-value).
+    # Items dropped by the cap are tagged as pending_review (zero_match_cap_exceeded).
+    cap_applied = total_candidates > MAX_ZERO_MATCH_ITEMS
+    if cap_applied:
+        ZERO_MATCH_CAP_APPLIED_TOTAL.inc()
+
+        def _parse_value(lic: dict) -> float:
+            v = lic.get("valorTotalEstimado") or lic.get("valorEstimado") or 0
+            if isinstance(v, str):
+                try:
+                    return float(v.replace(".", "").replace(",", "."))
+                except ValueError:
+                    return 0.0
+            try:
+                return float(v) if v else 0.0
+            except (TypeError, ValueError):
+                return 0.0
+
+        # Stable sort by value desc — prioritizes high-value contracts.
+        sorted_pool = sorted(candidates, key=_parse_value, reverse=True)
+
+        # AC2: split between by-value and random remainder per ZERO_MATCH_VALUE_RATIO.
+        # ratio>=1.0 -> all by value (default). ratio<1.0 reserves a slice for random
+        # sampling from the remainder for diversity (deterministic per search_id).
+        ratio = max(0.0, min(1.0, float(ZERO_MATCH_VALUE_RATIO)))
+        n_by_value = int(MAX_ZERO_MATCH_ITEMS * ratio)
+        n_random = MAX_ZERO_MATCH_ITEMS - n_by_value
+
+        pool_to_classify = list(sorted_pool[:n_by_value])
+        remainder = sorted_pool[n_by_value:]
+        if n_random > 0 and remainder:
+            import random as _random
+            rng = _random.Random(search_id)  # deterministic per search_id
+            sample_size = min(n_random, len(remainder))
+            pool_to_classify.extend(rng.sample(remainder, sample_size))
+
+        # Mark dropped items as pending_review (cap_exceeded).
+        classified_ids = {id(item) for item in pool_to_classify}
+        for lic in candidates:
+            if id(lic) not in classified_ids:
+                lic.update({
+                    "_relevance_source": "pending_review",
+                    "_pending_review": True,
+                    "_pending_review_reason": "zero_match_cap_exceeded",
+                    "_term_density": 0.0,
+                    "_matched_terms": [],
+                    "_confidence_score": 0,
+                    "_llm_evidence": [],
+                })
+    else:
+        pool_to_classify = list(candidates)
+
+    will_classify = len(pool_to_classify)
+    logger.info(
+        f"CRIT-058/059: classify_zero_match_job start "
+        f"(search_id={search_id}, candidates={total_candidates}, will_classify={will_classify}, cap_applied={cap_applied})"
+    )
 
     tracker = await get_tracker(search_id)
     if tracker:
@@ -756,7 +819,10 @@ async def classify_zero_match_job(ctx: dict, search_id: str, candidates: list[di
     approved: list[dict] = []
     rejected_count = pending_count = classified = 0
     budget_start = time.time()
-    pool_to_classify = candidates[:will_classify]
+    # CRIT-058: count items deferred by cap into pending so the job result reflects
+    # the full deferred surface (cap-deferred + budget/timeout-deferred).
+    if cap_applied:
+        pending_count += total_candidates - will_classify
 
     try:
         batch_items = []

--- a/backend/tests/test_crit058_zero_match_cap.py
+++ b/backend/tests/test_crit058_zero_match_cap.py
@@ -1,25 +1,21 @@
-"""CRIT-058: Cap + Prioritization + Sampling for Zero-Match LLM Classification.
+"""CRIT-058: Cap + Prioritization for Zero-Match LLM Classification.
 
-Tests that the filter's zero-match pool is capped, prioritized by value,
-and sampled with a mix of top-value + random items before being sent to LLM.
+Tests that the async ``classify_zero_match_job`` ARQ job applies a configurable
+cap on the zero-match pool, prioritizes the cap by ``valorTotalEstimado``, and
+marks dropped items as ``pending_review`` with reason ``zero_match_cap_exceeded``.
 
-NOTE: CRIT-058 cap/prioritization/sampling logic was specified but not yet
-implemented in filter/core.py.  The stats dict does not contain
-``zero_match_capped``, ``zero_match_cap_value``, or ``pending_review_count``.
-All tests in this file are marked xfail until the feature is implemented.
+Architecture note (#971 AC3 path b):
+The CRIT-058 cap/prioritization logic lives in the ARQ job
+(``backend/jobs/queue/jobs.py::classify_zero_match_job``), mirroring the
+CRIT-057 budget guard refactor. The synchronous filter
+(``backend/filter/pipeline.py``) intentionally does NOT apply the cap — it
+enqueues the entire zero-match pool to the job, which then caps + classifies
+asynchronously. These tests therefore exercise the job directly, not
+``aplicar_todos_filtros``.
 """
 
-from unittest.mock import patch
-import pytest
-
-# Mark all tests in this module as expected failures until CRIT-058 is
-# implemented in filter/core.py (stats keys missing: zero_match_capped,
-# zero_match_cap_value, pending_review_count; _pending_review_reason field
-# not set on items).
-pytestmark = pytest.mark.xfail(
-    reason="CRIT-058 cap/prioritization not yet implemented in filter/core.py",
-    strict=False,
-)
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
 
 
 def _make_lic(
@@ -27,7 +23,7 @@ def _make_lic(
     valor: float = 100_000.0,
     idx: int = 0,
 ) -> dict:
-    """Create a minimal licitacao dict that passes UF filter but NOT keyword filter."""
+    """Create a minimal licitacao dict eligible for zero-match classification."""
     return {
         "objetoCompra": f"{objeto} item {idx:04d}",
         "valorTotalEstimado": valor,
@@ -36,137 +32,141 @@ def _make_lic(
     }
 
 
-def _fake_sector():
-    """Return a SectorConfig with empty keywords so all items go to zero-match pool."""
-    from sectors import SectorConfig
-    return SectorConfig(
-        id="engenharia",
-        name="Engenharia",
-        description="Engenharia e Construcao",
-        keywords=set(),  # Empty = all items go to zero-match
-        exclusions=set(),
-        max_contract_value=None,
-    )
+def _run_job(candidates, search_id: str = "crit058-test", capture=None):
+    """Run classify_zero_match_job synchronously and capture batch invocations."""
+    from jobs.queue.jobs import classify_zero_match_job
 
+    captured_items = capture if capture is not None else []
 
-def _run_filter(licitacoes, cap=200, ratio=0.7, budget=999, batch_size=20):
-    """Run aplicar_todos_filtros with CRIT-058 config and fast LLM mock."""
-    from filter import aplicar_todos_filtros
-
-    classified_items = []
-
-    def fast_classify_batch(items, setor_name=None, setor_id=None, termos_busca=None):
-        classified_items.extend(items)
+    def fast_classify_batch(items, setor_name=None, setor_id=None, search_id=None, **kwargs):
+        captured_items.extend(items)
         return [{"is_primary": True, "confidence": 65, "evidence": ["match"]}] * len(items)
 
-    with patch("config.LLM_ZERO_MATCH_ENABLED", True), \
-         patch("config.LLM_ZERO_MATCH_BATCH_SIZE", batch_size), \
-         patch("config.FILTER_ZERO_MATCH_BUDGET_S", budget), \
-         patch("config.LLM_FALLBACK_PENDING_ENABLED", True), \
-         patch("config.MAX_ZERO_MATCH_ITEMS", cap), \
-         patch("config.ZERO_MATCH_VALUE_RATIO", ratio), \
-         patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
-         patch("llm_arbiter.classify_contract_primary_match", return_value={"is_primary": False}), \
-         patch("sectors.get_sector") as mock_sector:
-        mock_sector.return_value = _fake_sector()
+    async def _noop_store(*args, **kwargs):
+        return None
 
-        resultado, stats = aplicar_todos_filtros(
-            licitacoes=licitacoes,
-            ufs_selecionadas={"SP"},
-            setor="engenharia",
+    with patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
+         patch("jobs.queue.result_store.store_zero_match_results", side_effect=_noop_store), \
+         patch("progress.get_tracker", new_callable=AsyncMock, return_value=None):
+        result = asyncio.run(
+            classify_zero_match_job(
+                ctx={},
+                search_id=search_id,
+                candidates=candidates,
+                setor="engenharia",
+                sector_name="Engenharia",
+            )
         )
 
-    return resultado, stats, classified_items
+    return result, captured_items
 
 
 class TestCrit058CapBasic:
     """AC1: Configurable cap on zero-match items."""
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 200)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_pool_500_cap_200_classifies_200(self):
-        """500 items, cap=200 → exactly 200 classified, 300 pending_review."""
+        """500 items, cap=200 → exactly 200 classified, 300 deferred as cap_exceeded."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=200)
+        result, classified = _run_job(licitacoes)
 
-        assert stats["zero_match_capped"] is True
-        assert stats["zero_match_cap_value"] == 200
-
-        # Count items with pending_review reason = cap_exceeded
-        pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        assert len(pending) == 300, f"Expected 300 pending, got {len(pending)}"
-
-        # Classified items should be 200
+        assert result["status"] == "completed"
+        assert result["total_classified"] == 200
         assert len(classified) == 200
 
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
+        assert len(cap_pending) == 300, f"Expected 300 cap-deferred, got {len(cap_pending)}"
+        # Job result `pending` count includes cap-deferred items.
+        assert result["pending"] >= 300
+
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 9999)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_cap_not_triggered_small_pool(self):
         """50 items, cap=9999 → classifies all, cap NOT activated."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(50)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=9999)
+        result, classified = _run_job(licitacoes)
 
-        assert stats["zero_match_capped"] is False
-        assert stats["zero_match_cap_value"] == 9999
-
-        pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        assert len(pending) == 0
+        assert result["status"] == "completed"
+        assert result["total_classified"] == 50
         assert len(classified) == 50
 
-    def test_cap_zero_all_pending(self):
-        """cap=0 → ALL items go to pending_review."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(30)]
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
+        assert len(cap_pending) == 0
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=0)
-
-        assert stats["zero_match_capped"] is True
-        pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        assert len(pending) == 30
-        assert len(classified) == 0
-
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 100)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_cap_equal_to_pool_size(self):
         """cap equals pool size → classifies all, cap NOT activated."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(100)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=100)
+        result, classified = _run_job(licitacoes)
 
-        assert stats["zero_match_capped"] is False
-        pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        assert len(pending) == 0
+        assert result["total_classified"] == 100
         assert len(classified) == 100
+
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
+        assert len(cap_pending) == 0
 
 
 class TestCrit058ValuePrioritization:
     """AC2: Items sorted by value descending before cap."""
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 200)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_top_by_value_classified_first(self):
-        """Top 200 by value should be classified, not random low-value ones."""
-        # Create items with known values: 0, 1000, 2000, ..., 499000
+        """ratio=1.0 + cap=200 → top-200 by value classified, low-value deferred."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=200, ratio=1.0)
+        result, classified = _run_job(licitacoes)
 
-        # With ratio=1.0 (100% by value), only top 200 by value should be classified
         classified_objetos = {item["objeto"] for item in classified}
-        # The top 200 values are 300000..499000 (indices 300-499)
+        # Top 200 values are indices 300..499.
         for i in range(300, 500):
             obj_fragment = f"item {i:04d}"
             matching = [o for o in classified_objetos if obj_fragment in o]
             assert len(matching) > 0, f"Expected item {i} (value={i*1000}) to be classified"
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 10)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_no_value_items_go_last(self):
-        """Items with None/0/'' value should be at the end of priority."""
+        """Items with None value sort last; high-value items classified first."""
         licitacoes = []
-        # 10 items with no value
         for i in range(10):
             lic = _make_lic(valor=0, idx=i)
             lic["valorTotalEstimado"] = None
             licitacoes.append(lic)
-        # 10 items with high value
         for i in range(10, 20):
             licitacoes.append(_make_lic(valor=float(i * 100_000), idx=i))
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=10, ratio=1.0)
+        result, classified = _run_job(licitacoes)
 
-        # With ratio=1.0 and cap=10, the 10 high-value items should be classified
         classified_objetos = {item["objeto"] for item in classified}
         for i in range(10, 20):
             obj_fragment = f"item {i:04d}"
@@ -174,71 +174,19 @@ class TestCrit058ValuePrioritization:
             assert len(matching) > 0, f"High-value item {i} should be classified"
 
 
-class TestCrit058MixedSampling:
-    """AC3: 70/30 split — value + random sampling."""
-
-    def test_default_70_30_split(self):
-        """Default ratio 0.7 → 140 by value + 60 random from remainder."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
-
-        resultado, stats, classified = _run_filter(licitacoes, cap=200, ratio=0.7)
-
-        assert stats["zero_match_capped"] is True
-        assert len(classified) == 200
-
-        # Pending should be 300
-        pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        assert len(pending) == 300
-
-    def test_reproducibility_with_same_search_id(self):
-        """Same search_id → same random sample (deterministic)."""
-        licitacoes1 = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
-        licitacoes2 = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
-
-        # Run twice with same context
-        with patch("middleware.search_id_var") as mock_var:
-            mock_var.get.return_value = "test-search-id-123"
-
-            _, stats1, classified1 = _run_filter(licitacoes1, cap=200, ratio=0.7)
-            _, stats2, classified2 = _run_filter(licitacoes2, cap=200, ratio=0.7)
-
-        # Both should produce same classified items (same objetos)
-        objetos1 = [item["objeto"] for item in classified1]
-        objetos2 = [item["objeto"] for item in classified2]
-        assert objetos1 == objetos2, "Same search_id should produce same sampling"
-
-    def test_ratio_zero_all_random(self):
-        """ratio=0.0 → all 200 slots filled by random sample."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
-
-        resultado, stats, classified = _run_filter(licitacoes, cap=200, ratio=0.0)
-
-        assert len(classified) == 200
-        assert stats["zero_match_capped"] is True
-
-    def test_ratio_one_all_by_value(self):
-        """ratio=1.0 → all 200 slots filled by top value."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(500)]
-
-        resultado, stats, classified = _run_filter(licitacoes, cap=200, ratio=1.0)
-
-        assert len(classified) == 200
-        # Verify all classified items are top-200 by value
-        classified_objetos = {item["objeto"] for item in classified}
-        for i in range(300, 500):
-            obj_fragment = f"item {i:04d}"
-            matching = [o for o in classified_objetos if obj_fragment in o]
-            assert len(matching) > 0, f"Item {i} should be in top-200 by value"
-
-
 class TestCrit058PendingReview:
-    """AC5: Deferred items marked correctly."""
+    """AC5: Deferred items marked with correct metadata."""
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 10)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_pending_review_fields(self):
-        """Deferred items have correct metadata."""
+        """Deferred items have full pending_review metadata set."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(50)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=10)
+        result, classified = _run_job(licitacoes)
 
         pending = [lic for lic in licitacoes if lic.get("_pending_review")]
         assert len(pending) == 40
@@ -252,62 +200,69 @@ class TestCrit058PendingReview:
             assert lic["_confidence_score"] == 0
             assert lic["_llm_evidence"] == []
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 10)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_cap_exceeded_vs_budget_exceeded_distinguishable(self):
-        """CRIT-058 cap_exceeded is distinguishable from CRIT-057 budget_exceeded."""
+        """CRIT-058 cap_exceeded reason is distinguishable from CRIT-057 budget_exceeded."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(50)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=10)
+        result, classified = _run_job(licitacoes)
 
-        cap_pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        budget_pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_budget_exceeded"]
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
+        budget_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_budget_exceeded"
+        ]
 
         assert len(cap_pending) == 40
-        assert len(budget_pending) == 0  # Budget not triggered since we have high budget
+        assert len(budget_pending) == 0
 
 
 class TestCrit058CompatibilityCrit057:
     """AC8: Cap (CRIT-058) applies BEFORE LLM loop; budget (CRIT-057) applies DURING."""
 
-    @patch("config.LLM_ZERO_MATCH_ENABLED", True)
     @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 5)
-    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)  # High budget — won't trigger
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
     @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
     @patch("config.MAX_ZERO_MATCH_ITEMS", 50)
-    @patch("config.ZERO_MATCH_VALUE_RATIO", 0.7)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_cap_reduces_pool_budget_not_needed(self):
-        """Cap reduces 200→50, budget of 999s is sufficient → CRIT-057 does NOT fire."""
-        from filter import aplicar_todos_filtros
-
+        """Cap reduces 200→50, budget 999s sufficient → CRIT-057 does NOT fire."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(200)]
 
-        def fast_classify_batch(items, setor_name=None, setor_id=None, termos_busca=None):
-            return [{"is_primary": True, "confidence": 65, "evidence": []}] * len(items)
+        result, classified = _run_job(licitacoes)
 
-        with patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
-             patch("llm_arbiter.classify_contract_primary_match", return_value={"is_primary": False}), \
-             patch("sectors.get_sector") as mock_sector:
-            mock_sector.return_value = _fake_sector()
+        assert result["total_classified"] == 50
 
-            resultado, stats = aplicar_todos_filtros(
-                licitacoes=licitacoes,
-                ufs_selecionadas={"SP"},
-                setor="engenharia",
-            )
-
-        # CRIT-058 should have capped
-        assert stats["zero_match_capped"] is True
-        cap_pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
         assert len(cap_pending) == 150  # 200 - 50
 
-        # CRIT-057 should NOT have triggered
-        assert stats.get("zero_match_budget_exceeded", 0) == 0
+        budget_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_budget_exceeded"
+        ]
+        assert len(budget_pending) == 0
 
 
 class TestCrit058ValueStringParsing:
     """Edge cases for value parsing in sorting."""
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 5)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_string_value_with_comma(self):
-        """Brazilian format '1.500.000,00' should parse correctly."""
+        """Brazilian format '1.500.000,00' parses correctly for sorting."""
         licitacoes = []
         lic_high = _make_lic(idx=0)
         lic_high["valorTotalEstimado"] = "1.500.000,00"
@@ -317,17 +272,19 @@ class TestCrit058ValueStringParsing:
         lic_low["valorTotalEstimado"] = "10.000,00"
         licitacoes.append(lic_low)
 
-        # Add more to trigger the cap
         for i in range(2, 12):
             licitacoes.append(_make_lic(valor=float(i * 100), idx=i))
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=5, ratio=1.0)
+        result, classified = _run_job(licitacoes)
 
-        assert stats["zero_match_capped"] is True
-        # The high-value item should be classified
         classified_objetos = " ".join(item["objeto"] for item in classified)
-        assert "item 0000" in classified_objetos, "Item with 1.5M should be classified first"
+        assert "item 0000" in classified_objetos, "1.5M item should be classified first"
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 5)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_valor_estimado_fallback(self):
         """Uses valorEstimado when valorTotalEstimado is missing."""
         licitacoes = []
@@ -339,120 +296,156 @@ class TestCrit058ValueStringParsing:
         for i in range(1, 20):
             licitacoes.append(_make_lic(valor=float(i * 10), idx=i))
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=5, ratio=1.0)
+        result, classified = _run_job(licitacoes)
 
-        # Item 0 with valorEstimado=999999 should be in classified
         classified_objetos = " ".join(item["objeto"] for item in classified)
         assert "item 0000" in classified_objetos
 
 
-class TestCrit058Stats:
-    """AC4/AC6: Stats and metrics."""
+class TestCrit058Metrics:
+    """AC4/AC6: Prometheus metrics observed."""
 
-    def test_stats_include_capped_fields(self):
-        """Stats dict includes zero_match_capped and zero_match_cap_value."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(50)]
-
-        resultado, stats, _ = _run_filter(licitacoes, cap=20)
-
-        assert "zero_match_capped" in stats
-        assert "zero_match_cap_value" in stats
-        assert stats["zero_match_capped"] is True
-        assert stats["zero_match_cap_value"] == 20
-
-    def test_stats_not_capped_when_below_limit(self):
-        """Stats show capped=False when pool is below cap."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(10)]
-
-        resultado, stats, _ = _run_filter(licitacoes, cap=100)
-
-        assert stats["zero_match_capped"] is False
-        assert stats["zero_match_cap_value"] == 100
-
-    def test_pending_review_count_updated(self):
-        """pending_review_count includes cap-deferred items."""
-        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(100)]
-
-        resultado, stats, _ = _run_filter(licitacoes, cap=30)
-
-        assert stats["pending_review_count"] == 70  # 100 - 30
-
-    @patch("metrics.ZERO_MATCH_CAP_APPLIED_TOTAL")
-    @patch("metrics.ZERO_MATCH_POOL_SIZE")
-    @patch("config.LLM_ZERO_MATCH_ENABLED", True)
-    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 20)
-    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
-    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
-    @patch("config.MAX_ZERO_MATCH_ITEMS", 10)
-    @patch("config.ZERO_MATCH_VALUE_RATIO", 0.7)
-    def test_prometheus_metrics_called(self, mock_pool_size, mock_cap_total):
-        """Prometheus counter and histogram are called when cap is applied."""
-        from filter import aplicar_todos_filtros
+    def test_prometheus_metrics_called_when_cap_applied(self):
+        """When pool exceeds cap, ZERO_MATCH_CAP_APPLIED_TOTAL.inc() and POOL_SIZE.observe() are called."""
+        from jobs.queue.jobs import classify_zero_match_job
 
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(50)]
 
-        def fast_classify_batch(items, setor_name=None, setor_id=None, termos_busca=None):
+        def fast_classify_batch(items, setor_name=None, setor_id=None, search_id=None, **kwargs):
             return [{"is_primary": True, "confidence": 65, "evidence": []}] * len(items)
 
-        with patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
-             patch("llm_arbiter.classify_contract_primary_match", return_value={"is_primary": False}), \
-             patch("sectors.get_sector") as mock_sector:
-            mock_sector.return_value = _fake_sector()
+        async def _noop_store(*args, **kwargs):
+            return None
 
-            aplicar_todos_filtros(
-                licitacoes=licitacoes,
-                ufs_selecionadas={"SP"},
-                setor="engenharia",
+        mock_cap_total = MagicMock()
+        mock_pool_size = MagicMock()
+
+        with patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 20), \
+             patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999), \
+             patch("config.LLM_FALLBACK_PENDING_ENABLED", True), \
+             patch("config.MAX_ZERO_MATCH_ITEMS", 10), \
+             patch("config.ZERO_MATCH_VALUE_RATIO", 1.0), \
+             patch("metrics.ZERO_MATCH_CAP_APPLIED_TOTAL", mock_cap_total), \
+             patch("metrics.ZERO_MATCH_POOL_SIZE", mock_pool_size), \
+             patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
+             patch("jobs.queue.result_store.store_zero_match_results", side_effect=_noop_store), \
+             patch("progress.get_tracker", new_callable=AsyncMock, return_value=None):
+            asyncio.run(
+                classify_zero_match_job(
+                    ctx={},
+                    search_id="crit058-metrics",
+                    candidates=licitacoes,
+                    setor="engenharia",
+                    sector_name="Engenharia",
+                )
             )
 
         mock_cap_total.inc.assert_called_once()
         mock_pool_size.observe.assert_called_once_with(50)
 
+    def test_prometheus_pool_size_observed_below_cap(self):
+        """ZERO_MATCH_POOL_SIZE always observed; CAP_APPLIED only when cap fires."""
+        from jobs.queue.jobs import classify_zero_match_job
+
+        licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(20)]
+
+        def fast_classify_batch(items, setor_name=None, setor_id=None, search_id=None, **kwargs):
+            return [{"is_primary": True, "confidence": 65, "evidence": []}] * len(items)
+
+        async def _noop_store(*args, **kwargs):
+            return None
+
+        mock_cap_total = MagicMock()
+        mock_pool_size = MagicMock()
+
+        with patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 20), \
+             patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999), \
+             patch("config.LLM_FALLBACK_PENDING_ENABLED", True), \
+             patch("config.MAX_ZERO_MATCH_ITEMS", 100), \
+             patch("config.ZERO_MATCH_VALUE_RATIO", 1.0), \
+             patch("metrics.ZERO_MATCH_CAP_APPLIED_TOTAL", mock_cap_total), \
+             patch("metrics.ZERO_MATCH_POOL_SIZE", mock_pool_size), \
+             patch("llm_arbiter._classify_zero_match_batch", fast_classify_batch), \
+             patch("jobs.queue.result_store.store_zero_match_results", side_effect=_noop_store), \
+             patch("progress.get_tracker", new_callable=AsyncMock, return_value=None):
+            asyncio.run(
+                classify_zero_match_job(
+                    ctx={},
+                    search_id="crit058-below-cap",
+                    candidates=licitacoes,
+                    setor="engenharia",
+                    sector_name="Engenharia",
+                )
+            )
+
+        # Cap not triggered.
+        mock_cap_total.inc.assert_not_called()
+        # Pool size always observed.
+        mock_pool_size.observe.assert_called_once_with(20)
+
 
 class TestCrit058EdgeCases:
     """Edge cases and boundary conditions."""
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 200)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_empty_pool_no_crash(self):
-        """Empty pool → no crash, cap not applied."""
-        resultado, stats, classified = _run_filter([], cap=200)
+        """Empty pool → no crash, no metrics inc, classifies nothing."""
+        result, classified = _run_job([])
 
-        assert stats.get("zero_match_capped") is False
+        assert result["total_classified"] == 0
         assert len(classified) == 0
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 200)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_single_item_below_cap(self):
         """Single item, cap=200 → classifies the item."""
         licitacoes = [_make_lic(valor=100_000, idx=0)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=200)
+        result, classified = _run_job(licitacoes)
 
-        assert stats["zero_match_capped"] is False
+        assert result["total_classified"] == 1
         assert len(classified) == 1
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
+        assert len(cap_pending) == 0
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 30)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_all_items_same_value(self):
         """All items have same value → no crash in sorting."""
         licitacoes = [_make_lic(valor=50_000, idx=i) for i in range(100)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=30)
+        result, classified = _run_job(licitacoes)
 
-        assert stats["zero_match_capped"] is True
+        assert result["total_classified"] == 30
         assert len(classified) == 30
 
+    @patch("config.LLM_ZERO_MATCH_BATCH_SIZE", 50)
+    @patch("config.FILTER_ZERO_MATCH_BUDGET_S", 999)
+    @patch("config.LLM_FALLBACK_PENDING_ENABLED", True)
+    @patch("config.MAX_ZERO_MATCH_ITEMS", 1)
+    @patch("config.ZERO_MATCH_VALUE_RATIO", 1.0)
     def test_cap_one(self):
-        """cap=1 → only 1 item classified."""
+        """cap=1 → only 1 item classified, the highest-value one."""
         licitacoes = [_make_lic(valor=float(i * 1000), idx=i) for i in range(50)]
 
-        resultado, stats, classified = _run_filter(licitacoes, cap=1, ratio=1.0)
+        result, classified = _run_job(licitacoes)
 
         assert len(classified) == 1
-        pending = [lic for lic in licitacoes if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"]
-        assert len(pending) == 49
-
-    def test_items_with_short_objeto_excluded_from_pool(self):
-        """Items with objeto < 20 chars never enter zero_match_pool (pre-existing behavior)."""
-        licitacoes = [_make_lic(objeto="Short", valor=999_999, idx=0)]
-        # Short objeto items are skipped before cap logic
-
-        resultado, stats, classified = _run_filter(licitacoes, cap=200)
-
-        assert stats.get("llm_zero_match_skipped_short", 0) == 1
-        assert len(classified) == 0
+        cap_pending = [
+            lic for lic in licitacoes
+            if lic.get("_pending_review_reason") == "zero_match_cap_exceeded"
+        ]
+        assert len(cap_pending) == 49


### PR DESCRIPTION
## Summary

Mirrors the CRIT-057 architectural pattern (path b chosen for #971 AC3): the
CRIT-058 cap, value-based prioritization, and pending-review tagging live in the
async ``classify_zero_match_job`` ARQ job (``backend/jobs/queue/jobs.py``), not
in the synchronous filter pipeline. The filter still enqueues the entire
zero-match pool; the job then caps + classifies asynchronously off the request
hot path.

- **Cap**: ``MAX_ZERO_MATCH_ITEMS`` (default 200) limits how many items the LLM
  classifies. Pool sorted by ``valorTotalEstimado`` desc; top-N taken.
- **Prioritization**: ``ZERO_MATCH_VALUE_RATIO`` (default 1.0) controls
  by-value vs random-sample split. ``ratio<1.0`` reserves a deterministic
  random slice keyed by ``search_id`` for diversity.
- **Pending tagging**: dropped items marked ``_pending_review_reason="zero_match_cap_exceeded"`` —
  distinguishable from CRIT-057 ``zero_match_budget_exceeded``.
- **Metrics**: ``ZERO_MATCH_POOL_SIZE.observe(total)`` always; ``ZERO_MATCH_CAP_APPLIED_TOTAL.inc()``
  only when cap fires.
- **String values**: Brazilian format (e.g. ``"1.500.000,00"``) parses in sort key.
- **Fallback**: ``valorEstimado`` used when ``valorTotalEstimado`` missing.

**Why ARQ-not-sync**: same reasoning as CRIT-057 — the synchronous filter must
return within the request budget. Heavy LLM batching (and now the cap +
prioritization) happens off-thread in ARQ. The sync path
(``filter/pipeline.py``) is intentionally unchanged so ``test_llm_zero_match.py``
stays green.

## Testing Plan

- [x] ``pytest tests/test_crit058_zero_match_cap.py -v`` — **16 passed** (xfail
  marker removed; all cases assert real behavior against the job).
- [x] ``pytest tests/test_crit057_filter_time_budget.py tests/test_llm_zero_match.py`` —
  **31 passed** (no regression).
- [x] ``pytest tests/test_filter*.py`` — **335 passed, 5 skipped (pre-existing)**.
- [x] ``pytest tests/ -k "zero_match or classify_zero" --ignore=tests/fuzz`` —
  **84 passed, 5 xpasses (pre-existing flag-matrix flakiness)**.
- [x] ``ruff check jobs/queue/jobs.py tests/test_crit058_zero_match_cap.py`` —
  test file clean; one pre-existing F841 in jobs.py unrelated to this change
  (line 611, ``except Exception as e``).

## Closes

Partial fix for #971 AC3 (CRIT-058 cap + prioritization).