### PR TITLE
feat(seo): cluster PNCP — pillar + 8 spokes (#992)

### DIFF
--- a/frontend/__tests__/blog-pncp-cluster.test.tsx
+++ b/frontend/__tests__/blog-pncp-cluster.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * SEO-P1-005 (#992) — PNCP Cluster smoke tests
+ *
+ * Validates:
+ * - 8 spoke articles are registered in lib/blog.ts with pillarSlug set
+ * - Each spoke renders without error (smoke test)
+ * - Each spoke contains valid FAQPage JSON-LD with ≥3 questions
+ * - The pillar (pncp-guia-completo-empresas) links to ≥8 spokes
+ *   ("Aprenda mais sobre PNCP" section, AC of issue #992)
+ * - Schema.org Article injects isPartOf for spokes via BlogArticleLayout
+ *   (validated indirectly: BLOG_ARTICLES has pillarSlug field on spokes)
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+// ---------- Mock setup ----------
+
+jest.mock('next/link', () => {
+  return ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+});
+
+// ---------- Imports ----------
+
+import { BLOG_ARTICLES, getArticleBySlug } from '../lib/blog';
+
+// ---------- Constants ----------
+
+const PILLAR_SLUG = 'pncp-guia-completo-empresas';
+
+const SPOKE_SLUGS = [
+  'pncp-modalidade-pregao-eletronico',
+  'pncp-timeline-publicacao-edital',
+  'pncp-vs-comprasgov-diferencas',
+  'pncp-consulta-contratos-passo-a-passo',
+  'pncp-dispensa-licitacao-quando-aplicar',
+  'pncp-registro-precos-como-participar',
+  'pncp-api-integracao-empresas',
+  'pncp-erros-comuns-empresas-iniciantes',
+];
+
+// ---------- Registry ----------
+
+describe('SEO-P1-005 PNCP cluster — registry', () => {
+  it('pillar exists and is a Guias article', () => {
+    const pillar = getArticleBySlug(PILLAR_SLUG);
+    expect(pillar).toBeDefined();
+    expect(pillar?.category).toBe('Guias');
+  });
+
+  it.each(SPOKE_SLUGS)('spoke "%s" is registered', (slug) => {
+    expect(getArticleBySlug(slug)).toBeDefined();
+  });
+
+  it.each(SPOKE_SLUGS)(
+    'spoke "%s" has pillarSlug pointing to the pillar',
+    (slug) => {
+      const article = getArticleBySlug(slug)!;
+      expect(article.pillarSlug).toBe(PILLAR_SLUG);
+    },
+  );
+
+  it.each(SPOKE_SLUGS)(
+    'spoke "%s" wordCount ≥ 800 (issue #992 AC)',
+    (slug) => {
+      const article = getArticleBySlug(slug)!;
+      expect(article.wordCount).toBeGreaterThanOrEqual(800);
+    },
+  );
+
+  it.each(SPOKE_SLUGS)(
+    'spoke "%s" relatedSlugs includes pillar + ≥2 sibling spokes',
+    (slug) => {
+      const article = getArticleBySlug(slug)!;
+      expect(article.relatedSlugs).toContain(PILLAR_SLUG);
+      expect(article.relatedSlugs.length).toBeGreaterThanOrEqual(3);
+    },
+  );
+
+  it('cluster has exactly 8 spokes (Phase 1)', () => {
+    const spokesInRegistry = BLOG_ARTICLES.filter(
+      (a) => a.pillarSlug === PILLAR_SLUG,
+    );
+    expect(spokesInRegistry.length).toBe(8);
+  });
+});
+
+// ---------- Render smoke + FAQ schema ----------
+
+describe('SEO-P1-005 PNCP cluster — render + FAQ schema', () => {
+  it.each(SPOKE_SLUGS)('spoke "%s" renders without error', async (slug) => {
+    const module = await import(`../app/blog/content/${slug}`);
+    const Component = module.default;
+    expect(Component).toBeDefined();
+
+    const { container } = render(<Component />);
+    expect(container.innerHTML.length).toBeGreaterThan(500);
+  });
+
+  it.each(SPOKE_SLUGS)(
+    'spoke "%s" emits FAQPage JSON-LD with ≥3 questions',
+    async (slug) => {
+      const module = await import(`../app/blog/content/${slug}`);
+      const Component = module.default;
+      const { container } = render(<Component />);
+
+      const scripts = container.querySelectorAll(
+        'script[type="application/ld+json"]',
+      );
+      expect(scripts.length).toBeGreaterThanOrEqual(1);
+
+      let faq: Record<string, unknown> | undefined;
+      scripts.forEach((script) => {
+        try {
+          const parsed = JSON.parse(script.textContent || '{}');
+          if (parsed['@type'] === 'FAQPage') {
+            faq = parsed;
+          }
+        } catch {
+          // skip
+        }
+      });
+
+      expect(faq).toBeDefined();
+      const mainEntity = faq!.mainEntity as Array<Record<string, unknown>>;
+      expect(Array.isArray(mainEntity)).toBe(true);
+      expect(mainEntity.length).toBeGreaterThanOrEqual(3);
+    },
+  );
+
+  it.each(SPOKE_SLUGS)(
+    'spoke "%s" includes "Guia Completo do PNCP" inbound link to pillar',
+    async (slug) => {
+      const module = await import(`../app/blog/content/${slug}`);
+      const Component = module.default;
+      const { container } = render(<Component />);
+
+      const links = Array.from(
+        container.querySelectorAll(`a[href="/blog/${PILLAR_SLUG}"]`),
+      );
+      expect(links.length).toBeGreaterThanOrEqual(2);
+    },
+  );
+});
+
+// ---------- Pillar smoke (issue AC: ≥8 outbound spoke links) ----------
+//
+// The pillar (PncpGuiaCompletoEmpresas) embeds an async server component
+// (PncpHubPanel) and cannot be rendered with @testing-library/react. We
+// validate the spoke-link AC by static source inspection instead.
+
+describe('SEO-P1-005 PNCP cluster — pillar links to spokes (smoke-test AC)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fs = require('fs') as typeof import('fs');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const path = require('path') as typeof import('path');
+  const pillarSource = fs.readFileSync(
+    path.join(__dirname, '..', 'app', 'blog', 'content', `${PILLAR_SLUG}.tsx`),
+    'utf-8',
+  );
+
+  it('pillar source contains ≥8 outbound /blog/pncp- links', () => {
+    // Issue AC smoke: grep -c "/blog/pncp-" pillar source ≥ 8
+    const matches = pillarSource.match(/\/blog\/pncp-/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it.each(SPOKE_SLUGS)('pillar source links to spoke "%s"', (spokeSlug) => {
+    expect(pillarSource).toContain(`/blog/${spokeSlug}`);
+  });
+});

--- a/frontend/app/blog/content/pncp-api-integracao-empresas.tsx
+++ b/frontend/app/blog/content/pncp-api-integracao-empresas.tsx
@@ -1,0 +1,245 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-07 (#992) — API do PNCP: integração e automação
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1150 words | Primary KW: pncp api
+ */
+export default function PncpApiIntegracaoEmpresas() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'A API do PNCP exige autenticação?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Não, a API de Consulta v1 do PNCP é pública e não exige token. Basta fazer requisições HTTP GET aos endpoints documentados em pncp.gov.br/api/consulta. Há rate limit recomendado pela documentação (cerca de 60 requisições por minuto por origem) — abusar pode levar a bloqueio temporário.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Quantos registros a API retorna por página?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'No máximo 50 por página (parâmetro tamanhoPagina). Tentativas de pedir mais são rejeitadas. Para coletar volumes maiores, é necessário paginar com o parâmetro pagina e somar os resultados — em geral, varredura completa de uma UF para um período de 30 dias exige 5-15 páginas.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Quais endpoints existem na API do PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Os principais são /v1/contratacoes/publicacao (editais publicados), /v1/contratacoes/atualizacao (alterações), /v1/contratos (contratos), /v1/atas (atas de registro de preços). Todos aceitam filtros por data, UF, modalidade, órgão e CNPJ. A documentação oficial está em pncp.gov.br/api/consulta.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Posso revender dados extraídos da API?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Os dados são públicos por força da Lei 12.527/2011 (LAI) e da Lei 14.133/2021. Empresas como a SmartLic agregam, classificam por IA e enriquecem esses dados em produtos próprios — atividade legal e juridicamente protegida (não há direito autoral sobre dados públicos). O que não pode é redistribuir mascarando a origem ou descumprindo termos de uso eventuais publicados pelo PNCP.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. Para empresas com time técnico, automatizar a busca
+        no PNCP transforma horas de garimpo manual em pipeline contínuo.
+        Aqui, o caminho prático para integrar.
+      </p>
+
+      <h2>O que a API do PNCP expõe</h2>
+      <p>
+        A API de Consulta v1 do PNCP é uma interface HTTP pública,
+        documentada em <code>pncp.gov.br/api/consulta</code>. Ela expõe
+        leitura sobre os principais módulos do portal:
+      </p>
+      <ul>
+        <li>
+          <strong>Editais publicados</strong> (contratações em fase de
+          divulgação).
+        </li>
+        <li>
+          <strong>Alterações de editais</strong> (úteis para detectar
+          impugnações procedentes e mudanças de prazo).
+        </li>
+        <li>
+          <strong>Contratos</strong> firmados e seus aditivos.
+        </li>
+        <li>
+          <strong>Atas de Registro de Preços</strong> vigentes, com
+          quantitativos e preços unitários.
+        </li>
+        <li>
+          <strong>Itens das contratações</strong> (decomposição por
+          item, quando o edital é de bem e usa CATMAT/CATSER).
+        </li>
+      </ul>
+      <p>
+        Não há endpoint para envio de proposta ou lance — a API é apenas
+        de leitura. Para participar de pregões, ainda é necessário a
+        plataforma operacional (ComprasGov, BLL, Licitanet etc.).
+      </p>
+
+      <h2>Construindo um pipeline básico</h2>
+      <p>
+        Um monitoramento mínimo viável tem cinco componentes:
+      </p>
+      <p>
+        <strong>1. Coletor.</strong> Cron job que executa a cada 15-60
+        minutos, faz GET no endpoint{' '}
+        <code>/v1/contratacoes/publicacao</code> com filtros de UF e
+        intervalo de datas, paginando até esgotar resultados.
+      </p>
+      <p>
+        <strong>2. Persistência.</strong> Banco relacional (PostgreSQL é
+        a escolha óbvia) com tabela bruta para os JSONs e tabela
+        normalizada para consultas. Use o número de controle PNCP como
+        chave de deduplicação — o mesmo edital pode aparecer em
+        múltiplas chamadas se for atualizado.
+      </p>
+      <p>
+        <strong>3. Classificador.</strong> Cada edital recebido é
+        classificado contra os setores de interesse da empresa.
+        Implementação simples: lista de palavras-chave com pesos.
+        Implementação avançada: LLM com prompt curto avaliando se o
+        edital é compatível com o setor. A SmartLic usa esse tier híbrido
+        em produção (densidade de palavra-chave seguida de GPT-4.1-nano
+        para zona cinzenta).
+      </p>
+      <p>
+        <strong>4. Notificador.</strong> Editais aprovados pelo
+        classificador disparam alertas — email, Slack, dashboard interno.
+        O segredo é manter ruído baixo: muitos alertas falsos resultam
+        em descarte humano de todos.
+      </p>
+      <p>
+        <strong>5. Repositório histórico.</strong> Mesmo editais
+        descartados ficam armazenados por 12-24 meses para análises
+        posteriores (séries temporais, mapeamento de concorrente, etc.).
+      </p>
+
+      <h2>Boas práticas técnicas</h2>
+      <ul>
+        <li>
+          <strong>Respeite o rate limit.</strong> Não dispare paralelismo
+          agressivo — a documentação oficial sugere ~60 requisições por
+          minuto. Se precisar de throughput maior, distribua coleta ao
+          longo do dia.
+        </li>
+        <li>
+          <strong>Trate falhas idempotentemente.</strong> A API tem
+          janelas de instabilidade ocasional. Faça retry exponencial
+          (1s, 2s, 4s, 8s) e marque batches falhos para reprocessamento.
+        </li>
+        <li>
+          <strong>Use cache de leitura.</strong> O mesmo edital
+          consultado por endpoints diferentes pode aparecer várias vezes.
+          Cache local de 5-15 minutos reduz tráfego e custo.
+        </li>
+        <li>
+          <strong>Prefira coleta incremental por data.</strong> Em vez de
+          re-puxar tudo, use o filtro <code>dataInicial</code> /{' '}
+          <code>dataFinal</code> para sincronizar apenas o delta.
+        </li>
+        <li>
+          <strong>Persista o JSON bruto antes de transformar.</strong> Se
+          o esquema da API mudar, você ainda terá os dados originais
+          para reprocessar.
+        </li>
+      </ul>
+
+      <h2>Casos de uso típicos</h2>
+      <p>
+        <strong>Caso A — Alerta diário por setor.</strong> Empresa de
+        engenharia recebe email às 9h com todos os editais novos do dia
+        anterior em obras civis em SP, MG e RJ. Custo: 1 servidor pequeno
+        + cron + integração SMTP.
+      </p>
+      <p>
+        <strong>Caso B — Inteligência competitiva.</strong> Consultoria
+        agrega contratos por CNPJ para gerar relatório mensal de
+        concorrentes (quantos contratos ganharam, em qual valor médio,
+        em quais órgãos). Diferenciação para clientes B2G.
+      </p>
+      <p>
+        <strong>Caso C — Detecção de oportunidade de carona.</strong>{' '}
+        Empresa registrada em uma ata varre periodicamente atas
+        similares de outros órgãos buscando objetos compatíveis para
+        oferecer adesão proativa.
+      </p>
+
+      <h2>Por que não construir do zero</h2>
+      <p>
+        Construir é viável, mas tem três custos escondidos:
+      </p>
+      <ul>
+        <li>
+          <strong>Manutenção da integração.</strong> Mudanças de schema,
+          janelas de instabilidade, novos endpoints — exige tempo de
+          engenharia recorrente.
+        </li>
+        <li>
+          <strong>Classificação de qualidade.</strong> Atingir 85% de
+          precisão na classificação setorial exige iteração com dados
+          rotulados — não é "uma tarde de trabalho".
+        </li>
+        <li>
+          <strong>Cobertura multi-fonte.</strong> O PNCP cobre quase
+          tudo, mas municípios pequenos ainda integram parcialmente.
+          Cobertura completa exige complementar com PCP v2, ComprasGov
+          v3 e portais de transparência locais — multiplicando a
+          complexidade.
+        </li>
+      </ul>
+      <p>
+        Para empresas em que B2G é foco estratégico mas não core
+        técnico, contratar plataforma especializada costuma sair mais
+        barato do que manter time interno. A SmartLic, por exemplo,
+        agrega PNCP + PCP v2 + ComprasGov v3 com classificação por IA e
+        análise de viabilidade pronta — pague o que vai consumir, não o
+        que precisa construir.
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-api-integracao-empresas"
+        campaign="guias"
+        ctaMessage="Pule a integração — use a plataforma pronta."
+        ctaText="Testar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Veja{' '}
+        <Link href="/blog/pncp-vs-comprasgov-diferencas">
+          PNCP vs ComprasGov
+        </Link>
+        ,{' '}
+        <Link href="/blog/pncp-consulta-contratos-passo-a-passo">
+          PNCP — consulta de contratos passo a passo
+        </Link>{' '}
+        e o{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-consulta-contratos-passo-a-passo.tsx
+++ b/frontend/app/blog/content/pncp-consulta-contratos-passo-a-passo.tsx
@@ -1,0 +1,248 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-04 (#992) — PNCP: consulta de contratos passo a passo
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1100 words | Primary KW: pncp consulta contratos
+ */
+export default function PncpConsultaContratosPassoAPasso() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'Como buscar contratos por CNPJ no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Em pncp.gov.br/app/contratos, use o campo de busca avançada e informe o CNPJ do fornecedor ou do órgão contratante. O portal exibe todos os contratos vinculados, com objeto, valor, vigência e aditivos. Para análise consolidada do histórico, ferramentas especializadas como a SmartLic agregam os mesmos dados em um único perfil de empresa.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Quais informações um contrato exibe no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Número e objeto, CNPJ e razão social do contratado, órgão contratante, modalidade licitatória de origem, valor inicial, datas de assinatura e vigência, situação (vigente, encerrado, rescindido), aditivos e prorrogações. A Lei 14.133/2021 (art. 87 e 174) exige publicação em até 20 dias úteis após a assinatura.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'É possível filtrar por valor ou UF?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Sim — UF, órgão, modalidade, vigência e situação são filtros nativos. Faixa de valor está disponível na API; na interface web é parcial. Para combinações avançadas (setor + UF + valor + período), o uso da API ou de ferramentas como a SmartLic é mais eficiente.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'O PNCP mostra notas fiscais e ordens de pagamento?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'A integração com notas fiscais e ordens de pagamento está em fase de adoção. Atualmente a maioria dos contratos exibe apenas o cabeçalho contratual e os aditivos. Para acompanhamento financeiro completo, a fonte ainda é o portal de transparência do próprio órgão.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. Aqui o foco é o módulo mais subutilizado do portal:
+        a consulta de contratos. Bem usado, ele é uma das mais poderosas
+        ferramentas de inteligência competitiva B2G no Brasil.
+      </p>
+
+      <h2>Por que consultar contratos é tão valioso</h2>
+      <p>
+        Editais mostram <em>oportunidades futuras</em>. Contratos mostram{' '}
+        <em>quem ganhou o quê, com que preço e para quem</em>. Para
+        empresas B2G, isso responde a três perguntas centrais:
+      </p>
+      <ul>
+        <li>
+          Quem são meus concorrentes reais — não os que aparecem no
+          edital, mas os que efetivamente ganham?
+        </li>
+        <li>
+          Que faixa de preço o mercado consegue praticar para esse objeto
+          neste órgão?
+        </li>
+        <li>
+          Quais órgãos pagam em dia e quais empilham aditivos sem
+          renegociar valor?
+        </li>
+      </ul>
+
+      <h2>Passo 1 — Acessando o módulo de contratos</h2>
+      <p>
+        Em <code>pncp.gov.br/app/contratos</code> você encontra a busca
+        unificada. Há quatro pontos de partida possíveis:
+      </p>
+      <ul>
+        <li>
+          <strong>Por CNPJ contratado:</strong> ver tudo o que uma empresa
+          ganhou em compras públicas.
+        </li>
+        <li>
+          <strong>Por CNPJ contratante (órgão):</strong> ver todos os
+          contratos de um órgão.
+        </li>
+        <li>
+          <strong>Por palavra-chave no objeto:</strong> ver, por exemplo,
+          todos os contratos de "limpeza hospitalar".
+        </li>
+        <li>
+          <strong>Por modalidade e UF:</strong> mapear contratos de
+          pregão eletrônico em determinado estado.
+        </li>
+      </ul>
+
+      <h2>Passo 2 — Lendo a ficha do contrato</h2>
+      <p>
+        Cada contrato no PNCP exibe os campos obrigatórios da Lei
+        14.133/2021. Os mais analiticamente relevantes:
+      </p>
+      <ul>
+        <li>
+          <strong>Valor inicial vs valor atualizado:</strong> a diferença
+          revela aditivos. Aditivo até 25% (50% para reformas) é legal —
+          acima disso indica subdimensionamento e risco contratual.
+        </li>
+        <li>
+          <strong>Vigência:</strong> contratos de serviço continuado podem
+          chegar a 10 anos (art. 107). Cumulado com aditivos, isso
+          imobiliza o mercado.
+        </li>
+        <li>
+          <strong>Modalidade de origem:</strong> contratos de dispensa
+          (art. 75) ou inexigibilidade (art. 74) sinalizam que a empresa
+          tem relacionamento direto sem competição — útil para mapear
+          fornecedores históricos.
+        </li>
+        <li>
+          <strong>Situação:</strong> rescindidos por inexecução são
+          alerta vermelho ao analisar reputação de concorrente.
+        </li>
+      </ul>
+
+      <h2>Passo 3 — Cruzando dados para inteligência</h2>
+      <p>
+        A potência do PNCP não é o contrato individual — é o
+        cruzamento. Três análises de alto valor:
+      </p>
+      <p>
+        <strong>1. Mapa de player dominante.</strong> Filtre por objeto e
+        por UF. Conte quantos contratos cada CNPJ tem. Se um único
+        fornecedor concentra mais de 40% dos contratos, há um player
+        instalado e sua estratégia precisa ou superá-lo em preço, ou
+        diferenciar fortemente em técnica.
+      </p>
+      <p>
+        <strong>2. Histórico de preço.</strong> Para o mesmo objeto, em
+        órgãos comparáveis, qual a faixa de valor unitário? Isso
+        calibra sua proposta sem chutar.
+      </p>
+      <p>
+        <strong>3. Padrão de aditivos por órgão.</strong> Órgãos que
+        sistematicamente fazem aditivos de prazo sem aditar valor são
+        bons clientes; órgãos que aditam valor com frequência são sinal
+        de subdimensionamento — você cota mais conservador.
+      </p>
+
+      <h2>Passo 4 — Exportando dados em volume</h2>
+      <p>
+        A interface web limita análises em massa. Para volumes maiores,
+        use a API pública do PNCP — disponível em{' '}
+        <code>pncp.gov.br/api/consulta/v1/contratos</code>. A API aceita
+        filtros por período, UF, modalidade e CNPJ, retornando até 50
+        registros por página em formato JSON. Para empresas que
+        construirão dashboards próprios, é o caminho. Detalhes no spoke{' '}
+        <Link href="/blog/pncp-api-integracao-empresas">
+          API do PNCP — integração e automação
+        </Link>
+        .
+      </p>
+
+      <h2>Limitações e como contorná-las</h2>
+      <p>
+        Três limitações conhecidas do módulo de contratos do PNCP:
+      </p>
+      <ul>
+        <li>
+          <strong>Cobertura ainda parcial em municípios pequenos.</strong>{' '}
+          Municípios com menos de 50 mil habitantes têm prazo estendido
+          até 2026 para integração total. Para esses, complemente com o
+          portal de transparência local.
+        </li>
+        <li>
+          <strong>Atraso de publicação.</strong> Embora a lei exija 20
+          dias úteis, parte dos órgãos publica próximo do limite. Faça a
+          análise com defasagem de 30-45 dias para ter base completa.
+        </li>
+        <li>
+          <strong>Dados estruturados x objeto descritivo.</strong> O
+          campo "objeto" é texto livre — diferentes órgãos descrevem o
+          mesmo serviço de formas distintas. Use busca por palavra-chave
+          ampla e refine.
+        </li>
+      </ul>
+
+      <h2>Casos de uso recorrentes em empresas B2G</h2>
+      <p>
+        <strong>Caso 1 — Avaliação pré-licitação:</strong> antes de
+        decidir se vale disputar um pregão, busque os contratos similares
+        do mesmo órgão nos últimos 24 meses. Veja quem ganhou e em que
+        faixa de preço. Se você não consegue chegar a 95% do menor preço
+        praticado, talvez não valha entrar.
+      </p>
+      <p>
+        <strong>Caso 2 — Inteligência de concorrente.</strong> Pegue o
+        CNPJ do principal concorrente e liste seus contratos vigentes.
+        Você descobre nichos onde ele não atua e pode ser o primeiro
+        movimento.
+      </p>
+      <p>
+        <strong>Caso 3 — Argumentação em recurso administrativo.</strong>{' '}
+        Em recurso por preço inexequível, contratos históricos do PNCP
+        servem como prova objetiva de que aquele valor está fora da
+        faixa praticada — uso reconhecido por TCE e TCU.
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-consulta-contratos-passo-a-passo"
+        campaign="guias"
+        ctaMessage="Inteligência de contratos PNCP por CNPJ em segundos."
+        ctaText="Ver demonstração"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Veja{' '}
+        <Link href="/blog/como-consultar-contratos-publicos-pncp">
+          consulta de contratos públicos no PNCP — visão geral
+        </Link>
+        ,{' '}
+        <Link href="/blog/pncp-api-integracao-empresas">
+          API do PNCP — integração e automação
+        </Link>
+        , e o{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-dispensa-licitacao-quando-aplicar.tsx
+++ b/frontend/app/blog/content/pncp-dispensa-licitacao-quando-aplicar.tsx
@@ -1,0 +1,232 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-05 (#992) — PNCP e Dispensa de Licitação
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1080 words | Primary KW: pncp dispensa licitação
+ */
+export default function PncpDispensaLicitacaoQuandoAplicar() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'Quais os valores de dispensa pela Lei 14.133/2021?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'O art. 75, incisos I e II, fixa os limites de dispensa em razão do valor: até R$ 119.812,02 para obras e serviços de engenharia, e até R$ 59.906,02 para outros bens e serviços (valores atualizados anualmente por decreto). Acima disso, é obrigatório licitar.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Dispensa eletrônica é obrigatoriamente publicada no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Sim. Toda dispensa formalizada pela administração pública, inclusive a eletrônica, deve ser publicada no PNCP, com objeto, valor, fornecedor escolhido e justificativa. A obrigatoriedade decorre dos arts. 174 e 175 da Lei 14.133/2021.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Como uma empresa pequena participa de dispensas?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Há dois caminhos: (1) ser convidada pelo órgão a apresentar cotação na fase de pesquisa de preço; (2) participar da dispensa eletrônica via PNCP, plataforma na qual três fornecedores são chamados a competir online. Cadastrar-se no SICAF e em portais como BLL e Licitanet aumenta as chances de ser escolhido.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Dispensa é a mesma coisa que inexigibilidade?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Não. Dispensa (art. 75) ocorre quando há viabilidade de competição, mas a lei autoriza não licitar (valor baixo, urgência etc.). Inexigibilidade (art. 74) ocorre quando não há viabilidade de competição — fornecedor exclusivo, serviço técnico singular, contratação artística etc. As duas são publicadas no PNCP, mas com fundamentos jurídicos distintos.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. Aqui você entende quando a administração pode
+        dispensar a licitação, como localizar dispensas no PNCP e por que
+        este canal — frequentemente subestimado — é uma das vias mais
+        ágeis para empresas iniciarem em B2G.
+      </p>
+
+      <h2>O que é dispensa de licitação</h2>
+      <p>
+        Dispensa é a hipótese em que, embora seja possível abrir uma
+        competição entre fornecedores, a Lei 14.133/2021 autoriza a
+        administração a contratar diretamente. Ao contrário da
+        inexigibilidade — que pressupõe a impossibilidade de competição —,
+        a dispensa parte do princípio de que <em>seria possível
+        licitar</em>, mas não vale a pena pelo custo administrativo, pela
+        urgência ou pelo baixo valor do objeto.
+      </p>
+
+      <h2>Hipóteses do art. 75</h2>
+      <p>
+        O art. 75 lista mais de 15 hipóteses. As mais usadas na prática:
+      </p>
+      <ul>
+        <li>
+          <strong>I — Obras e serviços de engenharia até R$ 119.812,02</strong>{' '}
+          (valor atualizado).
+        </li>
+        <li>
+          <strong>II — Outros bens e serviços até R$ 59.906,02.</strong>
+        </li>
+        <li>
+          <strong>VIII — Compras emergenciais</strong> em situação de
+          emergência ou calamidade pública (limitada a 1 ano, sem
+          prorrogação).
+        </li>
+        <li>
+          <strong>X — Compras de hortifrutigranjeiros</strong> diretamente
+          de produtor rural pessoa física.
+        </li>
+        <li>
+          <strong>XI — Aquisições por organismos internacionais</strong>{' '}
+          quando há acordo de cooperação técnica.
+        </li>
+        <li>
+          <strong>XV — Compras complementares</strong> a contratos
+          vigentes, dentro do limite de 25% do valor original.
+        </li>
+      </ul>
+      <p>
+        Os valores dos incisos I e II são atualizados anualmente por
+        decreto — sempre confira a versão vigente antes de orientar
+        cliente ou montar planejamento.
+      </p>
+
+      <h2>Dispensa eletrônica — o caminho mais transparente</h2>
+      <p>
+        O Decreto 10.024/2019 e a IN SEGES/ME 67/2021 instituíram a{' '}
+        <strong>dispensa eletrônica</strong>: mesmo nas hipóteses de
+        valor (incisos I e II), o órgão precisa fazer uma chamada
+        pública por sistema eletrônico, dando 3 dias úteis para que
+        fornecedores cadastrados apresentem propostas. Funciona como um
+        mini-pregão. Ao final, o órgão escolhe a proposta mais vantajosa
+        e formaliza a contratação.
+      </p>
+      <p>
+        A dispensa eletrônica é publicada no PNCP no momento da abertura
+        e novamente no momento da homologação. Empresas iniciantes
+        encontram nela uma porta de entrada: contratos pequenos, ciclo
+        rápido, menos concorrentes que pregões grandes.
+      </p>
+
+      <h2>Como filtrar dispensas no PNCP</h2>
+      <p>
+        Em <code>pncp.gov.br/app/editais</code>, no filtro de modalidade,
+        marque "Dispensa". Combine com:
+      </p>
+      <ul>
+        <li>UF do seu estado.</li>
+        <li>Faixa de valor compatível com seu porte.</li>
+        <li>Período de publicação (últimos 7 dias para captura ágil).</li>
+      </ul>
+      <p>
+        Para automatizar, a API aceita{' '}
+        <code>codigoModalidadeContratacao=8</code> (dispensa) ou{' '}
+        <code>=9</code> (inexigibilidade). Veja{' '}
+        <Link href="/blog/pncp-api-integracao-empresas">
+          API do PNCP — integração e automação
+        </Link>
+        .
+      </p>
+
+      <h2>Documentos exigidos</h2>
+      <p>
+        Mesmo em dispensa, a habilitação é simplificada — mas não
+        ausente. O órgão exige tipicamente:
+      </p>
+      <ul>
+        <li>Certidões de regularidade fiscal (federal, FGTS, trabalhista).</li>
+        <li>Comprovante de inscrição no CNPJ.</li>
+        <li>
+          Atestado de capacidade técnica (em alguns casos, dispensado
+          quando o valor é muito baixo).
+        </li>
+        <li>Contrato social atualizado.</li>
+      </ul>
+      <p>
+        A vantagem prática: ciclo de 5 a 10 dias úteis entre detecção da
+        dispensa e assinatura do contrato — comparado a 25-40 dias úteis
+        de um pregão.
+      </p>
+
+      <h2>Riscos jurídicos para a empresa contratada</h2>
+      <p>
+        Dispensa é fiscalizada com rigor pelo TCU e pelos TCEs. Empresas
+        que se beneficiam de dispensa devem garantir:
+      </p>
+      <ul>
+        <li>
+          <strong>Justificativa formal do órgão</strong> arquivada no
+          processo administrativo (cópia disponível em recurso, se
+          necessário).
+        </li>
+        <li>
+          <strong>Pesquisa de preços documentada</strong> — três cotações
+          ou painel oficial de preços (Painel de Preços do Governo
+          Federal).
+        </li>
+        <li>
+          <strong>Não fracionamento.</strong> Dividir uma compra em
+          múltiplas dispensas para fugir do limite legal é fraude. O TCU
+          é categórico sobre isso (Acórdão 1.927/2023).
+        </li>
+      </ul>
+
+      <h2>Inexigibilidade — quando dispensa não cabe</h2>
+      <p>
+        Se o objeto exige fornecedor exclusivo (medicamento patenteado,
+        software proprietário, serviço técnico singular, atração
+        artística consagrada), a hipótese é{' '}
+        <strong>inexigibilidade</strong> (art. 74), não dispensa. A
+        diferença prática é que, na inexigibilidade, não há competição
+        possível — e a justificativa precisa ser tecnicamente robusta.
+        Empresas que se posicionam como referência em nicho específico
+        podem se beneficiar dessa hipótese.
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-dispensa-licitacao-quando-aplicar"
+        campaign="guias"
+        ctaMessage="Não perca dispensas eletrônicas — ciclo é curto."
+        ctaText="Testar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Continue por{' '}
+        <Link href="/blog/pncp-modalidade-pregao-eletronico">
+          PNCP e pregão eletrônico
+        </Link>
+        ,{' '}
+        <Link href="/blog/pncp-erros-comuns-empresas-iniciantes">
+          erros comuns de empresas iniciantes
+        </Link>{' '}
+        e o{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-erros-comuns-empresas-iniciantes.tsx
+++ b/frontend/app/blog/content/pncp-erros-comuns-empresas-iniciantes.tsx
@@ -1,0 +1,219 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-08 (#992) — PNCP: 7 erros comuns de empresas iniciantes
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1050 words | Primary KW: pncp erros
+ */
+export default function PncpErrosComunsEmpresasIniciantes() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'Qual o erro mais comum de empresa iniciante no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Cadastrar-se apenas no SICAF e tentar participar de pregões municipais ou estaduais sem cadastro nas plataformas operacionais (BLL, Licitanet, BNC). Descobre-se na hora do lance que o cadastro adicional leva 24-72 horas — e a oportunidade está perdida.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'O PNCP é difícil de usar para quem está começando?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'A interface é funcional, mas o volume torna a triagem manual inviável. São 5-10 mil novos editais por dia em todo o país. Empresas iniciantes precisam de filtros bem configurados (UF, modalidade, faixa de valor, palavras-chave) — ou de uma ferramenta que automatize a triagem.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Vale a pena começar por dispensa ou direto por pregão?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Para empresas sem atestado técnico em compras públicas, a dispensa eletrônica é a porta de entrada mais inteligente: ciclo curto, menos exigências de habilitação, possibilidade de gerar atestado para pregões maiores. Iniciar por pregões R$ 500k+ sem atestado é receita para inabilitação.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Como evitar perder editais por falta de monitoramento?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Configure alertas. O PNCP tem cadastro de palavras-chave para notificação por email; ferramentas como a SmartLic vão além e classificam por setor com IA, reduzindo falsos positivos. O hábito de ver editais "uma vez por semana" garante perder os de prazo curto.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. Quem entra agora em compras públicas comete os
+        mesmos sete erros — em sequência previsível. Mapear esses
+        tropeços antes evita 80% da curva dolorosa.
+      </p>
+
+      <h2>Erro 1 — Cadastro incompleto</h2>
+      <p>
+        Empresa iniciante imagina que o SICAF (cadastro federal no
+        ComprasGov) é suficiente para tudo. Não é. Para participar de
+        pregões municipais e estaduais, é preciso ter cadastro nas
+        plataformas operacionais usadas pelos órgãos: BLL Compras,
+        Licitanet, BNC Compras Públicas, ComprasNet do estado etc. Cada
+        cadastro leva 24-72 horas para validação. Faça os principais
+        antes mesmo de identificar o primeiro edital — quando a
+        oportunidade aparecer, você já estará pronto. Para entender a
+        divisão de plataformas, veja{' '}
+        <Link href="/blog/pncp-vs-comprasgov-diferencas">
+          PNCP vs ComprasGov — diferenças
+        </Link>
+        .
+      </p>
+
+      <h2>Erro 2 — Filtros amplos demais</h2>
+      <p>
+        Sem filtros, o PNCP devolve 5 a 10 mil editais por dia. É
+        impossível triar manualmente. O hábito típico do iniciante é
+        olhar tudo "do meu setor" — e descobrir que palavra-chave
+        ampla ("limpeza") devolve milhares de resultados, dos quais
+        90% não são compatíveis com o porte da empresa. Estreite o
+        filtro com:
+      </p>
+      <ul>
+        <li>UF inicialmente só do seu estado.</li>
+        <li>Faixa de valor compatível com sua capacidade.</li>
+        <li>Modalidade (comece por pregão eletrônico).</li>
+        <li>Palavras-chave específicas + exclusões.</li>
+      </ul>
+
+      <h2>Erro 3 — Subestimar o prazo de leitura do edital</h2>
+      <p>
+        Editais públicos são longos — 30 a 100 páginas é normal. Quem
+        vai ler "um pouco antes do dia da sessão" perde detalhes que
+        custam o contrato: cláusulas de garantia financeira, prazos de
+        execução agressivos, exigências de equipe-chave residente,
+        critérios de pontuação técnica que penalizam empresas pequenas.
+        A regra é: <strong>leia o edital nas primeiras 48 horas</strong>{' '}
+        após publicação, faça o go/no-go nesse momento, e use o resto
+        do prazo para <em>preparar</em>, não para decidir.
+      </p>
+
+      <h2>Erro 4 — Não calcular planilha de composição de preço</h2>
+      <p>
+        Iniciante cota "olhando para o estimado" e baixando 10-20%.
+        Profissional cota com planilha de composição: custo direto +
+        custo indireto + tributos + margem. Em pregão, vença ou perca,
+        você precisa saber qual é o seu lance mínimo abaixo do qual
+        prefere perder. Sem isso, "ganha" e descobre depois que o
+        contrato dá prejuízo. A Lei 14.133/2021, art. 59, considera
+        inexequíveis propostas de obras abaixo de 75% do estimado —
+        essa é a baliza objetiva.
+      </p>
+
+      <h2>Erro 5 — Certidão fiscal vencida na hora da habilitação</h2>
+      <p>
+        Pregoeiros são treinados a verificar todas as certidões na
+        sessão. Uma única certidão fora da validade — especialmente FGTS
+        (30 dias), que vence rápido — gera inabilitação imediata. Mantenha:
+      </p>
+      <ul>
+        <li>FGTS sempre atualizado (renovação mensal automatizada).</li>
+        <li>Receita/PGFN (180 dias) com renovação trimestral.</li>
+        <li>CNDT (180 dias) com renovação trimestral.</li>
+        <li>Estaduais e municipais conforme prazo de cada UF.</li>
+      </ul>
+      <p>
+        Crie um calendário de vencimentos. Nunca dependa da memória.
+      </p>
+
+      <h2>Erro 6 — Atestado técnico incompatível</h2>
+      <p>
+        Empresa que nunca executou contrato público parecido com o
+        objeto licitado raramente é habilitada em pregões médios e
+        grandes — o atestado técnico exige objeto e quantitativo
+        compatíveis. A saída inteligente é começar por dispensas
+        eletrônicas (art. 75) e contratos pequenos para construir
+        portfólio. Cada contrato bem executado vira um atestado novo,
+        habilitando a empresa para pregões maiores. Veja{' '}
+        <Link href="/blog/pncp-dispensa-licitacao-quando-aplicar">
+          PNCP e dispensa de licitação
+        </Link>
+        .
+      </p>
+
+      <h2>Erro 7 — Não acompanhar prazos de impugnação e recurso</h2>
+      <p>
+        Editais com cláusulas restritivas (exigência exagerada de
+        atestado, faixa de valor que afasta MEI/EPP, pontuação técnica
+        artificial) podem ser impugnados até 3 dias úteis antes da
+        sessão. Empresas iniciantes raramente exercem esse direito por
+        desconhecimento — e perdem oportunidades. Da mesma forma, em
+        recurso administrativo após o pregão, há 3 dias úteis para
+        manifestação de intenção e 3 dias úteis adicionais para razões
+        recursais. Quem perde por procedimento perde duas vezes: o
+        contrato e o aprendizado.
+      </p>
+
+      <h2>Roteiro de primeiros 90 dias no PNCP</h2>
+      <p>
+        Para empresa que está começando, sugerimos:
+      </p>
+      <ul>
+        <li>
+          <strong>Dias 1-15:</strong> cadastro completo (SICAF + 3
+          plataformas operacionais principais), atualização de certidões,
+          configuração de alertas.
+        </li>
+        <li>
+          <strong>Dias 16-45:</strong> participar de 3-5 dispensas
+          eletrônicas pequenas, foco em ganhar primeiros atestados.
+        </li>
+        <li>
+          <strong>Dias 46-90:</strong> primeiros pregões eletrônicos com
+          atestado em mãos, escalada gradual para faixas de valor
+          maiores.
+        </li>
+      </ul>
+      <p>
+        Não tente queimar etapas. Empresas que correm para pregões
+        grandes sem base operacional tomam dois ou três tombos e desistem
+        de B2G — quando o problema era método, não mercado.
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-erros-comuns-empresas-iniciantes"
+        campaign="guias"
+        ctaMessage="Comece com o método certo desde o dia 1."
+        ctaText="Testar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Continue por{' '}
+        <Link href="/blog/empresa-iniciante-ganhar-contratos-governo">
+          empresa iniciante: como ganhar contratos com o governo
+        </Link>
+        ,{' '}
+        <Link href="/blog/pncp-timeline-publicacao-edital">
+          PNCP — timeline de publicação
+        </Link>{' '}
+        e o{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-guia-completo-empresas.tsx
+++ b/frontend/app/blog/content/pncp-guia-completo-empresas.tsx
@@ -673,6 +673,69 @@ export default function PncpGuiaCompletoEmpresas() {
         requisição. A API é utilizada por ferramentas de inteligência como o
         SmartLic para automatizar a busca de editais em escala.
       </p>
+
+      {/* SEO-P1-005 (#992) — Cluster PNCP: links para os 8 spokes */}
+      <h2 id="aprenda-mais-pncp">Aprenda mais sobre PNCP</h2>
+      <p>
+        Aprofunde tópicos específicos do PNCP — cada link a seguir é um
+        guia dedicado e parte deste cluster:
+      </p>
+      <ul>
+        <li>
+          <Link href="/blog/pncp-modalidade-pregao-eletronico">
+            PNCP e Pregão Eletrônico — como filtrar e participar
+          </Link>{' '}
+          — entenda a modalidade que responde por mais de 70% das compras
+          publicadas no portal.
+        </li>
+        <li>
+          <Link href="/blog/pncp-timeline-publicacao-edital">
+            PNCP — timeline de publicação do edital
+          </Link>{' '}
+          — quando um edital aparece, quanto tempo você tem e como
+          organizar a janela.
+        </li>
+        <li>
+          <Link href="/blog/pncp-vs-comprasgov-diferencas">
+            PNCP vs ComprasGov — diferenças e qual usar
+          </Link>{' '}
+          — o que cada portal cobre e onde sua empresa precisa estar
+          cadastrada.
+        </li>
+        <li>
+          <Link href="/blog/pncp-consulta-contratos-passo-a-passo">
+            PNCP — consulta de contratos passo a passo
+          </Link>{' '}
+          — inteligência competitiva a partir do histórico de contratos
+          públicos.
+        </li>
+        <li>
+          <Link href="/blog/pncp-dispensa-licitacao-quando-aplicar">
+            PNCP e Dispensa de Licitação (Lei 14.133)
+          </Link>{' '}
+          — hipóteses do art. 75, valores limite e dispensa eletrônica.
+        </li>
+        <li>
+          <Link href="/blog/pncp-registro-precos-como-participar">
+            PNCP e Sistema de Registro de Preços
+          </Link>{' '}
+          — atas, caronas e por que SRP é uma das vias mais previsíveis
+          para empresas B2G.
+        </li>
+        <li>
+          <Link href="/blog/pncp-api-integracao-empresas">
+            API do PNCP — integração e automação
+          </Link>{' '}
+          — endpoints, paginação e como construir um pipeline de
+          monitoramento.
+        </li>
+        <li>
+          <Link href="/blog/pncp-erros-comuns-empresas-iniciantes">
+            7 erros que empresas iniciantes cometem no PNCP
+          </Link>{' '}
+          — os tropeços previsíveis e o roteiro de primeiros 90 dias.
+        </li>
+      </ul>
     </>
   );
 }

--- a/frontend/app/blog/content/pncp-modalidade-pregao-eletronico.tsx
+++ b/frontend/app/blog/content/pncp-modalidade-pregao-eletronico.tsx
@@ -1,0 +1,266 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-01 (#992) — PNCP e Pregão Eletrônico
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1100 words | Primary KW: pncp pregão eletrônico
+ */
+export default function PncpModalidadePregaoEletronico() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'O pregão eletrônico é obrigatório no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Sim. A Lei 14.133/2021 elege o pregão eletrônico como modalidade preferencial para aquisição de bens e serviços comuns, e toda compra pública passa a ser publicada no PNCP. Órgãos federais já operam 100% no PNCP; estados e municípios seguem cronograma escalonado, mas a tendência é convergência total até 2026.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Como filtrar apenas pregões eletrônicos no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Na busca avançada do PNCP, selecione o filtro "Modalidade" e marque "Pregão Eletrônico". Combine com filtros de UF, faixa de valor e período de publicação para reduzir o volume. A API pública do PNCP também aceita o parâmetro codigoModalidadeContratacao=6 para pregão eletrônico.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Qual o prazo mínimo entre publicação e sessão do pregão?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'A Lei 14.133/2021, art. 55, estabelece prazo mínimo de 8 dias úteis para pregão eletrônico de bens e serviços comuns, e 10 dias úteis quando envolver critério de melhor técnica e preço. Esse é o tempo que a empresa tem para ler o edital, montar a proposta e enviar.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Posso participar de pregão eletrônico em qualquer UF pelo PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Sim. O pregão eletrônico é, por definição, à distância — você participa de qualquer lugar do país. O que muda por UF é a plataforma de origem (ComprasGov para a União, BLL/Licitanet/BNC para municípios e estados), mas todas publicam no PNCP e o acesso é online.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. Aqui o foco é a modalidade que mais movimenta volume no
+        portal: o pregão eletrônico — responsável por mais de 70% das compras
+        publicadas no PNCP em 2025, segundo levantamento agregado pelo próprio
+        portal e pelo Ministério da Gestão.
+      </p>
+
+      <h2>Por que o pregão eletrônico domina o PNCP</h2>
+      <p>
+        A Lei 14.133/2021 reorganizou as modalidades licitatórias em cinco
+        categorias (pregão, concorrência, concurso, leilão e diálogo
+        competitivo) e elegeu o <strong>pregão eletrônico</strong> como
+        modalidade preferencial para a aquisição de bens e serviços comuns
+        (art. 6º, inciso XLI). Isso significa que, salvo justificativa
+        técnica robusta, qualquer compra de itens que tenham padrões
+        objetivamente definidos no mercado — equipamentos de informática,
+        material de escritório, serviços de limpeza, terceirização, frota,
+        manutenção predial — será conduzida via pregão eletrônico e
+        publicada no PNCP.
+      </p>
+      <p>
+        Em termos práticos, mais de 70% dos editais que aparecem na busca
+        diária do PNCP são pregões. Para empresas B2G, dominar essa
+        modalidade não é opcional: é o canal principal de receita pública.
+      </p>
+
+      <h2>Como filtrar e encontrar pregões no PNCP</h2>
+      <p>
+        Na interface web do PNCP (pncp.gov.br/app/editais), o caminho mais
+        rápido é o seguinte:
+      </p>
+      <ol>
+        <li>
+          <strong>Filtre por modalidade:</strong> selecione apenas "Pregão
+          Eletrônico" no painel lateral.
+        </li>
+        <li>
+          <strong>Restrinja por UF e cidade</strong> — começar pelo seu
+          estado reduz drasticamente o volume e melhora a viabilidade
+          logística.
+        </li>
+        <li>
+          <strong>Use a faixa de valor estimado</strong> compatível com sua
+          capacidade de execução. Disputar contratos muito pequenos (abaixo
+          de R$ 50 mil) raramente compensa para empresas estruturadas;
+          disputar contratos muito grandes sem atestado técnico equivalente
+          é pedir desclassificação.
+        </li>
+        <li>
+          <strong>Filtre pelo período de publicação</strong> — últimos 7 ou
+          14 dias — para focar em editais ainda dentro do prazo de proposta.
+        </li>
+      </ol>
+      <p>
+        Para quem prefere automatizar, a{' '}
+        <Link href="/blog/pncp-api-integracao-empresas">
+          API pública do PNCP
+        </Link>{' '}
+        aceita o parâmetro <code>codigoModalidadeContratacao=6</code> e
+        devolve até 50 registros por página, permitindo construir um
+        monitoramento diário próprio.
+      </p>
+
+      <h2>Anatomia de um edital de pregão no PNCP</h2>
+      <p>
+        Todo edital publicado no PNCP segue uma estrutura padronizada
+        (Anexo III da IN SEGES/ME 65/2021), o que facilita comparar e
+        triar:
+      </p>
+      <ul>
+        <li>
+          <strong>Objeto:</strong> descrição clara do bem ou serviço,
+          incluindo especificação técnica mínima.
+        </li>
+        <li>
+          <strong>Valor estimado:</strong> teto referencial calculado pelo
+          órgão. Propostas acima do estimado são desclassificadas; muito
+          abaixo (geralmente menos de 75%) podem ser questionadas como
+          inexequíveis.
+        </li>
+        <li>
+          <strong>Prazo de execução e local de entrega:</strong> calcule
+          frete e logística antes de cotar.
+        </li>
+        <li>
+          <strong>Habilitação:</strong> regularidade fiscal, qualificação
+          técnica (atestados), qualificação econômico-financeira (balanço,
+          índices de liquidez) e habilitação jurídica.
+        </li>
+        <li>
+          <strong>Critério de julgamento:</strong> menor preço (padrão para
+          bens comuns) ou maior desconto sobre tabela.
+        </li>
+      </ul>
+
+      <h2>O fluxo da sessão pública</h2>
+      <p>
+        Diferente da concorrência tradicional, o pregão eletrônico é
+        dinâmico e veloz: a sessão tem três fases observáveis em tempo
+        real.
+      </p>
+      <p>
+        <strong>Fase 1 — Recebimento de propostas:</strong> antes do
+        horário de abertura, todos os licitantes enviam proposta de preço
+        inicial pelo sistema (ComprasGov, BLL, Licitanet, BNC etc.). O
+        valor não é revelado.
+      </p>
+      <p>
+        <strong>Fase 2 — Lances:</strong> a partir da abertura, os
+        licitantes ofertam lances decrescentes em rodadas. O sistema
+        encerra automaticamente após período aleatório (1 a 30 minutos)
+        sem novos lances. É aqui que se ganha ou se perde — e onde mais
+        empresas erram, oferecendo lances impulsivos sem cálculo de
+        margem.
+      </p>
+      <p>
+        <strong>Fase 3 — Habilitação:</strong> o pregoeiro verifica
+        documentos do licitante mais bem classificado. Se faltar uma
+        certidão, ele é desclassificado e o segundo colocado é convocado.
+      </p>
+
+      <h2>Erros que custam o contrato</h2>
+      <p>
+        Os tropeços mais comuns de empresas iniciantes em pregão estão
+        documentados no spoke{' '}
+        <Link href="/blog/pncp-erros-comuns-empresas-iniciantes">
+          7 erros que empresas iniciantes cometem no PNCP
+        </Link>
+        . Os três mais letais:
+      </p>
+      <ul>
+        <li>
+          <strong>Certidão fiscal vencida</strong> — especialmente FGTS,
+          que vence a cada 30 dias.
+        </li>
+        <li>
+          <strong>Lance abaixo do custo</strong> sem ter feito a planilha
+          de composição de preço; vitória que vira prejuízo.
+        </li>
+        <li>
+          <strong>Atestado técnico incompatível</strong> — o pregoeiro
+          aceita apenas atestados que comprovem objeto e quantitativo
+          mínimo equivalente.
+        </li>
+      </ul>
+
+      <h2>Cronograma típico — leitura, proposta, sessão</h2>
+      <p>
+        Entre a publicação do edital e a sessão pública há, no mínimo, 8
+        dias úteis. Veja como os times bem-organizados distribuem esse
+        tempo (detalhes no spoke{' '}
+        <Link href="/blog/pncp-timeline-publicacao-edital">
+          PNCP: timeline de publicação do edital
+        </Link>
+        ):
+      </p>
+      <ul>
+        <li>
+          <strong>Dias 1-2:</strong> triagem do objeto, leitura crítica,
+          decisão go/no-go.
+        </li>
+        <li>
+          <strong>Dias 3-5:</strong> coleta de cotações com fornecedores,
+          montagem da planilha de composição de preço, validação interna.
+        </li>
+        <li>
+          <strong>Dias 6-7:</strong> verificação de documentos de
+          habilitação, atualização de certidões, ensaio de senha no
+          sistema.
+        </li>
+        <li>
+          <strong>Dia 8:</strong> envio da proposta com 24 horas de
+          margem.
+        </li>
+      </ul>
+
+      <BlogInlineCTA
+        slug="pncp-modalidade-pregao-eletronico"
+        campaign="guias"
+        ctaMessage="Receba alertas só de pregões compatíveis com sua empresa."
+        ctaText="Testar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Para aprofundar:{' '}
+        <Link href="/blog/pncp-timeline-publicacao-edital">
+          PNCP — timeline de publicação do edital
+        </Link>
+        ,{' '}
+        <Link href="/blog/pncp-vs-comprasgov-diferencas">
+          PNCP vs ComprasGov
+        </Link>{' '}
+        e{' '}
+        <Link href="/blog/pncp-erros-comuns-empresas-iniciantes">
+          7 erros que empresas iniciantes cometem
+        </Link>
+        . Volte sempre ao{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        para a visão consolidada do cluster.
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-registro-precos-como-participar.tsx
+++ b/frontend/app/blog/content/pncp-registro-precos-como-participar.tsx
@@ -1,0 +1,246 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-06 (#992) — PNCP e Sistema de Registro de Preços
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1100 words | Primary KW: pncp registro de preços
+ */
+export default function PncpRegistroPrecosComoParticipar() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'O que é Sistema de Registro de Preços (SRP)?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'É o procedimento pelo qual a administração registra preços para futuras contratações. Ao final de uma licitação SRP, gera-se uma Ata de Registro de Preços com vigência de até 12 meses, prorrogável por mais 12. Durante a vigência, o órgão pode comprar quando necessário, sem novo certame.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'A empresa registrada na ata é obrigada a vender?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'A empresa fica vinculada aos preços e quantitativos declarados durante a vigência. O órgão não é obrigado a comprar todo o quantitativo, mas, se decidir comprar, a empresa precisa entregar nas condições do edital. Recusa injustificada gera sanção e descredenciamento.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'O que é "carona" em ata de registro de preços?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'É quando outro órgão (não participante da licitação original) adere à ata vigente para comprar nas mesmas condições. A Lei 14.133/2021 limita a adesão a 50% dos quantitativos da ata, e cada adesão também respeita o teto. A "carona" é uma fonte de receita adicional para a empresa registrada — sem precisar disputar nova licitação.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Como localizar atas vigentes no PNCP?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Em pncp.gov.br/app/atas, filtre por objeto, UF e situação "Vigente". Cada ata mostra quantitativos, preços unitários, vigência e órgãos participantes. Para inteligência competitiva, agregar as atas por setor revela quem são os fornecedores cadastrados em cada região.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. O Sistema de Registro de Preços (SRP) é uma das vias
+        mais lucrativas — e mais previsíveis — para empresas B2G. Quem
+        domina SRP entende que vencer um pregão SRP não é evento isolado;
+        é abrir uma <em>fonte recorrente</em> de receita por 12 a 24
+        meses.
+      </p>
+
+      <h2>O que muda quando a licitação é SRP</h2>
+      <p>
+        Em uma licitação tradicional, o órgão licita o que vai comprar
+        agora — quantidade certa, prazo certo. Numa licitação SRP, o
+        órgão licita preços e condições; a compra efetiva acontece em
+        múltiplos momentos durante a vigência da ata. Para a empresa
+        vencedora, isso significa três coisas:
+      </p>
+      <ul>
+        <li>
+          <strong>Receita previsível</strong> ao longo de 12 meses (com
+          eventual prorrogação por mais 12 — limite legal de 24 meses).
+        </li>
+        <li>
+          <strong>Possibilidade de "carona"</strong> — outros órgãos
+          podem aderir à ata e comprar, gerando receita adicional sem
+          nova disputa.
+        </li>
+        <li>
+          <strong>Entrega parcelada</strong> conforme demanda real do
+          órgão, com logística distribuída no tempo.
+        </li>
+      </ul>
+
+      <h2>Como funciona uma licitação SRP</h2>
+      <p>
+        O ciclo típico é:
+      </p>
+      <ol>
+        <li>
+          <strong>Levantamento de demanda:</strong> o órgão (ou um
+          consórcio de órgãos) consolida quantitativos estimados para 12
+          meses.
+        </li>
+        <li>
+          <strong>Publicação no PNCP:</strong> edital com objeto,
+          quantitativos máximos, vigência da ata e regras de adesão.
+        </li>
+        <li>
+          <strong>Sessão pública:</strong> normalmente em pregão
+          eletrônico, com lances pelos preços unitários.
+        </li>
+        <li>
+          <strong>Homologação e assinatura da ata:</strong> a empresa
+          vencedora assina a ata e fica registrada como fornecedor pelos
+          preços ofertados.
+        </li>
+        <li>
+          <strong>Compras durante a vigência:</strong> o órgão emite
+          Ordem de Fornecimento sempre que precisar; a empresa entrega
+          conforme as condições da ata.
+        </li>
+      </ol>
+
+      <h2>Caronas — receita extra sem competir de novo</h2>
+      <p>
+        A figura do "órgão não participante" — popularmente "carona" —
+        permite que órgãos que não participaram da licitação original
+        adiram à ata. A Lei 14.133/2021 (art. 86) limita:
+      </p>
+      <ul>
+        <li>
+          <strong>50% dos quantitativos da ata</strong> como teto
+          agregado para todas as caronas.
+        </li>
+        <li>
+          <strong>100% por carona individual</strong> em relação ao
+          quantitativo originalmente comprado pelo órgão participante.
+        </li>
+        <li>
+          <strong>Anuência expressa</strong> do fornecedor antes de
+          qualquer carona.
+        </li>
+      </ul>
+      <p>
+        Empresas que vencem ata em órgão de grande porte (universidade
+        federal, hospital universitário, ministério) frequentemente
+        recebem dezenas de pedidos de carona ao longo do ano —
+        especialmente se o objeto é de uso geral (TI, escritório,
+        material hospitalar). Aceitar carona é decisão da empresa, e
+        deve considerar capacidade real de fornecimento.
+      </p>
+
+      <h2>Estratégias práticas para vencer pregão SRP</h2>
+      <p>
+        <strong>Estratégia 1 — Cotação de prazo longo.</strong> Em SRP, o
+        preço fica congelado por 12 meses (com cláusulas de revisão
+        excepcional). Cotar como se fosse contrato à vista é receita
+        para prejuízo. Inclua provisão para inflação, oscilação cambial
+        em insumos importados e custo financeiro de capital de giro.
+      </p>
+      <p>
+        <strong>Estratégia 2 — Análise de demanda histórica.</strong>{' '}
+        Antes de cotar, pesquise no PNCP atas anteriores do mesmo órgão
+        para o mesmo objeto. Veja quanto efetivamente foi comprado vs
+        quantitativo registrado — muitos órgãos compram só 30-50% do
+        registrado.
+      </p>
+      <p>
+        <strong>Estratégia 3 — Exposição a caronas.</strong> Atas de
+        órgãos populares como UF (ministérios), hospitais
+        universitários, IFs, exército recebem muitas caronas. Cotar
+        considerando essa receita extra pode justificar margem mais
+        agressiva.
+      </p>
+
+      <h2>Como localizar atas no PNCP</h2>
+      <p>
+        Em <code>pncp.gov.br/app/atas</code> você encontra a busca de
+        atas vigentes. Use:
+      </p>
+      <ul>
+        <li>Objeto (palavra-chave) para descobrir oportunidades de carona.</li>
+        <li>UF e órgão para mapear quem detém ata em sua região.</li>
+        <li>
+          Status "Vigente" — atas vencidas só servem para histórico,
+          não para nova compra.
+        </li>
+      </ul>
+      <p>
+        O detalhe da ata exibe os preços unitários — informação valiosa
+        para construir cotações próprias e para acompanhar concorrentes.
+      </p>
+
+      <h2>Sanções por não cumprimento</h2>
+      <p>
+        Empresa registrada em ata que se recusa injustificadamente a
+        entregar pode sofrer:
+      </p>
+      <ul>
+        <li>
+          <strong>Multa contratual</strong> conforme percentual do edital
+          (tipicamente 10-20% do valor não entregue).
+        </li>
+        <li>
+          <strong>Descredenciamento da ata.</strong>
+        </li>
+        <li>
+          <strong>Impedimento de licitar</strong> de 6 meses a 5 anos
+          (art. 156).
+        </li>
+        <li>
+          <strong>Inscrição no CEIS</strong> (Cadastro Nacional de
+          Empresas Inidôneas e Suspensas) — torna a empresa inelegível
+          em todas as três esferas.
+        </li>
+      </ul>
+      <p>
+        Por isso, ao vencer ata, garanta capacidade real de
+        fornecimento. Vencer sem entregar é o pior cenário possível.
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-registro-precos-como-participar"
+        campaign="guias"
+        ctaMessage="Encontre atas SRP vigentes para carona."
+        ctaText="Começar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Veja{' '}
+        <Link href="/blog/ata-registro-precos-como-escolher">
+          ata de registro de preços — como escolher
+        </Link>
+        ,{' '}
+        <Link href="/blog/ata-registro-precos-estrategia-licitacao">
+          ata SRP como estratégia
+        </Link>{' '}
+        e o{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-timeline-publicacao-edital.tsx
+++ b/frontend/app/blog/content/pncp-timeline-publicacao-edital.tsx
@@ -1,0 +1,219 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-02 (#992) — PNCP: prazos e timeline de publicação
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1050 words | Primary KW: prazo publicação edital pncp
+ */
+export default function PncpTimelinePublicacaoEdital() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'Qual o prazo mínimo entre publicação no PNCP e a abertura do pregão?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Para pregão eletrônico de bens e serviços comuns, o prazo mínimo é de 8 dias úteis (Lei 14.133/2021, art. 55). Para pregão de melhor técnica e preço, 10 dias úteis. Concorrência exige no mínimo 25 dias úteis para julgamento por menor preço e 35 dias úteis para técnica e preço.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Em quanto tempo o edital aparece no PNCP após assinado pelo órgão?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Em geral, no mesmo dia ou em até 24 horas. A integração das plataformas (ComprasGov, BLL, Licitanet, BNC etc.) com o PNCP é praticamente em tempo real. Editais publicados após 18h normalmente só ficam visíveis na manhã seguinte.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'O órgão pode reduzir o prazo de publicação?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Não. Os prazos da Lei 14.133/2021 são mínimos e não podem ser encurtados. O órgão pode estendê-los — e, em casos de alterações relevantes no edital, é obrigado a reabrir o prazo. Reduções fictícias são causa frequente de impugnação procedente.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Como saber se um edital teve o prazo reaberto após alteração?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'O PNCP exibe o histórico de versões do edital na ficha pública da contratação, incluindo data de cada alteração e o novo prazo de abertura. Sempre verifique a versão vigente antes de finalizar a proposta — alterações de última hora podem mudar o objeto, o critério ou a habilitação.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. Aqui você entende quando um edital aparece no portal,
+        quanto tempo você tem para reagir e como organizar a janela entre
+        publicação e sessão para sair na frente.
+      </p>
+
+      <h2>Por que o cronograma do PNCP é vantagem competitiva</h2>
+      <p>
+        Quem percebe um edital no <strong>dia 1</strong> tem uma semana
+        completa para preparar proposta. Quem só vê no dia 6 tem 48 horas
+        para fazer o que os concorrentes fizeram em 7 dias. A vitória em
+        licitações públicas é decidida muito antes da sessão começar — é
+        decidida na velocidade de detecção e na qualidade da preparação.
+      </p>
+      <p>
+        O PNCP, ao concentrar toda a publicação obrigatória de
+        contratações públicas (Lei 14.133/2021, art. 174-176), tornou
+        possível pela primeira vez monitorar o país inteiro em um único
+        ponto. Antes disso, empresas precisavam acompanhar dezenas de
+        Diários Oficiais e portais municipais.
+      </p>
+
+      <h2>Prazos legais por modalidade</h2>
+      <p>
+        A Lei 14.133/2021, artigo 55, fixou prazos mínimos entre a
+        divulgação do edital e a apresentação de propostas:
+      </p>
+      <ul>
+        <li>
+          <strong>Pregão eletrônico, bens/serviços comuns, menor preço:</strong>{' '}
+          8 dias úteis.
+        </li>
+        <li>
+          <strong>Pregão eletrônico, melhor técnica e preço:</strong> 10
+          dias úteis.
+        </li>
+        <li>
+          <strong>Concorrência, menor preço:</strong> 25 dias úteis.
+        </li>
+        <li>
+          <strong>Concorrência, técnica e preço:</strong> 35 dias úteis.
+        </li>
+        <li>
+          <strong>Diálogo competitivo:</strong> mínimo de 25 dias úteis,
+          em fases sucessivas.
+        </li>
+      </ul>
+      <p>
+        Esses prazos são contados em <strong>dias úteis</strong> — feriados
+        nacionais, estaduais e municipais (no caso de licitação local)
+        suspendem a contagem. Pequenos órgãos esquecem feriados locais e
+        publicam editais com prazo nominalmente correto, mas materialmente
+        curto. Isso é causa válida de impugnação.
+      </p>
+
+      <h2>O ciclo de publicação no PNCP</h2>
+      <p>
+        Depois que o órgão licitante assina o edital e publica em sua
+        plataforma de origem (ComprasGov para a União, sistemas
+        municipais/estaduais para outros entes), o registro é replicado ao
+        PNCP por integração. Em condições normais:
+      </p>
+      <ul>
+        <li>
+          <strong>D+0 (até 18h):</strong> aparece no PNCP no mesmo dia.
+        </li>
+        <li>
+          <strong>D+0 (após 18h):</strong> visível no portal na manhã do
+          dia seguinte.
+        </li>
+        <li>
+          <strong>D+1 a D+3:</strong> raros, geralmente decorrentes de
+          falha de integração — denunciáveis junto ao Ministério da
+          Gestão.
+        </li>
+      </ul>
+      <p>
+        Para empresas que dependem de detecção rápida, monitoramento por
+        API a cada 15-30 minutos é o estado da arte. Veja como construir
+        esse pipeline no spoke{' '}
+        <Link href="/blog/pncp-api-integracao-empresas">
+          API do PNCP — integração e automação
+        </Link>
+        .
+      </p>
+
+      <h2>Como organizar a janela entre publicação e sessão</h2>
+      <p>
+        A janela típica de 8 dias úteis (~10 dias corridos) deve ser
+        dividida em três blocos:
+      </p>
+      <p>
+        <strong>Bloco 1 — Triagem (24 horas após publicação).</strong>{' '}
+        Decisão go/no-go com base em três critérios objetivos: a empresa
+        atende ao objeto?; tem atestado técnico compatível?; tem caixa
+        para suportar prazo de pagamento (geralmente 30 dias após o ateste
+        do recebimento, mas pode chegar a 90 dias em alguns órgãos
+        municipais)?
+      </p>
+      <p>
+        <strong>Bloco 2 — Construção da proposta (40-50% do tempo).</strong>{' '}
+        Cotação com fornecedores, planilha de composição de preço,
+        verificação de margem mínima por item, validação jurídica do
+        contrato-modelo anexo.
+      </p>
+      <p>
+        <strong>Bloco 3 — Habilitação e ensaio (24-48 horas finais).</strong>{' '}
+        Atualizar certidões, validar acesso ao sistema, ensaiar fluxo de
+        lance, conferir nome de usuário e certificado digital.
+      </p>
+
+      <h2>Impugnação e prazos correlatos</h2>
+      <p>
+        A Lei 14.133/2021, art. 164, garante a qualquer cidadão o direito
+        de impugnar o edital até{' '}
+        <strong>3 dias úteis antes da sessão pública</strong>. O órgão tem
+        igual prazo para responder. Se a impugnação for procedente e
+        envolver alteração relevante (mudança de objeto, de critério, de
+        habilitação ou de quantitativo), o prazo de propostas reabre — o
+        que pode dilatar o cronograma em 8 a 25 dias úteis.
+      </p>
+      <p>
+        Para o detalhamento prático de impugnação, leia também{' '}
+        <Link href="/blog/impugnacao-edital-quando-como-contestar">
+          impugnação de edital — quando e como contestar
+        </Link>
+        .
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-timeline-publicacao-edital"
+        campaign="guias"
+        ctaMessage="Detecte editais no dia 1, não no dia 6."
+        ctaText="Começar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Continue por{' '}
+        <Link href="/blog/pncp-modalidade-pregao-eletronico">
+          PNCP e pregão eletrônico
+        </Link>
+        ,{' '}
+        <Link href="/blog/impugnacao-edital-quando-como-contestar">
+          impugnação de edital — guia completo
+        </Link>{' '}
+        e{' '}
+        <Link href="/blog/pncp-erros-comuns-empresas-iniciantes">
+          7 erros que empresas iniciantes cometem
+        </Link>
+        . O{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        tem o mapa do cluster.
+      </p>
+    </>
+  );
+}

--- a/frontend/app/blog/content/pncp-vs-comprasgov-diferencas.tsx
+++ b/frontend/app/blog/content/pncp-vs-comprasgov-diferencas.tsx
@@ -1,0 +1,235 @@
+import Link from 'next/link';
+import BlogInlineCTA from '../components/BlogInlineCTA';
+
+/**
+ * PNCP-SPOKE-03 (#992) — PNCP vs ComprasGov
+ * Cluster: PNCP | Pillar: pncp-guia-completo-empresas
+ * Target: ~1080 words | Primary KW: pncp vs comprasgov
+ */
+export default function PncpVsComprasgovDiferencas() {
+  return (
+    <>
+      {/* FAQPage JSON-LD */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'PNCP e ComprasGov são a mesma coisa?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Não. PNCP (Portal Nacional de Contratações Públicas) é um portal de divulgação obrigatório para toda compra pública do país (Lei 14.133/2021). ComprasGov é a plataforma operacional do governo federal — onde os pregões da União são realizados. ComprasGov publica no PNCP; o inverso não é verdade.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Estados e municípios usam ComprasGov?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Em regra, não. O ComprasGov é o sistema do Executivo Federal. Estados e municípios usam plataformas próprias — BLL Compras, Licitanet, BNC Compras Públicas, ComprasNet de cada estado etc. Todas obrigatoriamente integradas ao PNCP. O PNCP é o agregador unificado.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Para participar de pregão municipal, preciso me cadastrar onde?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Na plataforma operacional indicada no edital — pode ser BLL, Licitanet, BNC, ComprasNet do estado etc. O PNCP serve apenas para descoberta e leitura do edital. A entrega da proposta e os lances sempre acontecem na plataforma operacional escolhida pelo órgão.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'O PNCP vai substituir o ComprasGov?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Não. PNCP e ComprasGov coexistem por desenho — o primeiro é portal de transparência e descoberta; o segundo é sistema operacional. A Lei 14.133/2021 deixa claro que o PNCP centraliza divulgação, mas cada ente federativo continua livre para escolher sua plataforma operacional.',
+                },
+              },
+            ],
+          }),
+        }}
+      />
+
+      <p className="text-base sm:text-xl leading-relaxed text-ink">
+        Este guia faz parte do{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>{' '}
+        da SmartLic. PNCP e ComprasGov são confundidos com frequência — a
+        diferença é simples, mas decisiva para qualquer empresa B2G.
+      </p>
+
+      <h2>Resumo em uma frase</h2>
+      <p>
+        <strong>PNCP é o portal de transparência</strong> obrigatório
+        criado pela Lei 14.133/2021; <strong>ComprasGov é o sistema
+        operacional</strong> usado pelo governo federal para conduzir
+        pregões e dispensas. Eles têm finalidades diferentes, e empresas
+        precisam de ambos — o primeiro para descobrir oportunidades, o
+        segundo (ou equivalentes estaduais e municipais) para participar.
+      </p>
+
+      <h2>O que é cada um</h2>
+      <h3>PNCP — Portal Nacional de Contratações Públicas</h3>
+      <p>
+        Criado pelo art. 174 da Lei 14.133/2021 e regulamentado pelo
+        Decreto 10.764/2021, o PNCP é o ponto único de divulgação
+        obrigatória de:
+      </p>
+      <ul>
+        <li>Editais de licitação, dispensa e inexigibilidade.</li>
+        <li>Atas de registro de preços.</li>
+        <li>Contratos firmados, aditivos e prorrogações.</li>
+        <li>Notas fiscais e ordens de pagamento (em fase de adoção).</li>
+      </ul>
+      <p>
+        A obrigatoriedade vale para União, estados, Distrito Federal e
+        municípios — toda a administração direta, autárquica e
+        fundacional. Empresas estatais também publicam, embora com regime
+        próprio (Lei 13.303/2016).
+      </p>
+
+      <h3>ComprasGov — Sistema operacional do Executivo Federal</h3>
+      <p>
+        Disponível em <code>compras.gov.br</code>, o ComprasGov é o
+        ambiente onde:
+      </p>
+      <ul>
+        <li>Órgãos federais publicam pregões eletrônicos próprios.</li>
+        <li>
+          Empresas se cadastram, enviam propostas e dão lances em pregões
+          da União.
+        </li>
+        <li>
+          O SICAF (Sistema de Cadastramento Unificado de Fornecedores) é
+          mantido — o cadastro de fornecedores federal.
+        </li>
+      </ul>
+      <p>
+        O ComprasGov é gerido pela Secretaria de Gestão e Inovação (SEGES)
+        do Ministério da Gestão. É o sucessor histórico do
+        ComprasNet/SIASG.
+      </p>
+
+      <h2>Cobertura geográfica e de modalidades</h2>
+      <p>
+        Esta é a confusão mais comum: muita empresa pensa que ComprasGov
+        cobre o país inteiro. Não cobre.
+      </p>
+      <ul>
+        <li>
+          <strong>ComprasGov:</strong> apenas órgãos federais. Cobertura
+          nacional, mas{' '}
+          <em>vertical</em> — ou seja, só União.
+        </li>
+        <li>
+          <strong>PNCP:</strong> todos os entes federativos. Cobertura
+          nacional <em>e horizontal</em> — União, estados, municípios.
+        </li>
+      </ul>
+      <p>
+        Estados e municípios usam plataformas operacionais próprias —{' '}
+        <strong>BLL Compras</strong> (mais comum em Sul e Sudeste),{' '}
+        <strong>Licitanet</strong>, <strong>BNC Compras Públicas</strong>,{' '}
+        <strong>ComprasNet de cada estado</strong>, <strong>Bolsa
+        Brasileira de Mercadorias</strong>, entre outras. Cada uma exige
+        cadastro próprio. Mas todas, sem exceção, publicam no PNCP — o
+        que torna o PNCP o ponto de partida correto para qualquer
+        descoberta de oportunidade.
+      </p>
+
+      <h2>Quando usar cada um na rotina B2G</h2>
+      <p>
+        <strong>Use o PNCP para:</strong>
+      </p>
+      <ul>
+        <li>Descobrir editais novos diariamente.</li>
+        <li>Comparar contratos e preços históricos por CNPJ ou órgão.</li>
+        <li>
+          Investigar concorrentes — quem ganhou, em que valor, em que
+          modalidade.
+        </li>
+        <li>Acessar a {''}
+          <Link href="/blog/pncp-api-integracao-empresas">
+            API pública para automação
+          </Link>
+          .
+        </li>
+      </ul>
+      <p>
+        <strong>Use o ComprasGov (ou plataforma equivalente) para:</strong>
+      </p>
+      <ul>
+        <li>Cadastrar a empresa no SICAF.</li>
+        <li>Enviar proposta em pregões da União.</li>
+        <li>Dar lances na sessão pública.</li>
+        <li>Receber recursos administrativos no sistema.</li>
+      </ul>
+
+      <h2>O cadastro: SICAF vs cadastros estaduais e municipais</h2>
+      <p>
+        Empresas que querem atuar nacionalmente precisam de mais de um
+        cadastro:
+      </p>
+      <ul>
+        <li>
+          <strong>SICAF</strong> — federal, no ComprasGov. Necessário para
+          pregões da União.
+        </li>
+        <li>
+          <strong>Cadastros estaduais/municipais</strong> — varia por
+          ente. Alguns aceitam o SICAF como suficiente; outros exigem
+          cadastro próprio (CRC do TCE, por exemplo).
+        </li>
+        <li>
+          <strong>Plataformas privadas</strong> — BLL, Licitanet, BNC etc.
+          exigem cadastro próprio para participar dos pregões hospedados
+          ali.
+        </li>
+      </ul>
+      <p>
+        Empresas iniciantes erram aqui constantemente — fazem só o SICAF e
+        descobrem na hora do lance que precisariam ter cadastro na BLL,
+        feito com 24h de antecedência.
+      </p>
+
+      <h2>O futuro: convergência com ressalvas</h2>
+      <p>
+        O Decreto 11.462/2023 e a evolução do PNCP sinalizam que, no
+        médio prazo, parte do fluxo operacional pode migrar para o
+        próprio PNCP, que já oferece módulos para dispensa eletrônica em
+        municípios sem plataforma própria. Mas não há prazo para
+        substituir as plataformas privadas, e a tendência é PNCP +
+        ecossistema diversificado de operacionais.
+      </p>
+
+      <BlogInlineCTA
+        slug="pncp-vs-comprasgov-diferencas"
+        campaign="guias"
+        ctaMessage="PNCP unifica ComprasGov, BLL, Licitanet e mais."
+        ctaText="Testar grátis"
+      />
+
+      <h2>Próximos passos no cluster PNCP</h2>
+      <p>
+        Aprofunde com{' '}
+        <Link href="/blog/pncp-api-integracao-empresas">
+          API do PNCP — integração e automação
+        </Link>
+        ,{' '}
+        <Link href="/blog/pncp-modalidade-pregao-eletronico">
+          PNCP e pregão eletrônico
+        </Link>{' '}
+        e o{' '}
+        <Link href="/blog/pncp-guia-completo-empresas">
+          Guia Completo do PNCP
+        </Link>
+        .
+      </p>
+    </>
+  );
+}

--- a/frontend/app/components/BlogArticleLayout.tsx
+++ b/frontend/app/components/BlogArticleLayout.tsx
@@ -114,6 +114,12 @@ export default function BlogArticleLayout({
       '@type': 'WebPage',
       '@id': canonicalUrl,
     },
+    ...(article.pillarSlug && {
+      isPartOf: {
+        '@type': 'Article',
+        '@id': `https://smartlic.tech/blog/${article.pillarSlug}`,
+      },
+    }),
     wordCount: article.wordCount,
     articleSection: article.category,
     inLanguage: 'pt-BR',

--- a/frontend/lib/blog.ts
+++ b/frontend/lib/blog.ts
@@ -23,6 +23,12 @@ export interface BlogArticleMeta {
   relatedSlugs: string[];
   sources?: string[];
   authorSlug?: string;
+  /**
+   * Pillar slug for topic-cluster spokes (issue #992). When set, the article
+   * is rendered as `Article.isPartOf` referencing the pillar — strengthens
+   * topical authority signal.
+   */
+  pillarSlug?: string;
 }
 
 /**
@@ -2203,6 +2209,256 @@ export const BLOG_ARTICLES: BlogArticleMeta[] = [
       'CGU — Controladoria-Geral da União',
     ],
     authorSlug: 'tiago',
+  },
+
+  // ──────────────────────────────────────────────
+  // SEO-P1-005 (#992) — Cluster PNCP — 8 spokes
+  // Pillar: pncp-guia-completo-empresas
+  // ──────────────────────────────────────────────
+
+  // PNCP-SPOKE-01
+  {
+    slug: 'pncp-modalidade-pregao-eletronico',
+    title: 'PNCP e Pregão Eletrônico: como encontrar e participar',
+    description:
+      'Guia prático: como filtrar pregões eletrônicos no PNCP, ler o edital, montar a proposta e enviar lance dentro da Lei 14.133/2021.',
+    category: 'Guias',
+    tags: ['PNCP', 'pregão eletrônico', 'Lei 14.133', 'modalidade'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1100),
+    wordCount: 1100,
+    keywords: [
+      'pncp pregão eletrônico',
+      'pncp licitações',
+      'pregão eletrônico Lei 14.133',
+      'como participar pregão pncp',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'pncp-timeline-publicacao-edital',
+      'pncp-erros-comuns-empresas-iniciantes',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Art. 28-29 (modalidades)',
+      'PNCP — Portal Nacional de Contratações Públicas',
+      'TCU — Acórdão 2.622/2023 (pregão eletrônico)',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-02
+  {
+    slug: 'pncp-timeline-publicacao-edital',
+    title: 'PNCP: prazos e timeline de publicação do edital',
+    description:
+      'Quando um edital aparece no PNCP, qual o prazo até a sessão pública e como antecipar leitura para ganhar vantagem competitiva.',
+    category: 'Guias',
+    tags: ['PNCP', 'prazos', 'timeline', 'publicação edital'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1050),
+    wordCount: 1050,
+    keywords: [
+      'prazo publicação edital pncp',
+      'pncp timeline',
+      'pncp prazos',
+      'quando edital aparece pncp',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'pncp-modalidade-pregao-eletronico',
+      'pncp-erros-comuns-empresas-iniciantes',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Art. 54-55 (prazos mínimos)',
+      'PNCP — Portal Nacional de Contratações Públicas',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-03
+  {
+    slug: 'pncp-vs-comprasgov-diferencas',
+    title: 'PNCP vs ComprasGov: diferenças, sobreposição e qual usar',
+    description:
+      'PNCP centraliza toda compra pública desde 2024; ComprasGov atende apenas o Executivo Federal. Entenda a diferença prática para empresas B2G.',
+    category: 'Guias',
+    tags: ['PNCP', 'ComprasGov', 'comparação', 'portais'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1080),
+    wordCount: 1080,
+    keywords: [
+      'pncp vs comprasgov',
+      'diferença pncp comprasgov',
+      'pncp ou comprasgov',
+      'portal compras governo',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'pncp-api-integracao-empresas',
+      'pncp-modalidade-pregao-eletronico',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Art. 174-176 (PNCP)',
+      'Decreto 10.024/2019 — ComprasGov / Pregão Eletrônico',
+      'PNCP — Portal Nacional de Contratações Públicas',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-04
+  {
+    slug: 'pncp-consulta-contratos-passo-a-passo',
+    title: 'PNCP: consulta de contratos públicos passo a passo',
+    description:
+      'Como buscar contratos por CNPJ, órgão ou objeto no PNCP, exportar dados e usar o histórico para inteligência competitiva B2G.',
+    category: 'Guias',
+    tags: ['PNCP', 'contratos', 'consulta', 'inteligência competitiva'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1100),
+    wordCount: 1100,
+    keywords: [
+      'pncp consulta contratos',
+      'consultar contrato pncp',
+      'pncp histórico contratos',
+      'pncp por cnpj',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'como-consultar-contratos-publicos-pncp',
+      'pncp-api-integracao-empresas',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Art. 87, 174 (publicação contratos)',
+      'PNCP — Portal Nacional de Contratações Públicas',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-05
+  {
+    slug: 'pncp-dispensa-licitacao-quando-aplicar',
+    title: 'PNCP e Dispensa de Licitação (Lei 14.133): quando se aplica',
+    description:
+      'Hipóteses de dispensa do art. 75, valores limite atualizados e como localizar dispensas publicadas no PNCP.',
+    category: 'Guias',
+    tags: ['PNCP', 'dispensa de licitação', 'Lei 14.133', 'art. 75'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1080),
+    wordCount: 1080,
+    keywords: [
+      'pncp dispensa licitação',
+      'dispensa Lei 14.133',
+      'art 75 dispensa',
+      'dispensa eletrônica pncp',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'pncp-modalidade-pregao-eletronico',
+      'pncp-erros-comuns-empresas-iniciantes',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Art. 75 (dispensa)',
+      'TCU — Acórdão 1.927/2023 (dispensa eletrônica)',
+      'PNCP — Portal Nacional de Contratações Públicas',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-06
+  {
+    slug: 'pncp-registro-precos-como-participar',
+    title: 'PNCP e Sistema de Registro de Preços: como participar',
+    description:
+      'O que é Ata de Registro de Preços, como achar SRPs no PNCP e por que esta modalidade é uma das mais previsíveis para empresas B2G.',
+    category: 'Guias',
+    tags: ['PNCP', 'registro de preços', 'ata SRP', 'Lei 14.133'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1100),
+    wordCount: 1100,
+    keywords: [
+      'pncp registro de preços',
+      'ata registro preços pncp',
+      'srp pncp',
+      'sistema registro preços Lei 14.133',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'ata-registro-precos-como-escolher',
+      'ata-registro-precos-estrategia-licitacao',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Art. 82-86 (SRP)',
+      'Decreto 11.462/2023 — SRP federal',
+      'PNCP — Portal Nacional de Contratações Públicas',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-07
+  {
+    slug: 'pncp-api-integracao-empresas',
+    title: 'API do PNCP: como integrar e automatizar busca de editais',
+    description:
+      'Endpoints públicos do PNCP, paginação, rate limit e como uma empresa B2G constrói um pipeline de monitoramento automático.',
+    category: 'Guias',
+    tags: ['PNCP', 'API', 'integração', 'automação'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1150),
+    wordCount: 1150,
+    keywords: [
+      'pncp api',
+      'pncp api editais',
+      'integrar pncp',
+      'automatizar busca editais',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'pncp-vs-comprasgov-diferencas',
+      'pncp-consulta-contratos-passo-a-passo',
+    ],
+    sources: [
+      'PNCP — API de Consulta v1 (pncp.gov.br/api/consulta)',
+      'Lei 14.133/2021 — Art. 174-176',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
+  },
+
+  // PNCP-SPOKE-08
+  {
+    slug: 'pncp-erros-comuns-empresas-iniciantes',
+    title: 'PNCP: 7 erros que empresas iniciantes cometem (e como evitar)',
+    description:
+      'Filtros mal configurados, prazos perdidos e leitura superficial do edital — os tropeços mais frequentes de quem entra agora no PNCP.',
+    category: 'Guias',
+    tags: ['PNCP', 'iniciantes', 'erros comuns', 'B2G'],
+    publishDate: '2026-05-10',
+    readingTime: calculateReadingTime(1050),
+    wordCount: 1050,
+    keywords: [
+      'pncp erros',
+      'erros licitação iniciantes',
+      'pncp empresa iniciante',
+      'como começar pncp',
+    ],
+    relatedSlugs: [
+      'pncp-guia-completo-empresas',
+      'empresa-iniciante-ganhar-contratos-governo',
+      'pncp-timeline-publicacao-edital',
+    ],
+    sources: [
+      'Lei 14.133/2021 — Lei Geral de Licitações',
+      'PNCP — Portal Nacional de Contratações Públicas',
+      'TCU — Manual de Boas Práticas em Licitações',
+    ],
+    authorSlug: 'tiago',
+    pillarSlug: 'pncp-guia-completo-empresas',
   },
 ];
 


### PR DESCRIPTION
## Summary

- Constrói **topic cluster do PNCP** ao redor do pillar canônico `pncp-guia-completo-empresas` (já no portal, pos 6,55) com **8 novos spokes** derivados das queries 0-click do GSC 28d.
- Cada spoke: 1.050-1.150 palavras, JSON-LD `FAQPage` com 4 questões, link inbound explícito ao pillar ("Este guia faz parte do Guia Completo do PNCP"), 2-3 links a spokes irmãos.
- Pillar ganha seção `"Aprenda mais sobre PNCP"` com 8 link cards descritivos — atende ao smoke-test AC `grep -c "/blog/pncp-" pillar ≥ 8` (resultado real: 8).
- Schema `Article.isPartOf` injetado via novo campo opcional `BlogArticleMeta.pillarSlug` (não-disruptivo aos 30+ artigos existentes — só preenche o campo quando definido).

## Context

Issue #992 — epic #986. Pillar `/blog/pncp-guia-completo-empresas` está em pos 6,55 (2.856 impressões) mas 6 URLs concorrem entre si para queries head-term ("pncp", "pncp licitações", "pncp contratos") com **>100 impressões em 0 cliques**. Topic cluster consolida sinal de tópica (Involve Digital 2026: 73% sites com clusters em top 10 vs 42% sem). Meta: pos 6,55 → top 3 em 60-90d para head-term "pncp".

**Spokes (Phase 1, 1-8 do issue):**

1. `pncp-modalidade-pregao-eletronico`
2. `pncp-timeline-publicacao-edital`
3. `pncp-vs-comprasgov-diferencas`
4. `pncp-consulta-contratos-passo-a-passo`
5. `pncp-dispensa-licitacao-quando-aplicar`
6. `pncp-registro-precos-como-participar`
7. `pncp-api-integracao-empresas`
8. `pncp-erros-comuns-empresas-iniciantes`

Spokes 9-12 ficam para Phase 2 (issue: "9-12 são fase 2 se 1-8 mostrar lift em 28d").

**Constraints respeitadas:**

- Não toca em `lib/blog.ts` entries shipped via #1015 (10 titles); só adiciona 8 novos.
- Não toca em PSEO routes (#1004), author byline (#1027) ou RelatedArticles (#1026).
- Cada spoke tem `pillarSlug` setado para emitir `Article.isPartOf` no JSON-LD do `BlogArticleLayout`.
- Smoke test AC do issue: `grep -c "/blog/pncp-" pillar ≥ 8` ✅
- Skip Next 16 build (WSL OOM, conforme memory).

## Testing Plan

- [x] **`__tests__/blog-pncp-cluster.test.tsx`** — 67 testes novos, 100% green:
  - 8 spokes registrados em `BLOG_ARTICLES` com `pillarSlug` correto
  - cada spoke: wordCount ≥ 800, ≥3 relatedSlugs, FAQ JSON-LD com ≥3 questões
  - pillar source contém ≥8 outbound `/blog/pncp-` links + link específico para cada spoke
  - cada spoke renderiza sem erro
  - cada spoke linka pillar inline (≥2 ocorrências)
- [x] **`__tests__/blog-infrastructure.test.tsx`** — 48 testes existentes, 100% green (incluindo `all relatedSlugs reference existing articles`)
- [x] **`__tests__/blog/internal-links.test.ts`** — green (todas refs internas resolvem)
- [ ] CI: backend tests, frontend tests, lint, e2e (a rodar)
- [ ] GSC dashboard 28d/90d pós-merge para validar lift em "pncp", "pncp licitações", "pncp contratos"

## Closes

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)