### PR TITLE
feat(seo): /perguntas QAPage→Article+BreadcrumbList+HowTo (#991)

### DIFF
--- a/.github/workflows/audit-godmodule-loc.yml
+++ b/.github/workflows/audit-godmodule-loc.yml
@@ -164,8 +164,12 @@ jobs:
 
           FAILURES_JSON=$(printf '%s\n' "${FAILURES[@]+"${FAILURES[@]}"}" | jq -Rs 'split("\n") | map(select(length > 0))')
           WARNINGS_JSON=$(printf '%s\n' "${WARNINGS[@]+"${WARNINGS[@]}"}" | jq -Rs 'split("\n") | map(select(length > 0))')
-          echo "failures_json=${FAILURES_JSON}" >> "$GITHUB_OUTPUT"
-          echo "warnings_json=${WARNINGS_JSON}" >> "$GITHUB_OUTPUT"
+          echo "failures_json<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${FAILURES_JSON}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "warnings_json<<EOF" >> "$GITHUB_OUTPUT"
+          echo "${WARNINGS_JSON}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Post / update PR comment
         if: github.event_name == 'pull_request'

--- a/frontend/__tests__/perguntas-jsonld.test.ts
+++ b/frontend/__tests__/perguntas-jsonld.test.ts
@@ -86,7 +86,7 @@ describe('buildHowToLd', () => {
     expect(ld.inLanguage).toBe('pt-BR');
     expect(ld.mainEntityOfPage['@id']).toContain('/perguntas/como-calcular-preco-proposta-licitacao');
     expect(Array.isArray(ld.step)).toBe(true);
-    expect(ld.step.length).toBeGreaterThanOrEqual(3);
+    expect(ld.step.length).toBe(8);
     ld.step.forEach((step, i) => {
       expect(step['@type']).toBe('HowToStep');
       expect(step.position).toBe(i + 1);
@@ -135,10 +135,11 @@ describe('HowTo conditional emission (sample slugs)', () => {
     expect(question).toBeDefined();
     expect(isHowToEligible(slug)).toBe(true);
     const steps = extractHowToSteps(question!.answer);
-    // This particular question is procedural and has a "Passo a passo:" block,
-    // so we expect ≥3 steps to be extractable.
+    // This particular question is procedural and has a "Passo a passo:" block
+    // with exactly 8 procedure steps — extraction must be scoped to that block
+    // only (not mixing the 7-item "Estrutura básica" cost-categories list).
     expect(steps).not.toBeNull();
-    expect(steps!.length).toBeGreaterThanOrEqual(3);
+    expect(steps!.length).toBe(8);
   });
 
   it('does NOT emit HowTo for definitional "qualificacao-*" slug', () => {

--- a/frontend/__tests__/perguntas-jsonld.test.ts
+++ b/frontend/__tests__/perguntas-jsonld.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #991 — JSON-LD schema migration for /perguntas/[slug].
+ *
+ * Google deprecated FAQ rich results in May/2026 for non-gov/health sites,
+ * so QAPage-only emission no longer surfaces in SERP. We migrate to
+ * Article + BreadcrumbList (always) + HowTo (when slug starts with "como-"
+ * or contains "passo-a-passo"), keeping QAPage as secondary for AI
+ * Overviews ingestion.
+ *
+ * These tests exercise the pure JSON-LD builders directly — they assert
+ * shape/contract, not React rendering, so they stay fast and deterministic
+ * across our 53 question pages.
+ */
+
+import {
+  buildPersonAuthorLd,
+  buildArticleLd,
+  buildBreadcrumbLd,
+  buildQaPageLd,
+  buildHowToLd,
+  isHowToEligible,
+  extractHowToSteps,
+} from '@/app/perguntas/[slug]/json-ld';
+import { getQuestionBySlug } from '@/lib/questions';
+
+const PUBLISHED_AT = '2025-09-01';
+const UPDATED_AT = '2026-05-10';
+
+describe('isHowToEligible', () => {
+  it('returns true for slugs starting with "como-"', () => {
+    expect(isHowToEligible('como-calcular-preco-proposta-licitacao')).toBe(true);
+  });
+
+  it('returns true for slugs containing "passo-a-passo"', () => {
+    expect(isHowToEligible('concorrencia-eletronica-passo-a-passo')).toBe(true);
+  });
+
+  it('returns false for definitional slugs', () => {
+    expect(isHowToEligible('qualificacao-tecnica-lei-14133')).toBe(false);
+    expect(isHowToEligible('prazo-publicacao-edital')).toBe(false);
+  });
+});
+
+describe('extractHowToSteps', () => {
+  it('extracts bold-numbered headings (**1. Title:**) into ordered steps', () => {
+    const answer =
+      '**1. Identificação:**\nMonitore o PNCP.\n\n' +
+      '**2. Análise:**\nLeia o edital.\n\n' +
+      '**3. Documentação:**\nReuna os documentos.\n\n' +
+      '**4. Proposta:**\nFormule a proposta.';
+    const steps = extractHowToSteps(answer);
+    expect(steps).not.toBeNull();
+    expect(steps).toHaveLength(4);
+    expect(steps![0].name).toBe('Identificação');
+    expect(steps![0].text).toContain('PNCP');
+  });
+
+  it('returns null when fewer than 3 numbered steps are detectable', () => {
+    expect(extractHowToSteps('Texto puro sem estrutura.')).toBeNull();
+    expect(extractHowToSteps('**1. Apenas um:**\nUm passo só.')).toBeNull();
+  });
+
+  it('strips markdown bold markers from extracted step text', () => {
+    const answer =
+      '**1. Primeiro:**\nUse o **PNCP** para buscar.\n\n' +
+      '**2. Segundo:**\nLeia o **edital** com atenção.\n\n' +
+      '**3. Terceiro:**\nEnvie a **proposta**.';
+    const steps = extractHowToSteps(answer);
+    expect(steps).not.toBeNull();
+    expect(steps![0].text).not.toContain('**');
+    expect(steps![1].text).not.toContain('**');
+  });
+});
+
+describe('buildHowToLd', () => {
+  it('emits a valid HowTo schema with positioned steps and pt-BR locale', () => {
+    const question = getQuestionBySlug('como-calcular-preco-proposta-licitacao');
+    expect(question).toBeDefined();
+    const steps = extractHowToSteps(question!.answer);
+    expect(steps).not.toBeNull();
+
+    const ld = buildHowToLd(question!, question!.slug, steps!);
+    expect(ld['@context']).toBe('https://schema.org');
+    expect(ld['@type']).toBe('HowTo');
+    expect(ld.name).toBe(question!.title);
+    expect(ld.inLanguage).toBe('pt-BR');
+    expect(ld.mainEntityOfPage['@id']).toContain('/perguntas/como-calcular-preco-proposta-licitacao');
+    expect(Array.isArray(ld.step)).toBe(true);
+    expect(ld.step.length).toBeGreaterThanOrEqual(3);
+    ld.step.forEach((step, i) => {
+      expect(step['@type']).toBe('HowToStep');
+      expect(step.position).toBe(i + 1);
+      expect(typeof step.name).toBe('string');
+      expect(typeof step.text).toBe('string');
+    });
+  });
+});
+
+describe('Article + BreadcrumbList always-present (sample slugs)', () => {
+  const orgAuthor = buildPersonAuthorLd(undefined);
+
+  it.each([
+    'como-calcular-preco-proposta-licitacao',
+    'qualificacao-tecnica-lei-14133',
+    'prazo-publicacao-edital',
+  ])('emits Article + BreadcrumbList + QAPage for "%s"', (slug) => {
+    const question = getQuestionBySlug(slug);
+    expect(question).toBeDefined();
+
+    const articleLd = buildArticleLd(question!, slug, orgAuthor, PUBLISHED_AT, UPDATED_AT);
+    expect(articleLd['@type']).toBe('Article');
+    expect(articleLd.headline).toBe(question!.title);
+    expect(articleLd.author).toBeDefined();
+    expect(articleLd.publisher).toBeDefined();
+    expect(articleLd.datePublished).toBe(PUBLISHED_AT);
+    expect(articleLd.dateModified).toBe(UPDATED_AT);
+    expect(articleLd.inLanguage).toBe('pt-BR');
+
+    const breadcrumbLd = buildBreadcrumbLd(question!, slug);
+    expect(breadcrumbLd['@type']).toBe('BreadcrumbList');
+    expect(breadcrumbLd.itemListElement).toHaveLength(3);
+    expect(breadcrumbLd.itemListElement[2].item).toContain(`/perguntas/${slug}`);
+
+    // QAPage retained as secondary for AI Overviews (regression check).
+    const qaLd = buildQaPageLd(question!, 'plain', orgAuthor);
+    expect(qaLd['@type']).toBe('QAPage');
+    expect(qaLd.mainEntity['@type']).toBe('Question');
+  });
+});
+
+describe('HowTo conditional emission (sample slugs)', () => {
+  it('emits HowTo for "como-*" slug with extractable steps', () => {
+    const slug = 'como-calcular-preco-proposta-licitacao';
+    const question = getQuestionBySlug(slug);
+    expect(question).toBeDefined();
+    expect(isHowToEligible(slug)).toBe(true);
+    const steps = extractHowToSteps(question!.answer);
+    // This particular question is procedural and has a "Passo a passo:" block,
+    // so we expect ≥3 steps to be extractable.
+    expect(steps).not.toBeNull();
+    expect(steps!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does NOT emit HowTo for definitional "qualificacao-*" slug', () => {
+    const slug = 'qualificacao-tecnica-lei-14133';
+    expect(isHowToEligible(slug)).toBe(false);
+  });
+
+  it('does NOT emit HowTo for "prazo-*" slug', () => {
+    const slug = 'prazo-publicacao-edital';
+    expect(isHowToEligible(slug)).toBe(false);
+  });
+});

--- a/frontend/app/perguntas/[slug]/json-ld.ts
+++ b/frontend/app/perguntas/[slug]/json-ld.ts
@@ -106,3 +106,102 @@ export function buildFaqPageLd(relatedQuestions: Question[]) {
     })),
   };
 }
+
+/* ------------------------------------------------------------------ */
+/*  HowTo (#991) — replaces deprecated FAQ rich result for "como-*"   */
+/*                 and "*passo-a-passo*" question slugs.              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Heuristic eligibility: only emit HowTo for procedural questions where
+ * Google's HowTo rich result still pays off (gov/public-procurement).
+ * Avoids fabricating steps for definitional questions.
+ */
+export function isHowToEligible(slug: string): boolean {
+  return slug.startsWith('como-') || slug.includes('passo-a-passo');
+}
+
+/**
+ * Extract ordered procedure steps from question.answer.
+ *
+ * Recognises two markdown patterns used in `lib/questions.ts`:
+ *  - `**N. Title:**\nDescription`         (bold-numbered headings)
+ *  - `N. Title — description`             (plain numbered list)
+ *
+ * Steps are returned in source order. Each step is plain text (markdown
+ * stripped) so schema.org consumers (Google rich results, AI overviews)
+ * never see `**bold**` markers.
+ *
+ * Returns `null` when fewer than 3 steps can be extracted — below that,
+ * the heuristic is unreliable and we'd fabricate structure that doesn't
+ * exist in the source content. Caller should skip HowTo emission in that
+ * case (Article + BreadcrumbList alone suffice).
+ */
+export function extractHowToSteps(answer: string): Array<{ name: string; text: string }> | null {
+  const steps: Array<{ name: string; text: string }> = [];
+
+  // Pattern 1: **N. Title:** followed by body text until next `**N+1.` or end.
+  const boldNumbered = /\*\*(\d+)\.\s+([^*]+?):\*\*\s*\n([^]*?)(?=\n\*\*\d+\.|$)/g;
+  let match: RegExpExecArray | null;
+  while ((match = boldNumbered.exec(answer)) !== null) {
+    const name = match[2].trim();
+    const text = stripMarkdown(match[3]).trim().replace(/\s+/g, ' ');
+    if (name && text) steps.push({ name, text });
+  }
+
+  // Pattern 2 (fallback): `N. Title` numbered list lines.
+  // We can't use stripMarkdown here because it strips leading `N. `; instead
+  // we only remove inline bold/italic decorations and keep block structure.
+  if (steps.length === 0) {
+    const inlineStrip = (s: string) =>
+      s
+        .replace(/\*\*([^*]+)\*\*/g, '$1')
+        .replace(/__([^_]+)__/g, '$1')
+        .replace(/`([^`]+)`/g, '$1')
+        .trim();
+
+    const lines = answer.split('\n').map((l) => l.trim()).filter(Boolean);
+    for (const line of lines) {
+      const m = /^(\d+)\.\s+(.+)$/.exec(line);
+      if (m) {
+        const fullText = inlineStrip(m[2]);
+        // Bold-list pattern `1. **Title:** body` → split on first `:`.
+        const colonIdx = fullText.indexOf(':');
+        const name =
+          colonIdx > 0 && colonIdx < 80
+            ? fullText.slice(0, colonIdx).trim()
+            : fullText.length > 80
+              ? fullText.slice(0, 80) + '…'
+              : fullText;
+        steps.push({ name, text: fullText });
+      }
+    }
+  }
+
+  if (steps.length < 3) return null;
+  return steps;
+}
+
+export function buildHowToLd(
+  question: Question,
+  slug: string,
+  steps: Array<{ name: string; text: string }>,
+) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: question.title,
+    description: question.metaDescription,
+    inLanguage: 'pt-BR',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': buildCanonical(`/perguntas/${slug}`),
+    },
+    step: steps.map((s, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      name: s.name,
+      text: s.text,
+    })),
+  };
+}

--- a/frontend/app/perguntas/[slug]/json-ld.ts
+++ b/frontend/app/perguntas/[slug]/json-ld.ts
@@ -152,6 +152,11 @@ export function extractHowToSteps(answer: string): Array<{ name: string; text: s
   // Pattern 2 (fallback): `N. Title` numbered list lines.
   // We can't use stripMarkdown here because it strips leading `N. `; instead
   // we only remove inline bold/italic decorations and keep block structure.
+  //
+  // To avoid mixing two independent numbered lists (e.g. cost categories +
+  // procedure steps), we scope extraction in priority order:
+  //  a) Lines AFTER a "Passo a passo" section heading, if one exists.
+  //  b) Otherwise, the LAST contiguous numbered sequence in the answer.
   if (steps.length === 0) {
     const inlineStrip = (s: string) =>
       s
@@ -160,20 +165,58 @@ export function extractHowToSteps(answer: string): Array<{ name: string; text: s
         .replace(/`([^`]+)`/g, '$1')
         .trim();
 
-    const lines = answer.split('\n').map((l) => l.trim()).filter(Boolean);
-    for (const line of lines) {
-      const m = /^(\d+)\.\s+(.+)$/.exec(line);
-      if (m) {
-        const fullText = inlineStrip(m[2]);
-        // Bold-list pattern `1. **Title:** body` → split on first `:`.
-        const colonIdx = fullText.indexOf(':');
-        const name =
-          colonIdx > 0 && colonIdx < 80
-            ? fullText.slice(0, colonIdx).trim()
-            : fullText.length > 80
-              ? fullText.slice(0, 80) + '…'
-              : fullText;
-        steps.push({ name, text: fullText });
+    const lines = answer.split('\n').map((l) => l.trim());
+
+    // Locate "Passo a passo" anchor (e.g. "**Passo a passo:**" or "Passo a passo:").
+    const anchorIdx = lines.findIndex((l) => /passo\s+a\s+passo/i.test(l));
+
+    // Determine the slice of lines to collect numbered items from.
+    const candidateLines = anchorIdx >= 0 ? lines.slice(anchorIdx + 1) : lines;
+
+    if (anchorIdx >= 0) {
+      // Anchor found: collect all numbered lines in the post-anchor section.
+      for (const line of candidateLines) {
+        if (!line) continue;
+        const m = /^(\d+)\.\s+(.+)$/.exec(line);
+        if (m) {
+          const fullText = inlineStrip(m[2]);
+          const colonIdx = fullText.indexOf(':');
+          const name =
+            colonIdx > 0 && colonIdx < 80
+              ? fullText.slice(0, colonIdx).trim()
+              : fullText.length > 80
+                ? fullText.slice(0, 80) + '…'
+                : fullText;
+          steps.push({ name, text: fullText });
+        }
+      }
+    } else {
+      // No anchor: collect the LAST contiguous numbered sequence only,
+      // to avoid mixing two independent lists.
+      const groups: Array<Array<{ name: string; text: string }>> = [];
+      let current: Array<{ name: string; text: string }> = [];
+      for (const line of candidateLines) {
+        const m = /^(\d+)\.\s+(.+)$/.exec(line);
+        if (m) {
+          const fullText = inlineStrip(m[2]);
+          const colonIdx = fullText.indexOf(':');
+          const name =
+            colonIdx > 0 && colonIdx < 80
+              ? fullText.slice(0, colonIdx).trim()
+              : fullText.length > 80
+                ? fullText.slice(0, 80) + '…'
+                : fullText;
+          current.push({ name, text: fullText });
+        } else if (line && current.length > 0) {
+          // Non-blank, non-numbered line breaks the sequence.
+          groups.push(current);
+          current = [];
+        }
+      }
+      if (current.length > 0) groups.push(current);
+      // Use the last group (most likely the procedure steps).
+      if (groups.length > 0) {
+        steps.push(...groups[groups.length - 1]);
       }
     }
   }

--- a/frontend/app/perguntas/[slug]/page.tsx
+++ b/frontend/app/perguntas/[slug]/page.tsx
@@ -17,6 +17,9 @@ import {
   buildArticleLd,
   buildBreadcrumbLd,
   buildFaqPageLd,
+  buildHowToLd,
+  isHowToEligible,
+  extractHowToSteps,
 } from './json-ld';
 
 export const revalidate = 86400;
@@ -97,6 +100,19 @@ export default async function PerguntaPage({
   const articleLd = buildArticleLd(question, slug, personAuthorLd, ARTICLE_PUBLISHED_AT, ARTICLE_UPDATED_AT);
   const breadcrumbLd = buildBreadcrumbLd(question, slug);
   const faqPageLd = buildFaqPageLd(relatedQuestions);
+
+  /*
+   * #991 — HowTo JSON-LD for procedural questions.
+   *
+   * Google deprecated FAQ rich results in May/2026 for non-gov/health sites.
+   * QAPage-only emission no longer surfaces in SERP — only AI Overviews.
+   * For "como-*" and "*passo-a-passo*" slugs we extract step structure from
+   * the existing answer markdown and emit a HowTo schema. Article +
+   * BreadcrumbList remain the always-present primary schemas; QAPage stays
+   * as secondary for AI Overviews ingestion.
+   */
+  const howToSteps = isHowToEligible(slug) ? extractHowToSteps(question.answer) : null;
+  const howToLd = howToSteps ? buildHowToLd(question, slug, howToSteps) : null;
 
   return (
     <>
@@ -231,6 +247,9 @@ export default async function PerguntaPage({
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(qaPageLd) }} />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }} />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+        {howToLd && (
+          <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }} />
+        )}
         {faqPageLd && (
           <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageLd) }} />
         )}

--- a/frontend/app/perguntas/[slug]/page.tsx
+++ b/frontend/app/perguntas/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { QUESTIONS, getQuestionBySlug, getAllQuestionSlugs, CATEGORY_META, getQuestionsByCategory } from '@/lib/questions';
@@ -49,7 +49,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const question = getQuestionBySlug(slug);
-  if (!question) return {};
+  if (!question) return { robots: { index: false, follow: true } };
 
   return {
     title: `${question.title}`,
@@ -77,7 +77,20 @@ export default async function PerguntaPage({
 }) {
   const { slug } = await params;
   const question = getQuestionBySlug(slug);
-  if (!question) notFound();
+  if (!question) {
+    return (
+      <>
+        <LandingNavbar />
+        <EmptyStateSEO
+          title="Pergunta não encontrada"
+          description="Esta pergunta pode ter sido removida ou o endereço está incorreto. Consulte todas as perguntas sobre licitações públicas."
+          ctaHref="/perguntas"
+          ctaLabel="Ver todas as perguntas"
+        />
+        <Footer />
+      </>
+    );
+  }
 
   // Related glossary terms
   const relatedTermObjects = question.relatedTerms

--- a/frontend/components/seo/EmptyStateSEO.tsx
+++ b/frontend/components/seo/EmptyStateSEO.tsx
@@ -1,0 +1,63 @@
+/**
+ * Issue #1034: ISR-safe empty/missing-data state for SEO programmatic pages.
+ *
+ * Replaces `notFound()` calls in dynamic SEO routes that hit ISR
+ * (revalidate ≥ hours). `notFound()` becomes a TERMINAL state under ISR — a
+ * single transient backend blip turns into a 24h hard 404. This component
+ * lets the route render a real, indexable-aware page (with `robots:noindex`
+ * set in `generateMetadata`) so transient failures degrade gracefully and
+ * recover on next revalidation.
+ *
+ * Stateless server-component. No data fetching, no client hooks.
+ */
+
+import Link from 'next/link';
+
+export interface EmptyStateSEOProps {
+  title: string;
+  description: string;
+  ctaHref?: string;
+  ctaLabel?: string;
+  periodLabel?: string;
+}
+
+export default function EmptyStateSEO({
+  title,
+  description,
+  ctaHref,
+  ctaLabel,
+  periodLabel,
+}: EmptyStateSEOProps) {
+  return (
+    <section
+      className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+      aria-labelledby="empty-state-seo-title"
+      data-testid="empty-state-seo"
+    >
+      <div className="rounded-2xl border border-gray-200 bg-white p-8 sm:p-10 shadow-sm">
+        {periodLabel && (
+          <p className="text-sm font-medium uppercase tracking-wide text-gray-500 mb-3">
+            {periodLabel}
+          </p>
+        )}
+        <h1
+          id="empty-state-seo-title"
+          className="text-2xl sm:text-3xl font-semibold text-gray-900 mb-4"
+        >
+          {title}
+        </h1>
+        <p className="text-base text-gray-600 leading-relaxed mb-6">
+          {description}
+        </p>
+        {ctaHref && ctaLabel && (
+          <Link
+            href={ctaHref}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          >
+            {ctaLabel}
+          </Link>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary / Context

Google deprecou FAQ rich results em mai/2026 para sites não-gov/saúde. As 53+ páginas `/perguntas/[slug]` emitiam apenas QAPage, que **não renderiza mais rich result** em SERP — só persiste como sinal para AI Overviews.

Esta PR migra o schema para o stack que ainda tem rich result em 2026:

- **Article** — sempre presente (já existente via #997 SEO-P2-011, mantido)
- **BreadcrumbList** — sempre presente (já existente, mantido)
- **HowTo** — condicional, novo nesta PR
- **QAPage** — mantido como secundário para AI Overviews

## Decision rules (in-template heuristic)

- `slug.startsWith('como-')` ou `slug.includes('passo-a-passo')` → HowTo + Article + BreadcrumbList + QAPage
- Outros (`qualificacao-*`, `prazo-*`, `o-que-e-*`, etc.) → Article + BreadcrumbList + QAPage (sem HowTo)

Heurística inline evita fabricar steps em perguntas definicionais. Se o pattern de extração de steps render <3 passos, o HowTo é omitido (no fabrication).

## Changes

- `frontend/app/perguntas/[slug]/json-ld.ts` — adiciona `isHowToEligible(slug)`, `extractHowToSteps(answer)` e `buildHowToLd(question, slug, steps)`. Suporta dois patterns markdown (`**N. Title:**` bold-headings e `N. text` lista numerada).
- `frontend/app/perguntas/[slug]/page.tsx` — wires HowTo emission condicional no JSON-LD output.
- `frontend/__tests__/perguntas-jsonld.test.ts` — 13 testes cobrindo:
  - eligibility heuristic (como-*, passo-a-passo, definicional)
  - step extraction (bold-numbered, plain-numbered, edge cases)
  - HowTo schema shape (positions, pt-BR, mainEntityOfPage)
  - sample slugs: `como-calcular-preco-proposta-licitacao`, `qualificacao-tecnica-lei-14133`, `prazo-publicacao-edital`
  - regression: QAPage retained

## Deferred

- `scripts/seo/classify_questions.py` — full 53-page heuristic-vs-LLM classification deferred. Heurística in-template é suficiente para o slug-pool atual; caso o pool cresça, a script é reagendável.
- Backfill de campo dedicado `steps:` em `lib/questions.ts` — defer; extração via regex no `answer` cobre o caso atual sem mudança de data shape.
- Manual Rich Results Test em 5 amostras — pós-merge.

## Testing Plan

- [x] Jest: Article + BreadcrumbList present on sample slugs
- [x] Jest: HowTo present iff slug eligible and steps extractable
- [x] Jest: QAPage retained (regression check)
- [x] Jest: HowTo omitido para slugs definicionais
- [ ] Post-merge: Google Rich Results Test em 5 sample URLs

## Closes

Closes #991