### PR TITLE
feat(ci): SEO gates — title length, JSON-LD validate, drift (#998)

### DIFF
--- a/.github/workflows/seo-gates.yml
+++ b/.github/workflows/seo-gates.yml
@@ -77,12 +77,14 @@ jobs:
 
       - name: Append to step summary
         if: always()
+        env:
+          SUMMARY: ${{ steps.title.outputs.summary }}
         run: |
           {
             echo "## SEO Gate — Title Length"
             echo ""
             echo '```'
-            echo "${{ steps.title.outputs.summary }}"
+            printf '%s\n' "$SUMMARY"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -115,12 +117,14 @@ jobs:
 
       - name: Append to step summary
         if: always()
+        env:
+          SUMMARY: ${{ steps.jsonld.outputs.summary }}
         run: |
           {
             echo "## SEO Gate — JSON-LD Validate"
             echo ""
             echo '```'
-            echo "${{ steps.jsonld.outputs.summary }}"
+            printf '%s\n' "$SUMMARY"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -163,12 +167,14 @@ jobs:
 
       - name: Append to step summary
         if: always()
+        env:
+          SUMMARY: ${{ steps.drift.outputs.summary }}
         run: |
           {
             echo "## SEO Gate — Indexation Drift (warn-only)"
             echo ""
             echo '```'
-            echo "${{ steps.drift.outputs.summary }}"
+            printf '%s\n' "$SUMMARY"
             echo '```'
             echo ""
             echo "_GSC API token not wired into CI yet; gate runs against the most-recent row in \`docs/seo/indexation-history.csv\`. Flip warn-only off after the GSC fetch is automated._"

--- a/.github/workflows/seo-gates.yml
+++ b/.github/workflows/seo-gates.yml
@@ -1,0 +1,191 @@
+name: "SEO Gates"
+
+# SEO-P2-012 (Issue #998) — three deterministic gates that run on PRs
+# touching SEO surface area + a nightly drift check. Designed to be cheap
+# (no Next.js build, no Lighthouse, no Playwright) so the workflow stays
+# under the 20-job concurrency cap and finishes in <2 min.
+#
+# Gates:
+#   1. title-length  — scans BLOG_ARTICLES + QUESTIONS for title length
+#                      violations. Ships in REPORT mode (logs, never fails)
+#                      until the existing baseline of long titles is
+#                      rewritten; flip SEO_TITLE_ENFORCE=1 to enforce.
+#   2. jsonld-validate — scans every JSON-LD <script> in the source for
+#                        missing @context, @type, and per-type required
+#                        fields. Hard fail on schema violations.
+#   3. indexation-drift — non-blocking; reads history CSV / GSC env and
+#                         posts a step summary if drift > thresholds.
+#
+# The Lighthouse gate from issue #998 already exists in lighthouse.yml.
+# The uniqueness gate is tracked separately under SEO-P0-003.
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/lib/blog.ts'
+      - 'frontend/lib/questions.ts'
+      - 'frontend/lib/authors.ts'
+      - 'frontend/lib/cases.ts'
+      - 'frontend/lib/cities.ts'
+      - 'frontend/lib/glossary-terms.ts'
+      - 'frontend/components/seo/**'
+      - 'frontend/components/blog/**'
+      - 'frontend/app/**/page.tsx'
+      - 'frontend/app/**/*.mdx'
+      - 'scripts/seo/**'
+      - '.github/workflows/seo-gates.yml'
+  schedule:
+    # 04:30 UTC daily (01:30 BRT) — drift snapshot before the workday starts.
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: seo-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  title-length:
+    name: Title length
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run title length gate
+        id: title
+        run: |
+          set +e
+          OUTPUT="$(node scripts/seo/title-length-check.js)"
+          STATUS=$?
+          echo "$OUTPUT"
+          {
+            echo "summary<<EOF"
+            echo "$OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit $STATUS
+
+      - name: Append to step summary
+        if: always()
+        run: |
+          {
+            echo "## SEO Gate — Title Length"
+            echo ""
+            echo '```'
+            echo "${{ steps.title.outputs.summary }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  jsonld-validate:
+    name: JSON-LD validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run JSON-LD validate gate
+        id: jsonld
+        run: |
+          set +e
+          OUTPUT="$(node scripts/seo/jsonld-validate.js)"
+          STATUS=$?
+          echo "$OUTPUT"
+          {
+            echo "summary<<EOF"
+            echo "$OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit $STATUS
+
+      - name: Append to step summary
+        if: always()
+        run: |
+          {
+            echo "## SEO Gate — JSON-LD Validate"
+            echo ""
+            echo '```'
+            echo "${{ steps.jsonld.outputs.summary }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  indexation-drift:
+    name: Indexation drift (warn-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Non-blocking by design — `continue-on-error: true` so a warn never
+    # red-Xes the merge train. Real signal lives in the step summary and
+    # in the daily scheduled run (which can append to the history CSV).
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run indexation drift gate
+        id: drift
+        env:
+          # Optional. When the workflow is given access to a GSC service
+          # account, set this from a previous step that calls the GSC API.
+          # Empty by default — the gate then falls back to the most-recent
+          # row in docs/seo/indexation-history.csv.
+          GSC_INDEXED_COUNT: ${{ vars.GSC_INDEXED_COUNT || '' }}
+        run: |
+          set +e
+          OUTPUT="$(node scripts/seo/indexation-drift.js)"
+          STATUS=$?
+          echo "$OUTPUT"
+          {
+            echo "summary<<EOF"
+            echo "$OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit $STATUS
+
+      - name: Append to step summary
+        if: always()
+        run: |
+          {
+            echo "## SEO Gate — Indexation Drift (warn-only)"
+            echo ""
+            echo '```'
+            echo "${{ steps.drift.outputs.summary }}"
+            echo '```'
+            echo ""
+            echo "_GSC API token not wired into CI yet; gate runs against the most-recent row in \`docs/seo/indexation-history.csv\`. Flip warn-only off after the GSC fetch is automated._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  unit-tests:
+    name: Gate scripts unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run gate unit tests (node:test)
+        run: node --test scripts/seo/__tests__/

--- a/docs/seo/ci-gates.md
+++ b/docs/seo/ci-gates.md
@@ -1,0 +1,113 @@
+# SEO CI Gates
+
+Issue [#998](https://github.com/tjsasakifln/pncp-poc/issues/998) — SEO-P2-012.
+
+Three deterministic CI gates plus one nightly drift snapshot, wired in
+`.github/workflows/seo-gates.yml`. Scripts live under `scripts/seo/` and
+have unit tests under `scripts/seo/__tests__/` runnable via Node’s built-in
+test runner (no Jest, no extra deps).
+
+## Gate 1 — Title length (`scripts/seo/title-length-check.js`)
+
+**What it scans.** `frontend/lib/blog.ts` and `frontend/lib/questions.ts`
+— the source registries that drive the on-page `<title>` for blog posts
+and Q&A pages. Page-metadata generated dynamically inside `generateMetadata`
+(programmatic SEO routes under `frontend/app/licitacoes/...`) is *not*
+covered; those are validated by the JSON-LD gate plus the existing
+`scripts/gsc/rich-results-test.ts`.
+
+**Thresholds.**
+
+| env var | default | meaning |
+|---------|---------|---------|
+| `SEO_TITLE_WARN`    | 60 | warn when `title.length > WARN`         |
+| `SEO_TITLE_FAIL`    | 70 | fail when `title.length > FAIL` (only in enforce mode) |
+| `SEO_DESC_WARN`     | 170 | warn when questions metaDescription is too long |
+| `SEO_TITLE_ENFORCE` | 0  | when `1`, exit non-zero on any FAIL     |
+
+**Why it ships in report mode.** Auditing the registries on 2026-05-10
+flagged 61 titles in the 60–82 char range — `>60 = fail` would block
+every PR on day one, and `>70 = fail` would still block 26. The gate
+ships logging WARN/FAIL annotations without exiting non-zero. Flip
+`SEO_TITLE_ENFORCE=1` after the existing titles are rewritten (separate
+ticket).
+
+**Local run.**
+```bash
+node scripts/seo/title-length-check.js
+SEO_TITLE_ENFORCE=1 node scripts/seo/title-length-check.js   # strict
+```
+
+## Gate 2 — JSON-LD validate (`scripts/seo/jsonld-validate.js`)
+
+**What it scans.** Every `.ts(x)` / `.js(x)` under
+`frontend/components/seo/`, `frontend/components/blog/`, and
+`frontend/app/`. For each `<script type="application/ld+json">` it
+finds the matching `JSON.stringify({ ... })` literal, parses it (with
+TS-syntax tolerance and a placeholder pass for variable references),
+and validates against a minimal schema.org schema:
+
+- `@context` must reference `schema.org` (string or array containing).
+- `@type` must be present and recognized (typo guard).
+- Required fields per type — Article needs `headline` + `author`;
+  BlogPosting also needs `datePublished`; FAQPage needs `mainEntity`;
+  BreadcrumbList needs `itemListElement`; Organization, Person,
+  WebSite, WebPage, Product, Service all need `name`/`url`. See
+  `REQUIRED_FIELDS` in the script for the canonical list.
+
+**Why a static scan and not a built render.** The Next.js production
+build compiles 4k+ programmatic pages and consistently exhausts the
+runner heap; the existing `lighthouse.yml` documents the same trade-off
+and runs post-merge only. Static scan catches the >90% breakage class
+(typos in `@type`, missing required fields) at PR time. The Google Rich
+Results Test still runs on the deployed site via
+`scripts/gsc/rich-results-test.ts`.
+
+**Hard fail** on any schema violation. Warns (don’t block) on
+unparseable literals or unknown `@type`.
+
+**Local run.**
+```bash
+node scripts/seo/jsonld-validate.js
+```
+
+## Gate 3 — Indexation drift (`scripts/seo/indexation-drift.js`)
+
+**Non-blocking.** Runs on PR + nightly cron (04:30 UTC). Compares the
+count of URLs the site generates (counted from registry slugs in
+`frontend/lib/*.ts`) with the count of URLs Google has indexed (from
+the most-recent row of `docs/seo/indexation-history.csv` or the env
+`GSC_INDEXED_COUNT`). Surfaces drift via the workflow step summary;
+never red-Xes the merge train.
+
+**Thresholds (issue #998 ACs).**
+
+- Absolute ratio < 30% → WARN.
+- Drop > 10pp vs previous CSV row → WARN.
+
+**GSC token caveat.** The drift gate currently reads only env or the
+history CSV. Wiring a GSC service-account token into CI is a follow-up
+(the existing `scripts/gsc/weekly-health-check.ts` is the manual
+analog and uses Playwright). Once wired, the cron workflow can append
+fresh rows to the history CSV via `--append`.
+
+**Local run.**
+```bash
+node scripts/seo/indexation-drift.js
+GSC_INDEXED_COUNT=80 node scripts/seo/indexation-drift.js --append --json
+```
+
+## Out of scope here
+
+- **Lighthouse**. Lives in `.github/workflows/lighthouse.yml` (push-to-main + weekly cron).
+- **Uniqueness audit (≥40% diff vs nearest neighbor)**. Tracked separately under SEO-P0-003.
+- **Replacing the manual GSC weekly sync**. Stays in
+  `scripts/gsc/weekly-health-check.ts`; the new gate runs in parallel.
+
+## Bypassing a gate
+
+The title gate is already report-only. The JSON-LD gate is intended to
+fail builds — there is no override label. If a JSON-LD failure is a
+false positive (e.g. the parser fails on a brand-new TS pattern),
+either fix the script or move the literal into a constant the parser
+can resolve. Don’t add an escape hatch.

--- a/scripts/seo/__tests__/indexation-drift.test.js
+++ b/scripts/seo/__tests__/indexation-drift.test.js
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for scripts/seo/indexation-drift.js (Issue #998 / SEO-P2-012).
+ * Run with: node --test scripts/seo/__tests__/
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { check, RATIO_DROP_PP, RATIO_FLOOR_PCT } = require('../indexation-drift');
+
+test('check: emits info (not warn) when no indexed count is available', () => {
+  const { findings } = check({ generated: 100, indexed: 0, history: [] });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].level, 'info');
+});
+
+test('check: warns when ratio is below the absolute floor', () => {
+  const { findings, ratio } = check({ generated: 100, indexed: 20, history: [] });
+  assert.equal(Math.round(ratio), 20);
+  assert.ok(findings.some((f) => f.level === 'warn' && /below floor/.test(f.msg)));
+});
+
+test('check: does not warn when ratio is at the floor', () => {
+  const { findings } = check({ generated: 100, indexed: 30, history: [] });
+  assert.equal(findings.filter((f) => f.level === 'warn').length, 0);
+});
+
+test('check: warns when current ratio dropped > RATIO_DROP_PP vs previous', () => {
+  const history = [{ date: '2026-04-01', generated: 100, indexed: 80, ratio: 80 }];
+  const { findings } = check({ generated: 100, indexed: 50, history });
+  assert.ok(findings.some((f) => f.level === 'warn' && /dropped/.test(f.msg)));
+});
+
+test('check: does not warn for small dips below the drop threshold', () => {
+  const history = [{ date: '2026-04-01', generated: 100, indexed: 80, ratio: 80 }];
+  const { findings } = check({ generated: 100, indexed: 75, history });
+  assert.equal(findings.filter((f) => /dropped/.test(f.msg)).length, 0);
+});
+
+test('check: handles zero generated without crashing', () => {
+  const { ratio, findings } = check({ generated: 0, indexed: 50, history: [] });
+  assert.equal(ratio, 0);
+  // 0% < 30% floor → warn expected
+  assert.ok(findings.some((f) => /below floor/.test(f.msg)));
+});
+
+test('thresholds: calibrated values exposed', () => {
+  assert.equal(RATIO_DROP_PP, 10);
+  assert.equal(RATIO_FLOOR_PCT, 30);
+});

--- a/scripts/seo/__tests__/jsonld-validate.test.js
+++ b/scripts/seo/__tests__/jsonld-validate.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for scripts/seo/jsonld-validate.js (Issue #998 / SEO-P2-012).
+ * Run with: node --test scripts/seo/__tests__/
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { extractJsonLdLiterals, validateLd, REQUIRED_FIELDS } = require('../jsonld-validate');
+
+test('extractJsonLdLiterals: extracts a literal object passed to JSON.stringify', () => {
+  const src = `
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({ "@context": "https://schema.org", "@type": "Article" }) }}
+    />
+  `;
+  const literals = extractJsonLdLiterals(src);
+  assert.equal(literals.length, 1);
+  assert.match(literals[0].expr, /@context/);
+  assert.match(literals[0].expr, /@type/);
+});
+
+test('extractJsonLdLiterals: handles multiple JSON-LD blocks in one file', () => {
+  const src = `
+    <script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({ "@type": "Article" }) }}
+    />
+    <script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({ "@type": "FAQPage" }) }}
+    />
+  `;
+  const literals = extractJsonLdLiterals(src);
+  assert.equal(literals.length, 2);
+});
+
+test('extractJsonLdLiterals: respects nested braces inside object literals', () => {
+  const src = `
+    <script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@type": "BreadcrumbList",
+        itemListElement: [{ "@type": "ListItem", position: 1, name: "Home" }],
+      }) }}
+    />
+  `;
+  const literals = extractJsonLdLiterals(src);
+  assert.equal(literals.length, 1);
+  assert.match(literals[0].expr, /itemListElement/);
+  const open = (literals[0].expr.match(/\{/g) || []).length;
+  const close = (literals[0].expr.match(/\}/g) || []).length;
+  assert.equal(open, close);
+});
+
+test('extractJsonLdLiterals: returns empty when no JSON-LD script tag is present', () => {
+  assert.deepEqual(extractJsonLdLiterals('<div>no schema here</div>'), []);
+});
+
+test('validateLd: passes a fully-formed Article', () => {
+  const obj = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'My Title',
+    author: { '@type': 'Person', name: 'X' },
+  };
+  const findings = validateLd(obj, 'fake.tsx');
+  assert.deepEqual(findings, []);
+});
+
+test('validateLd: flags missing @context as fail', () => {
+  const findings = validateLd({ '@type': 'Article', headline: 'h', author: 'a' }, 'fake.tsx');
+  assert.ok(findings.some((f) => f.level === 'fail' && /@context/.test(f.msg)));
+});
+
+test('validateLd: flags missing @type as fail', () => {
+  const findings = validateLd({ '@context': 'https://schema.org' }, 'fake.tsx');
+  assert.ok(findings.some((f) => f.level === 'fail' && /@type/.test(f.msg)));
+});
+
+test('validateLd: flags missing required fields per type', () => {
+  const findings = validateLd(
+    { '@context': 'https://schema.org', '@type': 'BlogPosting', headline: 'h' },
+    'fake.tsx',
+  );
+  const fails = findings.filter((f) => f.level === 'fail');
+  assert.ok(fails.some((f) => /author/.test(f.msg)));
+  assert.ok(fails.some((f) => /datePublished/.test(f.msg)));
+});
+
+test('validateLd: warns on unknown @type (likely typo)', () => {
+  const findings = validateLd(
+    { '@context': 'https://schema.org', '@type': 'BlogPostingTypo' },
+    'fake.tsx',
+  );
+  assert.ok(findings.some((f) => f.level === 'warn' && /unknown @type/.test(f.msg)));
+});
+
+test('validateLd: accepts @context as array containing schema.org', () => {
+  const obj = {
+    '@context': ['https://schema.org', { custom: 'http://example.com/ns#' }],
+    '@type': 'Organization',
+    name: 'CONFENGE',
+  };
+  const findings = validateLd(obj, 'fake.tsx');
+  assert.deepEqual(findings, []);
+});
+
+test('validateLd: handles arrays of LD entities', () => {
+  const arr = [
+    { '@context': 'https://schema.org', '@type': 'Organization', name: 'A' },
+    { '@context': 'https://schema.org', '@type': 'WebSite', url: 'https://x' },
+  ];
+  const findings = validateLd(arr, 'fake.tsx');
+  assert.deepEqual(findings, []);
+});
+
+test('validateLd: flags parse errors as warnings (not blocking failures)', () => {
+  const findings = validateLd({ __parseError: 'syntax error' }, 'fake.tsx');
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].level, 'warn');
+});
+
+test('REQUIRED_FIELDS: declares the canonical set of types', () => {
+  assert.ok(REQUIRED_FIELDS.Article.includes('headline'));
+  assert.ok(REQUIRED_FIELDS.BlogPosting.includes('datePublished'));
+  assert.ok(REQUIRED_FIELDS.FAQPage.includes('mainEntity'));
+  assert.ok(REQUIRED_FIELDS.BreadcrumbList.includes('itemListElement'));
+});

--- a/scripts/seo/__tests__/title-length-check.test.js
+++ b/scripts/seo/__tests__/title-length-check.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for scripts/seo/title-length-check.js (Issue #998 / SEO-P2-012).
+ *
+ * Run with: node --test scripts/seo/__tests__/
+ *
+ * No external test runner — uses node:test (Node ≥18) so the gate stays
+ * dependency-free and matches how the workflow exercises the scripts.
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { extractEntries, check } = require('../title-length-check');
+
+test('extractEntries: parses slug + title from object literals', () => {
+  const src = `
+    export const X = [
+      { slug: 'foo', title: 'Foo Title', description: 'whatever' },
+      { slug: "bar", title: "Bar Title" },
+    ];
+  `;
+  const entries = extractEntries(src);
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].slug, 'foo');
+  assert.equal(entries[0].title, 'Foo Title');
+  assert.equal(entries[1].slug, 'bar');
+});
+
+test('extractEntries: captures metaDescription when present', () => {
+  const src = `{ slug: 'q1', title: 'Q1', metaDescription: 'A descriptive answer.' }`;
+  const entries = extractEntries(src);
+  assert.equal(entries[0].metaDescription, 'A descriptive answer.');
+});
+
+test('extractEntries: returns null metaDescription when absent', () => {
+  const src = `{ slug: 'q1', title: 'Q1' }`;
+  const entries = extractEntries(src);
+  assert.equal(entries[0].metaDescription, null);
+});
+
+test('check: flags titles exceeding the FAIL threshold', () => {
+  const long = 'x'.repeat(75); // > 70
+  const blogSrc = `{ slug: 'a', title: '${long}' }`;
+  const { failures } = check({ blogSrc, questionsSrc: '' });
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].slug, 'a');
+  assert.match(failures[0].reason, /FAIL=70/);
+});
+
+test('check: flags titles in the warn band (>60, ≤70) as warnings, not failures', () => {
+  const med = 'x'.repeat(65);
+  const blogSrc = `{ slug: 'a', title: '${med}' }`;
+  const { failures, warnings } = check({ blogSrc, questionsSrc: '' });
+  assert.equal(failures.length, 0);
+  assert.ok(warnings.some((w) => w.slug === 'a' && /WARN=60/.test(w.reason)));
+});
+
+test('check: passes titles within the safe band', () => {
+  const ok = 'x'.repeat(50);
+  const blogSrc = `{ slug: 'a', title: '${ok}' }`;
+  const { failures, warnings } = check({ blogSrc, questionsSrc: '' });
+  assert.equal(failures.length, 0);
+  assert.equal(warnings.filter((w) => /title length/.test(w.reason)).length, 0);
+});
+
+test('check: flags empty titles as failures', () => {
+  const blogSrc = `{ slug: 'a', title: '   ' }`;
+  const { failures } = check({ blogSrc, questionsSrc: '' });
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].reason, 'empty title');
+});
+
+test('check: flags literal "undefined" / "null" titles', () => {
+  const blogSrc = `
+    { slug: 'a', title: 'undefined' }
+    { slug: 'b', title: 'null' }
+  `;
+  const { failures } = check({ blogSrc, questionsSrc: '' });
+  assert.equal(failures.length, 2);
+  assert.match(failures[0].reason, /literal/);
+});
+
+test('check: warns on long metaDescription in questions', () => {
+  const longDesc = 'd'.repeat(180);
+  const questionsSrc = `{ slug: 'q1', title: 'short', metaDescription: '${longDesc}' }`;
+  const { warnings } = check({ blogSrc: '', questionsSrc });
+  assert.ok(warnings.some((w) => /metaDescription/.test(w.reason)));
+});
+
+test('check: counts entries from both blog and questions sources', () => {
+  const blogSrc = `{ slug: 'b1', title: 'okay' }`;
+  const questionsSrc = `{ slug: 'q1', title: 'okay' }`;
+  const { scanned } = check({ blogSrc, questionsSrc });
+  assert.equal(scanned, 2);
+});

--- a/scripts/seo/indexation-drift.js
+++ b/scripts/seo/indexation-drift.js
@@ -96,14 +96,21 @@ function readHistory() {
 }
 
 function appendHistory(row) {
-  const exists = fs.existsSync(HISTORY_CSV);
   const header = 'date,generated,indexed,ratio_pct\n';
   const line = `${row.date},${row.generated},${row.indexed},${row.ratio.toFixed(2)}\n`;
-  if (!exists) {
-    fs.mkdirSync(path.dirname(HISTORY_CSV), { recursive: true });
-    fs.writeFileSync(HISTORY_CSV, header + line);
-  } else {
-    fs.appendFileSync(HISTORY_CSV, line);
+  // Avoid TOCTOU race (CodeQL js/file-system-race): don't `existsSync` then act.
+  // Use the file open flag 'ax' (exclusive create) for the first write; on
+  // EEXIST fall through to append. mkdirSync(..., recursive: true) is itself
+  // race-safe (no-op when dir already exists).
+  fs.mkdirSync(path.dirname(HISTORY_CSV), { recursive: true });
+  try {
+    fs.writeFileSync(HISTORY_CSV, header + line, { flag: 'ax' });
+  } catch (err) {
+    if (err && err.code === 'EEXIST') {
+      fs.appendFileSync(HISTORY_CSV, line);
+    } else {
+      throw err;
+    }
   }
 }
 

--- a/scripts/seo/indexation-drift.js
+++ b/scripts/seo/indexation-drift.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * SEO Gate (warn-only) — Indexed/generated drift alert (Issue #998 / SEO-P2-012)
+ *
+ * Compares the count of URLs the site *generates* (from the Next.js sitemap
+ * registries) with the count of URLs Google has *indexed* (from a CSV export
+ * or the GSC API), and warns when the ratio drops below thresholds.
+ *
+ * This gate is **non-blocking**. It writes findings to stdout and to the
+ * GitHub Actions step summary, but never exits non-zero unless the script
+ * itself can't run. Rationale:
+ *   - GSC indexed counts arrive with 2–7 day latency, so a single bad day
+ *     should not fail merges.
+ *   - The GSC API requires `GSC_API_TOKEN` which is not always available in
+ *     CI for forks and PRs from external contributors.
+ *   - The authoritative weekly check already lives in
+ *     `scripts/gsc/weekly-health-check.ts`.
+ *
+ * Sources:
+ *   - Generated count: counts entries in BLOG_ARTICLES, QUESTIONS, AUTHORS,
+ *     SECTORS, CITIES, GLOSSARY_TERMS via simple regex over the .ts files
+ *     (avoids running a Next.js build).
+ *   - Indexed count: read from `docs/seo/indexation-history.csv` (most recent
+ *     row) OR from env `GSC_INDEXED_COUNT` (set by the workflow when API
+ *     access is available).
+ *
+ * Thresholds (issue #998):
+ *   - Drop in ratio (vs previous CSV row) > 10pp  → WARN
+ *   - Absolute ratio < 30%                        → WARN
+ *
+ * Outputs:
+ *   - stdout summary
+ *   - JSON to stdout when `--json` flag is passed (consumed by workflow)
+ *
+ * Exit codes:
+ *   0 = always (warn-only) unless --strict and a threshold tripped, or IO error
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const HISTORY_CSV = path.join(ROOT, 'docs', 'seo', 'indexation-history.csv');
+
+const REGISTRY_FILES = [
+  { file: 'frontend/lib/blog.ts', re: /slug:\s*['"][^'"\n]+['"]/g, label: 'blog' },
+  { file: 'frontend/lib/questions.ts', re: /slug:\s*['"][^'"\n]+['"]/g, label: 'questions' },
+  { file: 'frontend/lib/authors.ts', re: /slug:\s*['"][^'"\n]+['"]/g, label: 'authors' },
+  { file: 'frontend/lib/cases.ts', re: /slug:\s*['"][^'"\n]+['"]/g, label: 'cases' },
+  { file: 'frontend/lib/cities.ts', re: /slug:\s*['"][^'"\n]+['"]/g, label: 'cities' },
+  { file: 'frontend/lib/glossary-terms.ts', re: /slug:\s*['"][^'"\n]+['"]/g, label: 'glossary' },
+];
+
+const RATIO_DROP_PP = 10;
+const RATIO_FLOOR_PCT = 30;
+
+function countMatches(file, re) {
+  const full = path.join(ROOT, file);
+  let src;
+  try {
+    src = fs.readFileSync(full, 'utf8');
+  } catch {
+    return 0;
+  }
+  const matches = src.match(re);
+  return matches ? matches.length : 0;
+}
+
+function countGenerated() {
+  const breakdown = {};
+  let total = 0;
+  for (const reg of REGISTRY_FILES) {
+    const n = countMatches(reg.file, reg.re);
+    breakdown[reg.label] = n;
+    total += n;
+  }
+  return { total, breakdown };
+}
+
+function readHistory() {
+  if (!fs.existsSync(HISTORY_CSV)) return [];
+  const lines = fs.readFileSync(HISTORY_CSV, 'utf8').split('\n').filter(Boolean);
+  if (lines.length === 0) return [];
+  // Skip header
+  return lines.slice(1).map((line) => {
+    const [date, generated, indexed, ratio] = line.split(',');
+    return {
+      date: date && date.trim(),
+      generated: Number(generated),
+      indexed: Number(indexed),
+      ratio: Number(ratio),
+    };
+  });
+}
+
+function appendHistory(row) {
+  const exists = fs.existsSync(HISTORY_CSV);
+  const header = 'date,generated,indexed,ratio_pct\n';
+  const line = `${row.date},${row.generated},${row.indexed},${row.ratio.toFixed(2)}\n`;
+  if (!exists) {
+    fs.mkdirSync(path.dirname(HISTORY_CSV), { recursive: true });
+    fs.writeFileSync(HISTORY_CSV, header + line);
+  } else {
+    fs.appendFileSync(HISTORY_CSV, line);
+  }
+}
+
+function check({ generated, indexed, history }) {
+  const findings = [];
+  const ratio = generated > 0 ? (indexed / generated) * 100 : 0;
+  if (indexed === 0) {
+    findings.push({ level: 'info', msg: 'no indexed-count provided (GSC_INDEXED_COUNT env / history CSV); skipping drift evaluation' });
+    return { ratio, findings };
+  }
+  if (ratio < RATIO_FLOOR_PCT) {
+    findings.push({
+      level: 'warn',
+      msg: `absolute ratio ${ratio.toFixed(1)}% is below floor ${RATIO_FLOOR_PCT}% (indexed=${indexed} / generated=${generated})`,
+    });
+  }
+  if (history.length > 0) {
+    const last = history[history.length - 1];
+    if (Number.isFinite(last.ratio) && Number.isFinite(ratio)) {
+      const drop = last.ratio - ratio;
+      if (drop > RATIO_DROP_PP) {
+        findings.push({
+          level: 'warn',
+          msg: `ratio dropped ${drop.toFixed(1)}pp vs previous (was ${last.ratio.toFixed(1)}% on ${last.date}, now ${ratio.toFixed(1)}%)`,
+        });
+      }
+    }
+  }
+  return { ratio, findings };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const isJson = argv.includes('--json');
+  const isStrict = argv.includes('--strict');
+  const shouldAppend = argv.includes('--append');
+
+  const { total: generated, breakdown } = countGenerated();
+  const indexedFromEnv = Number(process.env.GSC_INDEXED_COUNT || 0);
+  const history = readHistory();
+  const indexed = indexedFromEnv > 0
+    ? indexedFromEnv
+    : (history.length > 0 ? history[history.length - 1].indexed : 0);
+
+  const { ratio, findings } = check({ generated, indexed, history });
+
+  const result = {
+    date: new Date().toISOString().split('T')[0],
+    generated,
+    breakdown,
+    indexed,
+    ratio_pct: Number(ratio.toFixed(2)),
+    findings,
+    thresholds: { drop_pp: RATIO_DROP_PP, floor_pct: RATIO_FLOOR_PCT },
+  };
+
+  if (isJson) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    process.stdout.write(`[indexation-drift] generated=${generated} indexed=${indexed} ratio=${ratio.toFixed(1)}%\n`);
+    process.stdout.write(`  breakdown: ${JSON.stringify(breakdown)}\n`);
+    for (const f of findings) {
+      process.stdout.write(`  ${f.level.toUpperCase()}  ${f.msg}\n`);
+    }
+  }
+
+  if (shouldAppend && indexed > 0) {
+    appendHistory(result);
+  }
+
+  const hasWarn = findings.some((f) => f.level === 'warn');
+  if (isStrict && hasWarn) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { countGenerated, check, readHistory, RATIO_DROP_PP, RATIO_FLOOR_PCT };

--- a/scripts/seo/jsonld-validate.js
+++ b/scripts/seo/jsonld-validate.js
@@ -209,7 +209,18 @@ function validateLd(obj, fileLabel) {
       findings.push({ level: 'fail', file: fileLabel, msg: 'missing @context' });
     } else {
       const ctxArr = Array.isArray(ctx) ? ctx : [ctx];
-      const ok = ctxArr.some((c) => typeof c === 'string' && c.includes('schema.org'));
+      // Strict match: scheme + exact host (with optional path). Avoids the
+      // "incomplete URL substring sanitization" CodeQL alert — `c.includes`
+      // would let `https://attacker.example/schema.org/...` slip through.
+      const ok = ctxArr.some((c) => {
+        if (typeof c !== 'string') return false;
+        return (
+          c === 'https://schema.org' ||
+          c === 'http://schema.org' ||
+          c.startsWith('https://schema.org/') ||
+          c.startsWith('http://schema.org/')
+        );
+      });
       if (!ok) {
         findings.push({ level: 'fail', file: fileLabel, msg: `@context does not reference schema.org (got ${JSON.stringify(ctx)})` });
       }

--- a/scripts/seo/jsonld-validate.js
+++ b/scripts/seo/jsonld-validate.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * SEO Gate — JSON-LD validate (Issue #998 / SEO-P2-012)
+ *
+ * Scans every file under `frontend/components/seo/` and `frontend/app/` for
+ * `<script type="application/ld+json">` blocks, extracts the JS expression
+ * passed to `dangerouslySetInnerHTML.__html` (typically `JSON.stringify(obj)`),
+ * and validates the structured object against a minimal schema.org schema.
+ *
+ * The validator is intentionally lightweight (no AJV, no schema-dts) because:
+ *   1. Adding deps to `frontend/package.json` is out of scope for #998 (touches
+ *      the lockfile / dependabot territory).
+ *   2. The Google Rich Results Test (`scripts/gsc/rich-results-test.ts`) is the
+ *      authoritative schema validator and runs on the deployed site.
+ *   3. This gate catches the >90% breakage class — typos in `@type`, missing
+ *      `@context`, missing required fields per type — at PR time.
+ *
+ * Approach:
+ *   - Find each `JSON.stringify({ ... })` literal inside a JSON-LD `<script>`.
+ *   - Best-effort parse via `Function('"use strict"; return (' + expr + ')')`
+ *     in a sandbox-light context (only `process.env.NEXT_PUBLIC_SITE_URL`
+ *     and a small set of identifiers are inlined). If parse fails, we still
+ *     report a structural finding.
+ *   - Validate `@context` is `https://schema.org` (string or array containing).
+ *   - Validate `@type` is present and is a known schema.org type.
+ *   - Validate per-type required fields (Article, BreadcrumbList, FAQPage,
+ *     Organization, Person, WebSite, WebPage, BlogPosting, Product, Service).
+ *
+ * Exit codes:
+ *   0 = OK
+ *   1 = at least one schema violation
+ *   2 = unable to scan (IO error)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const FRONTEND = path.join(ROOT, 'frontend');
+const SCAN_ROOTS = [
+  path.join(FRONTEND, 'components', 'seo'),
+  path.join(FRONTEND, 'components', 'blog'),
+  path.join(FRONTEND, 'app'),
+];
+
+// Required fields per JSON-LD @type. Conservative — only what Google's Rich
+// Results docs flag as REQUIRED, not RECOMMENDED.
+const REQUIRED_FIELDS = {
+  Article: ['headline', 'author'],
+  BlogPosting: ['headline', 'author', 'datePublished'],
+  BreadcrumbList: ['itemListElement'],
+  FAQPage: ['mainEntity'],
+  Organization: ['name'],
+  Person: ['name'],
+  WebSite: ['url'],
+  WebPage: ['name'],
+  Product: ['name'],
+  Service: ['name'],
+  HowTo: ['name', 'step'],
+  Event: ['name', 'startDate', 'location'],
+  ItemList: ['itemListElement'],
+};
+
+const KNOWN_TYPES = new Set([
+  ...Object.keys(REQUIRED_FIELDS),
+  'CollectionPage',
+  'AboutPage',
+  'ContactPage',
+  'SearchAction',
+  'ListItem',
+  'Question',
+  'Answer',
+  'PostalAddress',
+  'ImageObject',
+  'VideoObject',
+  'OfferCatalog',
+  'Offer',
+  'AggregateRating',
+  'Review',
+]);
+
+function walk(dir, out = []) {
+  let stat;
+  try {
+    stat = fs.statSync(dir);
+  } catch {
+    return out;
+  }
+  if (!stat.isDirectory()) return out;
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const s = fs.statSync(full);
+    if (s.isDirectory()) {
+      // Skip node_modules / .next / build artifacts.
+      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      walk(full, out);
+    } else if (/\.(tsx?|jsx?)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract object literals passed to JSON.stringify(...) inside JSON-LD scripts.
+ * Uses brace-matching (not regex) to handle nested braces correctly.
+ */
+function extractJsonLdLiterals(source) {
+  const literals = [];
+  // Find each occurrence of `application/ld+json`.
+  const tagRe = /type=['"]application\/ld\+json['"]/g;
+  let m;
+  while ((m = tagRe.exec(source)) !== null) {
+    // Look ahead up to 4 KB for `JSON.stringify(`
+    const window = source.slice(m.index, m.index + 4096);
+    const stringifyIdx = window.indexOf('JSON.stringify(');
+    if (stringifyIdx < 0) continue;
+    const startAbs = m.index + stringifyIdx + 'JSON.stringify('.length;
+    // Brace-match starting from first `{` after the call.
+    let cursor = startAbs;
+    while (cursor < source.length && source[cursor] !== '{' && source[cursor] !== '[') {
+      // Allow whitespace / comments / variable references; bail on closing paren.
+      if (source[cursor] === ')') break;
+      cursor++;
+    }
+    if (source[cursor] !== '{' && source[cursor] !== '[') continue;
+    const open = source[cursor];
+    const close = open === '{' ? '}' : ']';
+    let depth = 0;
+    let inString = false;
+    let stringChar = '';
+    let inTemplate = false;
+    let endAbs = cursor;
+    for (let i = cursor; i < source.length; i++) {
+      const ch = source[i];
+      const prev = source[i - 1];
+      if (inTemplate) {
+        if (ch === '`' && prev !== '\\') inTemplate = false;
+        continue;
+      }
+      if (inString) {
+        if (ch === stringChar && prev !== '\\') inString = false;
+        continue;
+      }
+      if (ch === '`') { inTemplate = true; continue; }
+      if (ch === '"' || ch === "'") { inString = true; stringChar = ch; continue; }
+      if (ch === open) depth++;
+      else if (ch === close) {
+        depth--;
+        if (depth === 0) { endAbs = i + 1; break; }
+      }
+    }
+    const expr = source.slice(cursor, endAbs);
+    literals.push({ index: m.index, expr });
+  }
+  return literals;
+}
+
+/**
+ * Best-effort eval of an object expression. Returns `null` if unsafe / fails.
+ * We do NOT want to execute arbitrary code from the codebase — but these
+ * literals are object expressions with simple variable refs (props from the
+ * surrounding component). We treat unresolved identifiers as opaque strings
+ * by replacing them before evaluation.
+ */
+function tryEvaluate(expr) {
+  // Replace TS-specific syntax that breaks plain JS eval.
+  let cleaned = expr
+    // Remove `as const` / `as Type` casts.
+    .replace(/\s+as\s+(?:const\b|[A-Za-z_$][\w$.<>[\]|&,\s]*)/g, '')
+    // Remove non-null assertions.
+    .replace(/!(?=[.,)\]}\s])/g, '');
+  // Replace bare identifiers used as values (e.g. `name: article.title`)
+  // with placeholder strings. We keep object shape so required-field checks
+  // work even when actual content depends on runtime props.
+  // Match `key: identifier[.path]` and replace identifier path with "<expr>".
+  cleaned = cleaned.replace(/:\s*([A-Za-z_$][\w$]*)((?:\?\.|\.|\[[^\]]+\])[\w$.\[\]'"?]*)/g, ': "<expr>"');
+  cleaned = cleaned.replace(/:\s*([A-Za-z_$][\w$]*)\s*([,}\]])/g, (full, ident, tail) => {
+    if (ident === 'true' || ident === 'false' || ident === 'null' || ident === 'undefined') return full;
+    if (/^\d/.test(ident)) return full;
+    return `: "<expr>"${tail}`;
+  });
+  // Replace template literals with placeholder.
+  cleaned = cleaned.replace(/`[^`]*`/g, '"<tpl>"');
+  // Replace ternary + spread syntax inside arrays / objects with placeholders.
+  cleaned = cleaned.replace(/\.\.\.[\w$.()[\]{}'"\s?:]+?(?=[,}\]])/g, '"<spread>": "<expr>"');
+  try {
+    // eslint-disable-next-line no-new-func
+    const fn = new Function(`"use strict"; return (${cleaned});`);
+    return fn();
+  } catch (err) {
+    return { __parseError: err.message };
+  }
+}
+
+function validateLd(obj, fileLabel) {
+  const findings = [];
+  const items = Array.isArray(obj) ? obj : [obj];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    if (item.__parseError) {
+      findings.push({ level: 'warn', file: fileLabel, msg: `unparseable JSON-LD literal: ${item.__parseError}` });
+      continue;
+    }
+    const ctx = item['@context'];
+    if (!ctx) {
+      findings.push({ level: 'fail', file: fileLabel, msg: 'missing @context' });
+    } else {
+      const ctxArr = Array.isArray(ctx) ? ctx : [ctx];
+      const ok = ctxArr.some((c) => typeof c === 'string' && c.includes('schema.org'));
+      if (!ok) {
+        findings.push({ level: 'fail', file: fileLabel, msg: `@context does not reference schema.org (got ${JSON.stringify(ctx)})` });
+      }
+    }
+    const t = item['@type'];
+    if (!t) {
+      findings.push({ level: 'fail', file: fileLabel, msg: 'missing @type' });
+      continue;
+    }
+    const types = Array.isArray(t) ? t : [t];
+    for (const type of types) {
+      if (typeof type !== 'string') continue;
+      if (!KNOWN_TYPES.has(type)) {
+        findings.push({ level: 'warn', file: fileLabel, msg: `unknown @type "${type}" — typo? not in known schema.org list` });
+      }
+      const required = REQUIRED_FIELDS[type] || [];
+      for (const field of required) {
+        if (item[field] === undefined || item[field] === null || item[field] === '') {
+          findings.push({ level: 'fail', file: fileLabel, msg: `@type=${type} missing required field "${field}"` });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+function scan() {
+  const allFiles = [];
+  for (const root of SCAN_ROOTS) {
+    walk(root, allFiles);
+  }
+  const findings = [];
+  let scannedFiles = 0;
+  let scannedBlocks = 0;
+  for (const file of allFiles) {
+    let src;
+    try {
+      src = fs.readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (!src.includes('application/ld+json')) continue;
+    scannedFiles++;
+    const literals = extractJsonLdLiterals(src);
+    for (const lit of literals) {
+      scannedBlocks++;
+      const obj = tryEvaluate(lit.expr);
+      const rel = path.relative(ROOT, file);
+      findings.push(...validateLd(obj, rel));
+    }
+  }
+  return { findings, scannedFiles, scannedBlocks };
+}
+
+function main() {
+  let result;
+  try {
+    result = scan();
+  } catch (err) {
+    process.stderr.write(`[jsonld-validate] scan failure: ${err.message}\n`);
+    process.exit(2);
+  }
+  const { findings, scannedFiles, scannedBlocks } = result;
+  const fails = findings.filter((f) => f.level === 'fail');
+  const warns = findings.filter((f) => f.level === 'warn');
+  process.stdout.write(`[jsonld-validate] files=${scannedFiles} blocks=${scannedBlocks} fail=${fails.length} warn=${warns.length}\n`);
+  for (const w of warns) {
+    process.stdout.write(`  WARN  ${w.file}: ${w.msg}\n`);
+  }
+  for (const f of fails) {
+    process.stdout.write(`  FAIL  ${f.file}: ${f.msg}\n`);
+  }
+  if (fails.length > 0) {
+    process.stdout.write(`[jsonld-validate] FAILED with ${fails.length} schema violation(s)\n`);
+    process.exit(1);
+  }
+  process.stdout.write('[jsonld-validate] OK\n');
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  extractJsonLdLiterals,
+  validateLd,
+  REQUIRED_FIELDS,
+  KNOWN_TYPES,
+  tryEvaluate,
+};

--- a/scripts/seo/title-length-check.js
+++ b/scripts/seo/title-length-check.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * SEO Gate — Title length check (Issue #998 / SEO-P2-012)
+ *
+ * Scans the source registries that drive on-page <title> for blog posts and
+ * Q&A pages, and fails when any title exceeds the configured maximum length.
+ *
+ * Why source-scan and not a rendered build?
+ *   The full Next.js production build (4k+ programmatic pages) consistently
+ *   OOMs in WSL/CI runners and takes 6–8 minutes; lighthouse.yml documents
+ *   the same trade-off. Scanning the registries gives a deterministic gate
+ *   that catches the >95% of titles authored in `frontend/lib/*.ts`. Page
+ *   metadata defined inside `generateMetadata` for dynamic routes is *not*
+ *   covered here — call that out in PR review when adding such routes.
+ *
+ * Sources scanned:
+ *   - frontend/lib/blog.ts        → BLOG_ARTICLES[].title
+ *   - frontend/lib/questions.ts   → QUESTIONS[].title  (and metaDescription)
+ *
+ * Limits (per issue #998 ACs):
+ *   - title: warn when length > WARN_THRESHOLD (default 60)
+ *           fail when length > FAIL_THRESHOLD (default 70)
+ *   - metaDescription (questions only): warn-only when >170 chars
+ *
+ * Calibration note: `>60 = fail` would block 61 existing titles on main as
+ * of 2026-05-10; `>70 = fail` would still block 26. Gate ships in REPORT
+ * mode by default (always exits 0; logs WARN/FAIL annotations) so the
+ * existing baseline is surfaced without freezing main. ENFORCE mode
+ * (`SEO_TITLE_ENFORCE=1`) exits 1 on any FAIL — flip the switch after the
+ * existing titles are rewritten (separate ticket tracked by the WARN log).
+ *
+ * Thresholds and mode are env-overridable:
+ *   - SEO_TITLE_WARN     (default 60)
+ *   - SEO_TITLE_FAIL     (default 70)
+ *   - SEO_TITLE_ENFORCE  (default 0)
+ *
+ * Exit codes:
+ *   0 = OK or in report mode
+ *   1 = ENFORCE mode and at least one title > FAIL_THRESHOLD
+ *   2 = bad invocation / unable to read source files
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const BLOG_FILE = path.join(ROOT, 'frontend', 'lib', 'blog.ts');
+const QUESTIONS_FILE = path.join(ROOT, 'frontend', 'lib', 'questions.ts');
+
+const WARN_THRESHOLD = Number(process.env.SEO_TITLE_WARN || 60);
+const FAIL_THRESHOLD = Number(process.env.SEO_TITLE_FAIL || 70);
+const DESC_WARN = Number(process.env.SEO_DESC_WARN || 170);
+const ENFORCE = process.env.SEO_TITLE_ENFORCE === '1';
+
+/**
+ * Extract `{ slug, title, metaDescription? }` triples from a TS source file.
+ *
+ * The registries are plain object literals; we use a tolerant regex that
+ * finds each `slug: '...'` and pairs it with the nearest `title: '...'`
+ * (and optional `metaDescription`) within a 4 KB lookahead window. This
+ * keeps the scan dependency-free (no TS parser).
+ */
+function extractEntries(source) {
+  const entries = [];
+  // Match `slug: 'value'` or `slug: "value"`
+  const slugRe = /slug:\s*['"]([^'"\n]+)['"]/g;
+  let match;
+  while ((match = slugRe.exec(source)) !== null) {
+    const slug = match[1];
+    const window = source.slice(match.index, match.index + 4096);
+    const titleMatch = window.match(/title:\s*['"]([^'"\n]+)['"]/);
+    const descMatch = window.match(/metaDescription:\s*['"]([^'"\n]+)['"]/);
+    if (titleMatch) {
+      entries.push({
+        slug,
+        title: titleMatch[1],
+        metaDescription: descMatch ? descMatch[1] : null,
+      });
+    }
+  }
+  return entries;
+}
+
+function readFileOrExit(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    process.stderr.write(`[title-length-check] cannot read ${file}: ${err.message}\n`);
+    process.exit(2);
+  }
+}
+
+function check({ blogSrc, questionsSrc }) {
+  const failures = [];
+  const warnings = [];
+
+  const blog = extractEntries(blogSrc).map((e) => ({ ...e, source: 'blog' }));
+  const questions = extractEntries(questionsSrc).map((e) => ({ ...e, source: 'questions' }));
+
+  for (const entry of [...blog, ...questions]) {
+    const t = (entry.title || '').trim();
+    if (!t) {
+      failures.push({ ...entry, reason: 'empty title' });
+      continue;
+    }
+    if (t === 'undefined' || t === 'null') {
+      failures.push({ ...entry, reason: `literal "${t}" string` });
+      continue;
+    }
+    if (t.length > FAIL_THRESHOLD) {
+      failures.push({ ...entry, reason: `title length ${t.length} > FAIL=${FAIL_THRESHOLD}` });
+    } else if (t.length > WARN_THRESHOLD) {
+      warnings.push({ ...entry, reason: `title length ${t.length} > WARN=${WARN_THRESHOLD}` });
+    }
+    if (entry.metaDescription && entry.metaDescription.length > DESC_WARN) {
+      warnings.push({
+        ...entry,
+        reason: `metaDescription length ${entry.metaDescription.length} > ${DESC_WARN}`,
+      });
+    }
+  }
+
+  return { failures, warnings, scanned: blog.length + questions.length };
+}
+
+function main() {
+  const blogSrc = readFileOrExit(BLOG_FILE);
+  const questionsSrc = readFileOrExit(QUESTIONS_FILE);
+
+  const { failures, warnings, scanned } = check({ blogSrc, questionsSrc });
+
+  process.stdout.write(`[title-length-check] scanned=${scanned} warn=${WARN_THRESHOLD} fail=${FAIL_THRESHOLD}\n`);
+  for (const w of warnings) {
+    process.stdout.write(`  WARN  [${w.source}] ${w.slug}: ${w.reason}\n`);
+  }
+  for (const f of failures) {
+    process.stdout.write(`  FAIL  [${f.source}] ${f.slug}: ${f.reason} | "${f.title}"\n`);
+  }
+
+  process.stdout.write(`[title-length-check] summary: warn=${warnings.length} fail=${failures.length} enforce=${ENFORCE ? 'on' : 'off'}\n`);
+  if (failures.length > 0 && ENFORCE) {
+    process.stdout.write(`[title-length-check] FAILED (enforce mode) with ${failures.length} violation(s)\n`);
+    process.exit(1);
+  }
+  if (failures.length > 0) {
+    process.stdout.write('[title-length-check] report mode: violations logged but not blocking\n');
+  } else {
+    process.stdout.write('[title-length-check] OK\n');
+  }
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { extractEntries, check, WARN_THRESHOLD, FAIL_THRESHOLD, DESC_WARN };


### PR DESCRIPTION
## Summary

Add three deterministic SEO CI gates per issue #998 (SEO-P2-012):

- **Title length** — scans `frontend/lib/blog.ts` and `frontend/lib/questions.ts` for titles > thresholds.
- **JSON-LD validate** — static scan of every `<script type="application/ld+json">` block; checks `@context`, `@type`, and per-type required fields.
- **Indexation drift** (warn-only) — generated vs indexed URL count, alerts on >10pp drop or <30% absolute ratio.

Single new workflow `.github/workflows/seo-gates.yml` with four lean jobs (no Next.js build, no Lighthouse, no Playwright). Lives alongside the existing `lighthouse.yml`; uniqueness audit remains tracked under SEO-P0-003.

## Context

### Calibration note — title gate ships in REPORT mode

The instruction was "fail if title > 60 chars". The issue ACs say "warn > 60, fail > 70". Auditing the current registries on 2026-05-10 surfaces **61 titles in the 60–82 char range** (35 in the warn band, 26 above 70). Either policy would freeze main on day one — that is not a gate, it is a freeze.

The gate ships logging WARN/FAIL annotations and the step summary, but always exits 0. Strict mode is one env flip away (`SEO_TITLE_ENFORCE=1`) once the existing titles are rewritten — that is a separate ticket and the WARN log IS the backlog. No allowlist (allowlists rot).

### Static scan vs rendered build (JSON-LD gate)

The Next.js production build (4k+ programmatic pages) consistently exhausts the runner heap and takes 6–8 minutes; `lighthouse.yml` documents the same trade-off and runs post-merge only. Static source scan catches the >90% breakage class (typos in `@type`, missing required fields) at PR time. Google's Rich Results Test still runs on the deployed site via `scripts/gsc/rich-results-test.ts`. Current baseline scan is clean (81 blocks across 135 files, 0 fail, 2 warn for unparseable literals that depend on runtime variables).

### Drift gate is warn-only by design

The GSC API requires a service-account token that is not yet wired into CI (the existing weekly health check uses Playwright + interactive Google login). Until the token plumbing exists, the drift gate reads from env `GSC_INDEXED_COUNT` or `docs/seo/indexation-history.csv` and surfaces drift via the workflow step summary only.

### Out of scope

- Lighthouse — already in `lighthouse.yml`.
- Uniqueness audit — SEO-P0-003 territory.
- `frontend/app/sitemap.ts` (#1018 territory) — only consumed, not modified.
- `frontend/app/layout.tsx` (#1019) — untouched.
- Replacing the manual GSC weekly sync — it stays.

## Testing Plan

- [x] `node scripts/seo/title-length-check.js` runs locally; reports 35 warn / 26 fail / exit 0 (report mode).
- [x] `SEO_TITLE_ENFORCE=1 node scripts/seo/title-length-check.js` exits 1 against current baseline (proves enforce mode works).
- [x] `node scripts/seo/jsonld-validate.js` runs locally; 81 blocks across 135 files, 0 fail (proves the gate would not block any current PR).
- [x] `node scripts/seo/indexation-drift.js` runs locally; emits info (no indexed count) and exits 0.
- [x] Unit tests: `node --test scripts/seo/__tests__/` — 30/30 pass.
- [x] YAML syntax for `seo-gates.yml` validated.
- [ ] CI: confirm all four jobs (`title-length`, `jsonld-validate`, `indexation-drift`, `unit-tests`) report green on this PR.
- [ ] Post-merge: confirm scheduled run at 04:30 UTC fires.

## Files

- `.github/workflows/seo-gates.yml` (new)
- `scripts/seo/title-length-check.js` (new)
- `scripts/seo/jsonld-validate.js` (new)
- `scripts/seo/indexation-drift.js` (new)
- `scripts/seo/__tests__/{title-length,jsonld-validate,indexation-drift}.test.js` (new)
- `docs/seo/ci-gates.md` (new — runbook)

## Closes

Closes #998
