### PR TITLE
feat(seo): canonical default + hreflang pt-BR + geo-target (#990 #988)

### DIFF
--- a/frontend/__tests__/seo/root-layout-metadata.test.ts
+++ b/frontend/__tests__/seo/root-layout-metadata.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Root layout metadata invariants (issues #990 + #988).
+ *
+ * SEO-P0-004 (#990): Global canonical default in layout.tsx.
+ * SEO-P0-001 (#988): hreflang pt-BR + geo-target meta tags for HCU classifier.
+ *
+ * We assert against the source text of `frontend/app/layout.tsx` so the test
+ * stays decoupled from runtime imports (the layout module pulls in many
+ * providers + CSS which would otherwise need extensive mocking). The contract
+ * we want to lock down is the *metadata declaration*, which is static.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const LAYOUT_PATH = join(__dirname, '..', '..', 'app', 'layout.tsx');
+const SOURCE = readFileSync(LAYOUT_PATH, 'utf-8');
+
+describe('Root layout metadata — SEO-P0 invariants', () => {
+  describe('SEO-P0-004 (#990) — global canonical default', () => {
+    it('declares metadataBase pointing to smartlic.tech', () => {
+      expect(SOURCE).toMatch(/metadataBase:\s*new URL\([^)]*smartlic\.tech/);
+    });
+
+    it('declares alternates.canonical as relative "/" so per-page generateMetadata can override', () => {
+      // The default MUST be relative so that route-level `generateMetadata`
+      // returning a route-specific canonical takes precedence (Next.js merges
+      // metadata top-down; absolute strings at the root would also override
+      // but relative '/' keeps the contract explicit + portable across envs).
+      expect(SOURCE).toMatch(/alternates:\s*\{[^}]*canonical:\s*['"]\/['"]/);
+    });
+  });
+
+  describe('SEO-P0-001 (#988) — hreflang pt-BR + geo-target', () => {
+    it('declares hreflang pt-BR in alternates.languages', () => {
+      expect(SOURCE).toMatch(/['"]pt-BR['"]:\s*['"]/);
+    });
+
+    it('declares hreflang x-default fallback', () => {
+      expect(SOURCE).toMatch(/['"]x-default['"]:\s*['"]/);
+    });
+
+    it('renders <html lang="pt-BR"> for the document', () => {
+      expect(SOURCE).toMatch(/<html\s+lang="pt-BR"/);
+    });
+
+    it('emits <meta name="content-language" content="pt-BR">', () => {
+      expect(SOURCE).toMatch(/<meta\s+name="content-language"\s+content="pt-BR"/);
+    });
+
+    it('emits <meta name="geo.region" content="BR"> for geo-targeting', () => {
+      expect(SOURCE).toMatch(/<meta\s+name="geo\.region"\s+content="BR"/);
+    });
+
+    it('emits <meta name="geo.country" content="Brazil">', () => {
+      expect(SOURCE).toMatch(/<meta\s+name="geo\.country"\s+content="Brazil"/);
+    });
+
+    it('emits <meta httpEquiv="Content-Language" content="pt-BR"> as legacy fallback', () => {
+      expect(SOURCE).toMatch(/<meta\s+httpEquiv="Content-Language"\s+content="pt-BR"/);
+    });
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -103,12 +103,15 @@ export const metadata: Metadata = {
     images: ["/api/og"],
     // No Twitter/X profile — omit creator/site handles
   },
-  // GTM-COPY-006 AC9: Canonical URL + hreflang (pt-BR only site)
+  // SEO-P0-004 (#990): Global canonical default uses relative '/' so that
+  // per-page generateMetadata() can override with route-specific canonicals.
+  // metadataBase resolves relative URLs to https://smartlic.tech automatically.
+  // SEO-P0-001 (#988): hreflang pt-BR signals single-language Brazilian Portuguese site.
   alternates: {
-    canonical: "https://smartlic.tech",
+    canonical: "/",
     languages: {
-      'pt-BR': 'https://smartlic.tech',
-      'x-default': 'https://smartlic.tech',
+      'pt-BR': '/',
+      'x-default': '/',
     },
   },
   robots: {
@@ -149,6 +152,14 @@ export default function RootLayout({
         {/* SEO: PWA manifest (completes sw.js + offline.html signal chain) */}
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#0a1e3f" />
+        {/* SEO-P0-001 (#988): Geo-targeting + content-language signals for HCU classifier.
+            Suppresses off-intent SERP exposure in non-BR markets (US/CA/UK/MX 0% CTR traffic).
+            Pairs with GSC International Targeting → Country = Brazil (set via Search Console UI). */}
+        <meta name="content-language" content="pt-BR" />
+        <meta name="geo.region" content="BR" />
+        <meta name="geo.country" content="Brazil" />
+        <meta name="geo.placename" content="Brasil" />
+        <meta httpEquiv="Content-Language" content="pt-BR" />
         {/* SEO: Preconnect to critical origins for faster TTFB */}
         <link rel="preconnect" href="https://fqqyovlzdzimiwfofdjk.supabase.co" />
         <link rel="dns-prefetch" href="https://fqqyovlzdzimiwfofdjk.supabase.co" />


### PR DESCRIPTION
## Summary

- **SEO-P0-004 (#990):** root canonical default switched from absolute `https://smartlic.tech` to relative `/`, so per-page `generateMetadata` canonicals override cleanly via `metadataBase`. Closes duplicate-content gap on routes without explicit canonical (e.g. `?modalidade=`, `?utm_source=` querystring variants).
- **SEO-P0-001 (#988):** added geo-targeting + content-language meta tags to suppress off-intent SERP exposure (7k+ US impressions @ 0.03% CTR were dragging the HCU classifier). Pairs with GSC International Targeting → Country = Brazil (set in Search Console UI by repo owner).
- **Tests:** 9 source-text invariants in `__tests__/seo/root-layout-metadata.test.ts` (decoupled from layout module runtime so no provider/CSS mocking needed).

## Context

Both issues live in epic #986 and target the same file (`frontend/app/layout.tsx`), so they ship in one PR per task brief. Per-page `generateMetadata` canonicals (blog posts, observatório, sitemap routes) are unaffected — Next.js metadata merging keeps them as overrides over the relative root default.

`metadataBase` already pointed to `https://smartlic.tech` so the relative `/` resolves to the canonical apex automatically.

## Testing Plan

- [x] `npx jest __tests__/seo/root-layout-metadata.test.ts` — 9/9 passing locally (validated against fresh worktree, parent `node_modules` linked).
- [ ] CI Frontend Test job re-runs the suite on PR.
- [ ] Post-merge smoke (manual, 28d window per issue ACs):
  - `curl -s https://smartlic.tech/ | grep -E 'canonical|hreflang|geo\.region|content-language'` — exactly 1 canonical line, geo meta present.
  - GSC International Targeting → confirm Brazil set; track US impressions trend (target: 7014 → <500 in 28d).
  - GSC Coverage → "Duplicate, Google chose different canonical" should drop.

## Out of scope (deferred to separate PRs)

- Sitemap changes (#1018 sister PR handles `frontend/app/sitemap*.ts`).
- `noindex` helpers for thin/programmatic pages (#1018).
- GSC International Targeting UI change — manual step by repo owner, documented in issue #988.

## Closes

Closes #990
Closes #988