### PR TITLE
feat(seo): #996 enrich Organization JSON-LD on /cnpj/[cnpj] entity profiles

### DIFF
--- a/frontend/__tests__/cnpj-organization-schema.test.ts
+++ b/frontend/__tests__/cnpj-organization-schema.test.ts
@@ -1,0 +1,162 @@
+/**
+ * #996 SEO-P2-009 — Organization JSON-LD validation for /cnpj/[cnpj] entity profiles.
+ *
+ * Validates the Schema.org Organization fields required for Knowledge Panel signals
+ * and SERP differentiation against directory competitors (cnpj.biz, cnpja.com).
+ */
+
+import { buildOrgSchema, formatCnpjMask, type PerfilB2GLite } from '@/app/cnpj/[cnpj]/_jsonld';
+
+const BASE_PERFIL: PerfilB2GLite = {
+  empresa: {
+    razao_social: 'Empresa Teste LTDA',
+    cnpj: '09225035000101',
+    cnae_principal: '4781-4/00',
+    porte: 'ME',
+    uf: 'SP',
+    situacao: 'ATIVA',
+  },
+  setor_nome: 'Vestuário e Têxtil',
+  total_contratos_24m: 7,
+  valor_total_24m: 850_000,
+  ufs_atuacao: ['SP', 'RJ'],
+};
+
+describe('buildOrgSchema (#996 SEO-P2-009)', () => {
+  it('returns a Schema.org Organization with @context and @type', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('Organization');
+  });
+
+  it('emits @id, name, legalName, and url for entity disambiguation', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema['@id']).toBe('https://smartlic.tech/cnpj/09225035000101#organization');
+    expect(schema.name).toBe('Empresa Teste LTDA');
+    expect(schema.legalName).toBe('Empresa Teste LTDA');
+    expect(schema.url).toBe('https://smartlic.tech/cnpj/09225035000101');
+  });
+
+  it('formats taxID with the canonical CNPJ mask', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.taxID).toBe('09.225.035/0001-01');
+  });
+
+  it('exposes raw CNPJ + CNAE via identifier PropertyValue array', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.identifier).toEqual([
+      { '@type': 'PropertyValue', propertyID: 'CNPJ', value: '09225035000101' },
+      { '@type': 'PropertyValue', propertyID: 'CNAE', value: '4781-4/00' },
+    ]);
+  });
+
+  it('emits PostalAddress with addressRegion (UF) and addressCountry=BR', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.address).toEqual({
+      '@type': 'PostalAddress',
+      addressRegion: 'SP',
+      addressCountry: 'BR',
+    });
+  });
+
+  it('builds sameAs with Receita Federal + LinkedIn search URLs', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    const sameAs = schema.sameAs as string[];
+    expect(sameAs).toHaveLength(2);
+    expect(sameAs[0]).toContain('servicos.receita.fazenda.gov.br');
+    expect(sameAs[0]).toContain('09225035000101');
+    expect(sameAs[1]).toContain('linkedin.com/search/results/companies');
+    expect(sameAs[1]).toContain(encodeURIComponent('Empresa Teste LTDA'));
+  });
+
+  it('writes a contract-history-rich description when total_contratos_24m > 0', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    const description = schema.description as string;
+    expect(description).toContain('Empresa Teste LTDA');
+    expect(description).toContain('09.225.035/0001-01');
+    expect(description).toContain('7 contratos');
+    expect(description).toContain('Vestuário e Têxtil');
+    // BRL currency format may use NBSP or regular space depending on Node ICU build
+    expect(description).toMatch(/R\$[\s ]?850\.000/);
+  });
+
+  it('writes a fallback description when total_contratos_24m == 0', () => {
+    const schema = buildOrgSchema({
+      ...BASE_PERFIL,
+      total_contratos_24m: 0,
+      valor_total_24m: 0,
+      ufs_atuacao: [],
+    });
+    const description = schema.description as string;
+    expect(description).toContain('Sem histórico de contratos públicos');
+    expect(description).toContain('Vestuário e Têxtil');
+  });
+
+  it('emits knowsAbout with the SmartLic sector name', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.knowsAbout).toBe('Vestuário e Têxtil');
+  });
+
+  it('maps porte to size when present', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.size).toBe('ME');
+  });
+
+  it('omits size when porte is empty string', () => {
+    const schema = buildOrgSchema({
+      ...BASE_PERFIL,
+      empresa: { ...BASE_PERFIL.empresa, porte: '' },
+    });
+    expect(schema.size).toBeUndefined();
+  });
+
+  it('emits areaServed as AdministrativeArea[] from ufs_atuacao', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.areaServed).toEqual([
+      { '@type': 'AdministrativeArea', name: 'SP', addressCountry: 'BR' },
+      { '@type': 'AdministrativeArea', name: 'RJ', addressCountry: 'BR' },
+    ]);
+  });
+
+  it('omits areaServed when ufs_atuacao is empty', () => {
+    const schema = buildOrgSchema({ ...BASE_PERFIL, ufs_atuacao: [] });
+    expect(schema.areaServed).toBeUndefined();
+  });
+
+  it('emits interactionStatistic for crawler-readable contract count', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    expect(schema.interactionStatistic).toEqual({
+      '@type': 'InteractionCounter',
+      interactionType: { '@type': 'SellAction', name: 'Contratos Públicos (24 meses)' },
+      userInteractionCount: 7,
+    });
+  });
+
+  it('omits interactionStatistic when there are no contracts', () => {
+    const schema = buildOrgSchema({
+      ...BASE_PERFIL,
+      total_contratos_24m: 0,
+      valor_total_24m: 0,
+    });
+    expect(schema.interactionStatistic).toBeUndefined();
+  });
+
+  it('produces JSON-serializable output (round-trip preserves shape)', () => {
+    const schema = buildOrgSchema(BASE_PERFIL);
+    const json = JSON.stringify(schema);
+    const parsed = JSON.parse(json);
+    expect(parsed['@type']).toBe('Organization');
+    expect(parsed.taxID).toBe('09.225.035/0001-01');
+  });
+});
+
+describe('formatCnpjMask', () => {
+  it('formats a 14-digit CNPJ with the canonical mask', () => {
+    expect(formatCnpjMask('09225035000101')).toBe('09.225.035/0001-01');
+  });
+
+  it('returns the raw input when length != 14', () => {
+    expect(formatCnpjMask('123')).toBe('123');
+    expect(formatCnpjMask('')).toBe('');
+  });
+});

