### PR TITLE
feat(backend): apply_seo_empty_response utility (#1036)

### DIFF
--- a/backend/routes/observatorio.py
+++ b/backend/routes/observatorio.py
@@ -127,6 +127,11 @@ class RelatorioMensal(BaseModel):
     # STORY-431 AC11: marker for historical empty months (no data ingested in window).
     # Frontend uses this to render EmptyStatePeriod CTA instead of "R$ 0,00" cards.
     is_empty_period: bool = False
+    # Issue #1036: SEO empty-period fields set by apply_seo_empty_response.
+    # Without these declarations Pydantic v2 silently drops them on model
+    # construction, so the frontend never receives them.
+    period_label: Optional[str] = None
+    coverage_window: Optional[dict] = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routes/observatorio.py
+++ b/backend/routes/observatorio.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel
 from metrics import OBSERVATORIO_BUDGET_EXCEEDED
 from pipeline.budget import _run_with_budget
 from utils.postgrest_paginate import paginate_full
+from utils.seo_response import apply_seo_empty_response
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["observatorio"])
@@ -179,11 +180,23 @@ def _apply_empty_period_response(
         )
 
     # behavior in {"noindex", "auto"+historical} → 200 + is_empty_period + noindex
-    # Mark the payload as an empty period so the frontend renders the
-    # EmptyStatePeriod CTA rather than the misleading "R$ 0,00" cards.
-    if response is not None:
-        response.headers["X-Robots-Tag"] = "noindex"
-    payload = {**data, "is_empty_period": True}
+    # Issue #1036: delegate header + payload mark to the central
+    # `apply_seo_empty_response` helper so all programmatic SEO routes share
+    # the same shape (also adds X-Coverage-Status:empty for sitemap-gating).
+    period_label = f"{MONTH_NAMES_PT.get(mes, str(mes))}/{ano}"
+    try:
+        _, last_day = calendar.monthrange(ano, mes)
+        coverage_window = (date(ano, mes, 1), date(ano, mes, last_day))
+    except (ValueError, calendar.IllegalMonthError):
+        coverage_window = None
+    payload = apply_seo_empty_response(
+        {**data},
+        is_empty=True,
+        is_historical=is_historical,
+        period_label=period_label,
+        coverage_window=coverage_window,
+        response=response,
+    )
     return RelatorioMensal(**payload)
 
 

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -11140,6 +11140,18 @@
             "title": "Ano",
             "type": "integer"
           },
+          "coverage_window": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Coverage Window"
+          },
           "fonte": {
             "title": "Fonte",
             "type": "string"
@@ -11171,6 +11183,17 @@
             },
             "title": "Modalidades",
             "type": "array"
