### PR TITLE
feat(copy): COPY-FOUND-002 garantia 60d termos + welcome email Fundadores

### DIFF
--- a/backend/templates/emails/founders_welcome.py
+++ b/backend/templates/emails/founders_welcome.py
@@ -83,6 +83,25 @@ def render_founders_welcome_email(user_name: str) -> str:
       de pagamento com o desconto aplicado direto para voce.
     </p>
 
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="background-color: #fff8e1; border-left: 4px solid #f9a825; border-radius: 6px; margin: 0 0 24px;">
+      <tr>
+        <td style="padding: 16px 20px;">
+          <p style="color: #333; font-size: 15px; line-height: 1.6; margin: 0 0 8px;">
+            <strong>Garantia de 60 dias &mdash; incondicional.</strong>
+          </p>
+          <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 0 0 8px;">
+            Voce tem 60 dias pra usar a vontade. Se nao fizer sentido, devolvo R$997 cheios.
+          </p>
+          <p style="color: #555; font-size: 14px; line-height: 1.6; margin: 0;">
+            Sem letra miuda: e so responder este email (ou escrever para
+            <a href="mailto:tiago@smartlic.tech" style="color: {SMARTLIC_GREEN};">tiago@smartlic.tech</a>)
+            com o assunto <strong>"reembolso"</strong>. Retorno em ate 5 dias uteis.
+          </p>
+        </td>
+      </tr>
+    </table>
+
     <p style="text-align: center; margin: 28px 0 24px;">
       <a href="{FRONTEND_URL}/buscar"
          style="display: inline-block; padding: 14px 32px; background-color: {SMARTLIC_GREEN};
@@ -135,6 +154,11 @@ Aqui esta o que esta incluido no seu plano:
 Para resgatar o 50% de desconto na Consultoria: quando quiser contratar,
 responda este email com o assunto "Consultoria Fundador". Eu gero um link
 de pagamento com o desconto aplicado direto para voce.
+
+Garantia de 60 dias - incondicional.
+Voce tem 60 dias pra usar a vontade. Se nao fizer sentido, devolvo R$997 cheios.
+Sem letra miuda: responda este email (ou escreva para tiago@smartlic.tech)
+com o assunto "reembolso". Retorno em ate 5 dias uteis.
 
 Faca sua primeira busca agora: {FRONTEND_URL}/buscar
 

--- a/backend/tests/test_founders_welcome_email.py
+++ b/backend/tests/test_founders_welcome_email.py
@@ -61,6 +61,35 @@ class TestRenderFoundersWelcomeEmail:
         # Tiago signs the email
         assert "Tiago" in html
 
+    def test_mentions_60_day_guarantee_html(self):
+        """COPY-FOUND-002 (#1001): welcome email must surface the 60-day guarantee."""
+        from templates.emails.founders_welcome import render_founders_welcome_email
+
+        html = render_founders_welcome_email("Fundador")
+
+        assert "60 dias" in html
+        assert "R$997" in html
+        # Refund procedure (subject + SLA)
+        assert "reembolso" in html
+        assert "5 dias uteis" in html
+        # Contact channel
+        assert "tiago@smartlic.tech" in html
+        # No drift back to the legacy 7-day promise
+        assert "garantia de 7 dias" not in html
+
+    def test_mentions_60_day_guarantee_plain(self):
+        """Plain-text rendering must mirror the 60-day guarantee block."""
+        from templates.emails.founders_welcome import render_founders_welcome_plain
+
+        text = render_founders_welcome_plain("Fundador")
+
+        assert "60 dias" in text
+        assert "R$997" in text
+        assert "reembolso" in text
+        assert "5 dias uteis" in text
+        assert "tiago@smartlic.tech" in text
+        assert "garantia de 7 dias" not in text
+
     def test_subject_constant(self):
         from templates.emails.founders_welcome import FOUNDERS_WELCOME_SUBJECT
 

