### PR TITLE
feat(perf): blog next/image migration for LCP (#994)

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -152,6 +152,9 @@ export default function RootLayout({
         {/* SEO: Preconnect to critical origins for faster TTFB */}
         <link rel="preconnect" href="https://fqqyovlzdzimiwfofdjk.supabase.co" />
         <link rel="dns-prefetch" href="https://fqqyovlzdzimiwfofdjk.supabase.co" />
+        {/* Issue #994: Preconnect to backend API to shave LCP on first data fetch */}
+        <link rel="preconnect" href="https://api.smartlic.tech" />
+        <link rel="dns-prefetch" href="https://api.smartlic.tech" />
         {/* SEO-FIX: nonce removed — CSP allows this via SHA-256 hash (see middleware.ts) */}
         <script
           dangerouslySetInnerHTML={{

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -25,6 +25,11 @@ const nextConfig = {
     return `build-${Date.now()}-${Math.random().toString(36).substring(7)}`;
   },
   images: {
+    // Issue #994: Pin modern formats (AVIF first, WebP fallback) for next/image
+    // optimization on blog hero, author avatars, and any future imagery. Next.js
+    // 16 default already includes both, but pinning makes intent explicit and
+    // survives upstream default changes.
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## Summary / Context

Issue #994 audit asked to migrate blog hero + author avatars to `next/image` so that LCP gets AVIF/WebP, responsive `sizes`, and native lazy. Discovery on the actual blog templates returned **zero `<img>` elements** to migrate:

- `frontend/app/blog/[slug]/page.tsx` + `frontend/app/components/BlogArticleLayout.tsx` — header is text + structured data, no hero `<img>`.
- `frontend/app/blog/BlogListClient.tsx`, `frontend/app/blog/components/BlogInlineCTA.tsx`, `frontend/components/blog/BlogCTA.tsx`, `frontend/app/blog/weekly/[slug]/page.tsx` — no `<img>`.
- `frontend/app/blog/author/[slug]/page.tsx` — author "avatar" is currently rendered as initial letters inside a styled div; the `image` field on the author record is consumed only by JSON-LD / OG, not as a visual `<img>`.
- The single `<img>` in the entire frontend (`/estatisticas/embed/page.tsx`) is HTML-in-string for users to copy as an embed snippet — not a render.

Per the prompt's contingency ("If discovery shows blog already uses next/image and has no remaining `<img>`, scope shrinks to next.config + preconnect only"), this PR ships the two LCP levers that still apply with no `<img>` to migrate.

## Changes

- `frontend/next.config.js`: pin `images.formats: ['image/avif', 'image/webp']`. Next.js 16 default already includes both, but pinning makes the intent explicit and survives upstream default changes.
- `frontend/app/layout.tsx`: add `<link rel="preconnect" href="https://api.smartlic.tech">` + `<link rel="dns-prefetch">` alongside the existing Supabase preconnect, shaving TLS+DNS off the first backend fetch on cold loads.

## Out of scope (deferred / separate issues)

- Lighthouse CI gate — SEO-P2-012.
- Perf baseline doc `docs/seo/perf-baseline-2026-05.md`.
- Migration of non-blog routes (e.g. `/fornecedores`, `/perguntas`) — separate scope.
- Rendering an actual author avatar `<Image>` (currently initials in a div) — feature work, not migration.
- Third-party script strategy: GA `afterInteractive` + Clarity LGPD-gated lazy are already current strategy; left untouched per "do NOT change if already set".

## Testing Plan

- [x] `tsc --noEmit` clean for the two edited files (env-level errors about missing `@types/node` / Sentry types in pre-existing files are worktree noise — CI installs deps).
- [ ] CI build green (Next.js 16 will validate `images.formats` shape).
- [ ] Post-merge Lighthouse: 5 sample blog URLs, target LCP <2.5s p75 mobile.
- [ ] CrUX 28d post-deploy.
- [ ] Network tab on first cold load shows `api.smartlic.tech` warm-up before first backend fetch.

## Closes

Closes #994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized backend API connectivity with preconnect and DNS prefetching to improve response times
  * Enhanced image delivery with support for AVIF and WebP formats for faster loading and better compression

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1047)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->