+          },
+          "period_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Period Label"
           },
           "periodo": {
             "title": "Periodo",

--- a/backend/tests/test_seo_response.py
+++ b/backend/tests/test_seo_response.py
@@ -1,0 +1,158 @@
+"""Tests for `backend/utils/seo_response.apply_seo_empty_response` (Issue #1036).
+
+Covers the four documented branches:
+
+1. empty + historical → 200 mark + ``X-Robots-Tag``/``X-Coverage-Status`` set
+2. empty + current    → same shape (NEVER 404 for a transient gap)
+3. non-empty           → payload passthrough + ``X-Coverage-Status: full``
+4. response=None       → payload mutated, no header side effects
+"""
+
+from datetime import date
+
+import pytest
+from fastapi import Response
+
+from utils.seo_response import apply_seo_empty_response
+
+
+def _make_response() -> Response:
+    """Fresh `fastapi.Response` for each test (headers are mutable)."""
+    return Response()
+
+
+class TestApplySeoEmptyResponse:
+    def test_empty_historical_marks_payload_and_sets_headers(self):
+        response = _make_response()
+        payload: dict = {"total_editais": 0, "valor_total": 0.0}
+
+        result = apply_seo_empty_response(
+            payload,
+            is_empty=True,
+            is_historical=True,
+            period_label="abril/2026",
+            coverage_window=(date(2026, 4, 1), date(2026, 4, 30)),
+            response=response,
+        )
+
+        # Payload mutated in-place.
+        assert result is payload
+        assert result["is_empty_period"] is True
+        assert result["period_label"] == "abril/2026"
+        assert result["coverage_window"] == {
+            "start": "2026-04-01",
+            "end": "2026-04-30",
+        }
+        # Headers reflect noindex + sitemap-gating signal.
+        assert "noindex" in response.headers["X-Robots-Tag"]
+        assert "follow" in response.headers["X-Robots-Tag"]
+        assert response.headers["X-Coverage-Status"] == "empty"
+
+    def test_empty_current_period_never_404s(self):
+        """Programmatic SEO routes never 404 on a transient data gap.
+
+        The helper applies the same noindex+is_empty_period shape regardless
+        of whether the period is current or historical; the route layer
+        (e.g. observatorio's behavior toggle) decides if it ALSO 404s.
+        """
+        response = _make_response()
+        payload = {"total_editais": 0}
+
+        result = apply_seo_empty_response(
+            payload,
+            is_empty=True,
+            is_historical=False,  # current month
+            period_label="maio/2026",
+            response=response,
+        )
+
+        assert result["is_empty_period"] is True
+        assert result["period_label"] == "maio/2026"
+        # No coverage_window provided → key absent (caller didn't supply it).
+        assert "coverage_window" not in result
+        assert "noindex" in response.headers["X-Robots-Tag"]
+        assert response.headers["X-Coverage-Status"] == "empty"
+
+    def test_non_empty_passthrough_sets_full_coverage(self):
+        response = _make_response()
+        payload = {"total_editais": 42, "valor_total": 1234.56}
+
+        result = apply_seo_empty_response(
+            payload,
+            is_empty=False,
+            is_historical=False,
+            period_label="abril/2026",
+            response=response,
+        )
+
+        # Payload unchanged.
+        assert result == {"total_editais": 42, "valor_total": 1234.56}
+        assert "is_empty_period" not in result
+        assert "period_label" not in result
+        # No noindex header on a healthy page.
+        assert "X-Robots-Tag" not in response.headers
+        assert response.headers["X-Coverage-Status"] == "full"
+
+    def test_no_response_object_only_mutates_payload(self):
+        """When ``response`` is None, headers cannot be set — verify no
+        AttributeError, payload is still marked correctly."""
+        payload = {"total_editais": 0}
+
+        result = apply_seo_empty_response(
+            payload,
+            is_empty=True,
+            is_historical=True,
+            period_label="abril/2026",
+            response=None,
+        )
+
+        assert result["is_empty_period"] is True
+        assert result["period_label"] == "abril/2026"
+
+    def test_caller_default_false_is_force_overridden(self):
+        """``is_empty_period`` is force-set when ``is_empty=True``.
+
+        Important for observatorio.py: ``_generate_relatorio`` returns a
+        payload with ``is_empty_period: False`` (Pydantic default); the
+        helper must override it, not honor the upstream default.
+        Other annotation keys (``period_label``) honor caller pre-population
+        via ``setdefault``.
+        """
+        response = _make_response()
+        payload = {
+            "total_editais": 0,
+            "is_empty_period": False,  # Pydantic default leaked in
+            "period_label": "custom-label",
+        }
+
+        result = apply_seo_empty_response(
+            payload,
+            is_empty=True,
+            is_historical=True,
+            period_label="should-be-ignored",
+            response=response,
+        )
+
+        assert result["is_empty_period"] is True
+        assert result["period_label"] == "custom-label"
+        assert response.headers["X-Coverage-Status"] == "empty"
+
+
+@pytest.mark.parametrize("is_historical", [True, False])
+def test_empty_branches_share_response_shape(is_historical: bool):
+    """Smoke test: empty payload always renders is_empty_period regardless
+    of historical vs current — the 404 routing decision lives at the route
+    layer, not in this helper."""
+    response = _make_response()
+    payload = {"total_editais": 0}
+
+    result = apply_seo_empty_response(
+        payload,
+        is_empty=True,
+        is_historical=is_historical,
+        period_label="qualquer/2026",
+        response=response,
+    )
+
+    assert result["is_empty_period"] is True
+    assert response.headers["X-Coverage-Status"] == "empty"

--- a/backend/utils/seo_response.py
+++ b/backend/utils/seo_response.py
@@ -1,0 +1,96 @@
+"""Centralized empty-period response helper for programmatic SEO routes.
+
+Issue #1036 — extracted from `routes/observatorio.py::_apply_empty_period_response`
+so all SEO public endpoints (`*_publicos.py`, `observatorio.py`, `blog_stats.py`,
+`dados_publicos.py`, etc.) can render the same shape on a data gap rather than
+404'ing (which Search Console flags as a Soft 404 / data-quality signal).
+
+Pattern:
+- empty + historical → 200 + ``is_empty_period:true`` + ``X-Robots-Tag: noindex``
+- empty + current    → same (NEVER 404 for a transient data gap)
+- non-empty          → returns payload unchanged (caller renders normally)
+
+Headers (when ``response`` provided):
+- ``X-Robots-Tag: noindex, follow`` whenever the period is empty.
+- ``X-Coverage-Status: full | empty`` for downstream sitemap-gating (#1039).
+
+The route-level decision of whether to ALSO 404 (for current month, anti-Soft-404)
+is intentionally out of scope here: callers that need that branch should still
+implement it inline (see ``observatorio.py``). This helper covers the
+"render the empty payload + correctly tag headers" branch only.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional, Tuple
+
+from fastapi import Response
+
+
+def apply_seo_empty_response(
+    payload: dict,
+    *,
+    is_empty: bool,
+    is_historical: bool,
+    period_label: str,
+    coverage_window: Optional[Tuple[date, date]] = None,
+    response: Optional[Response] = None,
+) -> dict:
+    """Mark ``payload`` as an empty-period response and set SEO headers.
+
+    Args:
+        payload: The base response dict the route would otherwise return.
+            Mutated in-place (and returned) when ``is_empty`` is True.
+        is_empty: True when the underlying query returned zero rows.
+        is_historical: True when the requested period has fully elapsed.
+            Currently informational (does NOT 404 — programmatic SEO routes
+            never 404 on a data gap). Reserved for future tag differentiation.
+        period_label: Human-readable label for the period
+            (e.g. ``"abril/2026"``, ``"semana 18 de 2026"``). Stored under
+            ``payload["period_label"]`` for frontend rendering.
+        coverage_window: Optional ``(start, end)`` tuple describing the
+            window the route attempted to cover. Stored under
+            ``payload["coverage_window"]`` as ISO-format strings.
+        response: FastAPI ``Response`` to mutate with cache-control / robots
+            headers. When ``None``, only the payload is mutated.
+
+    Returns:
+        The same ``payload`` dict. When ``is_empty`` is False the dict is
+        unchanged; when True it gains ``is_empty_period``, ``period_label``
+        and (optionally) ``coverage_window`` keys (only set if absent —
+        callers can pre-populate them).
+    """
+    # Reserved for future header differentiation between current vs historical
+    # empty periods (e.g. tighter cache TTL on current). Currently both
+    # paths share the same response shape, so the parameter is accepted but
+    # not yet branched on.
+    _ = is_historical
+
+    if not is_empty:
+        if response is not None:
+            response.headers["X-Coverage-Status"] = "full"
+        return payload
+
+    # Always force ``is_empty_period`` True when the caller declared the
+    # period empty — this overrides any default-False that may have leaked in
+    # from a Pydantic-shaped payload upstream (e.g. observatorio's
+    # `_generate_relatorio` returns `is_empty_period: False` by default).
+    payload["is_empty_period"] = True
+    payload.setdefault("period_label", period_label)
+    if coverage_window is not None:
+        payload.setdefault(
+            "coverage_window",
+            {
+                "start": coverage_window[0].isoformat(),
+                "end": coverage_window[1].isoformat(),
+            },
+        )
+
+    if response is not None:
+        # ``follow`` lets crawlers traverse links back to the hub even on
+        # noindex'd empty leaves — improves crawl budget reuse.
+        response.headers["X-Robots-Tag"] = "noindex, follow"
+        response.headers["X-Coverage-Status"] = "empty"
+
+    return payload

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -10203,6 +10203,10 @@ export interface components {
         RelatorioMensal: {
             /** Ano */
             ano: number;
+            /** Coverage Window */
+            coverage_window?: {
+                [key: string]: unknown;
+            } | null;
             /** Fonte */
             fonte: string;
             /** Gerado Em */
@@ -10220,6 +10224,8 @@ export interface components {
             mes_nome: string;
             /** Modalidades */
             modalidades: components["schemas"]["routes__observatorio__ModalidadeCount"][];
+            /** Period Label */
+            period_label?: string | null;
             /** Periodo */
             periodo: string;
             /** Setores Em Alta */


### PR DESCRIPTION
## Summary / Context

Extracts `_apply_empty_period_response` from `routes/observatorio.py` into a central `backend/utils/seo_response.py` helper. Programmatic SEO routes never 404 on a transient data gap — they return 200 + `is_empty_period:true` + `X-Robots-Tag:noindex, follow` + new `X-Coverage-Status` header (`full | empty`).

This unblocks #1039 (sitemap-gate via `X-Coverage-Status`) and prevents recidiva of the SEN-FE-001 / observatorio 404 incident across all 18 `*_publicos.py` SEO routers.

## Changes

- **New:** `backend/utils/seo_response.py` — `apply_seo_empty_response(payload, *, is_empty, is_historical, period_label, coverage_window, response)`
- **Refactor:** `backend/routes/observatorio.py` — the empty+200 branch now delegates to the helper. The 404 (current empty) and `render` (test override) branches are preserved exactly — the `OBSERVATORIO_EMPTY_PERIOD_BEHAVIOR` toggle still drives routing.
- **Tests:** `backend/tests/test_seo_response.py` — 7 tests covering 4 documented branches + caller-precedence semantics.

### Header behavior change (additive, backward-compatible)

| Header | Before | After |
|---|---|---|
| `X-Robots-Tag` (empty) | `noindex` | `noindex, follow` |
| `X-Coverage-Status` | (absent) | `full` (non-empty) / `empty` (empty) |

Existing observatorio tests assert `"noindex" in resp.headers["X-Robots-Tag"]` so the new value is compatible. `follow` improves crawl-budget reuse for empty leaves linking back to non-empty hubs.

## Deferred (follow-up — out of scope for this PR)

- **AC4** Route-by-route sweep across `*_publicos.py` and `dados_publicos.py`/`blog_stats.py` — each route has its own empty/malformed-catalog distinction; deferred to avoid regression risk.
- **AC5** OpenAPI schema models with `is_empty_period` + `coverage_window` fields on response models.
- **AC6** Regen `frontend/app/api-types.generated.ts` (will follow once AC5 lands).

## Testing Plan

- [x] `pytest tests/test_seo_response.py` — 7/7 green
- [x] `pytest tests/test_observatorio.py` — 14/14 green (no regression)
- [ ] CI green (backend-tests + audit-execute-without-budget)
- [ ] Post-merge spot check: `curl -I https://api.smartlic.tech/v1/observatorio/relatorio/3/2026 | grep -E "X-(Robots|Coverage)"` returns the new headers

## Closes

Closes #1036