--- a/frontend/app/termos/page.tsx
+++ b/frontend/app/termos/page.tsx
@@ -172,8 +172,9 @@ export default function TermosPage() {
               <ul className="list-disc pl-6 space-y-2 text-gray-700 dark:text-gray-300">
                 <li>Você pode cancelar sua assinatura a qualquer momento através das configurações de conta</li>
                 <li>Cancelamentos terão efeito ao final do período de cobrança atual (não há reembolso proporcional)</li>
-                <li><strong>Garantia de Reembolso:</strong> Planos pagos têm garantia de 7 dias (reembolso integral se solicitado dentro deste período)</li>
-                <li>Após 7 dias, não oferecemos reembolsos, exceto em casos excepcionais a nosso critério</li>
+                <li><strong>Garantia de Reembolso (assinaturas mensais e anuais):</strong> Planos pagos recorrentes têm garantia de 7 dias (reembolso integral se solicitado dentro deste período)</li>
+                <li><strong>Plano Fundadores (acesso vitalício):</strong> garantia incondicional de 60 dias a partir da data da compra. Para solicitar reembolso, envie um email para <a href="mailto:tiago@smartlic.tech" className="text-brand-blue underline">tiago@smartlic.tech</a> com o assunto <em>&quot;reembolso&quot;</em>. Retorno em até 5 dias úteis com devolução integral de R$ 997.</li>
+                <li>Fora dos períodos de garantia acima, não oferecemos reembolsos, exceto em casos excepcionais a nosso critério</li>
               </ul>
 
               <h3 className="text-xl font-semibold mb-3 mt-6 text-gray-800 dark:text-gray-200">


### PR DESCRIPTION
## Summary

Updates the **Plano Fundadores** guarantee to **60 days** (research-backed: +23% conv vs 7d, no refund-rate uplift) in two surfaces this PR owns:

- **Welcome email pos-compra** (`backend/templates/emails/founders_welcome.py`) - novo bloco destacado: "Voce tem 60 dias pra usar a vontade. Se nao fizer sentido, devolvo R$997 cheios." + procedimento (email `tiago@smartlic.tech`, assunto `"reembolso"`, retorno em 5 dias uteis). Aplicado em ambos renders (HTML + plain text), preservando o tom pessoal Resend (from `tiago.sasaki@confenge.com.br`, reply-to gmail).
- **Termos de uso secao 6.2** (`frontend/app/termos/page.tsx`) - separa a clausula de reembolso em duas linhas: assinaturas mensais/anuais mantem garantia de 7 dias (status quo dos planos recorrentes); Plano Fundadores (acesso vitalicio R$997) ganha clausula explicita de **60 dias incondicional** + procedimento + SLA de retorno.

## Context

Issue #1001 (COPY-FOUND-002) pediu o sweep global da garantia 7d -> 60d (pagina /fundadores + FAQ + termos + email boas-vindas). Sister PR #1016 ja enviou o **/fundadores page + FAQ + selo visual + JSON-LD**; este PR cobre os artefatos restantes (termos + welcome email pos-compra) sem colidir com o territorio de #1016.

### Out of scope (auditoria deliberada, nao um esquecimento)

- **`/fundadores` page e seu FAQ** -> ja shipped por PR #1016 com 60d.
- **`frontend/components/subscriptions/DowngradeModal.tsx:134`** ("fora do periodo de garantia (7 dias)") -> esse e o fluxo Pro->monthly, nao Fundadores. Existe inconsistencia generica (TrustSignals diz 30d, DowngradeModal 7d) que merece follow-up dedicado, mas trocar 7d->60d ali seria uma mentira sobre os planos recorrentes Pro/Consultoria. Deixei intacto.
- **`frontend/app/ajuda/faqData.ts`** -> grep confirmou: zero clausula de garantia/reembolso no help center. O "FAQ global" do issue refere-se ao FAQ embutido em `/fundadores` (ja em #1016). Nada a fazer.
- **Trial reminder emails (D7/D10/D13)** -> issue #1005 sister PR.

## Testing Plan

- [x] `pytest backend/tests/test_founders_welcome_email.py::TestRenderFoundersWelcomeEmail -v` -> 8/8 PASSED (inclui 2 novos: `test_mentions_60_day_guarantee_html`, `test_mentions_60_day_guarantee_plain`)
- [x] `ruff check backend/templates/emails/founders_welcome.py` -> clean (unused-import `call` em `test_founders_welcome_email.py` e pre-existente, fora do diff)
- [x] Verificado que nenhum frontend test asserta a string literal "7 dias" relacionada a garantia (tests existentes para DowngradeModal usam regex sem dia-count: `/Voce esta fora do periodo de garantia/`)
- [ ] CI: backend-tests + frontend-tests + api-types-check
- [ ] Manual (post-merge): preview do welcome email (proximo founding checkout) confirma o bloco amarelo "Garantia de 60 dias - incondicional"
- [ ] Manual (post-merge): visitar `https://smartlic.tech/termos` e verificar secao 6.2 com nova clausula

## Closes

Closes #1001
