### PR TITLE
feat(backend): trial emails Belgray + Founders cross-sell (#1005)

### DIFF
--- a/backend/services/trial_email_sequence.py
+++ b/backend/services/trial_email_sequence.py
@@ -27,6 +27,43 @@ _UNSUBSCRIBE_SECRET = os.getenv("WEBHOOK_SECRET", os.getenv("SECRET_KEY", "smart
 
 TIMEZONE_SCHEDULING_ENABLED = os.getenv("TIMEZONE_SCHEDULING_ENABLED", "true").lower() == "true"
 
+# EMAIL-TRIAL-006 (#1005): personal-tone send for trial sequence
+# Memory: Resend personal tone — tiago@smartlic.tech (verified domain) + reply-to gmail
+TRIAL_EMAIL_FROM = os.getenv(
+    "TRIAL_EMAIL_FROM", "Tiago do SmartLic <tiago@smartlic.tech>"
+)
+TRIAL_EMAIL_REPLY_TO = os.getenv("TRIAL_EMAIL_REPLY_TO", "tiago.sasaki@gmail.com")
+
+
+def _get_founders_seats_remaining() -> int | None:
+    """EMAIL-TRIAL-006 (#1005) cross-sell helper: live founders availability counter.
+
+    Wraps routes.founding._check_availability with a try/except so any DB issue
+    falls back to None — the email templates render generic "vagas limitadas" copy
+    in that case (no broken email, no over-promising on numbers).
+
+    Returns:
+        seats_remaining as int when feature flag enabled and RPC succeeds,
+        None on any failure (templates use fallback copy).
+    """
+    try:
+        from config.features import get_feature_flag
+
+        if not get_feature_flag("FOUNDERS_OFFER_ENABLED"):
+            return None
+
+        from supabase_client import get_supabase
+        from routes.founding import _check_availability
+
+        snapshot = _check_availability(get_supabase())
+        if not snapshot.get("available"):
+            return None
+        seats = int(snapshot.get("seats_remaining") or 0)
+        return seats if seats > 0 else None
+    except Exception as e:
+        logger.debug(f"EMAIL-TRIAL-006: founders availability fetch failed: {e}")
+        return None
+
 
 def _is_in_send_window(user_tz_str: str, window_start: int = 8, window_end: int = 11) -> bool:
     """Check if current UTC time falls within send window in user's local timezone.
@@ -318,7 +355,7 @@ async def process_trial_emails(batch_size: int = 50) -> dict:
                     .select(
                         "id, email, full_name, plan_type, marketing_emails_enabled, "
                         "trial_conversion_emails_enabled, timezone, "
-                        "stripe_default_pm_id, created_at"
+                        "stripe_default_pm_id, created_at, is_admin, is_master"
                     )
                     .eq("plan_type", "free_trial")
                     .gte("created_at", target_start)
@@ -351,6 +388,15 @@ async def process_trial_emails(batch_size: int = 50) -> dict:
                     plan_type = user.get("plan_type", "")
                     if plan_type != "free_trial":
                         converted_skipped += 1
+                        continue
+
+                    # EMAIL-TRIAL-006 (#1005): skip admin/master accounts.
+                    # Memory: admin users bypass paywall via is_admin=True;
+                    # they're internal accounts, not real trial users — so trial-
+                    # nurture sequence is noise to them and their stats are bogus
+                    # (admin accounts run staff testing searches, not real trials).
+                    if user.get("is_admin") or user.get("is_master"):
+                        skipped += 1
                         continue
 
                     # AC5 + P2 §1.2: Differentiate marketing vs conversion emails
@@ -458,6 +504,8 @@ async def process_trial_emails(batch_size: int = 50) -> dict:
                         )
 
                         # Fire-and-forget send
+                        # EMAIL-TRIAL-006 (#1005): personal tone — from tiago@smartlic.tech
+                        # + reply-to gmail (memory: reference_resend_personal_tone_send).
                         send_email_async(
                             to=email_addr,
                             subject=subject,
@@ -467,6 +515,8 @@ async def process_trial_emails(batch_size: int = 50) -> dict:
                                 {"name": "type", "value": email_type},
                                 {"name": "email_number", "value": str(email_number)},
                             ],
+                            from_email=TRIAL_EMAIL_FROM,
+                            reply_to=TRIAL_EMAIL_REPLY_TO,
                         )
 
                         # Record in log for idempotency.
@@ -652,36 +702,43 @@ def _render_email(
     tier = "high_value" if stats.get("total_value_estimated", 0) > 100_000 else \
            "active" if stats.get("searches_count", 0) > 0 else "dormant"
 
+    # EMAIL-TRIAL-006 (#1005): pull live founders availability for Day 7/10/13 cross-sell
+    # (Day 3/16 only soft-link, no counter needed)
+    seats_remaining = None
+    if email_type in ("paywall_alert", "value", "last_day"):
+        seats_remaining = _get_founders_seats_remaining()
+
     if email_type == "welcome":
         subject = "Bem-vindo ao SmartLic — seu trial de 14 dias comecou!"
         html = render_trial_welcome_email(user_name, unsubscribe_url=unsubscribe_url)
 
     elif email_type == "engagement":
-        if tier == "dormant":
-            subject = "Empresas do seu setor estão encontrando oportunidades — e você?"
-        elif value > 0:
-            subject = f"Voce ja analisou {_format_brl(value)} em oportunidades"
-        else:
-            subject = "Descubra as oportunidades que esperam por voce"
+        # EMAIL-TRIAL-006 (#1005) Day 3: founder-led, friend-text
+        subject = "Pergunta rápida: tá fazendo sentido?"
         html = render_trial_engagement_email(user_name, stats, unsubscribe_url=unsubscribe_url)
 
     elif email_type == "paywall_alert":
-        if value > 0:
-            subject = f"Metade do trial — {_format_brl(value)} em oportunidades até agora"
-        else:
-            subject = "Metade do trial — preview limitado a partir de hoje"
-        html = render_trial_paywall_alert_email(user_name, stats, unsubscribe_url=unsubscribe_url)
+        # EMAIL-TRIAL-006 (#1005) Day 7: pricing comparison + Founders cross-sell
+        subject = "Ouça antes de decidir: a conta do Pro vs vitalício"
+        html = render_trial_paywall_alert_email(
+            user_name, stats,
+            unsubscribe_url=unsubscribe_url,
+            seats_remaining=seats_remaining,
+        )
 
     elif email_type == "value":
-        if tier == "dormant":
-            subject = "Milhares de oportunidades publicadas esta semana — descubra as suas"
-        elif value > 0:
-            subject = f"Voce ja analisou {_format_brl(value)} — nao perca esse progresso"
-        elif opps > 0:
-            subject = f"{opps} oportunidades encontradas — nao perca"
+        # EMAIL-TRIAL-006 (#1005) Day 10: Chaperon open loop + Founders cross-sell
+        days_remaining = stats.get("days_remaining", 4) or 4
+        if seats_remaining is not None and seats_remaining > 0:
+            subject = f"Faltam {seats_remaining} vagas vitalícias (e {days_remaining} dias)"
         else:
-            subject = "Restam 4 dias no seu trial SmartLic"
-        html = render_trial_value_email(user_name, stats, unsubscribe_url=unsubscribe_url)
+            subject = f"Antes de decidir, tem uma terceira opção (faltam {days_remaining} dias)"
+        html = render_trial_value_email(
+            user_name, stats,
+            unsubscribe_url=unsubscribe_url,
+            seats_remaining=seats_remaining,
+            days_remaining=days_remaining,
+        )
 
     elif email_type == "last_day":
         # STORY-CONV-003c AC1: branch by rollout cohort.
@@ -738,20 +795,17 @@ def _render_email(
                 unsubscribe_url=unsubscribe_url,
             )
         else:
-            if value > 0:
-                subject = f"Amanhã você perde acesso a {_format_brl(value)} em oportunidades"
-            else:
-                subject = "Amanhã seu acesso expira — assine agora"
+            # EMAIL-TRIAL-006 (#1005) Day 13 legacy branch: "vira abóbora" + comparison
+            subject = "Amanhã seu trial vira abóbora 🎃 — sem pressão, mas..."
             html = render_trial_last_day_email(
-                user_name, stats, unsubscribe_url=unsubscribe_url
+                user_name, stats,
+                unsubscribe_url=unsubscribe_url,
+                seats_remaining=seats_remaining,
             )
 
     elif email_type == "expired":
-        count = pipeline if pipeline > 0 else opps
-        if count > 0:
-            subject = f"Suas {count} oportunidades estao esperando — volte com 20% off"
-        else:
-            subject = "Sentimos sua falta — volte com 20% off"
+        # EMAIL-TRIAL-006 (#1005) Day 16 lapsed: founder-led "errei algo?"
+        subject = "Errei algo? Resposta direta de 1 linha resolve"
         coupon_url = get_coupon_checkout_url()
         html = render_trial_expired_email(
             user_name, stats,

--- a/backend/templates/emails/_trial_helpers.py
+++ b/backend/templates/emails/_trial_helpers.py
@@ -1,0 +1,198 @@
+"""
+Internal helpers for `templates.emails.trial` email templates.
+
+Extracted from `trial.py` (EMAIL-TRIAL-006 #1005) to keep that module under the
+godmodule LOC threshold without changing render output. All functions here are
+pure HTML fragment builders consumed by the public `render_trial_*` functions.
+
+Re-exported via `templates.emails.trial` for backwards-compatible imports.
+"""
+
+from templates.emails.base import SMARTLIC_GREEN, FRONTEND_URL
+
+
+# ============================================================================
+# EMAIL-TRIAL-006: Founders cross-sell helpers
+# ============================================================================
+
+# R$397/mes × 12 = R$4.764 vs R$997 vitalício = economia R$3.767 no primeiro ano
+FOUNDERS_PRICE_BRL = "R$ 997"
+FOUNDERS_PRICE_BRL_NUMERIC = 997
+PRO_MONTHLY_BRL = "R$ 397"
+PRO_ANNUAL_TOTAL_BRL = "R$ 4.764"
+
+
+def _founders_cross_sell_block(seats_remaining: int | None = None) -> str:
+    """Render the Plano Fundadores cross-sell block.
+
+    Used on Day 7/10/13 trial emails. Falls back to generic copy when
+    ``seats_remaining`` is None (counter API unavailable — issue #1002).
+    """
+    if seats_remaining is not None and seats_remaining > 0:
+        scarcity_line = (
+            f"<strong>{seats_remaining} vagas vitalícias restantes</strong> · "
+            f"oferta encerra em 30/06/2026"
+        )
+    else:
+        scarcity_line = (
+            "<strong>Vagas vitalícias limitadas</strong> · oferta encerra em 30/06/2026"
+        )
+
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="margin: 20px 0 24px;">
+      <tr>
+        <td style="background-color: #fff8e1; border: 2px solid #f59e0b; border-radius: 12px; padding: 20px;">
+          <p style="color: #92400e; font-size: 12px; margin: 0 0 6px; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700;">
+            Plano Fundadores · vitalício
+          </p>
+          <p style="color: #78350f; font-size: 18px; font-weight: 700; margin: 0 0 8px; line-height: 1.3;">
+            Pague {FOUNDERS_PRICE_BRL} uma vez. Use pra sempre.
+          </p>
+          <p style="color: #555; font-size: 14px; margin: 0 0 12px; line-height: 1.5;">
+            Em vez de {PRO_MONTHLY_BRL}/mês ({PRO_ANNUAL_TOTAL_BRL} no primeiro ano), você
+            paga {FOUNDERS_PRICE_BRL} <em>uma única vez</em> e mantém o SmartLic Pro vitalício.
+          </p>
+          <p style="color: #92400e; font-size: 13px; margin: 0 0 14px;">
+            {scarcity_line}
+          </p>
+          <a href="{FRONTEND_URL}/fundadores"
+             style="display: inline-block; padding: 12px 24px; background-color: #f59e0b; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 15px;">
+            Ver Plano Fundadores →
+          </a>
+        </td>
+      </tr>
+    </table>"""
+
+
+def _founders_pricing_table_html() -> str:
+    """Day 7 specific: visual table comparing Pro mensal vs Vitalício.
+
+    Belgray-style "show me the math" — concrete numbers beat abstract value props.
+    """
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="margin: 20px 0 24px; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden;">
+      <tr>
+        <td colspan="3" style="background-color: #f9fafb; padding: 12px 16px; border-bottom: 1px solid #e5e7eb;">
+          <p style="color: #374151; font-size: 14px; font-weight: 600; margin: 0;">
+            A conta nua e crua:
+          </p>
+        </td>
+      </tr>
+      <tr style="background-color: #ffffff;">
+        <td style="padding: 12px 16px; color: #6b7280; font-size: 14px; border-bottom: 1px solid #f3f4f6;">
+          SmartLic Pro mensal
+        </td>
+        <td style="padding: 12px 16px; color: #374151; font-size: 14px; text-align: right; border-bottom: 1px solid #f3f4f6;">
+          {PRO_MONTHLY_BRL}/mês
+        </td>
+        <td style="padding: 12px 16px; color: #ef4444; font-size: 14px; font-weight: 600; text-align: right; border-bottom: 1px solid #f3f4f6;">
+          {PRO_ANNUAL_TOTAL_BRL}/ano
+        </td>
+      </tr>
+      <tr style="background-color: #fef3c7;">
+        <td style="padding: 14px 16px; color: #78350f; font-size: 14px; font-weight: 700;">
+          Plano Fundadores
+        </td>
+        <td style="padding: 14px 16px; color: #78350f; font-size: 14px; font-weight: 700; text-align: right;">
+          {FOUNDERS_PRICE_BRL} uma vez
+        </td>
+        <td style="padding: 14px 16px; color: {SMARTLIC_GREEN}; font-size: 14px; font-weight: 700; text-align: right;">
+          economiza R$ 3.767
+        </td>
+      </tr>
+    </table>"""
+
+
+def _founder_signature_html() -> str:
+    """Founder-led signature — Belgray-style personal close."""
+    return """
+    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 32px 0 4px;">
+      No que eu puder ajudar, é só responder esse email.
+    </p>
+    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 0 0 4px;">
+      Tiago<br/>
+      <span style="color: #888; font-size: 13px;">fundador, SmartLic</span>
+    </p>"""
+
+
+def _format_brl(value: float) -> str:
+    """Format a float as Brazilian Real currency string."""
+    if value >= 1_000_000:
+        return f"R$ {value / 1_000_000:.1f}M"
+    if value >= 1_000:
+        return f"R$ {value / 1_000:.0f}k"
+    return f"R$ {value:,.0f}".replace(",", ".")
+
+
+def _stats_block(stats: dict, show_pipeline: bool = False) -> str:
+    """AC8: Render a stats summary block for email templates."""
+    searches = stats.get("searches_count", 0)
+    opps = stats.get("opportunities_found", 0)
+    value = stats.get("total_value_estimated", 0.0)
+    pipeline = stats.get("pipeline_items_count", 0)
+
+    rows = f"""
+    <tr>
+      <td style="padding: 8px 16px; color: #555; font-size: 15px; border-bottom: 1px solid #eee;">
+        Análises realizadas
+      </td>
+      <td style="padding: 8px 16px; color: #333; font-size: 15px; font-weight: 600; text-align: right; border-bottom: 1px solid #eee;">
+        {searches}
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 8px 16px; color: #555; font-size: 15px; border-bottom: 1px solid #eee;">
+        Oportunidades encontradas
+      </td>
+      <td style="padding: 8px 16px; color: #333; font-size: 15px; font-weight: 600; text-align: right; border-bottom: 1px solid #eee;">
+        {opps}
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 8px 16px; color: #555; font-size: 15px; border-bottom: 1px solid #eee;">
+        Valor total estimado
+      </td>
+      <td style="padding: 8px 16px; color: {SMARTLIC_GREEN}; font-size: 15px; font-weight: 600; text-align: right; border-bottom: 1px solid #eee;">
+        {_format_brl(value)}
+      </td>
+    </tr>"""
+
+    if show_pipeline:
+        rows += f"""
+    <tr>
+      <td style="padding: 8px 16px; color: #555; font-size: 15px;">
+        Itens no pipeline
+      </td>
+      <td style="padding: 8px 16px; color: #333; font-size: 15px; font-weight: 600; text-align: right;">
+        {pipeline}
+      </td>
+    </tr>"""
+
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="background-color: #f8f9fa; border-radius: 8px; margin: 16px 0 24px; overflow: hidden;">
+      {rows}
+    </table>"""
+
+
+def _unsubscribe_block(unsubscribe_url: str) -> str:
+    """Render unsubscribe link block (AC2: RFC 8058 one-click)."""
+    if not unsubscribe_url:
+        return ""
+    return f"""
+    <p style="color: #999; font-size: 12px; text-align: center; margin: 24px 0 0;">
+      <a href="{unsubscribe_url}" style="color: #999; text-decoration: underline;">
+        Não desejo receber emails sobre o trial
+      </a>
+    </p>"""
+
+
+def _preheader(text: str) -> str:
+    """AC2: Hidden preheader text for email clients (Gmail, Apple Mail)."""
+    return (
+        f'<div style="display:none;font-size:1px;color:#f4f4f4;'
+        f'line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">'
+        f'{text}</div>'
+    )

--- a/backend/templates/emails/trial.py
+++ b/backend/templates/emails/trial.py
@@ -8,9 +8,120 @@ Compressed sequence (replaces STORY-310 8-email sequence):
 - Day 10: Valor acumulado — social proof R$X ("Não perca esse progresso")
 - Day 13: Último dia — escassez ("Assinar agora")
 - Day 16: Expirado — reengajamento com cupom 20% off ("Voltar com 20% off")
+
+EMAIL-TRIAL-006 (#1005): Day 3/7/10/13/16 reformulados em tom Belgray friend-text +
+cross-sell Plano Fundadores (R$997 vitalício one-time, deadline 2026-06-30) nos
+days 7/10/13. Day 0 (welcome) e Day 16 cupom 20% off preservam estrutura existente
+mas voz alinhada (founder-led, "Tiago" assina).
 """
 
 from templates.emails.base import email_base, SMARTLIC_GREEN, FRONTEND_URL
+
+
+# ============================================================================
+# EMAIL-TRIAL-006: Founders cross-sell helpers
+# ============================================================================
+
+# R$397/mes × 12 = R$4.764 vs R$997 vitalício = economia R$3.767 no primeiro ano
+FOUNDERS_PRICE_BRL = "R$ 997"
+FOUNDERS_PRICE_BRL_NUMERIC = 997
+PRO_MONTHLY_BRL = "R$ 397"
+PRO_ANNUAL_TOTAL_BRL = "R$ 4.764"
+
+
+def _founders_cross_sell_block(seats_remaining: int | None = None) -> str:
+    """Render the Plano Fundadores cross-sell block.
+
+    Used on Day 7/10/13 trial emails. Falls back to generic copy when
+    ``seats_remaining`` is None (counter API unavailable — issue #1002).
+    """
+    if seats_remaining is not None and seats_remaining > 0:
+        scarcity_line = (
+            f"<strong>{seats_remaining} vagas vitalícias restantes</strong> · "
+            f"oferta encerra em 30/06/2026"
+        )
+    else:
+        scarcity_line = (
+            "<strong>Vagas vitalícias limitadas</strong> · oferta encerra em 30/06/2026"
+        )
+
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="margin: 20px 0 24px;">
+      <tr>
+        <td style="background-color: #fff8e1; border: 2px solid #f59e0b; border-radius: 12px; padding: 20px;">
+          <p style="color: #92400e; font-size: 12px; margin: 0 0 6px; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700;">
+            Plano Fundadores · vitalício
+          </p>
+          <p style="color: #78350f; font-size: 18px; font-weight: 700; margin: 0 0 8px; line-height: 1.3;">
+            Pague {FOUNDERS_PRICE_BRL} uma vez. Use pra sempre.
+          </p>
+          <p style="color: #555; font-size: 14px; margin: 0 0 12px; line-height: 1.5;">
+            Em vez de {PRO_MONTHLY_BRL}/mês ({PRO_ANNUAL_TOTAL_BRL} no primeiro ano), você
+            paga {FOUNDERS_PRICE_BRL} <em>uma única vez</em> e mantém o SmartLic Pro vitalício.
+          </p>
+          <p style="color: #92400e; font-size: 13px; margin: 0 0 14px;">
+            {scarcity_line}
+          </p>
+          <a href="{FRONTEND_URL}/fundadores"
+             style="display: inline-block; padding: 12px 24px; background-color: #f59e0b; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 15px;">
+            Ver Plano Fundadores →
+          </a>
+        </td>
+      </tr>
+    </table>"""
+
+
+def _founders_pricing_table_html() -> str:
+    """Day 7 specific: visual table comparing Pro mensal vs Vitalício.
+
+    Belgray-style "show me the math" — concrete numbers beat abstract value props.
+    """
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="margin: 20px 0 24px; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden;">
+      <tr>
+        <td colspan="3" style="background-color: #f9fafb; padding: 12px 16px; border-bottom: 1px solid #e5e7eb;">
+          <p style="color: #374151; font-size: 14px; font-weight: 600; margin: 0;">
+            A conta nua e crua:
+          </p>
+        </td>
+      </tr>
+      <tr style="background-color: #ffffff;">
+        <td style="padding: 12px 16px; color: #6b7280; font-size: 14px; border-bottom: 1px solid #f3f4f6;">
+          SmartLic Pro mensal
+        </td>
+        <td style="padding: 12px 16px; color: #374151; font-size: 14px; text-align: right; border-bottom: 1px solid #f3f4f6;">
+          {PRO_MONTHLY_BRL}/mês
+        </td>
+        <td style="padding: 12px 16px; color: #ef4444; font-size: 14px; font-weight: 600; text-align: right; border-bottom: 1px solid #f3f4f6;">
+          {PRO_ANNUAL_TOTAL_BRL}/ano
+        </td>
+      </tr>
+      <tr style="background-color: #fef3c7;">
+        <td style="padding: 14px 16px; color: #78350f; font-size: 14px; font-weight: 700;">
+          Plano Fundadores
+        </td>
+        <td style="padding: 14px 16px; color: #78350f; font-size: 14px; font-weight: 700; text-align: right;">
+          {FOUNDERS_PRICE_BRL} uma vez
+        </td>
+        <td style="padding: 14px 16px; color: {SMARTLIC_GREEN}; font-size: 14px; font-weight: 700; text-align: right;">
+          economiza R$ 3.767
+        </td>
+      </tr>
+    </table>"""
+
+
+def _founder_signature_html() -> str:
+    """Founder-led signature — Belgray-style personal close."""
+    return f"""
+    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 32px 0 4px;">
+      No que eu puder ajudar, é só responder esse email.
+    </p>
+    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 0 0 4px;">
+      Tiago<br/>
+      <span style="color: #888; font-size: 13px;">fundador, SmartLic</span>
+    </p>"""
 
 
 def _format_brl(value: float) -> str:
@@ -170,7 +281,10 @@ def render_trial_welcome_email(user_name: str, unsubscribe_url: str = "") -> str
 # ============================================================================
 
 def render_trial_engagement_email(user_name: str, stats: dict, unsubscribe_url: str = "") -> str:
-    """STORY-321 AC7: Day 3 — Engagement email with real stats.
+    """EMAIL-TRIAL-006 (#1005) Day 3: Pergunta direta founder-led, 3-5 frases.
+
+    Belgray friend-text — não vendendo nada, perguntando se tá fazendo sentido.
+    PS soft com link Founders (não é o foco do email).
 
     Args:
         user_name: User's display name.
@@ -181,51 +295,64 @@ def render_trial_engagement_email(user_name: str, stats: dict, unsubscribe_url: 
     value = stats.get("total_value_estimated", 0.0)
     opps = stats.get("opportunities_found", 0)
 
-    if has_usage and value > 0:
-        preheader_text = f"Você já analisou {_format_brl(value)} em oportunidades"
-        headline = f"Você já analisou {_format_brl(value)} em oportunidades"
-        intro = (
-            f"Olá, {user_name}! Em apenas 3 dias no SmartLic, você já está "
-            f"descobrindo oportunidades reais de licitação."
+    # Personalize intro based on usage tier — keep it founder-led, never institutional
+    if has_usage and (value > 0 or opps > 0):
+        usage_line = (
+            f"Vi que você já rodou algumas análises por aí — "
+            f"{opps if opps else 'várias'} oportunidades aparecendo até agora."
         )
-    elif has_usage and opps > 0:
-        preheader_text = f"{opps} oportunidades encontradas em 3 dias"
-        headline = f"{opps} oportunidades encontradas em 3 dias"
-        intro = (
-            f"Olá, {user_name}! Você já encontrou {opps} oportunidades. "
-            f"Explore mais setores para ampliar seus resultados."
-        )
+        question = "Tá batendo com o que sua empresa procura? Falta alguma coisa?"
+    elif has_usage:
+        usage_line = "Vi que você fez sua primeira busca — bom começo."
+        question = "Os filtros tão fazendo sentido? Algum setor faltando que devíamos cobrir?"
     else:
-        preheader_text = "Você ainda tem 11 dias para descobrir oportunidades"
-        headline = "Você ainda tem 11 dias para descobrir oportunidades"
-        intro = (
-            f"Olá, {user_name}! Seu trial do SmartLic está apenas começando e "
-            f"há oportunidades esperando por você. Faça sua primeira análise agora!"
+        usage_line = (
+            "Vi que você ainda não rodou nenhuma busca — sem stress, "
+            "leva uns 30 segundos."
+        )
+        question = (
+            "Antes de você apertar o play: tem algum setor específico que sua empresa atende? "
+            "Posso te dar dicas de filtro pra pegar os editais certos."
         )
 
     body = f"""
-    {_preheader(preheader_text)}
-    <h1 style="color: #333; font-size: 22px; margin: 0 0 16px;">
-      {headline}
+    {_preheader("Pergunta rápida: tá fazendo sentido?")}
+    <h1 style="color: #333; font-size: 22px; margin: 0 0 20px;">
+      Tá fazendo sentido?
     </h1>
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
-      {intro}
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {user_name}, aqui é o Tiago, fundador do SmartLic.
     </p>
-    {_stats_block(stats) if has_usage else ''}
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {usage_line}
+    </p>
+    <p style="color: #333; font-size: 16px; line-height: 1.6; margin: 0 0 14px; font-weight: 600;">
+      {question}
+    </p>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
+      Responde esse email com 1 linha — chega direto na minha caixa.
+      Leio e respondo todos.
+    </p>
+
     <p style="text-align: center; margin: 24px 0 16px;">
-      <a href="{FRONTEND_URL}/buscar" class="btn"
-         style="display: inline-block; padding: 14px 32px; background-color: {SMARTLIC_GREEN}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        Explorar mais setores
+      <a href="{FRONTEND_URL}/buscar"
+         style="display: inline-block; padding: 12px 28px; background-color: {SMARTLIC_GREEN}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px;">
+        {'Voltar pra busca' if has_usage else 'Fazer minha primeira busca'}
       </a>
     </p>
-    <p style="color: #888; font-size: 13px; text-align: center; margin: 16px 0 0;">
-      Seu trial gratuito termina em 11 dias.
+
+    {_founder_signature_html()}
+
+    <p style="color: #999; font-size: 13px; line-height: 1.6; margin: 28px 0 0; padding-top: 16px; border-top: 1px solid #f0f0f0;">
+      P.S.: existe um <a href="{FRONTEND_URL}/fundadores" style="color: #f59e0b; text-decoration: underline; font-weight: 600;">plano vitalício de R$ 997</a>
+      — pra quem tá usando ativo e quer travar o preço pra sempre. Não é pra todo mundo, mas tá lá se interessar.
     </p>
+
     {_unsubscribe_block(unsubscribe_url)}
     """
 
     return email_base(
-        title="Suas primeiras descobertas — SmartLic",
+        title="Pergunta rápida: tá fazendo sentido?",
         body_html=body,
         is_transactional=False,
         unsubscribe_url=unsubscribe_url,
@@ -236,70 +363,80 @@ def render_trial_engagement_email(user_name: str, stats: dict, unsubscribe_url: 
 # Email #3 — Day 7: Paywall Alert (AC7 — NEW)
 # ============================================================================
 
-def render_trial_paywall_alert_email(user_name: str, stats: dict, unsubscribe_url: str = "") -> str:
-    """STORY-321 AC7: Day 7 — Paywall alert. Preview limited starting tomorrow.
+def render_trial_paywall_alert_email(
+    user_name: str,
+    stats: dict,
+    unsubscribe_url: str = "",
+    seats_remaining: int | None = None,
+) -> str:
+    """EMAIL-TRIAL-006 (#1005) Day 7: Pro vs Vitalício — a conta nua.
 
-    References STORY-320 soft paywall that activates on day 7.
+    Tom Belgray "ouça antes de decidir" + tabela visual R$397 × 12 = R$4.764 vs R$997.
+    CTA primário Founders, CTA secundário Pro mensal.
 
     Args:
         user_name: User's display name.
         stats: Dict with keys from TrialUsageStats.
         unsubscribe_url: URL for one-click unsubscribe.
+        seats_remaining: From #1002 founders availability. None → fallback genérico.
     """
     has_usage = stats.get("searches_count", 0) > 0
     value = stats.get("total_value_estimated", 0.0)
 
     if has_usage and value > 0:
-        value_line = f"Você já descobriu <strong>{_format_brl(value)}</strong> em oportunidades. "
+        usage_line = (
+            f"Em 7 dias você já mapeou <strong>{_format_brl(value)}</strong> em "
+            f"oportunidades. Tá funcionando."
+        )
+    elif has_usage:
+        usage_line = "Você já tá usando — bom sinal."
     else:
-        value_line = ""
+        usage_line = (
+            "Você ainda não rodou uma busca — sem stress, "
+            "mas tem 7 dias pra testar antes do trial virar preview limitado."
+        )
 
     body = f"""
-    {_preheader("A partir de hoje, resultados ficam limitados. Assine para acesso completo.")}
-    <h1 style="color: #333; font-size: 22px; margin: 0 0 16px;">
-      Metade do trial — preview limitado a partir de hoje
+    {_preheader("Ouça antes de decidir: a conta do Pro mensal vs vitalício.")}
+    <h1 style="color: #333; font-size: 22px; margin: 0 0 18px;">
+      A conta nua: Pro mensal × Vitalício
     </h1>
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
-      Olá, {user_name}! Você está na metade do seu trial de 14 dias.
-      {value_line}A partir de hoje, os resultados de busca serão
-      exibidos em modo preview (limitado a 10 resultados).
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {user_name}, metade do trial e queria ser direto com você.
     </p>
-    {_stats_block(stats, show_pipeline=True) if has_usage else ''}
-
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
-      <tr>
-        <td style="background-color: #fff3e0; border-radius: 8px; padding: 16px; border-left: 4px solid #ff9800;">
-          <p style="color: #e65100; font-size: 14px; margin: 0; font-weight: 600;">
-            O que muda a partir de hoje:
-          </p>
-          <ul style="color: #555; font-size: 14px; margin: 8px 0 0; padding-left: 20px;">
-            <li>Resultados limitados a 10 por busca (preview)</li>
-            <li>Pipeline limitado a 5 itens</li>
-            <li>Análises e IA continuam funcionando normalmente</li>
-          </ul>
-        </td>
-      </tr>
-    </table>
-
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
-      Assine o SmartLic Pro <strong>agora</strong> e recupere acesso
-      completo a todos os resultados, pipeline ilimitado e relatórios Excel.
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {usage_line}
+    </p>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 12px;">
+      Antes de você decidir entre seguir trial ou assinar, dá uma olhada nos números:
     </p>
 
-    <p style="text-align: center; margin: 24px 0 16px;">
-      <a href="{FRONTEND_URL}/planos" class="btn"
-         style="display: inline-block; padding: 14px 32px; background-color: {SMARTLIC_GREEN}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        Assine antes do limite
+    {_founders_pricing_table_html()}
+
+    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 0 0 14px;">
+      <strong>Por que o vitalício existe:</strong> tô captando os primeiros 50 fundadores
+      que vão ajudar o SmartLic a virar a ferramenta certa pra B2G. Em troca, você trava
+      acesso pra sempre — sem mensalidade, sem reajuste anual.
+    </p>
+
+    {_founders_cross_sell_block(seats_remaining)}
+
+    <p style="text-align: center; margin: 12px 0 8px;">
+      <a href="{FRONTEND_URL}/planos"
+         style="display: inline-block; padding: 10px 22px; color: {SMARTLIC_GREEN}; text-decoration: none; border: 1px solid {SMARTLIC_GREEN}; border-radius: 6px; font-weight: 600; font-size: 14px;">
+        Ou continuar com Pro mensal →
       </a>
     </p>
-    <p style="color: #888; font-size: 13px; text-align: center; margin: 16px 0 0;">
-      Seu trial gratuito termina em 7 dias.
+    <p style="color: #888; font-size: 13px; text-align: center; margin: 8px 0 0;">
+      Restam 7 dias do seu trial. Sem pressa, sem cartão.
     </p>
+
+    {_founder_signature_html()}
     {_unsubscribe_block(unsubscribe_url)}
     """
 
     return email_base(
-        title="Metade do trial — preview limitado a partir de hoje",
+        title="Ouça antes de decidir: a conta do Pro vs vitalício",
         body_html=body,
         is_transactional=False,
         unsubscribe_url=unsubscribe_url,
@@ -356,93 +493,107 @@ def _top_opportunity_block(stats: dict) -> str:
     </table>"""
 
 
-def render_trial_value_email(user_name: str, stats: dict, unsubscribe_url: str = "") -> str:
-    """STORY-321 AC7: Day 10 — Accumulated value. Social proof with big R$ number.
+def render_trial_value_email(
+    user_name: str,
+    stats: dict,
+    unsubscribe_url: str = "",
+    seats_remaining: int | None = None,
+    days_remaining: int = 4,
+) -> str:
+    """EMAIL-TRIAL-006 (#1005) Day 10: Chaperon open loop — terceira opção.
+
+    "Antes de você escolher entre cancelar ou virar Pro, tem uma terceira opção
+    que talvez ninguém te contou ainda." → Reveal: Founders.
 
     Args:
         user_name: User's display name.
         stats: Dict with keys from TrialUsageStats.
         unsubscribe_url: URL for one-click unsubscribe.
+        seats_remaining: From #1002. None → fallback copy.
+        days_remaining: dias até trial expirar (Day 10 → 4).
     """
     value = stats.get("total_value_estimated", 0.0)
     opps = stats.get("opportunities_found", 0)
-    pipeline = stats.get("pipeline_items_count", 0)
 
-    if value > 0:
-        big_value = _format_brl(value)
-        preheader_text = f"Você já analisou {big_value} em oportunidades. Não perca."
-        headline = f"Você já analisou {big_value}"
-    elif opps > 0:
-        preheader_text = f"{opps} oportunidades encontradas. Não perca esse progresso."
-        headline = f"{opps} oportunidades encontradas"
+    seats_text = (
+        f"{seats_remaining} vagas vitalícias"
+        if seats_remaining is not None and seats_remaining > 0
+        else "vagas vitalícias limitadas"
+    )
+
+    preheader_text = (
+        f"Faltam {seats_remaining} vagas vitalícias (e {days_remaining} dias)"
+        if seats_remaining is not None and seats_remaining > 0
+        else f"Antes de decidir: tem uma terceira opção (faltam {days_remaining} dias)"
+    )
+
+    if seats_remaining is not None and seats_remaining > 0:
+        headline = f"Faltam {seats_remaining} vagas vitalícias (e {days_remaining} dias)"
     else:
-        preheader_text = "Restam 4 dias. Descubra oportunidades antes que seu trial expire."
-        headline = "Restam 4 dias no seu trial"
+        headline = f"Antes de decidir, tem uma terceira opção (faltam {days_remaining} dias)"
 
-    # Big value highlight block
-    value_highlight = ""
-    if value > 0:
-        value_highlight = f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
-           style="margin: 16px 0 24px;">
+    # Open loop intro — Chaperon style
+    body = f"""
+    {_preheader(preheader_text)}
+    <h1 style="color: #333; font-size: 22px; margin: 0 0 18px;">
+      {headline}
+    </h1>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {user_name}, faltam {days_remaining} dias do seu trial.
+    </p>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      A maioria das pessoas chega aqui pensando em duas opções: <strong>cancelar</strong>
+      ou <strong>virar Pro mensal</strong> (R$ 397/mês).
+    </p>
+    <p style="color: #333; font-size: 16px; line-height: 1.6; margin: 0 0 14px; font-weight: 600;">
+      Mas tem uma terceira opção que talvez ninguém te contou ainda.
+    </p>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
+      Eu tô abrindo um <strong>Plano Fundadores</strong>: você paga R$ 997 uma vez e
+      usa o SmartLic Pro <em>vitalício</em> — sem mensalidade, sem reajuste, pra sempre.
+      Restam {seats_text}, e a oferta encerra dia 30/06.
+    </p>
+    """
+
+    # Inline progress block — concrete proof user is getting value
+    if value > 0 or opps > 0:
+        body += f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 16px 0 20px;">
       <tr>
-        <td align="center"
-            style="background-color: #e8f5e9; border-radius: 12px; padding: 24px;">
-          <p style="color: #888; font-size: 13px; margin: 0 0 4px; text-transform: uppercase; letter-spacing: 1px;">
-            Valor total analisado
-          </p>
-          <p style="color: {SMARTLIC_GREEN}; font-size: 36px; font-weight: 700; margin: 0; line-height: 1.2;">
-            {_format_brl(value)}
-          </p>
-          <p style="color: #666; font-size: 14px; margin: 8px 0 0;">
-            em {opps} oportunidades{f" | {pipeline} no pipeline" if pipeline > 0 else ""}
+        <td style="background-color: #f8faf8; border-left: 3px solid {SMARTLIC_GREEN}; padding: 14px 18px;">
+          <p style="color: #555; font-size: 14px; margin: 0; line-height: 1.5;">
+            Em 10 dias você já mapeou <strong>{opps} oportunidade{'s' if opps != 1 else ''}</strong>
+            {f"totalizando <strong>{_format_brl(value)}</strong>" if value > 0 else ""}.
+            Não jogue isso fora.
           </p>
         </td>
       </tr>
-    </table>"""
+    </table>
+    """
 
-    body = f"""
-    {_preheader(preheader_text)}
-    <h1 style="color: #333; font-size: 22px; margin: 0 0 16px;">
-      {headline}
-    </h1>
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
-      Olá, {user_name}! Seu trial termina em 4 dias. Veja o progresso que você
-      construiu até agora:
-    </p>
-    {value_highlight}
+    body += f"""
     {_top_opportunity_block(stats)}
-    {_stats_block(stats, show_pipeline=True) if value == 0 and opps > 0 else ''}
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
-      Não perca esse progresso. Com o SmartLic Pro, você mantém acesso a tudo:
-      análises ilimitadas, IA de classificação, pipeline e relatórios Excel.
-    </p>
-    <tr><td style="padding: 20px 30px;">
-      <p style="font-size: 15px; color: #1a1a2e; margin: 0 0 12px;">
-        <strong>Sabia que voce pode ganhar ate 7 dias extras?</strong>
-      </p>
-      <p style="font-size: 14px; color: #4a4a6a; margin: 0 0 16px;">
-        Complete seu perfil (+3 dias), de feedback sobre uma busca (+2 dias)
-        ou convide um colega (+7 dias).
-      </p>
-      <a href="{FRONTEND_URL}/dashboard" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 24px;border-radius:6px;text-decoration:none;font-size:14px;font-weight:600;">
-        Ver minhas opcoes
-      </a>
-    </td></tr>
-    <p style="text-align: center; margin: 24px 0 16px;">
-      <a href="{FRONTEND_URL}/planos" class="btn"
-         style="display: inline-block; padding: 14px 32px; background-color: {SMARTLIC_GREEN}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        Não perca esse progresso
+    {_founders_cross_sell_block(seats_remaining)}
+
+    <p style="text-align: center; margin: 12px 0 8px;">
+      <a href="{FRONTEND_URL}/planos"
+         style="display: inline-block; padding: 10px 22px; color: {SMARTLIC_GREEN}; text-decoration: none; border: 1px solid {SMARTLIC_GREEN}; border-radius: 6px; font-weight: 600; font-size: 14px;">
+        Prefiro Pro mensal →
       </a>
     </p>
-    <p style="color: #888; font-size: 13px; text-align: center; margin: 16px 0 0;">
-      Economize 20% com o plano anual.
-    </p>
+
+    {_founder_signature_html()}
     {_unsubscribe_block(unsubscribe_url)}
     """
 
+    title = (
+        f"Faltam {seats_remaining} vagas vitalícias"
+        if seats_remaining is not None and seats_remaining > 0
+        else "Antes de decidir, tem uma terceira opção"
+    )
+
     return email_base(
-        title="Você já analisou oportunidades — SmartLic",
+        title=title,
         body_html=body,
         is_transactional=False,
         unsubscribe_url=unsubscribe_url,
@@ -453,61 +604,128 @@ def render_trial_value_email(user_name: str, stats: dict, unsubscribe_url: str =
 # Email #5 — Day 13: Ultimo Dia (AC7)
 # ============================================================================
 
-def render_trial_last_day_email(user_name: str, stats: dict, unsubscribe_url: str = "") -> str:
-    """STORY-321 AC7: Day 13 — Last day. Maximum urgency with countdown.
+def _day13_comparison_table_html() -> str:
+    """3-column comparison: cancelar / Pro mensal / Vitalício.
+
+    EMAIL-TRIAL-006 (#1005) Day 13 — honesty-driven decision aid.
+    """
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+           style="margin: 18px 0 22px; border-collapse: separate; border-spacing: 0;">
+      <tr>
+        <td style="width: 33%; vertical-align: top; padding: 0 4px;">
+          <table width="100%" cellpadding="0" cellspacing="0" style="border: 1px solid #e5e7eb; border-radius: 8px;">
+            <tr><td style="padding: 14px; text-align: center;">
+              <p style="color: #6b7280; font-size: 12px; margin: 0 0 6px; text-transform: uppercase; font-weight: 600;">Cancelar</p>
+              <p style="color: #374151; font-size: 18px; font-weight: 700; margin: 0 0 6px;">R$ 0</p>
+              <p style="color: #6b7280; font-size: 12px; margin: 0; line-height: 1.4;">Você perde acesso e os dados ficam salvos por 30 dias.</p>
+            </td></tr>
+          </table>
+        </td>
+        <td style="width: 33%; vertical-align: top; padding: 0 4px;">
+          <table width="100%" cellpadding="0" cellspacing="0" style="border: 1px solid #e5e7eb; border-radius: 8px;">
+            <tr><td style="padding: 14px; text-align: center;">
+              <p style="color: #6b7280; font-size: 12px; margin: 0 0 6px; text-transform: uppercase; font-weight: 600;">Pro mensal</p>
+              <p style="color: #374151; font-size: 18px; font-weight: 700; margin: 0 0 6px;">R$ 397/mês</p>
+              <p style="color: #6b7280; font-size: 12px; margin: 0; line-height: 1.4;">Acesso completo. Cancele quando quiser.</p>
+            </td></tr>
+          </table>
+        </td>
+        <td style="width: 33%; vertical-align: top; padding: 0 4px;">
+          <table width="100%" cellpadding="0" cellspacing="0" style="border: 2px solid #f59e0b; border-radius: 8px; background-color: #fffbeb;">
+            <tr><td style="padding: 13px; text-align: center;">
+              <p style="color: #92400e; font-size: 12px; margin: 0 0 6px; text-transform: uppercase; font-weight: 700;">Vitalício</p>
+              <p style="color: #78350f; font-size: 18px; font-weight: 700; margin: 0 0 6px;">R$ 997 uma vez</p>
+              <p style="color: #92400e; font-size: 12px; margin: 0; line-height: 1.4;">Pague 1×, use pra sempre.</p>
+            </td></tr>
+          </table>
+        </td>
+      </tr>
+    </table>"""
+
+
+def render_trial_last_day_email(
+    user_name: str,
+    stats: dict,
+    unsubscribe_url: str = "",
+    seats_remaining: int | None = None,
+) -> str:
+    """EMAIL-TRIAL-006 (#1005) Day 13 (legacy branch): "amanhã vira abóbora" + comparison.
+
+    Tom leve, honest, sem urgência fake. 3-column table cancelar/Pro/Founders lado a lado.
+
+    NOTA: Aplica-se SOMENTE quando user NÃO tem cartão (rollout_branch="legacy").
+    Para cartão na mão, ver render_trial_last_day_card_email (compliance copy distinto).
 
     Args:
         user_name: User's display name.
         stats: Dict with keys from TrialUsageStats.
         unsubscribe_url: URL for one-click unsubscribe.
+        seats_remaining: From #1002. None → fallback genérico.
     """
     value = stats.get("total_value_estimated", 0.0)
-    opps = stats.get("opportunities_found", 0)  # noqa: F841
+    opps = stats.get("opportunities_found", 0)
 
     if value > 0:
-        preheader_text = f"Amanhã você perde acesso a {_format_brl(value)} em oportunidades."
+        preheader_text = (
+            f"Amanhã seu trial vira abóbora 🎃 — você perde acesso a "
+            f"{_format_brl(value)} em oportunidades mapeadas."
+        )
     else:
-        preheader_text = "Amanhã seu acesso expira. Assine agora."
+        preheader_text = "Amanhã seu trial vira abóbora 🎃 — sem pressão, mas..."
+
+    if value > 0 and opps > 0:
+        progress_line = (
+            f"Em 13 dias você mapeou <strong>{opps} oportunidades</strong> totalizando "
+            f"<strong>{_format_brl(value)}</strong>. Amanhã esse acesso vai embora — "
+            f"os dados ficam salvos por 30 dias, mas a busca/IA/pipeline não."
+        )
+    elif opps > 0:
+        progress_line = (
+            f"Você mapeou <strong>{opps} oportunidade{'s' if opps != 1 else ''}</strong> "
+            f"até aqui. Amanhã o acesso fecha — sem drama, é só o trial chegando ao fim."
+        )
+    else:
+        progress_line = (
+            "Você não chegou a rodar muita coisa, e tudo bem. "
+            "Amanhã o trial fecha mesmo assim — queria deixar todas as opções na mesa antes."
+        )
 
     body = f"""
     {_preheader(preheader_text)}
-    <h1 style="color: #d32f2f; font-size: 22px; margin: 0 0 16px;">
-      Amanhã seu acesso expira — não perca o que você construiu
+    <h1 style="color: #333; font-size: 22px; margin: 0 0 16px;">
+      Amanhã seu trial vira abóbora 🎃
     </h1>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {user_name}, sem pressão — mas queria ser direto com você antes do trial fechar.
+    </p>
     <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
-      Olá, {user_name}! Este é o <strong>último dia</strong> do seu trial no SmartLic.
-      Amanhã você perderá acesso às funcionalidades completas.
+      {progress_line}
     </p>
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 8px;">
-      <strong>Resumo do seu trial:</strong>
+    <p style="color: #333; font-size: 16px; line-height: 1.6; margin: 0 0 6px; font-weight: 600;">
+      Suas três opções, lado a lado:
     </p>
-    {_stats_block(stats, show_pipeline=True)}
 
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
-      <tr>
-        <td style="background-color: #fff3e0; border-radius: 8px; padding: 16px; border-left: 4px solid #ff9800;">
-          <p style="color: #e65100; font-size: 14px; margin: 0; font-weight: 600;">
-            Ative hoje e não perca nenhuma oportunidade
-          </p>
-          <p style="color: #555; font-size: 14px; margin: 8px 0 0;">
-            SmartLic Pro — R$ 397/mês &nbsp;|&nbsp;
-            Economia de 20% no plano anual
-          </p>
-        </td>
-      </tr>
-    </table>
+    {_day13_comparison_table_html()}
 
-    <p style="text-align: center; margin: 24px 0 16px;">
-      <a href="{FRONTEND_URL}/planos" class="btn"
-         style="display: inline-block; padding: 14px 32px; background-color: #d32f2f; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        Assinar agora — R$ 397/mês
+    {_founders_cross_sell_block(seats_remaining)}
+
+    <p style="text-align: center; margin: 4px 0 16px;">
+      <a href="{FRONTEND_URL}/planos"
+         style="display: inline-block; padding: 10px 22px; color: {SMARTLIC_GREEN}; text-decoration: none; border: 1px solid {SMARTLIC_GREEN}; border-radius: 6px; font-weight: 600; font-size: 14px;">
+        Ou continuar com Pro mensal →
       </a>
     </p>
+    <p style="color: #888; font-size: 13px; text-align: center; margin: 8px 0 0;">
+      Sem cartão cadastrado, então ninguém vai cobrar nada amanhã. É só seu trial fechando.
+    </p>
+
+    {_founder_signature_html()}
     {_unsubscribe_block(unsubscribe_url)}
     """
 
     return email_base(
-        title="Último dia de trial — SmartLic",
+        title="Amanhã seu trial vira abóbora 🎃 — sem pressão, mas...",
         body_html=body,
         is_transactional=False,
         unsubscribe_url=unsubscribe_url,
@@ -654,7 +872,9 @@ def render_trial_expired_email(
     unsubscribe_url: str = "",
     coupon_checkout_url: str = "",
 ) -> str:
-    """STORY-321 AC7 + AC14: Day 16 — Expired. Reengagement with 20% off coupon.
+    """EMAIL-TRIAL-006 (#1005) Day 16 (lapsed): "Errei algo? Resposta de 1 linha resolve"
+
+    Founder pergunta diretamente o que faltou. PS mantém cupom TRIAL_COMEBACK_20.
 
     Args:
         user_name: User's display name.
@@ -665,69 +885,60 @@ def render_trial_expired_email(
     opps = stats.get("opportunities_found", 0)
     pipeline = stats.get("pipeline_items_count", 0)
 
-    if opps > 0 or pipeline > 0:
-        if pipeline > 0:
-            headline = f"Suas {pipeline} oportunidades estão esperando por você"
-        else:
-            headline = f"Suas {opps} oportunidades estão esperando por você"
-        preheader_text = "Sentimos sua falta. Volte com 20% off."
-    else:
-        headline = "Sentimos sua falta"
-        preheader_text = "As oportunidades continuam surgindo. Volte com 20% off."
-
-    # Determine CTA URL — use coupon checkout if available, else /planos
     cta_url = coupon_checkout_url if coupon_checkout_url else f"{FRONTEND_URL}/planos"
-    cta_text = "Voltar com 20% off" if coupon_checkout_url else "Reativar acesso"
+
+    progress_recap = ""
+    if opps > 0 or pipeline > 0:
+        progress_recap = f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 14px 0 18px;">
+      <tr>
+        <td style="background-color: #f8faf8; border-left: 3px solid {SMARTLIC_GREEN}; padding: 12px 16px;">
+          <p style="color: #555; font-size: 14px; margin: 0; line-height: 1.5;">
+            Pra constar: você deixou {opps} oportunidade{'s' if opps != 1 else ''} mapeada{'s' if opps != 1 else ''}
+            {f"e {pipeline} item{'ns' if pipeline != 1 else ''} no pipeline" if pipeline > 0 else ""}.
+            Seus dados ficam salvos por 30 dias.
+          </p>
+        </td>
+      </tr>
+    </table>"""
 
     body = f"""
-    {_preheader(preheader_text)}
-    <h1 style="color: #333; font-size: 22px; margin: 0 0 16px;">
-      {headline}
+    {_preheader("Errei algo? Resposta direta de 1 linha resolve.")}
+    <h1 style="color: #333; font-size: 22px; margin: 0 0 18px;">
+      Errei algo?
     </h1>
-    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 16px;">
-      Olá, {user_name}! Seu trial expirou, mas seus dados ficam salvos por 30 dias.
-      Reative o acesso para continuar de onde parou.
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      {user_name}, seu trial fechou ontem.
     </p>
-    {_stats_block(stats, show_pipeline=True) if (opps > 0 or pipeline > 0) else ''}
-
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
-      <tr>
-        <td style="background-color: #e8f5e9; border-radius: 8px; padding: 16px; border-left: 4px solid {SMARTLIC_GREEN};">
-          <p style="color: #1b5e20; font-size: 14px; margin: 0;">
-            Seus dados ficam salvos por 30 dias — análises, pipeline e histórico.
-          </p>
-        </td>
-      </tr>
-    </table>
-
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 24px;">
-      <tr>
-        <td align="center"
-            style="background: linear-gradient(135deg, {SMARTLIC_GREEN}, #1B5E20); border-radius: 12px; padding: 20px;">
-          <p style="color: #ffffff; font-size: 13px; margin: 0 0 4px; text-transform: uppercase; letter-spacing: 1px;">
-            Oferta exclusiva de retorno
-          </p>
-          <p style="color: #ffffff; font-size: 28px; font-weight: 700; margin: 0;">
-            20% OFF
-          </p>
-          <p style="color: rgba(255,255,255,0.85); font-size: 14px; margin: 4px 0 0;">
-            no primeiro mês do SmartLic Pro
-          </p>
-        </td>
-      </tr>
-    </table>
-
-    <p style="text-align: center; margin: 24px 0 16px;">
-      <a href="{cta_url}" class="btn"
-         style="display: inline-block; padding: 14px 32px; background-color: {SMARTLIC_GREEN}; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px;">
-        {cta_text}
-      </a>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 14px;">
+      Sem dramatização — é só que eu preferia entender o que rolou. Te ajudaria
+      muito se você respondesse com 1 linha:
     </p>
+    <p style="color: #333; font-size: 16px; line-height: 1.6; margin: 0 0 14px; padding-left: 16px; border-left: 3px solid #d1d5db;">
+      <em>"Cancelei porque ___"</em>
+    </p>
+    <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 18px;">
+      Pode ser preço, pode ser que faltava feature X, pode ser que não era
+      o momento. Qualquer resposta me ajuda a melhorar o produto.
+    </p>
+    {progress_recap}
+
+    {_founder_signature_html()}
+
+    <p style="color: #999; font-size: 13px; line-height: 1.6; margin: 28px 0 0; padding-top: 16px; border-top: 1px solid #f0f0f0;">
+      P.S.: se quiser voltar, segura aí 20% off no primeiro mês do Pro com o cupom
+      <strong>TRIAL_COMEBACK_20</strong> —
+      <a href="{cta_url}" style="color: {SMARTLIC_GREEN}; text-decoration: underline; font-weight: 600;">aplicar agora</a>.
+      Ou se preferir vitalício pra travar preço pra sempre, o
+      <a href="{FRONTEND_URL}/fundadores" style="color: #f59e0b; text-decoration: underline; font-weight: 600;">Plano Fundadores R$ 997</a>
+      ainda tá em pé.
+    </p>
+
     {_unsubscribe_block(unsubscribe_url)}
     """
 
     return email_base(
-        title="Sentimos sua falta — SmartLic",
+        title="Errei algo? Resposta direta de 1 linha resolve",
         body_html=body,
         is_transactional=False,
         unsubscribe_url=unsubscribe_url,

--- a/backend/templates/emails/trial.py
+++ b/backend/templates/emails/trial.py
@@ -16,193 +16,33 @@ mas voz alinhada (founder-led, "Tiago" assina).
 """
 
 from templates.emails.base import email_base, SMARTLIC_GREEN, FRONTEND_URL
+from templates.emails._trial_helpers import (
+    FOUNDERS_PRICE_BRL,
+    FOUNDERS_PRICE_BRL_NUMERIC,
+    PRO_MONTHLY_BRL,
+    PRO_ANNUAL_TOTAL_BRL,
+    _founders_cross_sell_block,
+    _founders_pricing_table_html,
+    _founder_signature_html,
+    _format_brl,
+    _stats_block,
+    _unsubscribe_block,
+    _preheader,
+)
 
-
-# ============================================================================
-# EMAIL-TRIAL-006: Founders cross-sell helpers
-# ============================================================================
-
-# R$397/mes × 12 = R$4.764 vs R$997 vitalício = economia R$3.767 no primeiro ano
-FOUNDERS_PRICE_BRL = "R$ 997"
-FOUNDERS_PRICE_BRL_NUMERIC = 997
-PRO_MONTHLY_BRL = "R$ 397"
-PRO_ANNUAL_TOTAL_BRL = "R$ 4.764"
-
-
-def _founders_cross_sell_block(seats_remaining: int | None = None) -> str:
-    """Render the Plano Fundadores cross-sell block.
-
-    Used on Day 7/10/13 trial emails. Falls back to generic copy when
-    ``seats_remaining`` is None (counter API unavailable — issue #1002).
-    """
-    if seats_remaining is not None and seats_remaining > 0:
-        scarcity_line = (
-            f"<strong>{seats_remaining} vagas vitalícias restantes</strong> · "
-            f"oferta encerra em 30/06/2026"
-        )
-    else:
-        scarcity_line = (
-            "<strong>Vagas vitalícias limitadas</strong> · oferta encerra em 30/06/2026"
-        )
-
-    return f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
-           style="margin: 20px 0 24px;">
-      <tr>
-        <td style="background-color: #fff8e1; border: 2px solid #f59e0b; border-radius: 12px; padding: 20px;">
-          <p style="color: #92400e; font-size: 12px; margin: 0 0 6px; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700;">
-            Plano Fundadores · vitalício
-          </p>
-          <p style="color: #78350f; font-size: 18px; font-weight: 700; margin: 0 0 8px; line-height: 1.3;">
-            Pague {FOUNDERS_PRICE_BRL} uma vez. Use pra sempre.
-          </p>
-          <p style="color: #555; font-size: 14px; margin: 0 0 12px; line-height: 1.5;">
-            Em vez de {PRO_MONTHLY_BRL}/mês ({PRO_ANNUAL_TOTAL_BRL} no primeiro ano), você
-            paga {FOUNDERS_PRICE_BRL} <em>uma única vez</em> e mantém o SmartLic Pro vitalício.
-          </p>
-          <p style="color: #92400e; font-size: 13px; margin: 0 0 14px;">
-            {scarcity_line}
-          </p>
-          <a href="{FRONTEND_URL}/fundadores"
-             style="display: inline-block; padding: 12px 24px; background-color: #f59e0b; color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 700; font-size: 15px;">
-            Ver Plano Fundadores →
-          </a>
-        </td>
-      </tr>
-    </table>"""
-
-
-def _founders_pricing_table_html() -> str:
-    """Day 7 specific: visual table comparing Pro mensal vs Vitalício.
-
-    Belgray-style "show me the math" — concrete numbers beat abstract value props.
-    """
-    return f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
-           style="margin: 20px 0 24px; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden;">
-      <tr>
-        <td colspan="3" style="background-color: #f9fafb; padding: 12px 16px; border-bottom: 1px solid #e5e7eb;">
-          <p style="color: #374151; font-size: 14px; font-weight: 600; margin: 0;">
-            A conta nua e crua:
-          </p>
-        </td>
-      </tr>
-      <tr style="background-color: #ffffff;">
-        <td style="padding: 12px 16px; color: #6b7280; font-size: 14px; border-bottom: 1px solid #f3f4f6;">
-          SmartLic Pro mensal
-        </td>
-        <td style="padding: 12px 16px; color: #374151; font-size: 14px; text-align: right; border-bottom: 1px solid #f3f4f6;">
-          {PRO_MONTHLY_BRL}/mês
-        </td>
-        <td style="padding: 12px 16px; color: #ef4444; font-size: 14px; font-weight: 600; text-align: right; border-bottom: 1px solid #f3f4f6;">
-          {PRO_ANNUAL_TOTAL_BRL}/ano
-        </td>
-      </tr>
-      <tr style="background-color: #fef3c7;">
-        <td style="padding: 14px 16px; color: #78350f; font-size: 14px; font-weight: 700;">
-          Plano Fundadores
-        </td>
-        <td style="padding: 14px 16px; color: #78350f; font-size: 14px; font-weight: 700; text-align: right;">
-          {FOUNDERS_PRICE_BRL} uma vez
-        </td>
-        <td style="padding: 14px 16px; color: {SMARTLIC_GREEN}; font-size: 14px; font-weight: 700; text-align: right;">
-          economiza R$ 3.767
-        </td>
-      </tr>
-    </table>"""
-
-
-def _founder_signature_html() -> str:
-    """Founder-led signature — Belgray-style personal close."""
-    return f"""
-    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 32px 0 4px;">
-      No que eu puder ajudar, é só responder esse email.
-    </p>
-    <p style="color: #555; font-size: 15px; line-height: 1.6; margin: 0 0 4px;">
-      Tiago<br/>
-      <span style="color: #888; font-size: 13px;">fundador, SmartLic</span>
-    </p>"""
-
-
-def _format_brl(value: float) -> str:
-    """Format a float as Brazilian Real currency string."""
-    if value >= 1_000_000:
-        return f"R$ {value / 1_000_000:.1f}M"
-    if value >= 1_000:
-        return f"R$ {value / 1_000:.0f}k"
-    return f"R$ {value:,.0f}".replace(",", ".")
-
-
-def _stats_block(stats: dict, show_pipeline: bool = False) -> str:
-    """AC8: Render a stats summary block for email templates."""
-    searches = stats.get("searches_count", 0)
-    opps = stats.get("opportunities_found", 0)
-    value = stats.get("total_value_estimated", 0.0)
-    pipeline = stats.get("pipeline_items_count", 0)
-
-    rows = f"""
-    <tr>
-      <td style="padding: 8px 16px; color: #555; font-size: 15px; border-bottom: 1px solid #eee;">
-        Análises realizadas
-      </td>
-      <td style="padding: 8px 16px; color: #333; font-size: 15px; font-weight: 600; text-align: right; border-bottom: 1px solid #eee;">
-        {searches}
-      </td>
-    </tr>
-    <tr>
-      <td style="padding: 8px 16px; color: #555; font-size: 15px; border-bottom: 1px solid #eee;">
-        Oportunidades encontradas
-      </td>
-      <td style="padding: 8px 16px; color: #333; font-size: 15px; font-weight: 600; text-align: right; border-bottom: 1px solid #eee;">
-        {opps}
-      </td>
-    </tr>
-    <tr>
-      <td style="padding: 8px 16px; color: #555; font-size: 15px; border-bottom: 1px solid #eee;">
-        Valor total estimado
-      </td>
-      <td style="padding: 8px 16px; color: {SMARTLIC_GREEN}; font-size: 15px; font-weight: 600; text-align: right; border-bottom: 1px solid #eee;">
-        {_format_brl(value)}
-      </td>
-    </tr>"""
-
-    if show_pipeline:
-        rows += f"""
-    <tr>
-      <td style="padding: 8px 16px; color: #555; font-size: 15px;">
-        Itens no pipeline
-      </td>
-      <td style="padding: 8px 16px; color: #333; font-size: 15px; font-weight: 600; text-align: right;">
-        {pipeline}
-      </td>
-    </tr>"""
-
-    return f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
-           style="background-color: #f8f9fa; border-radius: 8px; margin: 16px 0 24px; overflow: hidden;">
-      {rows}
-    </table>"""
-
-
-def _unsubscribe_block(unsubscribe_url: str) -> str:
-    """Render unsubscribe link block (AC2: RFC 8058 one-click)."""
-    if not unsubscribe_url:
-        return ""
-    return f"""
-    <p style="color: #999; font-size: 12px; text-align: center; margin: 24px 0 0;">
-      <a href="{unsubscribe_url}" style="color: #999; text-decoration: underline;">
-        Não desejo receber emails sobre o trial
-      </a>
-    </p>"""
-
-
-def _preheader(text: str) -> str:
-    """AC2: Hidden preheader text for email clients (Gmail, Apple Mail)."""
-    return (
-        f'<div style="display:none;font-size:1px;color:#f4f4f4;'
-        f'line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">'
-        f'{text}</div>'
-    )
+__all__ = [
+    "FOUNDERS_PRICE_BRL",
+    "FOUNDERS_PRICE_BRL_NUMERIC",
+    "PRO_MONTHLY_BRL",
+    "PRO_ANNUAL_TOTAL_BRL",
+    "_founders_cross_sell_block",
+    "_founders_pricing_table_html",
+    "_founder_signature_html",
+    "_format_brl",
+    "_stats_block",
+    "_unsubscribe_block",
+    "_preheader",
+]
 
 
 # ============================================================================
@@ -280,7 +120,12 @@ def render_trial_welcome_email(user_name: str, unsubscribe_url: str = "") -> str
 # Email #2 — Day 3: Engajamento (AC7)
 # ============================================================================
 
-def render_trial_engagement_email(user_name: str, stats: dict, unsubscribe_url: str = "") -> str:
+def render_trial_engagement_email(
+    user_name: str,
+    stats: dict,
+    unsubscribe_url: str = "",
+    days_remaining: int = 11,
+) -> str:
     """EMAIL-TRIAL-006 (#1005) Day 3: Pergunta direta founder-led, 3-5 frases.
 
     Belgray friend-text — não vendendo nada, perguntando se tá fazendo sentido.
@@ -290,6 +135,7 @@ def render_trial_engagement_email(user_name: str, stats: dict, unsubscribe_url: 
         user_name: User's display name.
         stats: Dict with keys from TrialUsageStats.
         unsubscribe_url: URL for one-click unsubscribe.
+        days_remaining: Dias restantes do trial (Day 3 → 11). STORY-321 contract.
     """
     has_usage = stats.get("searches_count", 0) > 0
     value = stats.get("total_value_estimated", 0.0)
@@ -331,7 +177,8 @@ def render_trial_engagement_email(user_name: str, stats: dict, unsubscribe_url: 
     </p>
     <p style="color: #555; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
       Responde esse email com 1 linha — chega direto na minha caixa.
-      Leio e respondo todos.
+      Leio e respondo todos. Ainda faltam {days_remaining} dias do seu trial,
+      dá pra explorar com calma.
     </p>
 
     <p style="text-align: center; margin: 24px 0 16px;">

--- a/backend/tests/test_trial_email_sequence.py
+++ b/backend/tests/test_trial_email_sequence.py
@@ -605,15 +605,188 @@ class TestRenderEmail:
         )
         assert "coupon" in html.lower() or "20%" in html
 
-    def test_expired_subject_includes_20_off(self):
-        """AC14: Expired email subject mentions 20% off."""
+    def test_expired_subject_is_founder_question(self):
+        """EMAIL-TRIAL-006 (#1005): Day 16 subject is founder-led 'Errei algo?'.
+
+        20% off cupom moved from subject → body PS (still applied via
+        coupon_checkout_url). Validates issue copy spec.
+        """
         from services.trial_email_sequence import _render_email
         subject, html = _render_email(
             email_type="expired",
             user_name="Test",
             stats=SAMPLE_STATS,
         )
-        assert "20%" in subject
+        assert "Errei algo" in subject
+        # Cupom mantém-se no body (AC: PS link)
+        assert "TRIAL_COMEBACK_20" in html or "20%" in html
+
+
+class TestEmailTrial006Subjects:
+    """EMAIL-TRIAL-006 (#1005): subjects per issue copy spec."""
+
+    def test_day3_subject_is_question(self):
+        from services.trial_email_sequence import _render_email
+        subject, _ = _render_email("engagement", "Ana", SAMPLE_STATS)
+        assert "Pergunta" in subject and "fazendo sentido" in subject
+
+    def test_day7_subject_pricing_comparison(self):
+        from services.trial_email_sequence import _render_email
+        with patch(
+            "services.trial_email_sequence._get_founders_seats_remaining",
+            return_value=None,
+        ):
+            subject, html = _render_email("paywall_alert", "Ana", SAMPLE_STATS)
+        assert "Pro" in subject and ("vitalício" in subject or "Vitalício" in subject)
+        # Cross-sell Founders link must be in body
+        assert "/fundadores" in html
+
+    def test_day10_subject_with_seats_counter(self):
+        from services.trial_email_sequence import _render_email
+        stats = {**SAMPLE_STATS, "days_remaining": 4}
+        with patch(
+            "services.trial_email_sequence._get_founders_seats_remaining",
+            return_value=12,
+        ):
+            subject, html = _render_email("value", "Ana", stats)
+        assert "12 vagas" in subject
+        assert "4 dias" in subject
+        assert "/fundadores" in html
+
+    def test_day10_subject_fallback_no_counter(self):
+        from services.trial_email_sequence import _render_email
+        stats = {**SAMPLE_STATS, "days_remaining": 4}
+        with patch(
+            "services.trial_email_sequence._get_founders_seats_remaining",
+            return_value=None,
+        ):
+            subject, _ = _render_email("value", "Ana", stats)
+        # Fallback subject — no broken {placeholder}
+        assert "{" not in subject
+        assert "terceira opção" in subject or "decidir" in subject
+
+    def test_day13_subject_pumpkin_legacy_branch(self):
+        from services.trial_email_sequence import _render_email
+        with patch(
+            "services.trial_email_sequence._get_founders_seats_remaining",
+            return_value=None,
+        ):
+            subject, html = _render_email(
+                "last_day", "Ana", SAMPLE_STATS, has_payment_method=False
+            )
+        assert "abóbora" in subject
+        # Founders cross-sell appears in body
+        assert "/fundadores" in html
+
+    def test_day16_subject_founder_question(self):
+        from services.trial_email_sequence import _render_email
+        subject, _ = _render_email("expired", "Ana", SAMPLE_STATS)
+        assert "Errei algo" in subject
+
+
+class TestEmailTrial006AdminSkip:
+    """EMAIL-TRIAL-006 (#1005): admin/master accounts must be skipped."""
+
+    @pytest.mark.asyncio
+    async def test_admin_user_is_skipped(self):
+        """Memory: admin users bypass paywall via is_admin=True. The trial
+        nurture sequence must not target them — they're internal accounts.
+        """
+        import inspect
+        from services import trial_email_sequence
+
+        source = inspect.getsource(trial_email_sequence.process_trial_emails)
+        # The dispatch loop must guard on is_admin/is_master (issue AC)
+        assert "is_admin" in source
+        assert "is_master" in source
+
+    def test_profile_select_includes_admin_flags(self):
+        """SELECT must pull is_admin/is_master to enable the skip filter."""
+        import inspect
+        from services import trial_email_sequence
+
+        source = inspect.getsource(trial_email_sequence.process_trial_emails)
+        # Single-line check on the .select() call (whitespace-flexible)
+        normalized = " ".join(source.split())
+        assert "is_admin" in normalized and "is_master" in normalized
+
+
+class TestEmailTrial006FoundersFetch:
+    """EMAIL-TRIAL-006 (#1005): _get_founders_seats_remaining graceful fallback."""
+
+    def test_returns_none_when_flag_disabled(self):
+        from services.trial_email_sequence import _get_founders_seats_remaining
+        with patch(
+            "config.features.get_feature_flag", return_value=False
+        ):
+            assert _get_founders_seats_remaining() is None
+
+    def test_returns_none_on_db_failure(self):
+        """Any exception in the RPC path → None (templates use generic copy)."""
+        from services.trial_email_sequence import _get_founders_seats_remaining
+        with patch(
+            "config.features.get_feature_flag", return_value=True
+        ), patch(
+            "supabase_client.get_supabase", side_effect=RuntimeError("db down")
+        ):
+            # Must not raise
+            assert _get_founders_seats_remaining() is None
+
+    def test_returns_seats_when_available(self):
+        from services.trial_email_sequence import _get_founders_seats_remaining
+        snapshot = {
+            "available": True,
+            "seats_remaining": 27,
+            "seats_total": 50,
+            "deadline_at": None,
+            "paused": False,
+            "reason": "ok",
+            "offer_mode": "lifetime",
+            "price_brl_cents": 99700,
+        }
+        with patch(
+            "config.features.get_feature_flag", return_value=True
+        ), patch(
+            "supabase_client.get_supabase", return_value=MagicMock()
+        ), patch(
+            "routes.founding._check_availability", return_value=snapshot
+        ):
+            assert _get_founders_seats_remaining() == 27
+
+    def test_returns_none_when_unavailable_flag(self):
+        """RPC says available=False → None even though seats_remaining is set."""
+        from services.trial_email_sequence import _get_founders_seats_remaining
+        snapshot = {"available": False, "seats_remaining": 0}
+        with patch(
+            "config.features.get_feature_flag", return_value=True
+        ), patch(
+            "supabase_client.get_supabase", return_value=MagicMock()
+        ), patch(
+            "routes.founding._check_availability", return_value=snapshot
+        ):
+            assert _get_founders_seats_remaining() is None
+
+
+class TestEmailTrial006PersonalTone:
+    """EMAIL-TRIAL-006 (#1005): personal-tone send — from tiago@smartlic.tech + reply-to gmail."""
+
+    def test_constants_use_personal_tone(self):
+        """Memory: reference_resend_personal_tone_send."""
+        from services import trial_email_sequence
+
+        assert "smartlic.tech" in trial_email_sequence.TRIAL_EMAIL_FROM
+        assert "Tiago" in trial_email_sequence.TRIAL_EMAIL_FROM
+        # Reply-to is gmail (where the founder actually answers)
+        assert "@gmail.com" in trial_email_sequence.TRIAL_EMAIL_REPLY_TO
+
+    def test_dispatch_passes_from_email_and_reply_to(self):
+        """Dispatch loop must invoke send_email_async with from_email/reply_to."""
+        import inspect
+        from services import trial_email_sequence
+
+        source = inspect.getsource(trial_email_sequence.process_trial_emails)
+        assert "from_email=TRIAL_EMAIL_FROM" in source
+        assert "reply_to=TRIAL_EMAIL_REPLY_TO" in source
 
 
 class TestResendWebhook:

--- a/backend/tests/test_trial_emails.py
+++ b/backend/tests/test_trial_emails.py
@@ -163,28 +163,32 @@ class TestWelcomeEmail:
 # ============================================================================
 
 class TestEngagementEmail:
-    """AC17: Email #2 — Day 3: Engagement with stats."""
+    """EMAIL-TRIAL-006 (#1005) Day 3: founder-led "tá fazendo sentido?"."""
 
     def test_renders_with_stats(self):
         html = render_trial_engagement_email("Joao", SAMPLE_STATS)
         assert "<!DOCTYPE html>" in html
 
-    def test_shows_value_when_used(self):
+    def test_founder_signature_present(self):
+        """Day 3 is founder-led — signed Tiago, not Equipe SmartLic."""
         html = render_trial_engagement_email("Test", SAMPLE_STATS)
-        assert "2.4M" in html or "2.3M" in html
+        assert "Tiago" in html
 
-    def test_adapts_for_zero_usage(self):
-        html = render_trial_engagement_email("Test", ZERO_STATS)
-        assert "11 dias" in html
-
-    def test_cta_explore_sectors(self):
-        """AC1: CTA is 'Explorar mais setores'."""
+    def test_question_subject_in_body(self):
+        """Belgray-style direct question hook."""
         html = render_trial_engagement_email("Test", SAMPLE_STATS)
-        assert "Explorar mais setores" in html
+        assert "fazendo sentido" in html.lower()
 
     def test_contains_buscar_link(self):
         html = render_trial_engagement_email("Test", SAMPLE_STATS)
         assert "/buscar" in html
+
+    def test_founders_link_in_ps(self):
+        """Soft cross-sell — Founders link in PS, not primary CTA."""
+        html = render_trial_engagement_email("Test", SAMPLE_STATS)
+        assert "/fundadores" in html
+        assert "997" in html
+        assert "P.S." in html
 
     def test_empty_stats_safe(self):
         html = render_trial_engagement_email("Test", {})
@@ -204,43 +208,43 @@ class TestEngagementEmail:
 # ============================================================================
 
 class TestPaywallAlertEmail:
-    """AC17: Email #3 — Day 7: Paywall alert."""
+    """EMAIL-TRIAL-006 (#1005) Day 7: pricing comparison + Founders cross-sell."""
 
     def test_renders_without_error(self):
         html = render_trial_paywall_alert_email("Joao", SAMPLE_STATS)
         assert "<!DOCTYPE html>" in html
 
-    def test_mentions_preview_limited(self):
+    def test_pricing_table_present(self):
+        """Day 7 shows the math: R$397/mes vs R$997 vitalício."""
         html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
-        assert "preview" in html.lower() or "limitado" in html.lower()
+        assert "397" in html
+        assert "997" in html
+        assert "4.764" in html  # annual total — Belgray "show me the money"
 
-    def test_mentions_today(self):
-        """P0 zero-churn: Email now says 'a partir de hoje' (was 'amanhã')."""
+    def test_founders_cross_sell_primary(self):
+        """Day 7 primary CTA is Plano Fundadores."""
         html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
-        assert "hoje" in html.lower()
+        assert "/fundadores" in html
+        assert "Vitalício" in html or "vitalício" in html
 
-    def test_lists_what_changes(self):
-        """AC7: Lists what changes after paywall."""
-        html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
-        assert "10" in html  # limited to 10 results
-        assert "5" in html or "pipeline" in html.lower()
-
-    def test_cta_assine(self):
-        """AC1: CTA is 'Assine antes do limite'."""
-        html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
-        assert "Assine" in html
-
-    def test_links_to_planos(self):
+    def test_pro_mensal_secondary(self):
+        """Pro mensal is the secondary CTA — still present."""
         html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
         assert "/planos" in html
 
-    def test_7_days_remaining(self):
+    def test_founder_signature_present(self):
         html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
-        assert "7 dias" in html
+        assert "Tiago" in html
 
-    def test_shows_stats_when_used(self):
-        html = render_trial_paywall_alert_email("Test", SAMPLE_STATS)
-        assert "12" in html  # searches count
+    def test_seats_remaining_when_provided(self):
+        """When seats_remaining > 0, scarcity copy uses concrete number."""
+        html = render_trial_paywall_alert_email("Test", SAMPLE_STATS, seats_remaining=12)
+        assert "12 vagas" in html
+
+    def test_seats_fallback_when_none(self):
+        """Without counter (API fallback) → generic 'vagas limitadas' copy."""
+        html = render_trial_paywall_alert_email("Test", SAMPLE_STATS, seats_remaining=None)
+        assert "limitadas" in html.lower() or "vitalícias" in html
 
     def test_empty_stats_safe(self):
         html = render_trial_paywall_alert_email("Test", {})
@@ -260,48 +264,65 @@ class TestPaywallAlertEmail:
 # ============================================================================
 
 class TestValueEmail:
-    """AC17: Email #4 — Day 10: Accumulated value."""
+    """EMAIL-TRIAL-006 (#1005) Day 10: Chaperon open loop + Founders cross-sell."""
 
     def test_renders_without_error(self):
         html = render_trial_value_email("Joao", SAMPLE_STATS)
         assert "<!DOCTYPE html>" in html
 
-    def test_big_value_highlight(self):
-        """AC7: Shows valor acumulado em destaque (R$ grande)."""
+    def test_chaperon_open_loop(self):
+        """Day 10 uses 'terceira opção' open loop (Chaperon)."""
         html = render_trial_value_email("Test", SAMPLE_STATS)
-        assert "2.4M" in html or "2.3M" in html
-        assert "font-size: 36px" in html  # Big number
+        assert "terceira opção" in html
 
-    def test_cta_nao_perca(self):
-        """AC1: CTA is 'Não perca esse progresso'."""
+    def test_founders_cross_sell_primary(self):
+        """Day 10 primary CTA is Plano Fundadores."""
         html = render_trial_value_email("Test", SAMPLE_STATS)
-        assert "Não perca esse progresso" in html
+        assert "/fundadores" in html
+        assert "997" in html
 
-    def test_links_to_planos(self):
+    def test_pro_mensal_secondary(self):
         html = render_trial_value_email("Test", SAMPLE_STATS)
         assert "/planos" in html
 
-    def test_mentions_annual_discount(self):
+    def test_founder_signature_present(self):
         html = render_trial_value_email("Test", SAMPLE_STATS)
-        assert "20%" in html
-        assert "anual" in html.lower()
+        assert "Tiago" in html
 
-    def test_adapts_for_opps_no_value(self):
-        stats = {**SAMPLE_STATS, "total_value_estimated": 0}
-        html = render_trial_value_email("Test", stats)
-        assert "47" in html  # shows opp count
+    def test_seats_remaining_when_provided(self):
+        html = render_trial_value_email("Test", SAMPLE_STATS, seats_remaining=8)
+        assert "8 vagas" in html
 
-    def test_adapts_for_zero_usage(self):
-        html = render_trial_value_email("Test", ZERO_STATS)
+    def test_seats_fallback_when_none(self):
+        """Without counter → generic copy, no broken {placeholder} in copy text.
+
+        Only checks that template-style placeholders (e.g. {seats_remaining})
+        don't leak into the rendered body — CSS rules in <style> blocks
+        legitimately contain `{`, so we strip them before scanning.
+        """
+        html = render_trial_value_email("Test", SAMPLE_STATS, seats_remaining=None)
+        import re
+        # Strip <style>...</style> blocks; they legitimately contain CSS braces
+        body_text = re.sub(r"<style>.*?</style>", "", html, flags=re.DOTALL)
+        # Also strip inline style="..." attributes which may carry CSS
+        body_text = re.sub(r'style="[^"]*"', "", body_text)
+        assert "{seats" not in body_text
+        assert "{vagas" not in body_text
+        assert "vagas" in html.lower()
+
+    def test_days_remaining_default(self):
+        """Default days_remaining=4 (Day 10 trial → 4 days left)."""
+        html = render_trial_value_email("Test", SAMPLE_STATS)
         assert "4 dias" in html
+
+    def test_progress_recap_when_value(self):
+        """Shows opportunities mapped count when there is usage."""
+        html = render_trial_value_email("Test", SAMPLE_STATS)
+        assert "47" in html  # opps count
 
     def test_empty_stats_safe(self):
         html = render_trial_value_email("Test", {})
         assert "<!DOCTYPE html>" in html
-
-    def test_pipeline_count_shown(self):
-        html = render_trial_value_email("Test", SAMPLE_STATS)
-        assert "8" in html  # pipeline items in sub-text
 
     def test_contains_preheader(self):
         html = render_trial_value_email("Test", SAMPLE_STATS)
@@ -317,32 +338,45 @@ class TestValueEmail:
 # ============================================================================
 
 class TestLastDayEmail:
-    """AC17: Email #5 — Day 13: Last day."""
+    """EMAIL-TRIAL-006 (#1005) Day 13 (legacy branch): vira abóbora + 3-col comparison."""
 
     def test_renders_without_error(self):
         html = render_trial_last_day_email("Joao", SAMPLE_STATS)
         assert "<!DOCTYPE html>" in html
 
-    def test_urgency_styling(self):
+    def test_pumpkin_hook(self):
+        """Belgray-style headline: trial 'vira abóbora'."""
         html = render_trial_last_day_email("Test", SAMPLE_STATS)
-        assert "#d32f2f" in html
+        assert "abóbora" in html
 
-    def test_contains_price(self):
+    def test_three_column_comparison(self):
+        """Day 13 shows 3 options side-by-side: cancelar / Pro / Vitalício."""
         html = render_trial_last_day_email("Test", SAMPLE_STATS)
+        assert "Cancelar" in html
+        assert "Pro mensal" in html
+        assert "Vitalício" in html
+        # All three prices visible
+        assert "R$ 0" in html
         assert "397" in html
+        assert "997" in html
 
     def test_mentions_tomorrow(self):
         html = render_trial_last_day_email("Test", {})
-        assert "Amanhã" in html
+        assert "Amanhã" in html or "amanhã" in html
 
-    def test_cta_assinar_agora(self):
-        """AC1: CTA is 'Assinar agora'."""
-        html = render_trial_last_day_email("Test", {})
-        assert "Assinar agora" in html
-
-    def test_shows_stats(self):
+    def test_founders_cross_sell_block(self):
+        """Day 13 has Founders cross-sell block."""
         html = render_trial_last_day_email("Test", SAMPLE_STATS)
-        assert "12" in html
+        assert "/fundadores" in html
+
+    def test_no_card_charge_language(self):
+        """Legacy branch: user has NO card. Must say no charge tomorrow."""
+        html = render_trial_last_day_email("Test", SAMPLE_STATS)
+        assert "ninguém vai cobrar" in html or "Sem cartão" in html
+
+    def test_founder_signature_present(self):
+        html = render_trial_last_day_email("Test", SAMPLE_STATS)
+        assert "Tiago" in html
 
     def test_empty_stats_safe(self):
         html = render_trial_last_day_email("Test", {})
@@ -351,6 +385,10 @@ class TestLastDayEmail:
     def test_contains_preheader(self):
         html = render_trial_last_day_email("Test", SAMPLE_STATS)
         assert "display:none" in html
+
+    def test_seats_remaining_when_provided(self):
+        html = render_trial_last_day_email("Test", SAMPLE_STATS, seats_remaining=3)
+        assert "3 vagas" in html
 
 
 # ============================================================================
@@ -442,7 +480,7 @@ class TestLastDayCardBranchDispatch:
             captured["cancel_url"] = kwargs.get("cancel_url")
             return "<html>CARD</html>"
 
-        def fake_legacy(user_name, stats, unsubscribe_url=""):
+        def fake_legacy(user_name, stats, unsubscribe_url="", seats_remaining=None):
             captured["variant"] = "legacy"
             return "<html>LEGACY</html>"
 
@@ -481,7 +519,7 @@ class TestLastDayCardBranchDispatch:
             captured["variant"] = "card"
             return "<html>CARD</html>"
 
-        def fake_legacy(user_name, stats, unsubscribe_url=""):
+        def fake_legacy(user_name, stats, unsubscribe_url="", seats_remaining=None):
             captured["variant"] = "legacy"
             return "<html>LEGACY</html>"
 
@@ -565,53 +603,52 @@ class TestFormatChargeDateDisplay:
 # ============================================================================
 
 class TestExpiredEmail:
-    """AC17: Email #6 — Day 16: Expired with 20% off coupon."""
+    """EMAIL-TRIAL-006 (#1005) Day 16 (lapsed): "Errei algo?" founder-led ask."""
 
     def test_renders_without_error(self):
         html = render_trial_expired_email("Joao", SAMPLE_STATS)
         assert "<!DOCTYPE html>" in html
 
+    def test_errei_algo_question(self):
+        """Founder-led headline: 'Errei algo?'."""
+        html = render_trial_expired_email("Test", SAMPLE_STATS)
+        assert "Errei algo" in html
+
+    def test_invites_one_line_reply(self):
+        """Founder asks for 1-line response — primary engagement, not CTA."""
+        html = render_trial_expired_email("Test", SAMPLE_STATS)
+        assert "1 linha" in html or "uma linha" in html.lower()
+
     def test_mentions_data_saved(self):
         html = render_trial_expired_email("Test", SAMPLE_STATS)
         assert "30 dias" in html
 
-    def test_cta_20_off(self):
-        """AC14: Expired email includes 20% off CTA."""
+    def test_coupon_in_ps(self):
+        """Day 16 keeps TRIAL_COMEBACK_20 cupom — but in PS, not primary CTA."""
         html = render_trial_expired_email(
             "Test", SAMPLE_STATS,
             coupon_checkout_url="https://smartlic.tech/planos?coupon=TRIAL_COMEBACK_20",
         )
-        assert "20% OFF" in html or "20% off" in html.lower()
-        assert "Voltar com 20% off" in html
-
-    def test_coupon_url_in_cta(self):
-        """AC14: CTA links to checkout with coupon."""
-        url = "https://smartlic.tech/planos?coupon=TRIAL_COMEBACK_20"
-        html = render_trial_expired_email("Test", SAMPLE_STATS, coupon_checkout_url=url)
+        assert "TRIAL_COMEBACK_20" in html
         assert "coupon=TRIAL_COMEBACK_20" in html
+        assert "20% off" in html.lower()
+        assert "P.S." in html
 
-    def test_fallback_cta_without_coupon(self):
+    def test_founders_cross_sell_in_ps(self):
+        """Day 16 PS also offers Founders alternative."""
         html = render_trial_expired_email("Test", SAMPLE_STATS)
-        assert "Reativar acesso" in html
-        assert "/planos" in html
+        assert "/fundadores" in html
+        assert "997" in html
 
-    def test_adapts_headline_pipeline(self):
-        html = render_trial_expired_email("Test", {
-            "opportunities_found": 30,
-            "pipeline_items_count": 5,
-        })
-        assert "5 oportunidades" in html
+    def test_founder_signature_present(self):
+        html = render_trial_expired_email("Test", SAMPLE_STATS)
+        assert "Tiago" in html
 
-    def test_adapts_headline_opps(self):
-        html = render_trial_expired_email("Test", {
-            "opportunities_found": 30,
-            "pipeline_items_count": 0,
-        })
-        assert "30 oportunidades" in html
-
-    def test_zero_usage_generic(self):
+    def test_zero_usage_renders(self):
+        """Without prior activity still renders without crash."""
         html = render_trial_expired_email("Test", ZERO_STATS)
-        assert "Sentimos sua falta" in html
+        assert "<!DOCTYPE html>" in html
+        assert "Errei algo" in html
 
     def test_empty_stats_safe(self):
         html = render_trial_expired_email("Test", {})
@@ -621,14 +658,14 @@ class TestExpiredEmail:
         html = render_trial_expired_email("Test", SAMPLE_STATS)
         assert "display:none" in html
 
-    def test_20_off_badge(self):
-        """AC14: Shows 20% OFF badge."""
-        html = render_trial_expired_email(
-            "Test", SAMPLE_STATS,
-            coupon_checkout_url="https://smartlic.tech/planos?coupon=X",
-        )
-        assert "20% OFF" in html
-        assert "primeiro mês" in html.lower()
+    def test_progress_recap_when_opps(self):
+        """When user had activity, recap shows opp count."""
+        html = render_trial_expired_email("Test", {
+            "opportunities_found": 30,
+            "pipeline_items_count": 5,
+        })
+        assert "30" in html
+        assert "5" in html
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary / Context

Closes #1005 — reformulates the trial email sequence (days 3/7/10/13/16) to founder-led friend-text tone (Belgray + Chaperon + Sethi consensus from Copymasters) and adds **Plano Fundadores** cross-sell (R$ 997 vitalício one-time) on days 7/10/13.

Day 0 welcome is **untouched** (sister PR #1001 territory). Day 13 card branch (auto-charge compliance copy) is preserved — only the legacy branch (no card on file) was reformulated.

### Copy approach per day

| Day | Subject | Tone |
|-----|---------|------|
| 3 | "Pergunta rápida: tá fazendo sentido?" | Founder-led, 3-5 frases, PS soft Founders |
| 7 | "Ouça antes de decidir: a conta do Pro vs vitalício" | Pricing table R$397×12 vs R$997 + Founders primary CTA |
| 10 | "Faltam {N} vagas vitalícias (e {D} dias)" | Chaperon open loop "terceira opção" |
| 13 | "Amanhã seu trial vira abóbora 🎃 — sem pressão, mas..." | 3-col comparison cancelar/Pro/Vitalício |
| 16 | "Errei algo? Resposta direta de 1 linha resolve" | Founder pergunta; cupom TRIAL_COMEBACK_20 em PS |

### Technical changes

- **Admin/master skip** — `process_trial_emails` now filters out `is_admin` / `is_master` accounts (AC + memory: admin bypass paywall, polluting trial nurture)
- **Personal-tone send** — from `Tiago do SmartLic <tiago@smartlic.tech>` + reply-to gmail (memory: `reference_resend_personal_tone_send`)
- **Founder signature** in all 5 reformulated templates (Tiago, fundador) — card branch keeps `Equipe SmartLic` (compliance)
- **Live counter** for `{vagasRestantes}` via `routes.founding._check_availability` with graceful fallback to generic copy when RPC fails (issue #1002 dependency, but doesn't block this PR)
- **HMAC webhook untouched** — PR #534 / audit #954 path preserved

### Out of scope (deferred)

- Plain-text alternative — `send_email_async` wrapper does not currently expose `text=` to the Resend SDK; extending it touches a wider surface than this issue. HTML deliverability is already validated in production (Resend + verified `smartlic.tech` domain).

## Testing Plan

- [x] `pytest tests/test_trial_emails.py tests/test_trial_email_sequence.py` — 141 passing
- [x] `pytest tests/test_trial_email_extensions.py tests/test_story418_trial_email_dlq.py` — 28 passing
- [x] New test classes:
  - `TestEmailTrial006Subjects` — subjects per issue copy spec for all 5 days
  - `TestEmailTrial006AdminSkip` — admin/master profile fields filtered in dispatch
  - `TestEmailTrial006FoundersFetch` — feature flag, RPC failure, success, and unavailable paths
  - `TestEmailTrial006PersonalTone` — `TRIAL_EMAIL_FROM` constants + dispatch wiring
- [x] Existing legacy/card-branch dispatch tests still green (mocks updated for new kwargs)
- [ ] Manual preview in Litmus / Gmail / Outlook / iOS Mail (post-merge spot check)
- [ ] A/B funnel check post-deploy: Day 7/10 open rate + click-through to `/fundadores`

## Closes

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)