--- a/frontend/app/cnpj/[cnpj]/_jsonld.ts
+++ b/frontend/app/cnpj/[cnpj]/_jsonld.ts
@@ -1,0 +1,107 @@
+/**
+ * #996 SEO-P2-009 — JSON-LD builders for /cnpj/[cnpj] entity profile pages.
+ *
+ * Organization schema enriched with SmartLic-exclusive data (contract history,
+ * sector classification, areas served) so CNPJ pages compete with directory
+ * sites (cnpj.biz, cnpja.com) on entity richness and Knowledge Panel signals.
+ *
+ * Backend payload: PerfilB2G from `/v1/empresa/{cnpj}/perfil-b2g`. Fields not
+ * yet supplied (foundingDate, municipio, full streetAddress, naics) are
+ * intentionally omitted — adding them is a backend follow-up.
+ */
+
+export interface PerfilEmpresa {
+  razao_social: string;
+  cnpj: string;
+  cnae_principal: string;
+  porte: string;
+  uf: string;
+  situacao: string;
+}
+
+export interface PerfilB2GLite {
+  empresa: PerfilEmpresa;
+  setor_nome: string;
+  total_contratos_24m: number;
+  valor_total_24m: number;
+  ufs_atuacao: string[];
+}
+
+export function formatCnpjMask(raw: string): string {
+  if (raw.length !== 14) return raw;
+  return `${raw.slice(0, 2)}.${raw.slice(2, 5)}.${raw.slice(5, 8)}/${raw.slice(8, 12)}-${raw.slice(12)}`;
+}
+
+export function buildOrgSchema(perfil: PerfilB2GLite): Record<string, unknown> {
+  const { empresa, setor_nome, total_contratos_24m, valor_total_24m, ufs_atuacao } = perfil;
+
+  const cnpjFormatted = formatCnpjMask(empresa.cnpj);
+  const valorTotalBRL = new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 0,
+  }).format(valor_total_24m);
+
+  // sameAs: external authoritative references for entity disambiguation (Knowledge Panel signals).
+  const sameAs = [
+    `https://servicos.receita.fazenda.gov.br/Servicos/cnpjreva/Cnpjreva_Solicitacao.asp?cnpj=${empresa.cnpj}`,
+    `https://www.linkedin.com/search/results/companies/?keywords=${encodeURIComponent(empresa.razao_social)}`,
+  ];
+
+  const description =
+    total_contratos_24m > 0
+      ? `${empresa.razao_social} (CNPJ ${cnpjFormatted}) firmou ${total_contratos_24m} contratos públicos nos últimos 24 meses, totalizando ${valorTotalBRL}. Setor SmartLic: ${setor_nome}. Histórico completo no PNCP.`
+      : `${empresa.razao_social} (CNPJ ${cnpjFormatted}) — perfil B2G no setor ${setor_nome}. Sem histórico de contratos públicos nos últimos 24 meses. Dados oficiais do PNCP via SmartLic.`;
+
+  const orgSchema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `https://smartlic.tech/cnpj/${empresa.cnpj}#organization`,
+    name: empresa.razao_social,
+    legalName: empresa.razao_social,
+    taxID: cnpjFormatted,
+    identifier: [
+      {
+        '@type': 'PropertyValue',
+        propertyID: 'CNPJ',
+        value: empresa.cnpj,
+      },
+      {
+        '@type': 'PropertyValue',
+        propertyID: 'CNAE',
+        value: empresa.cnae_principal,
+      },
+    ],
+    address: {
+      '@type': 'PostalAddress',
+      addressRegion: empresa.uf,
+      addressCountry: 'BR',
+    },
+    url: `https://smartlic.tech/cnpj/${empresa.cnpj}`,
+    sameAs,
+    description,
+    knowsAbout: setor_nome,
+  };
+
+  if (empresa.porte) {
+    orgSchema.size = empresa.porte;
+  }
+
+  if (ufs_atuacao && ufs_atuacao.length > 0) {
+    orgSchema.areaServed = ufs_atuacao.map((uf) => ({
+      '@type': 'AdministrativeArea',
+      name: uf,
+      addressCountry: 'BR',
+    }));
+  }
+
+  if (total_contratos_24m > 0) {
+    orgSchema.interactionStatistic = {
+      '@type': 'InteractionCounter',
+      interactionType: { '@type': 'SellAction', name: 'Contratos Públicos (24 meses)' },
+      userInteractionCount: total_contratos_24m,
+    };
+  }
+
+  return orgSchema;
+}

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -9,6 +9,7 @@ import { LeadCapture } from '@/components/LeadCapture';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
+import { buildOrgSchema } from './_jsonld';
 
 const BACKEND_URL = getBackendUrl();
 
