### PR TITLE
feat(backend): /api/founders/availability endpoint (#1002)

### DIFF
--- a/backend/routes/founders.py
+++ b/backend/routes/founders.py
@@ -1,0 +1,345 @@
+"""Issue #1002 (API-FOUND-003): public availability endpoint for the
+Plano Fundadores landing page / cross-sell banners / SEO programmatic footer.
+
+GET /api/founders/availability
+------------------------------
+
+Anonymous (no auth). Returns a snapshot of seat counter + countdown that the
+landing page, /planos cross-sell banner, programmatic SEO footer, dashboard
+trial banner, and day-10 trial emails all consume.
+
+Source of truth:
+- Seats taken: count of ``profiles.is_founder = TRUE``.
+- Cap: 50 (docs/founders-policy.md).
+- Deadline: ``FOUNDERS_DEADLINE`` env var, default 2026-06-30T23:59:59-03:00.
+- Public listing opt-in: ``profiles.founder_public_listing_consent = TRUE``
+  (LGPD opt-in flag — column is added by a follow-up migration; absent for now,
+  so ``ultimasVagasOptIn`` returns an empty list in the meantime).
+
+Resilience:
+- Redis-cached for 60s (per AC: <500ms p95).
+- DB query wrapped in ``_run_with_budget`` with a 2s budget.
+- On any DB/Redis error → fallback payload with ``vagasRestantes=null``,
+  ``fallback=true``, conservative message — surfaced via 200 (NOT 503) so
+  the landing page can still render the conservative banner without breaking
+  the page. (The frontend hook treats ``fallback=true`` as a soft-down state.)
+- Cache-Control: public, s-maxage=30 (Googlebot fanout protection).
+
+Rate limit: 60 req/min per IP (anti-scraping).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel, Field
+
+from pipeline.budget import _run_with_budget
+from rate_limiter import require_rate_limit
+from supabase_client import get_supabase
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/founders", tags=["founders"])
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FOUNDERS_CAP_TOTAL = 50  # docs/founders-policy.md
+DEFAULT_FOUNDERS_DEADLINE = "2026-06-30T23:59:59-03:00"
+CACHE_TTL_SECONDS = 60
+CACHE_KEY = "founders:availability:v1"
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class UltimaVagaOptIn(BaseModel):
+    """LGPD-safe public listing entry (only included when consent=TRUE)."""
+
+    empresa: str = Field(..., description="Display name (razao_social or 'empresa').")
+    uf: str = Field(..., description="State code, 2 letters.")
+    preenchidaEm: str = Field(..., description="ISO-8601 timestamp.")
+
+
+class FoundersAvailabilityResponse(BaseModel):
+    """Response shape for ``GET /api/founders/availability`` (issue #1002).
+
+    On the happy path all numeric fields are populated and ``fallback=false``.
+    On DB/Redis failure ``vagasRestantes=null`` + ``fallback=true`` and the
+    frontend renders the conservative copy ("Vagas limitadas — encerra 30/06").
+    """
+
+    vagasRestantes: int | None = Field(
+        default=None,
+        description="Seats still available (50 - taken). NULL when fallback=true.",
+    )
+    vagasTotal: int = Field(default=FOUNDERS_CAP_TOTAL, description="Hard cap (50).")
+    vagasPreenchidas: int | None = Field(
+        default=None,
+        description="Seats already taken (count of is_founder=TRUE profiles).",
+    )
+    diasRestantes: int | None = Field(
+        default=None, description="Whole days until the deadline."
+    )
+    horasRestantes: int | None = Field(
+        default=None, description="Whole hours until the deadline."
+    )
+    deadline: str = Field(
+        default=DEFAULT_FOUNDERS_DEADLINE,
+        description="ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).",
+    )
+    ultimaVagaEm: str | None = Field(
+        default=None,
+        description="ISO-8601 timestamp of the most recent founder_since.",
+    )
+    ultimasVagasOptIn: list[UltimaVagaOptIn] = Field(
+        default_factory=list,
+        description=(
+            "Up to 5 most recent founders who explicitly opted in via "
+            "founder_public_listing_consent=TRUE (LGPD)."
+        ),
+    )
+    sold_out: bool = Field(
+        default=False,
+        description="TRUE when vagasPreenchidas >= cap (50).",
+    )
+    fallback: bool = Field(
+        default=False,
+        description=(
+            "TRUE when DB or Redis is unavailable. Frontend should render the "
+            "conservative copy without a number."
+        ),
+    )
+    message: str | None = Field(
+        default=None,
+        description="Conservative copy returned when fallback=true.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_deadline_iso() -> str:
+    """Return the FOUNDERS_DEADLINE env var or the documented default."""
+    raw = os.getenv("FOUNDERS_DEADLINE", "").strip()
+    return raw or DEFAULT_FOUNDERS_DEADLINE
+
+
+def _parse_deadline(raw: str) -> datetime | None:
+    """Parse ISO-8601 deadline with graceful fallback."""
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _compute_remaining(deadline_iso: str) -> tuple[int | None, int | None]:
+    """Return (dias, horas) from now until deadline. None if unparseable."""
+    deadline = _parse_deadline(deadline_iso)
+    if deadline is None:
+        return (None, None)
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=timezone.utc)
+    delta = deadline - datetime.now(tz=timezone.utc)
+    if delta.total_seconds() <= 0:
+        return (0, 0)
+    horas = int(delta.total_seconds() // 3600)
+    dias = delta.days
+    return (max(0, dias), max(0, horas))
+
+
+def _query_seats_snapshot(sb: Any) -> dict:
+    """Synchronous DB query — count founders + fetch most-recent opt-ins.
+
+    Wrapped via ``asyncio.to_thread`` + ``_run_with_budget`` by the caller.
+    Returns a dict consumed by the route. Raises on DB error so the route
+    can downgrade to ``fallback=true``.
+    """
+    # Count seats taken.
+    count_res = (
+        sb.table("profiles")
+        .select("id", count="exact")
+        .eq("is_founder", True)
+        .execute()
+    )
+    seats_taken: int = int(getattr(count_res, "count", None) or len(count_res.data or []))
+
+    # Most recent founder_since (any founder, regardless of consent).
+    last_res = (
+        sb.table("profiles")
+        .select("founder_since")
+        .eq("is_founder", True)
+        .order("founder_since", desc=True)
+        .limit(1)
+        .execute()
+    )
+    last_rows = last_res.data or []
+    ultima_vaga_em: str | None = None
+    if last_rows and last_rows[0].get("founder_since"):
+        raw = last_rows[0]["founder_since"]
+        ultima_vaga_em = raw if isinstance(raw, str) else str(raw)
+
+    # Opt-in public listing — gracefully handle missing column (404 from
+    # PostgREST when founder_public_listing_consent has not been migrated yet).
+    opt_in: list[dict] = []
+    try:
+        opt_res = (
+            sb.table("profiles")
+            .select("razao_social,uf,founder_since")
+            .eq("is_founder", True)
+            .eq("founder_public_listing_consent", True)
+            .order("founder_since", desc=True)
+            .limit(5)
+            .execute()
+        )
+        for row in opt_res.data or []:
+            empresa = (row.get("razao_social") or "Empresa Fundadora").strip() or "Empresa Fundadora"
+            uf = (row.get("uf") or "").strip().upper()[:2]
+            preenchida = row.get("founder_since")
+            if preenchida is None:
+                continue
+            opt_in.append(
+                {
+                    "empresa": empresa,
+                    "uf": uf,
+                    "preenchidaEm": preenchida if isinstance(preenchida, str) else str(preenchida),
+                }
+            )
+    except Exception as exc:  # column not present yet — non-blocking
+        logger.info(f"founders.availability: opt-in query skipped (likely missing column): {exc}")
+
+    return {
+        "seats_taken": seats_taken,
+        "ultima_vaga_em": ultima_vaga_em,
+        "opt_in": opt_in,
+    }
+
+
+async def _get_cached() -> dict | None:
+    try:
+        from redis_pool import get_redis_pool
+
+        redis = await get_redis_pool()
+        if redis is None:
+            return None
+        raw = await redis.get(CACHE_KEY)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+    except Exception as exc:
+        logger.debug(f"founders.availability: cache get failed (non-blocking): {exc}")
+        return None
+
+
+async def _set_cached(payload: dict) -> None:
+    try:
+        from redis_pool import get_redis_pool
+
+        redis = await get_redis_pool()
+        if redis is None:
+            return
+        await redis.set(CACHE_KEY, json.dumps(payload), ex=CACHE_TTL_SECONDS)
+    except Exception as exc:
+        logger.debug(f"founders.availability: cache set failed (non-blocking): {exc}")
+
+
+def _fallback_payload() -> dict:
+    """Conservative response when DB/Redis are unavailable."""
+    deadline_iso = _get_deadline_iso()
+    dias, horas = _compute_remaining(deadline_iso)
+    return {
+        "vagasRestantes": None,
+        "vagasTotal": FOUNDERS_CAP_TOTAL,
+        "vagasPreenchidas": None,
+        "diasRestantes": dias,
+        "horasRestantes": horas,
+        "deadline": deadline_iso,
+        "ultimaVagaEm": None,
+        "ultimasVagasOptIn": [],
+        "sold_out": False,
+        "fallback": True,
+        "message": "Vagas limitadas — encerra 30/06",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.get("/availability", response_model=FoundersAvailabilityResponse)
+async def founders_availability(
+    request: Request,
+    response: Response,
+    _rl=Depends(require_rate_limit(60, 60)),
+) -> Any:
+    """Public seat counter + countdown feed (issue #1002)."""
+    response.headers["Cache-Control"] = "public, s-maxage=30"
+
+    # 1) Try Redis cache first.
+    cached = await _get_cached()
+    if cached:
+        # Recompute time-sensitive fields so the timer still ticks even within
+        # the 60s cache window.
+        deadline_iso = cached.get("deadline") or _get_deadline_iso()
+        dias, horas = _compute_remaining(deadline_iso)
+        cached["diasRestantes"] = dias
+        cached["horasRestantes"] = horas
+        return FoundersAvailabilityResponse(**cached)
+
+    # 2) Cache miss — query DB under the time budget.
+    deadline_iso = _get_deadline_iso()
+    sb = get_supabase()
+
+    try:
+        snapshot = await _run_with_budget(
+            asyncio.to_thread(_query_seats_snapshot, sb),
+            budget=2.0,
+            phase="route",
+            source="founders.availability",
+        )
+    except Exception as exc:
+        logger.warning(f"founders.availability: DB query failed → fallback. err={exc}")
+        return FoundersAvailabilityResponse(**_fallback_payload())
+
+    seats_taken: int = int(snapshot["seats_taken"])
+    seats_taken = max(0, seats_taken)
+    seats_remaining = max(0, FOUNDERS_CAP_TOTAL - seats_taken)
+    sold_out = seats_taken >= FOUNDERS_CAP_TOTAL
+
+    dias, horas = _compute_remaining(deadline_iso)
+
+    payload: dict = {
+        "vagasRestantes": 0 if sold_out else seats_remaining,
+        "vagasTotal": FOUNDERS_CAP_TOTAL,
+        "vagasPreenchidas": seats_taken,
+        "diasRestantes": dias,
+        "horasRestantes": horas,
+        "deadline": deadline_iso,
+        "ultimaVagaEm": snapshot.get("ultima_vaga_em"),
+        "ultimasVagasOptIn": snapshot.get("opt_in", []),
+        "sold_out": sold_out,
+        "fallback": False,
+        "message": None,
+    }
+
+    # 3) Cache the result (best-effort).
+    await _set_cached(payload)
+
+    return FoundersAvailabilityResponse(**payload)

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -76,6 +76,7 @@ from routes.indice_municipal import router as indice_municipal_router
 from routes.notifications import router as notifications_router
 from routes.export import router as edital_export_router
 from routes.founding import router as founding_router
+from routes.founders import router as founders_router
 from routes.conta import router as conta_router
 from routes.intel_reports import router as intel_reports_router
 
@@ -141,6 +142,10 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(admin_billing_sync_router)
     app.include_router(admin_founding_router)
     app.include_router(slo_router)
+
+    # Issue #1002: founders availability — self-prefixed at /api/founders/*
+    # (NOT under /v1/ — public landing-page consumers + SEO programmatic).
+    app.include_router(founders_router)
 
     # Stripe webhook at root — DEBT-324: single registration only.
     # Removed from _v1_routers above to prevent duplicate at /v1/webhooks/stripe.

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -6135,6 +6135,117 @@
         "title": "FornecedoresStatsResponse",
         "type": "object"
       },
+      "FoundersAvailabilityResponse": {
+        "description": "Response shape for ``GET /api/founders/availability`` (issue #1002).\n\nOn the happy path all numeric fields are populated and ``fallback=false``.\nOn DB/Redis failure ``vagasRestantes=null`` + ``fallback=true`` and the\nfrontend renders the conservative copy (\"Vagas limitadas \u2014 encerra 30/06\").",
+        "properties": {
+          "deadline": {
+            "default": "2026-06-30T23:59:59-03:00",
+            "description": "ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).",
+            "title": "Deadline",
+            "type": "string"
+          },
+          "diasRestantes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whole days until the deadline.",
+            "title": "Diasrestantes"
+          },
+          "fallback": {
+            "default": false,
+            "description": "TRUE when DB or Redis is unavailable. Frontend should render the conservative copy without a number.",
+            "title": "Fallback",
+            "type": "boolean"
+          },
+          "horasRestantes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whole hours until the deadline.",
+            "title": "Horasrestantes"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Conservative copy returned when fallback=true.",
+            "title": "Message"
+          },
+          "sold_out": {
+            "default": false,
+            "description": "TRUE when vagasPreenchidas >= cap (50).",
+            "title": "Sold Out",
+            "type": "boolean"
+          },
+          "ultimaVagaEm": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the most recent founder_since.",
+            "title": "Ultimavagaem"
+          },
+          "ultimasVagasOptIn": {
+            "description": "Up to 5 most recent founders who explicitly opted in via founder_public_listing_consent=TRUE (LGPD).",
+            "items": {
+              "$ref": "#/components/schemas/UltimaVagaOptIn"
+            },
+            "title": "Ultimasvagasoptin",
+            "type": "array"
+          },
+          "vagasPreenchidas": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Seats already taken (count of is_founder=TRUE profiles).",
+            "title": "Vagaspreenchidas"
+          },
+          "vagasRestantes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Seats still available (50 - taken). NULL when fallback=true.",
+            "title": "Vagasrestantes"
+          },
+          "vagasTotal": {
+            "default": 50,
+            "description": "Hard cap (50).",
+            "title": "Vagastotal",
+            "type": "integer"
+          }
+        },
+        "title": "FoundersAvailabilityResponse",
+        "type": "object"
+      },
       "FoundingAvailabilityResponse": {
         "description": "Public availability snapshot for landing-page seat counter + countdown.",
         "properties": {
@@ -14271,6 +14382,33 @@
         "title": "UfStatusDetail",
         "type": "object"
       },
+      "UltimaVagaOptIn": {
+        "description": "LGPD-safe public listing entry (only included when consent=TRUE).",
+        "properties": {
+          "empresa": {
+            "description": "Display name (razao_social or 'empresa').",
+            "title": "Empresa",
+            "type": "string"
+          },
+          "preenchidaEm": {
+            "description": "ISO-8601 timestamp.",
+            "title": "Preenchidaem",
+            "type": "string"
+          },
+          "uf": {
+            "description": "State code, 2 letters.",
+            "title": "Uf",
+            "type": "string"
+          }
+        },
+        "required": [
+          "empresa",
+          "uf",
+          "preenchidaEm"
+        ],
+        "title": "UltimaVagaOptIn",
+        "type": "object"
+      },
       "UnreadCountResponse": {
         "description": "Unread message count for badge display.",
         "properties": {
@@ -15478,6 +15616,28 @@
           }
         },
         "summary": "Root"
+      }
+    },
+    "/api/founders/availability": {
+      "get": {
+        "description": "Public seat counter + countdown feed (issue #1002).",
+        "operationId": "founders_availability_api_founders_availability_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoundersAvailabilityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Founders Availability",
+        "tags": [
+          "founders"
+        ]
       }
     },
     "/debug/pncp-test": {

--- a/backend/tests/test_founders_availability.py
+++ b/backend/tests/test_founders_availability.py
@@ -1,0 +1,224 @@
+"""Issue #1002 (API-FOUND-003): tests for GET /api/founders/availability.
+
+Coverage:
+- Happy path — DB returns N seats taken, response shape matches spec.
+- Cap reached (50/50) — vagasRestantes=0 + sold_out=true.
+- DB error — fallback=true + vagasRestantes=null + conservative message.
+- Cache hit — returns cached payload, does NOT hit DB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from rate_limiter import require_rate_limit
+from routes.founders import (
+    FOUNDERS_CAP_TOTAL,
+    router as founders_router,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_founders():
+    app = FastAPI()
+    # Bypass rate-limiter (Redis) in unit tests.
+    app.dependency_overrides[require_rate_limit(60, 60)] = lambda: None
+    app.include_router(founders_router)
+    return app
+
+
+def _make_supabase_mock(seats_taken: int, last_founder_iso: str | None = None,
+                        opt_in_rows: list[dict] | None = None,
+                        opt_in_raises: bool = False) -> MagicMock:
+    """Build a fake supabase client whose chained ``.table()...execute()``
+    calls return specific shapes for each query the route makes.
+
+    The route makes 3 chained calls in order:
+      1) profiles.select(id, count="exact").eq(is_founder, True).execute()
+      2) profiles.select(founder_since).eq(...).order(...).limit(1).execute()
+      3) profiles.select(razao_social,uf,founder_since).eq(...).eq(...).order(...).limit(5).execute()
+
+    We use a side-effect on `.execute` to return them in order.
+    """
+    fake_sb = MagicMock()
+
+    # Build the chain so every chained method returns the same fake_sb.
+    fake_sb.table.return_value = fake_sb
+    fake_sb.select.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.order.return_value = fake_sb
+    fake_sb.limit.return_value = fake_sb
+
+    count_result = MagicMock(count=seats_taken, data=[])
+    last_result = MagicMock(data=(
+        [{"founder_since": last_founder_iso}] if last_founder_iso else []
+    ))
+    if opt_in_raises:
+        # The 3rd execute() call should raise.
+        side_effects: list = [count_result, last_result, Exception("opt-in column missing")]
+    else:
+        opt_result = MagicMock(data=opt_in_rows or [])
+        side_effects = [count_result, last_result, opt_result]
+
+    fake_sb.execute.side_effect = side_effects
+    return fake_sb
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.founders._set_cached", new_callable=AsyncMock)
+@patch("routes.founders._get_cached", new_callable=AsyncMock)
+@patch("routes.founders.get_supabase")
+def test_founders_availability_happy_path(
+    mock_get_sb, mock_get_cached, mock_set_cached, app_with_founders
+):
+    """Happy path: 23 seats taken → vagasRestantes=27, sold_out=false."""
+    mock_get_cached.return_value = None  # cache miss
+    mock_get_sb.return_value = _make_supabase_mock(
+        seats_taken=23,
+        last_founder_iso="2026-05-08T14:23:11-03:00",
+        opt_in_rows=[
+            {"razao_social": "Construtora X", "uf": "SC",
+             "founder_since": "2026-05-08T14:23:11-03:00"},
+            {"razao_social": "TI Y", "uf": "SP",
+             "founder_since": "2026-05-07T09:11:00-03:00"},
+        ],
+    )
+
+    client = TestClient(app_with_founders)
+    r = client.get("/api/founders/availability")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["vagasRestantes"] == 27
+    assert body["vagasTotal"] == FOUNDERS_CAP_TOTAL
+    assert body["vagasPreenchidas"] == 23
+    assert body["sold_out"] is False
+    assert body["fallback"] is False
+    assert body["deadline"]  # non-empty
+    assert body["ultimaVagaEm"] == "2026-05-08T14:23:11-03:00"
+    assert len(body["ultimasVagasOptIn"]) == 2
+    assert body["ultimasVagasOptIn"][0]["empresa"] == "Construtora X"
+    assert body["ultimasVagasOptIn"][0]["uf"] == "SC"
+    # Cache-Control header present
+    assert "public" in r.headers.get("cache-control", "")
+
+
+@patch("routes.founders._set_cached", new_callable=AsyncMock)
+@patch("routes.founders._get_cached", new_callable=AsyncMock)
+@patch("routes.founders.get_supabase")
+def test_founders_availability_cap_reached(
+    mock_get_sb, mock_get_cached, mock_set_cached, app_with_founders
+):
+    """Cap reached (50/50): vagasRestantes=0 + sold_out=true."""
+    mock_get_cached.return_value = None
+    mock_get_sb.return_value = _make_supabase_mock(seats_taken=50)
+
+    client = TestClient(app_with_founders)
+    r = client.get("/api/founders/availability")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["vagasRestantes"] == 0
+    assert body["vagasPreenchidas"] == 50
+    assert body["sold_out"] is True
+    assert body["fallback"] is False
+
+
+@patch("routes.founders._set_cached", new_callable=AsyncMock)
+@patch("routes.founders._get_cached", new_callable=AsyncMock)
+@patch("routes.founders.get_supabase")
+def test_founders_availability_db_error_returns_fallback(
+    mock_get_sb, mock_get_cached, mock_set_cached, app_with_founders
+):
+    """DB error → 200 with fallback=true and vagasRestantes=null."""
+    mock_get_cached.return_value = None
+    fake_sb = MagicMock()
+    fake_sb.table.return_value = fake_sb
+    fake_sb.select.return_value = fake_sb
+    fake_sb.eq.return_value = fake_sb
+    fake_sb.execute.side_effect = Exception("db down")
+    mock_get_sb.return_value = fake_sb
+
+    client = TestClient(app_with_founders)
+    r = client.get("/api/founders/availability")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["fallback"] is True
+    assert body["vagasRestantes"] is None
+    assert body["vagasPreenchidas"] is None
+    assert body["vagasTotal"] == FOUNDERS_CAP_TOTAL
+    assert "Vagas limitadas" in (body.get("message") or "")
+
+
+@patch("routes.founders._set_cached", new_callable=AsyncMock)
+@patch("routes.founders._get_cached", new_callable=AsyncMock)
+@patch("routes.founders.get_supabase")
+def test_founders_availability_uses_cache(
+    mock_get_sb, mock_get_cached, mock_set_cached, app_with_founders
+):
+    """Cache hit: response served from cache, DB never hit."""
+    mock_get_cached.return_value = {
+        "vagasRestantes": 12,
+        "vagasTotal": FOUNDERS_CAP_TOTAL,
+        "vagasPreenchidas": 38,
+        "diasRestantes": 50,
+        "horasRestantes": 1200,
+        "deadline": "2026-06-30T23:59:59-03:00",
+        "ultimaVagaEm": "2026-05-09T10:00:00-03:00",
+        "ultimasVagasOptIn": [],
+        "sold_out": False,
+        "fallback": False,
+        "message": None,
+    }
+
+    client = TestClient(app_with_founders)
+    r = client.get("/api/founders/availability")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["vagasRestantes"] == 12
+    assert body["vagasPreenchidas"] == 38
+    # DB was NOT called because cache returned a payload.
+    mock_get_sb.assert_not_called()
+    # Set should NOT have been called either (cache hit short-circuits).
+    mock_set_cached.assert_not_called()
+
+
+@patch("routes.founders._set_cached", new_callable=AsyncMock)
+@patch("routes.founders._get_cached", new_callable=AsyncMock)
+@patch("routes.founders.get_supabase")
+def test_founders_availability_opt_in_column_missing_is_non_blocking(
+    mock_get_sb, mock_get_cached, mock_set_cached, app_with_founders
+):
+    """If the LGPD opt-in column doesn't exist yet, route still returns
+    a 200 with empty ultimasVagasOptIn — graceful migration support."""
+    mock_get_cached.return_value = None
+    mock_get_sb.return_value = _make_supabase_mock(
+        seats_taken=5,
+        last_founder_iso="2026-05-09T10:00:00-03:00",
+        opt_in_raises=True,
+    )
+
+    client = TestClient(app_with_founders)
+    r = client.get("/api/founders/availability")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["vagasRestantes"] == 45
+    assert body["vagasPreenchidas"] == 5
+    assert body["ultimasVagasOptIn"] == []
+    assert body["fallback"] is False

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -24,6 +24,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/founders/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founders Availability
+         * @description Public seat counter + countdown feed (issue #1002).
+         */
+        get: operations["founders_availability_api_founders_availability_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/debug/pncp-test": {
         parameters: {
             query?: never;
@@ -8034,6 +8054,75 @@ export interface components {
             uf: string;
         };
         /**
+         * FoundersAvailabilityResponse
+         * @description Response shape for ``GET /api/founders/availability`` (issue #1002).
+         *
+         *     On the happy path all numeric fields are populated and ``fallback=false``.
+         *     On DB/Redis failure ``vagasRestantes=null`` + ``fallback=true`` and the
+         *     frontend renders the conservative copy ("Vagas limitadas — encerra 30/06").
+         */
+        FoundersAvailabilityResponse: {
+            /**
+             * Deadline
+             * @description ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).
+             * @default 2026-06-30T23:59:59-03:00
+             */
+            deadline: string;
+            /**
+             * Diasrestantes
+             * @description Whole days until the deadline.
+             */
+            diasRestantes?: number | null;
+            /**
+             * Fallback
+             * @description TRUE when DB or Redis is unavailable. Frontend should render the conservative copy without a number.
+             * @default false
+             */
+            fallback: boolean;
+            /**
+             * Horasrestantes
+             * @description Whole hours until the deadline.
+             */
+            horasRestantes?: number | null;
+            /**
+             * Message
+             * @description Conservative copy returned when fallback=true.
+             */
+            message?: string | null;
+            /**
+             * Sold Out
+             * @description TRUE when vagasPreenchidas >= cap (50).
+             * @default false
+             */
+            sold_out: boolean;
+            /**
+             * Ultimavagaem
+             * @description ISO-8601 timestamp of the most recent founder_since.
+             */
+            ultimaVagaEm?: string | null;
+            /**
+             * Ultimasvagasoptin
+             * @description Up to 5 most recent founders who explicitly opted in via founder_public_listing_consent=TRUE (LGPD).
+             */
+            ultimasVagasOptIn?: components["schemas"]["UltimaVagaOptIn"][];
+            /**
+             * Vagaspreenchidas
+             * @description Seats already taken (count of is_founder=TRUE profiles).
+             */
+            vagasPreenchidas?: number | null;
+            /**
+             * Vagasrestantes
+             * @description Seats still available (50 - taken). NULL when fallback=true.
+             */
+            vagasRestantes?: number | null;
+            /**
+             * Vagastotal
+             * @description Hard cap (50).
+             * @default 50
+             */
+            vagasTotal: number;
+        };
+        /**
          * FoundingAvailabilityResponse
          * @description Public availability snapshot for landing-page seat counter + countdown.
          */
@@ -11469,6 +11558,27 @@ export interface components {
             uf: string;
         };
         /**
+         * UltimaVagaOptIn
+         * @description LGPD-safe public listing entry (only included when consent=TRUE).
+         */
+        UltimaVagaOptIn: {
+            /**
+             * Empresa
+             * @description Display name (razao_social or 'empresa').
+             */
+            empresa: string;
+            /**
+             * Preenchidaem
+             * @description ISO-8601 timestamp.
+             */
+            preenchidaEm: string;
+            /**
+             * Uf
+             * @description State code, 2 letters.
+             */
+            uf: string;
+        };
+        /**
          * UnreadCountResponse
          * @description Unread message count for badge display.
          */
@@ -11994,6 +12104,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RootResponse"];
+                };
+            };
+        };
+    };
+    founders_availability_api_founders_availability_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundersAvailabilityResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- New public endpoint `GET /api/founders/availability` (anonymous, no auth) returning vagasRestantes, vagasTotal, vagasPreenchidas, deadline countdown, and LGPD-gated ultimasVagasOptIn.
- Redis-cached 60s + Cache-Control `public, s-maxage=30` for Googlebot fanout.
- Rate-limit 60 req/min per IP.
- Pydantic `FoundersAvailabilityResponse` with `response_model=` declared (feeds STORY-2.1 frontend codegen).
- Source of truth: count of `profiles.is_founder=TRUE` (cap 50, deadline `FOUNDERS_DEADLINE` env or `2026-06-30T23:59:59-03:00`).

## Context
Founders v2 lifetime offer (R$997, 50 vagas, 30/06/2026 deadline) needs genuine scarcity (Cialdini Pre-Suasion). Today FundadoresCountdown.tsx is static / client-only. Issue #1002 introduces the canonical seat counter that powers `/fundadores` hero, `/planos` cross-sell banner, programmatic SEO footer, dashboard trial banner, and day-10 trial emails.

Resilience:
- DB query wrapped in `_run_with_budget` (2s) — RES-BE-001 compliant.
- DB failure → 200 with `fallback=true` + `vagasRestantes=null` + conservative copy (`"Vagas limitadas — encerra 30/06"`); landing page degrades gracefully without breaking.
- LGPD opt-in column (`founder_public_listing_consent`) gracefully absent → empty list instead of error (forward-compat with future migration).

Out-of-scope (not blocking #1002):
- Stripe `checkout.session.completed` already flips `is_founder=TRUE` via existing `webhooks/handlers/founding.py` — counter decrements automatically; explicit cache invalidation can be added in a follow-up.
- `founder_public_listing_consent` column itself is a separate LGPD migration (route already supports it once shipped).
- Frontend `useFoundersAvailability()` SWR hook + Prometheus gauges → follow-up PRs.

## Testing Plan
- [x] `pytest backend/tests/test_founders_availability.py -v --timeout=30` — 5/5 passing locally
  - Happy path (23/50 → vagasRestantes=27)
  - Cap reached (50/50 → sold_out=true, vagasRestantes=0)
  - DB error → fallback=true + vagasRestantes=null
  - Cache hit → DB not called
  - LGPD opt-in column missing → graceful empty list
- [x] `ruff check backend/routes/founders.py backend/tests/test_founders_availability.py backend/startup/routes.py` — clean
- [ ] Post-deploy smoke: `curl https://api.smartlic.tech/api/founders/availability` returns 200 with the expected shape
- [ ] CI: api-types-check workflow validates OpenAPI drift (response_model declared)

## Closes
Closes #1002