### PR TITLE
fix(frontend): ban notFound() in /observatorio/[slug] (#1034)

### DIFF
--- a/frontend/__tests__/app/observatorio-slug-no-notfound.test.tsx
+++ b/frontend/__tests__/app/observatorio-slug-no-notfound.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Issue #1034 (HOTFIX): /observatorio/[slug] must NOT call `notFound()` for
+ * null/empty backend payloads under ISR — that turns a transient blip into
+ * a 24h hard 404. This test pins the new behavior:
+ *
+ * - Transient failure (5xx / network throw) → fetchRelatorio re-throws so ISR
+ *   keeps the last-good cache. `notFound()` is NOT called.
+ * - Empty period (`is_empty_period:true`, total_editais: 0) → page renders
+ *   <EmptyStateSEO> + generateMetadata sets `robots.index=false, follow=true`.
+ *   `notFound()` is NOT called.
+ * - Malformed slug → `notFound()` IS called (preserved 404 behavior).
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const mockNotFound = jest.fn(() => {
+  // Mimic next/navigation's notFound() control-flow throw so we can detect
+  // whether the page invoked it.
+  const err = new Error('NEXT_NOT_FOUND');
+  (err as any).digest = 'NEXT_NOT_FOUND';
+  throw err;
+});
+
+jest.mock('next/navigation', () => ({
+  notFound: mockNotFound,
+}));
+
+jest.mock('@/app/observatorio/[slug]/ObservatorioRelatorioClient', () => {
+  const Mock = () => <div data-testid="observatorio-client" />;
+  Mock.displayName = 'ObservatorioRelatorioClientMock';
+  return { __esModule: true, default: Mock };
+});
+
+jest.mock('@sentry/nextjs', () => ({
+  captureMessage: jest.fn(),
+}));
+
+const fullRelatorio = {
+  mes: 3,
+  ano: 2026,
+  mes_nome: 'março',
+  periodo: 'Editais publicados de 1 a 31 de março de 2026',
+  total_editais: 12543,
+  valor_total: 1580000000,
+  valor_medio: 125000,
+  top_ufs: [],
+  modalidades: [],
+  tendencia_semanal: [],
+  setores_em_alta: [],
+  gerado_em: '2026-04-01T10:00:00Z',
+  fonte: 'SmartLic Observatório — dados PNCP',
+  license: 'Creative Commons BY 4.0',
+};
+
+const emptyPeriodRelatorio = {
+  ...fullRelatorio,
+  total_editais: 0,
+  is_empty_period: true,
+  periodo: '',
+  top_ufs: [],
+  modalidades: [],
+  tendencia_semanal: [],
+  setores_em_alta: [],
+};
+
+global.fetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Page render — no notFound() for null/empty payloads (Issue #1034)
+// ---------------------------------------------------------------------------
+
+describe('RelatorioPage — Issue #1034 ban notFound() for null/empty payloads', () => {
+  it('payload com total_editais: 0 (is_empty_period) renderiza EmptyStateSEO e NÃO chama notFound()', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => emptyPeriodRelatorio,
+    });
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ slug: 'raio-x-marco-2026' }),
+    });
+    const { container, getByTestId } = render(element as React.ReactElement);
+
+    // notFound() NUNCA é chamado para empty period.
+    expect(mockNotFound).not.toHaveBeenCalled();
+    // EmptyStateSEO renderizado.
+    expect(getByTestId('empty-state-seo')).toBeTruthy();
+    // h1 contém o display do mês/ano.
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toContain('Março');
+    expect(h1?.textContent).toContain('2026');
+  });
+
+  it('backend retorna 4xx (resp.ok=false, status<500) → renderiza EmptyStateSEO e NÃO chama notFound()', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ slug: 'raio-x-abril-2026' }),
+    });
+    const { getByTestId } = render(element as React.ReactElement);
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(getByTestId('empty-state-seo')).toBeTruthy();
+  });
+
+  it('falha transitória (5xx) → fetchRelatorio THROWS para preservar last-good ISR; notFound() NÃO é chamado', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'service_unavailable' }),
+    });
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+
+    let thrown: unknown = null;
+    try {
+      await Page({ params: Promise.resolve({ slug: 'raio-x-marco-2026' }) });
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Page deve propagar erro (não chamar notFound() — ISR mantém cache antigo).
+    expect(thrown).not.toBeNull();
+    // Erro NÃO é o NEXT_NOT_FOUND digest.
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it('falha de rede (fetch rejeita) → bubble up; notFound() NÃO é chamado', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+
+    let thrown: unknown = null;
+    try {
+      await Page({ params: Promise.resolve({ slug: 'raio-x-marco-2026' }) });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).not.toBeNull();
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it('slug malformado → notFound() AINDA é chamado (preserva 404 para slug inválido)', async () => {
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+
+    let thrown: unknown = null;
+    try {
+      await Page({ params: Promise.resolve({ slug: 'slug-invalido' }) });
+    } catch (e) {
+      thrown = e;
+    }
+    // notFound() é invocado para slug malformado (preserva 404 behavior).
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+    // E sua exceção sobe para o caller.
+    expect(thrown).not.toBeNull();
+  });
+
+  it('payload com dados reais ainda renderiza o relatório completo (não regression)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => fullRelatorio,
+    });
+    const PageMod = await import('@/app/observatorio/[slug]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ slug: 'raio-x-marco-2026' }),
+    });
+    const { getByTestId, queryByTestId } = render(element as React.ReactElement);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(getByTestId('observatorio-client')).toBeTruthy();
+    expect(queryByTestId('empty-state-seo')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateMetadata — robots:noindex,follow para empty/null (Issue #1034)
+// ---------------------------------------------------------------------------
+
+describe('generateMetadata — Issue #1034 robots noindex,follow para empty/null', () => {
+  it('total_editais: 0 → robots.index=false, robots.follow=true', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => emptyPeriodRelatorio,
+    });
+    const { generateMetadata } = await import('@/app/observatorio/[slug]/page');
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: 'raio-x-marco-2026' }),
+    });
+    const robots = meta.robots as { index?: boolean; follow?: boolean } | undefined;
+    expect(robots?.index).toBe(false);
+    expect(robots?.follow).toBe(true);
+  });
+
+  it('5xx transitório → metadata não crasha; robots.index=false', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+    const { generateMetadata } = await import('@/app/observatorio/[slug]/page');
+    const meta = await generateMetadata({
+      params: Promise.resolve({ slug: 'raio-x-marco-2026' }),
+    });
+    const robots = meta.robots as { index?: boolean; follow?: boolean } | undefined;
+    expect(robots?.index).toBe(false);
+    expect(robots?.follow).toBe(true);
+  });
+});

