### PR TITLE
feat(frontend): rewrite landing hero (beachhead anti-assessor) (#1003)

### DIFF
--- a/frontend/__tests__/landing/HeroSection.test.tsx
+++ b/frontend/__tests__/landing/HeroSection.test.tsx
@@ -29,50 +29,75 @@ jest.mock('next/link', () => {
 });
 
 describe('HeroSection', () => {
-  it('renders headline with B2G intelligence positioning (REPO-006)', () => {
-    render(<HeroSection />);
+  // ---- COPY-LANDING-004 (#1003): Beachhead anti-assessor + trust signals 2026 ----
 
-    expect(screen.getByText(/Decisão comercial em licitação não nasce de PDF/i)).toBeInTheDocument();
-    expect(screen.getByText(/Nasce de inteligência/i)).toBeInTheDocument();
+  it('renders V1 anti-assessor headline (COPY-LANDING-004)', () => {
+    render(<HeroSection />);
+    const headline = screen.getByTestId('hero-headline');
+    expect(headline).toHaveTextContent(
+      /Pare de pagar R\$3\.000\/mês ao assessor que copia o PNCP\./i
+    );
   });
 
-  it('renders subheadline with go/no-go decision framing (REPO-006)', () => {
+  it('renders sub with mensal + Fundadores price anchor (COPY-LANDING-004)', () => {
     render(<HeroSection />);
-
-    expect(screen.getByText(/SmartLic lê o edital, mapeia o concorrente, calcula a chance real/i)).toBeInTheDocument();
-    expect(screen.getByText(/go\/no-go em minutos/i)).toBeInTheDocument();
+    const sub = screen.getByTestId('hero-subheadline');
+    expect(sub).toHaveTextContent(/SmartLic lê o edital, mapeia o concorrente/i);
+    expect(sub).toHaveTextContent(/R\$197\/mês/i);
+    expect(sub).toHaveTextContent(/R\$997 vitalício/i);
+    expect(sub).toHaveTextContent(/não R\$3\.000 por PDF no WhatsApp/i);
   });
 
-  it('renders primary CTA with correct data-testid and href (REPO-006)', () => {
+  it('renders primary CTA "Testar 14 dias grátis" with sub "Sem cartão" (COPY-LANDING-004)', () => {
     render(<HeroSection />);
-
     const primaryCTA = screen.getByTestId('hero-cta-primary');
-    expect(primaryCTA).toBeInTheDocument();
     expect(primaryCTA).toHaveAttribute('href', '/signup?source=hero-primary');
-    expect(primaryCTA).toHaveTextContent('Testar plataforma');
+    expect(primaryCTA).toHaveTextContent(/Testar 14 dias grátis/i);
+    expect(screen.getByTestId('hero-cta-primary-subtext')).toHaveTextContent(
+      /Sem cartão\. Cancele em 1 clique\./i
+    );
   });
 
-  it('renders secondary CTA with correct data-testid and href (REPO-006)', () => {
+  it('renders secondary CTA "Plano Fundadores R$997" (COPY-LANDING-004)', () => {
     render(<HeroSection />);
-
     const secondaryCTA = screen.getByTestId('hero-cta-secondary');
-    expect(secondaryCTA).toBeInTheDocument();
-    expect(secondaryCTA).toHaveAttribute('href', '/consultoria-b2g#diagnostico');
-    expect(secondaryCTA).toHaveTextContent('Solicitar diagnóstico B2G');
+    expect(secondaryCTA).toHaveAttribute('href', '/planos#fundadores');
+    expect(secondaryCTA).toHaveTextContent(/Ver Plano Fundadores R\$997/i);
   });
 
-  it('renders founding disclaimer below CTA buttons (REPO-007)', () => {
+  it('renders founder strip with name + role + LinkedIn link (COPY-LANDING-004)', () => {
     render(<HeroSection />);
+    const strip = screen.getByTestId('hero-founder-strip');
+    expect(strip).toHaveTextContent(/Tiago Sasaki/i);
+    expect(strip).toHaveTextContent(/Engenheiro civil/i);
+    expect(strip).toHaveTextContent(/10 anos servidor público em pregões/i);
 
-    expect(
-      screen.getByText(/Criado por servidor público com mais de 10 anos em licitações/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Plataforma independente, sem vínculo com órgãos governamentais/i)
-    ).toBeInTheDocument();
+    const linkedin = screen.getByTestId('hero-founder-linkedin');
+    expect(linkedin).toHaveAttribute('href', 'https://www.linkedin.com/in/tiago-sasaki/');
+    expect(linkedin).toHaveAttribute('target', '_blank');
+    expect(linkedin).toHaveAttribute('rel', expect.stringContaining('noopener'));
   });
 
-  it('does NOT use forbidden terms (AC11)', () => {
+  it('renders 2026 trust signals: changelog + roadmap + 60d garantia + sources', () => {
+    render(<HeroSection />);
+    const trust = screen.getByTestId('hero-trust-signals');
+    expect(trust).toHaveTextContent(/Changelog público/i);
+    expect(trust).toHaveTextContent(/Roadmap aberto/i);
+    expect(trust).toHaveTextContent(/60 dias de garantia/i);
+    expect(trust).toHaveTextContent(/devolução incondicional/i);
+    expect(trust).toHaveTextContent(/Fontes oficiais verificadas/i);
+
+    expect(screen.getByTestId('hero-trust-changelog')).toHaveAttribute('href', '/changelog');
+    expect(screen.getByTestId('hero-trust-roadmap')).toHaveAttribute('href', '/roadmap');
+  });
+
+  it('REMOVES legacy "Sem dados fabricados" microcopy (COPY-LANDING-004 AC)', () => {
+    const { container } = render(<HeroSection />);
+    const text = container.textContent || '';
+    expect(text).not.toMatch(/Sem dados fabricados/i);
+  });
+
+  it('does NOT use forbidden marketing terms', () => {
     const { container } = render(<HeroSection />);
     const text = container.textContent || '';
 
@@ -96,12 +121,11 @@ describe('HeroSection', () => {
     const { container } = render(<HeroSection />);
     const text = container.textContent || '';
 
-    // Stats badges removed — these values should NOT appear in HeroSection
     expect(text).not.toMatch(/87%/);
     expect(text).not.toMatch(/UFs cobertas/i);
   });
 
-  // ---- DEBT-125: Product Screenshot Tests ----
+  // ---- DEBT-125: Product Screenshot Tests (preserved from previous spec) ----
 
   describe('DEBT-125: Product Screenshot', () => {
     it('AC1: renders product screenshot in desktop layout', () => {
@@ -112,7 +136,6 @@ describe('HeroSection', () => {
       });
       expect(img).toBeInTheDocument();
 
-      // 50/50 layout uses flex-row on lg breakpoint
       const flexContainer = container.querySelector('.lg\\:flex-row');
       expect(flexContainer).toBeInTheDocument();
     });
@@ -151,7 +174,6 @@ describe('HeroSection', () => {
       const img = screen.getByRole('img', {
         name: /Tela de resultados do SmartLic/i,
       });
-      // dark:brightness-[0.85] dark:contrast-[1.1]
       expect(img.className).toContain('dark:brightness-');
       expect(img.className).toContain('dark:contrast-');
     });
@@ -159,13 +181,11 @@ describe('HeroSection', () => {
     it('renders browser chrome frame around screenshot', () => {
       const { container } = render(<HeroSection />);
 
-      // Browser URL bar text
       expect(screen.getByText('smartlic.tech/buscar')).toBeInTheDocument();
 
-      // Browser dots (red, yellow, green)
       const dots = container.querySelectorAll('.rounded-full');
-      // 3 browser dots + 3 trust indicator dots = 6
-      expect(dots.length).toBeGreaterThanOrEqual(6);
+      // 3 browser dots + 4 trust signal dots + 1 founder avatar bubble = 8
+      expect(dots.length).toBeGreaterThanOrEqual(7);
     });
 
     it('image uses blur placeholder', () => {
@@ -190,7 +210,6 @@ describe('HeroSection', () => {
     it('AC2: mobile layout stacks screenshot below headline (flex-col default)', () => {
       const { container } = render(<HeroSection />);
 
-      // Default is flex-col (mobile), lg:flex-row (desktop)
       const flexContainer = container.querySelector('.flex-col.lg\\:flex-row');
       expect(flexContainer).toBeInTheDocument();
     });

--- a/frontend/app/components/landing/FinalCTA.tsx
+++ b/frontend/app/components/landing/FinalCTA.tsx
@@ -37,8 +37,17 @@ export default function FinalCTA({ className = '' }: FinalCTAProps) {
               <a
                 href="/signup?source=landing-cta"
                 className="w-full sm:w-auto bg-white text-brand-navy hover:bg-surface-1 font-bold px-8 py-4 rounded-button transition-all hover:scale-[1.02] active:scale-[0.98] text-center text-lg focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-white/50"
+                data-testid="final-cta-primary"
               >
-                Analisar oportunidades do meu setor
+                Testar 14 dias grátis
+              </a>
+              {/* COPY-LANDING-004 (#1003): Cross-sell sutil Plano Fundadores */}
+              <a
+                href="/planos#fundadores"
+                className="w-full sm:w-auto border border-white/40 text-white hover:bg-white/10 font-semibold px-8 py-4 rounded-button transition-all text-center text-base focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-white/50"
+                data-testid="final-cta-fundadores"
+              >
+                Ou: Plano Fundadores R$997 vitalício →
               </a>
             </div>
           </AnimateOnScroll>

--- a/frontend/app/components/landing/HeroFounderStrip.tsx
+++ b/frontend/app/components/landing/HeroFounderStrip.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { fadeInUp } from '@/lib/animations';
+import { hero } from '@/lib/copy/valueProps';
+
+/**
+ * COPY-LANDING-004 (#1003): Founder-led visível — nome + cargo + LinkedIn.
+ * Schema.org Person já vive em StructuredData.tsx (E-E-A-T).
+ * Asset foto profissional fica como dependência separada; o strip exibe
+ * iniciais "TS" como placeholder até o asset ser disponibilizado.
+ *
+ * Extraído de HeroSection.tsx em refactor estrutural (LOC gate, #1017).
+ */
+export default function HeroFounderStrip() {
+  return (
+    <motion.div
+      className="mt-6 flex items-center justify-center lg:justify-start gap-3 text-sm"
+      variants={fadeInUp}
+      data-testid="hero-founder-strip"
+    >
+      <div
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue-subtle text-brand-blue font-semibold"
+        aria-hidden="true"
+      >
+        TS
+      </div>
+      <p className="text-ink-secondary text-left leading-snug">
+        Criado por{' '}
+        <a
+          href={hero.founder.linkedinUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold text-ink underline-offset-2 hover:underline"
+          data-testid="hero-founder-linkedin"
+        >
+          {hero.founder.name}
+        </a>
+        , {hero.founder.role}.
+      </p>
+    </motion.div>
+  );
+}

--- a/frontend/app/components/landing/HeroSection.tsx
+++ b/frontend/app/components/landing/HeroSection.tsx
@@ -8,6 +8,8 @@ import { GradientButton } from '@/app/components/ui/GradientButton';
 import { useScrollAnimation } from '@/lib/animations';
 import { fadeInUp, staggerContainer } from '@/lib/animations';
 import { hero } from '@/lib/copy/valueProps';
+import HeroFounderStrip from './HeroFounderStrip';
+import HeroTrustSignals from './HeroTrustSignals';
 
 interface HeroSectionProps {
   className?: string;
@@ -28,6 +30,10 @@ const HERO_SCREENSHOT_BLUR =
  *  - CTA secundário: ancoragem Plano Fundadores R$997
  *  - Founder-led visível: nome + cargo + LinkedIn (Schema.org Person já em StructuredData.tsx)
  *  - Trust signals 2026: founder + changelog + roadmap + 60d garantia (substitui "Sem dados fabricados")
+ *
+ * Sub-componentes (refactor estrutural #1017 — LOC gate):
+ *  - HeroFounderStrip: avatar + nome + cargo + LinkedIn
+ *  - HeroTrustSignals: 4 trust signals 2026
  */
 export default function HeroSection({ className = '' }: HeroSectionProps) {
   const { ref, isVisible } = useScrollAnimation(0.1);
@@ -138,70 +144,8 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
             </Link>
           </motion.div>
 
-          {/* COPY-LANDING-004: Founder-led visível — nome + cargo + LinkedIn */}
-          <motion.div
-            className="mt-6 flex items-center justify-center lg:justify-start gap-3 text-sm"
-            variants={fadeInUp}
-            data-testid="hero-founder-strip"
-          >
-            <div
-              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue-subtle text-brand-blue font-semibold"
-              aria-hidden="true"
-            >
-              TS
-            </div>
-            <p className="text-ink-secondary text-left leading-snug">
-              Criado por{' '}
-              <a
-                href={hero.founder.linkedinUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-semibold text-ink underline-offset-2 hover:underline"
-                data-testid="hero-founder-linkedin"
-              >
-                {hero.founder.name}
-              </a>
-              , {hero.founder.role}.
-            </p>
-          </motion.div>
-
-          {/* COPY-LANDING-004: Trust signals 2026 — substitui "Sem dados fabricados" por sinais positivos verificáveis */}
-          <motion.div
-            className="mt-6 flex flex-wrap items-center justify-center lg:justify-start gap-x-5 gap-y-2 text-xs text-ink-muted"
-            variants={fadeInUp}
-            data-testid="hero-trust-signals"
-          >
-            <Link
-              href="/changelog"
-              className="flex items-center gap-1.5 hover:text-ink-secondary transition-colors"
-              data-testid="hero-trust-changelog"
-            >
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              Changelog público
-            </Link>
-            <Link
-              href="/roadmap"
-              className="flex items-center gap-1.5 hover:text-ink-secondary transition-colors"
-              data-testid="hero-trust-roadmap"
-            >
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              Roadmap aberto
-            </Link>
-            <span
-              className="flex items-center gap-1.5"
-              data-testid="hero-trust-guarantee"
-            >
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              60 dias de garantia · devolução incondicional
-            </span>
-            <span
-              className="flex items-center gap-1.5"
-              data-testid="hero-trust-sources"
-            >
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              Fontes oficiais verificadas (PNCP, ComprasGov, PCP)
-            </span>
-          </motion.div>
+          <HeroFounderStrip />
+          <HeroTrustSignals />
         </div>
 
         {/* Right column — annotated product screenshot (DEBT-125 AC1-AC8) */}

--- a/frontend/app/components/landing/HeroSection.tsx
+++ b/frontend/app/components/landing/HeroSection.tsx
@@ -22,6 +22,12 @@ const HERO_SCREENSHOT_BLUR =
  * DEBT-125: 50/50 layout with annotated product screenshot
  * REPO-006: Copymasters consensus v1 — B2G intelligence positioning
  * REPO-007: Founding disclaimer below CTAs
+ * COPY-LANDING-004 (#1003): Beachhead anti-assessor + trust signals 2026
+ *  - V1 headline: "Pare de pagar R$3.000/mês ao assessor que copia o PNCP"
+ *  - CTA primário: "Testar 14 dias grátis →" + sub "Sem cartão. Cancele em 1 clique."
+ *  - CTA secundário: ancoragem Plano Fundadores R$997
+ *  - Founder-led visível: nome + cargo + LinkedIn (Schema.org Person já em StructuredData.tsx)
+ *  - Trust signals 2026: founder + changelog + roadmap + 60d garantia (substitui "Sem dados fabricados")
  */
 export default function HeroSection({ className = '' }: HeroSectionProps) {
   const { ref, isVisible } = useScrollAnimation(0.1);
@@ -60,7 +66,7 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
       >
         {/* Left column — text content */}
         <div className="flex-1 text-center lg:text-left max-w-xl lg:max-w-none">
-          {/* Headline with gradient text */}
+          {/* COPY-LANDING-004: Headline anti-assessor (V1) */}
           <motion.h1
             className="
               text-4xl sm:text-5xl lg:text-6xl
@@ -70,17 +76,17 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
               leading-[1.1]
             "
             variants={fadeInUp}
+            data-testid="hero-headline"
           >
             <span className="text-ink">
-              Decisão comercial em licitação não nasce de PDF.
-            </span>
-            <br />
+              Pare de pagar R$3.000/mês ao assessor
+            </span>{' '}
             <span className="text-gradient">
-              Nasce de inteligência.
+              que copia o PNCP.
             </span>
           </motion.h1>
 
-          {/* Subheadline */}
+          {/* COPY-LANDING-004: Sub com ancoragem de preço (mensal + Fundadores vitalício) */}
           <motion.p
             className="
               text-lg sm:text-xl
@@ -92,8 +98,10 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
               lg:max-w-lg
             "
             variants={fadeInUp}
+            data-testid="hero-subheadline"
           >
-            SmartLic lê o edital, mapeia o concorrente, calcula a chance real. Sua empresa decide go/no-go em minutos — não em três dias de leitura.
+            SmartLic lê o edital, mapeia o concorrente e calcula a chance real.
+            R$197/mês ou R$997 vitalício — não R$3.000 por PDF no WhatsApp.
           </motion.p>
 
           {/* CTA Buttons — AC5: Primary CTA visible above the fold */}
@@ -101,51 +109,97 @@ export default function HeroSection({ className = '' }: HeroSectionProps) {
             className="flex flex-col sm:flex-row items-center lg:items-start justify-center lg:justify-start gap-4 mt-10"
             variants={fadeInUp}
           >
-            <Link href="/signup?source=hero-primary" data-testid="hero-cta-primary">
-              <GradientButton
-                variant="primary"
-                size="lg"
-                glow={true}
+            <div className="flex flex-col items-center lg:items-start gap-1">
+              <Link href={hero.cta.primaryHref} data-testid="hero-cta-primary">
+                <GradientButton
+                  variant="primary"
+                  size="lg"
+                  glow={true}
+                >
+                  {hero.cta.primary}
+                </GradientButton>
+              </Link>
+              <span
+                className="text-xs text-ink-muted"
+                data-testid="hero-cta-primary-subtext"
               >
-                Testar plataforma
-              </GradientButton>
-            </Link>
+                {hero.cta.primarySubtext}
+              </span>
+            </div>
 
-            <Link href="/consultoria-b2g#diagnostico" data-testid="hero-cta-secondary">
+            <Link href={hero.cta.secondaryHref} data-testid="hero-cta-secondary">
               <GradientButton
                 variant="secondary"
                 size="lg"
                 glow={false}
               >
-                Solicitar diagnóstico B2G
+                {hero.cta.secondary}
               </GradientButton>
             </Link>
           </motion.div>
 
-          {/* REPO-007: Founding disclaimer — below CTAs, non-competitive */}
-          <motion.p
-            className="text-sm text-zinc-400 dark:text-zinc-500 max-w-md mx-auto lg:mx-0 text-center lg:text-left mt-4"
-            variants={fadeInUp}
-          >
-            {hero.disclaimer}
-          </motion.p>
-
-          {/* Trust indicators */}
+          {/* COPY-LANDING-004: Founder-led visível — nome + cargo + LinkedIn */}
           <motion.div
-            className="mt-6 flex flex-wrap items-center justify-center lg:justify-start gap-x-6 gap-y-2 text-xs text-ink-muted"
+            className="mt-6 flex items-center justify-center lg:justify-start gap-3 text-sm"
             variants={fadeInUp}
+            data-testid="hero-founder-strip"
           >
-            <span className="flex items-center gap-1.5">
+            <div
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue-subtle text-brand-blue font-semibold"
+              aria-hidden="true"
+            >
+              TS
+            </div>
+            <p className="text-ink-secondary text-left leading-snug">
+              Criado por{' '}
+              <a
+                href={hero.founder.linkedinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-ink underline-offset-2 hover:underline"
+                data-testid="hero-founder-linkedin"
+              >
+                {hero.founder.name}
+              </a>
+              , {hero.founder.role}.
+            </p>
+          </motion.div>
+
+          {/* COPY-LANDING-004: Trust signals 2026 — substitui "Sem dados fabricados" por sinais positivos verificáveis */}
+          <motion.div
+            className="mt-6 flex flex-wrap items-center justify-center lg:justify-start gap-x-5 gap-y-2 text-xs text-ink-muted"
+            variants={fadeInUp}
+            data-testid="hero-trust-signals"
+          >
+            <Link
+              href="/changelog"
+              className="flex items-center gap-1.5 hover:text-ink-secondary transition-colors"
+              data-testid="hero-trust-changelog"
+            >
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              Fontes oficiais verificadas
+              Changelog público
+            </Link>
+            <Link
+              href="/roadmap"
+              className="flex items-center gap-1.5 hover:text-ink-secondary transition-colors"
+              data-testid="hero-trust-roadmap"
+            >
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+              Roadmap aberto
+            </Link>
+            <span
+              className="flex items-center gap-1.5"
+              data-testid="hero-trust-guarantee"
+            >
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+              60 dias de garantia · devolução incondicional
             </span>
-            <span className="flex items-center gap-1.5">
+            <span
+              className="flex items-center gap-1.5"
+              data-testid="hero-trust-sources"
+            >
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              Critérios objetivos, não opinião
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-              Sem dados fabricados
+              Fontes oficiais verificadas (PNCP, ComprasGov, PCP)
             </span>
           </motion.div>
         </div>

--- a/frontend/app/components/landing/HeroTrustSignals.tsx
+++ b/frontend/app/components/landing/HeroTrustSignals.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { fadeInUp } from '@/lib/animations';
+
+/**
+ * COPY-LANDING-004 (#1003): Trust signals 2026 — substitui microcopy negativa
+ * "Sem dados fabricados" por 4 sinais positivos verificáveis: Changelog público,
+ * Roadmap aberto, 60d garantia + devolução incondicional, Fontes oficiais.
+ *
+ * Extraído de HeroSection.tsx em refactor estrutural (LOC gate, #1017).
+ */
+export default function HeroTrustSignals() {
+  return (
+    <motion.div
+      className="mt-6 flex flex-wrap items-center justify-center lg:justify-start gap-x-5 gap-y-2 text-xs text-ink-muted"
+      variants={fadeInUp}
+      data-testid="hero-trust-signals"
+    >
+      <Link
+        href="/changelog"
+        className="flex items-center gap-1.5 hover:text-ink-secondary transition-colors"
+        data-testid="hero-trust-changelog"
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+        Changelog público
+      </Link>
+      <Link
+        href="/roadmap"
+        className="flex items-center gap-1.5 hover:text-ink-secondary transition-colors"
+        data-testid="hero-trust-roadmap"
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+        Roadmap aberto
+      </Link>
+      <span
+        className="flex items-center gap-1.5"
+        data-testid="hero-trust-guarantee"
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+        60 dias de garantia · devolução incondicional
+      </span>
+      <span
+        className="flex items-center gap-1.5"
+        data-testid="hero-trust-sources"
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+        Fontes oficiais verificadas (PNCP, ComprasGov, PCP)
+      </span>
+    </motion.div>
+  );
+}

--- a/frontend/lib/copy/valueProps.ts
+++ b/frontend/lib/copy/valueProps.ts
@@ -16,21 +16,26 @@ import { Target, Globe, Bot, Search, ShieldCheck } from '@/lib/icons';
 // ============================================================================
 
 export const hero = {
-  // REPO-006: Copymasters consensus v1 — B2G intelligence positioning
+  // COPY-LANDING-004 (#1003): Beachhead anti-assessor — V1 default ativado
+  // Variantes mantidas para A/B test Mixpanel/PostHog (issue #1003 Test Plan).
   headlines: {
+    antiAssessor: "Pare de pagar R$3.000/mês ao assessor que copia o PNCP.",
+    aiAssessor: "Seu assessor não é IA. O nosso é.",
+    competitorTiming: "Encontre o próximo edital antes do seu concorrente.",
     b2gIntelligence: "Decisão comercial em licitação não nasce de PDF. Nasce de inteligência.",
     financialImpact: "Pare de perder dinheiro com licitações erradas.",
     filterFocus: "Só o que vale a pena chega até você.",
     wasteCut: "Licitações que realmente pagam. O resto, a gente descarta.",
-    default: "Decisão comercial em licitação não nasce de PDF. Nasce de inteligência.",
+    default: "Pare de pagar R$3.000/mês ao assessor que copia o PNCP.",
   },
 
-  // REPO-006: Copymasters consensus v1 subheadline
+  // COPY-LANDING-004 (#1003): Sub anti-assessor com ancoragem de preço (mensal + Fundadores)
   subheadlines: {
+    antiAssessor: "SmartLic lê o edital, mapeia o concorrente e calcula a chance real. R$197/mês ou R$997 vitalício — não R$3.000 por PDF no WhatsApp.",
     b2gIntelligence: "SmartLic lê o edital, mapeia o concorrente, calcula a chance real. Sua empresa decide go/no-go em minutos — não em três dias de leitura.",
     mechanism: "O SmartLic analisa cada edital contra o perfil da sua empresa. Elimina o que não faz sentido. Entrega só o que tem chance real de retorno — com justificativa objetiva.",
     filter: "Cada edital passa por análise de compatibilidade com seu perfil. Você só vê o que merece investimento de tempo e proposta.",
-    default: "SmartLic lê o edital, mapeia o concorrente, calcula a chance real. Sua empresa decide go/no-go em minutos — não em três dias de leitura.",
+    default: "SmartLic lê o edital, mapeia o concorrente e calcula a chance real. R$197/mês ou R$997 vitalício — não R$3.000 por PDF no WhatsApp.",
   },
 
   // GTM-COPY-001 AC3: Trust badges — practical confidence, not abstract metrics
@@ -52,19 +57,28 @@ export const hero = {
     },
   ],
 
-  // GTM-COPY-002: Action-oriented CTAs. REPO-006: dual-CTA with diagnostico secondary
+  // COPY-LANDING-004 (#1003): CTA primário trial 14d, secundário ancoragem Fundadores
   cta: {
-    primary: "Testar plataforma",
+    primary: "Testar 14 dias grátis →",
+    primarySubtext: "Sem cartão. Cancele em 1 clique.",
     primaryHref: "/signup?source=hero-primary",
-    secondary: "Solicitar diagnóstico B2G",
-    secondaryHref: "/consultoria-b2g#diagnostico",
+    secondary: "Ver Plano Fundadores R$997 →",
+    secondaryHref: "/planos#fundadores",
     pricing: "Começar a filtrar oportunidades",
-    default: "Testar plataforma",
+    default: "Testar 14 dias grátis →",
   },
 
-  // REPO-007: Founding disclaimer — locked copy v1 (below CTA buttons)
+  // COPY-LANDING-004 (#1003): Founder-led visível — nome + cargo + LinkedIn
+  founder: {
+    name: "Tiago Sasaki",
+    role: "Engenheiro civil · 10 anos servidor público em pregões",
+    linkedinUrl: "https://www.linkedin.com/in/tiago-sasaki/",
+    photoUrl: "/images/tiago-sasaki.webp",
+  },
+
+  // REPO-007: Founding disclaimer (mantido como fallback de cópia)
   disclaimer:
-    "Criado por servidor público com mais de 10 anos em licitações. Plataforma independente, sem vínculo com órgãos governamentais.",
+    "Criado por Tiago Sasaki, engenheiro civil, 10 anos como servidor público em pregões. Plataforma independente, sem vínculo com órgãos governamentais.",
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Reescreve o hero da landing com a headline V1 anti-assessor de #1003: "Pare de pagar R$3.000/mês ao assessor que copia o PNCP" — nomeia o vilão (Halbert starving crowd + Miller SB7).
- Sub com ancoragem dupla de preço: R$197/mês ou R$997 vitalício — vs R$3.000/mês do assessor.
- Atualiza CTAs (primário "Testar 14 dias grátis" + sub "Sem cartão. Cancele em 1 clique."; secundário "Ver Plano Fundadores R$997").
- Substitui microcopy "Sem dados fabricados" (negativa, genérica) por 4 trust signals 2026 verificáveis: Changelog público, Roadmap aberto, 60 dias de garantia + devolução incondicional, Fontes oficiais verificadas.
- Adiciona founder-led visível: Tiago Sasaki + cargo + link LinkedIn (canônico). Schema.org Person já vive em `StructuredData.tsx`.
- FinalCTA ganha cross-sell sutil do Plano Fundadores R$997 vitalício, mantendo a urgência "Licitações estão abrindo agora".

## Context

Issue #1003 (epic #999, label `epic:1-homepage`, `reposicionamento-b2g`). Diagnóstico Copymasters: copy atual abstrata para o visitante Problem-Aware. Frame consenso: SmartLic = "o fim do assessor de R$3.000/mês".

Variantes V2 ("Seu assessor não é IA. O nosso é.") e V3 (controle conservador) ficam em `hero.headlines` para o A/B framework do Mixpanel/PostHog ler quando ativarmos o teste.

Asset foto profissional do Tiago é dependência (issue separado) — o strip mostra avatar com iniciais "TS" até o asset chegar. Páginas `/changelog` e `/roadmap` são P3 separados (não bloqueiam este PR; os links já vão para os destinos canônicos).

## Files

- `frontend/app/components/landing/HeroSection.tsx` — rewrite completo do bloco textual, founder strip, trust signals 2026.
- `frontend/app/components/landing/FinalCTA.tsx` — CTA primário renomeado + cross-sell Fundadores.
- `frontend/lib/copy/valueProps.ts` — novas variantes de headline/sub, `hero.cta` ganha `primarySubtext` + `secondaryHref`, novo bloco `hero.founder`.
- `frontend/__tests__/landing/HeroSection.test.tsx` — testes atualizados para a nova spec (preserva DEBT-125 screenshot tests).

## Testing Plan

- [x] `npx jest --testPathPattern="landing/HeroSection"` → 20/20 passing
- [x] `npx jest --testPathPattern="story-273-social-proof|landing/"` → 114/114 passing (sem regressão em FinalCTA / DataSourcesSection / etc.)
- [x] Asserts explícitos: V1 headline, sub com price anchors, CTA primário + sub-text, CTA secundário Fundadores, founder strip + LinkedIn, 4 trust signals 2026, ausência de "Sem dados fabricados"
- [ ] (Pós-merge) A/B test 3 variantes em PostHog, n≥1000 sessions/variante, 14 dias mínimo (Test Plan #1003)
- [ ] (Pós-merge) Lighthouse CI ≥90, axe-core WCAG AA, mobile real iOS+Android
- [ ] (Pós-merge) Visual regression Playwright

Lint local não roda neste worktree (`next lint` removido em Next 16; ESLint v10 exige flat config — config legacy `.eslintrc.json` ainda em uso). CI `frontend-tests.yml` é a verificação efetiva.

## Closes

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
