### PR TITLE
fix(supabase): clear _consecutive_failures on CB reset (#1013)

### DIFF
--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -459,6 +459,7 @@ class SupabaseCircuitBreaker:
             self._window.clear()
             self._trial_successes = 0
             self._opened_at = None
+            self._consecutive_failures = 0
 
 
 def _is_schema_error(exc: Exception) -> bool:

--- a/backend/tests/test_supabase_circuit_breaker.py
+++ b/backend/tests/test_supabase_circuit_breaker.py
@@ -177,6 +177,23 @@ class TestCircuitBreakerStateTransitions:
         assert cb._trial_successes == 0
         assert cb._opened_at is None
 
+    def test_reset_clears_consecutive_failures(self):
+        """Issue #1013: reset() must also clear the STORY-416 consecutive_failures streak.
+
+        STORY-416 introduced the segregated CB with a hybrid AND/OR trip that tracks
+        ``_consecutive_failures``, but the original ``reset()`` only cleaned the rolling
+        window / trial successes / opened_at. As a result, callers (including the
+        admin ``POST /admin/cb/reset`` endpoint and tests like BTS-012) silently kept
+        a non-zero streak after a "reset" — making subsequent failures trip the CB
+        sooner than expected. Guard against regression.
+        """
+        cb = self._make_cb(window_size=10, failure_rate_threshold=0.5)
+        cb._consecutive_failures = 5
+
+        cb.reset()
+
+        assert cb._consecutive_failures == 0
+
 
 class TestCircuitBreakerCallSync:
     """Test call_sync() wrapper behavior."""


### PR DESCRIPTION
## Summary / Context
`SupabaseCircuitBreaker.reset()` resets state, window, trial successes and opened_at, but missed `_consecutive_failures` (added in STORY-416 segregated CB). This caused subtle test flakes (BTS-012 PR #981 worked around defensively) and incorrect admin reset behavior.

## Changes
- `backend/supabase_client.py`: add `self._consecutive_failures = 0` inside `reset()` lock block
- Unit test asserts streak cleared on reset()

## Testing Plan
- [x] New unit test passes locally: `pytest -k circuit_breaker and reset`
- [x] Existing CB tests still green (68/68 in test_supabase_circuit_breaker.py + test_story416_segregated_circuit_breakers.py)
- [ ] CI green

## Closes
Closes #1013