--- a/frontend/app/observatorio/[slug]/page.tsx
+++ b/frontend/app/observatorio/[slug]/page.tsx
@@ -4,9 +4,14 @@
  * Slug format: raio-x-abril-2026 → mes=4, ano=2026
  * Renders charts (BarChart, PieChart, LineChart), CSV download, embed button.
  *
- * AC13: notFound() on fetch failure or malformed slug; generateMetadata returns
- * robots:noindex when data is missing.
+ * AC13: notFound() on malformed slug only; generateMetadata returns
+ * robots:noindex when data is missing/empty.
  * AC14: Sentry.captureMessage when relatorio is empty (warning level + tags).
+ *
+ * Issue #1034 (HOTFIX): Removed `notFound()` for null/empty backend payloads.
+ * Under ISR (revalidate=86400), `notFound()` becomes a 24h terminal state from
+ * a single transient blip. Now: transient errors re-throw (preserve last-good
+ * ISR cache); empty-period payloads render <EmptyStateSEO> with noindex.
  */
 
 import { Metadata } from 'next';
@@ -15,6 +20,7 @@ import { notFound } from 'next/navigation';
 import * as Sentry from '@sentry/nextjs';
 import ObservatorioRelatorioClient from './ObservatorioRelatorioClient';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
@@ -40,17 +46,30 @@ function parseSlug(slug: string): { mes: number; ano: number } | null {
   return { mes, ano };
 }
 