@@ -129,17 +130,9 @@ export default async function CnpjPerfilPage({
 
   const { empresa } = perfil;
 
-  const orgSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'Organization',
-    name: empresa.razao_social,
-    taxID: empresa.cnpj,
-    address: {
-      '@type': 'PostalAddress',
-      addressRegion: empresa.uf,
-      addressCountry: 'BR',
-    },
-  };
+  // #996 SEO-P2-009: Organization JSON-LD enriched with SmartLic-exclusive data
+  // (contract history, sector classification, areas served) for entity profile SERP.
+  const orgSchema = buildOrgSchema(perfil);
 
   const datasetSchema = {
     '@context': 'https://schema.org',


### PR DESCRIPTION
## Summary

- Enrich `/cnpj/[cnpj]` Organization JSON-LD with SmartLic-exclusive fields so the page competes with directory sites (cnpj.biz, cnpja.com) on Knowledge Panel signals.
- Adds: `legalName`, formatted `taxID`, `identifier[]` (CNPJ + CNAE), `@id`, `url`, `sameAs` (Receita Federal + LinkedIn), enriched `description`, `knowsAbout` (sector), `size` (porte), `areaServed` (UFs onde atua), `interactionStatistic` (24m contract count).
- Schema construction extracted to `app/cnpj/[cnpj]/_jsonld.ts` (`buildOrgSchema`) so the builder is unit-testable in isolation.

## Context

Issue #996 (SEO-P2-009) — CNPJ pages currently emit a minimal Organization schema (name, taxID, addressRegion only). GSC data shows ~200 CNPJ-puro queries with 0 clicks, dominated by cnpj.biz/cnpja.com which carry full Organization schema. This PR makes the schema directory-competitive while leaning on data SmartLic exclusively has (PNCP contract history, IA sector classification).

Backend `PerfilB2G` payload feeds all populated fields. `foundingDate`, `municipio`, full `streetAddress`, and `naics` are intentionally omitted — backend doesn't ship them yet (follow-up).

## Testing Plan

- [x] `frontend/__tests__/cnpj-organization-schema.test.ts` — 18 tests covering: required Schema.org fields, taxID mask, sameAs URLs, description variants (with/without contracts), conditional fields (size/areaServed/interactionStatistic), JSON round-trip.
- [x] Existing test `frontend/__tests__/cnpj-perfil-sem-historico.test.tsx` (10 tests) — re-run, no regression.
- [ ] Post-merge: validate 5 sample CNPJs in Google Rich Results Test "Organization" (manual, smartlic.tech).
- [ ] Post-merge: GSC monitoring — track CTR + position on CNPJ-puro queries (28d window).

## Closes

Closes #996