+/**
+ * Issue #1034: Distinguish transient vs terminal failures.
+ *
+ * - 2xx OK (incl. `is_empty_period:true`) → return parsed payload.
+ * - 4xx (e.g. 404 truly not found) → return `null` so page renders EmptyState.
+ * - Network error / 5xx / abort → THROW so ISR keeps the last-good cache and
+ *   doesn't poison the URL with a 24h terminal `notFound()`.
+ *
+ * Timeout 15s (was 10s) aligns with Supabase statement_timeout floor for
+ * service_role queries.
+ */
 async function fetchRelatorio(mes: number, ano: number) {
-  try {
-    const resp = await fetch(`${BACKEND_URL}/v1/observatorio/relatorio/${mes}/${ano}`, {
-      next: { revalidate: 86400 }, // 24h ISR
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!resp.ok) return null;
-    return await resp.json();
-  } catch {
+  const resp = await fetch(`${BACKEND_URL}/v1/observatorio/relatorio/${mes}/${ano}`, {
+    next: { revalidate: 86400 }, // 24h ISR
+    signal: AbortSignal.timeout(15000),
+  });
+  if (resp.status >= 500) {
+    throw new Error(`observatorio_backend_5xx:${resp.status}`);
+  }
+  if (!resp.ok) {
+    // 4xx → treat as "no data for this period" (not transient).
     return null;
   }
+  return await resp.json();
 }
 
 export async function generateMetadata({
@@ -70,9 +89,16 @@ export async function generateMetadata({
 
   const { mes, ano } = parsed;
   const mesDisplay = MONTH_NAMES_DISPLAY[mes] ?? String(mes);
-  const relatorio = await fetchRelatorio(mes, ano);
+  // Issue #1034: swallow transient throws in metadata phase — we still want
+  // to ship a (noindex) <head> for the EmptyStateSEO render below.
+  let relatorio: any = null;
+  try {
+    relatorio = await fetchRelatorio(mes, ano);
+  } catch {
+    relatorio = null;
+  }
 
-  // STORY-431 AC13: missing or empty payload → noindex metadata so an
+  // STORY-431 AC13 + Issue #1034: missing or empty payload → noindex metadata so an
   // accidentally-cached blank page never lands in Google's index.
   // Issue #658: explicit canonical to own URL (não herdar root do layout.tsx).
   if (!relatorio || !relatorio.total_editais) {
@@ -122,22 +148,34 @@ export default async function RelatorioPage({
   if (!parsed) notFound();
 
   const { mes, ano } = parsed;
-  const relatorio = await fetchRelatorio(mes, ano);
-  // STORY-431 AC13: backend null/throw → 404 instead of rendering a blank page.
-  if (!relatorio) notFound();
-
   const mesDisplay = MONTH_NAMES_DISPLAY[mes] ?? String(mes);
+  // Issue #1034: NEVER call notFound() here. Transient throws bubble up so ISR
+  // preserves the last-good cache; null payloads (4xx) and empty periods render
+  // <EmptyStateSEO> with noindex metadata (set in generateMetadata above).
+  const relatorio = await fetchRelatorio(mes, ano);
+
+  if (!relatorio || !Number(relatorio.total_editais ?? 0)) {
+    Sentry.captureMessage('observatorio_empty_period', {
+      level: 'warning',
+      tags: { mes: String(mes), ano: String(ano), slug, render: 'empty_state' },
+    });
+    return (
+      <EmptyStateSEO
+        title={`Raio-X das Licitações — ${mesDisplay} ${ano}`}
+        description={`Ainda não temos um relatório consolidado para ${mesDisplay.toLowerCase()} de ${ano}. Os dados são publicados conforme o PNCP processa os editais do período. Volte em breve ou explore outros meses do observatório.`}
+        ctaHref="/observatorio"
+        ctaLabel="Ver outros meses do observatório"
+        periodLabel={`${mesDisplay} de ${ano}`}
+      />
+    );
+  }
+
   const totalEditais = Number(relatorio.total_editais ?? 0);
   const periodoNonEmpty = typeof relatorio.periodo === 'string' && relatorio.periodo.trim().length > 0;
 
-  // STORY-431 AC14: empty period → Sentry warning so we know how often this
-  // surface degrades to the EmptyStatePeriod CTA.
-  if (totalEditais === 0) {
-    Sentry.captureMessage('observatorio_empty_period', {
-      level: 'warning',
-      tags: { mes: String(mes), ano: String(ano), slug },
-    });
-  }
+  // STORY-431 AC14 + Issue #1034: empty-period Sentry warning is now emitted
+  // inside the early-return EmptyStateSEO branch above (this code path runs
+  // only when totalEditais > 0).
 
   // STORY-431 AC12: only emit the Dataset JSON-LD when the period is real
   // (non-empty + has a periodo string). Avoids polluting Google with an

--- a/frontend/components/seo/EmptyStateSEO.tsx
+++ b/frontend/components/seo/EmptyStateSEO.tsx
@@ -1,0 +1,63 @@
+/**
+ * Issue #1034: ISR-safe empty/missing-data state for SEO programmatic pages.
+ *
+ * Replaces `notFound()` calls in dynamic SEO routes that hit ISR
+ * (revalidate ≥ hours). `notFound()` becomes a TERMINAL state under ISR — a
+ * single transient backend blip turns into a 24h hard 404. This component
+ * lets the route render a real, indexable-aware page (with `robots:noindex`
+ * set in `generateMetadata`) so transient failures degrade gracefully and
+ * recover on next revalidation.
+ *
+ * Stateless server-component. No data fetching, no client hooks.
+ */
+
+import Link from 'next/link';
+
+export interface EmptyStateSEOProps {
+  title: string;
+  description: string;
+  ctaHref?: string;
+  ctaLabel?: string;
+  periodLabel?: string;
+}
+
+export default function EmptyStateSEO({
+  title,
+  description,
+  ctaHref,
+  ctaLabel,
+  periodLabel,
+}: EmptyStateSEOProps) {
+  return (
+    <section
+      className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+      aria-labelledby="empty-state-seo-title"
+      data-testid="empty-state-seo"
+    >
+      <div className="rounded-2xl border border-gray-200 bg-white p-8 sm:p-10 shadow-sm">
+        {periodLabel && (
+          <p className="text-sm font-medium uppercase tracking-wide text-gray-500 mb-3">
+            {periodLabel}
+          </p>
+        )}
+        <h1
+          id="empty-state-seo-title"
+          className="text-2xl sm:text-3xl font-semibold text-gray-900 mb-4"
+        >
+          {title}
+        </h1>
+        <p className="text-base text-gray-600 leading-relaxed mb-6">
+          {description}
+        </p>
+        {ctaHref && ctaLabel && (
+          <Link
+            href={ctaHref}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          >
+            {ctaLabel}
+          </Link>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary / Context
HOTFIX for `/observatorio/raio-x-marco-2026` returning HTTP 404 while backend returns 200 + `is_empty_period:true`. Root cause: ISR cached `notFound()` from transient fetch failure (revalidate 86400 → 24h terminal state). Pattern `if (!relatorio) notFound()` is incompatible with programmatic SEO ISR.

Scope: ONLY `/observatorio/[slug]` route. Systemic sweep across 17 routes tracked in #1035.

## Changes
- New: `frontend/components/seo/EmptyStateSEO.tsx`
- Edit: `frontend/app/observatorio/[slug]/page.tsx`
  - Replace `notFound()` for null/empty data with EmptyStateSEO render
  - `fetchRelatorio` re-throws transient errors (5xx / network) to preserve last-good ISR
  - 4xx returns null (renders EmptyStateSEO with noindex)
  - Timeout 10s → 15s (Supabase statement_timeout floor)
  - `generateMetadata` sets `robots:noindex,follow` when empty
- Tests: transient null does NOT call `notFound()`; empty period renders EmptyStateSEO + noindex meta

## Testing Plan
- [x] Unit: transient 5xx → fetchRelatorio throws; notFound() NOT called (preserves ISR last-good)
- [x] Unit: network reject → bubbles up; notFound() NOT called
- [x] Unit: 4xx → renders EmptyStateSEO; notFound() NOT called
- [x] Unit: is_empty_period:true / total_editais:0 → EmptyStateSEO rendered + robots noindex,follow
- [x] Unit: malformed slug → notFound() STILL called (preserves 404)
- [x] Unit: full data → ObservatorioRelatorioClient still renders (no regression)
- [x] Existing tests pass (observatorio-page.test.tsx, observatorio-slug-breadcrumb.test.tsx — 10/10)
- [ ] Post-deploy curl `/observatorio/raio-x-marco-2026` → 200
- [ ] Curl `/observatorio/slug-invalido` (malformed) → 404 preserved

## Closes
Closes #1034