### PR TITLE
feat(seo): on-demand ISR revalidation — POST /api/revalidate + ARQ hook (#1037)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,16 @@ STRIPE_SECRET_KEY=
 FOUNDING_ONE_TIME_PRICE_ID=
 
 # --------------------------------------------
+# On-demand ISR revalidation (#1037)
+# --------------------------------------------
+# URL of the Next.js route handler that accepts revalidation requests.
+# Set to the production frontend URL in Railway backend env.
+FRONTEND_REVALIDATE_URL=https://smartlic.tech/api/revalidate
+# Shared secret — must match REVALIDATE_SECRET in the frontend service.
+# Generate with: openssl rand -hex 32
+REVALIDATE_SECRET=
+
+# --------------------------------------------
 # Custom Configuration
 # --------------------------------------------
 # Add your custom API keys below

--- a/backend/ingestion/scheduler.py
+++ b/backend/ingestion/scheduler.py
@@ -25,6 +25,54 @@ from ingestion.contracts_crawler import CONTRACTS_FULL_CRAWL_TIMEOUT, CONTRACTS_
 logger = logging.getLogger(__name__)
 
 
+_MONTH_NAMES = {
+    1: "janeiro", 2: "fevereiro", 3: "marco", 4: "abril",
+    5: "maio", 6: "junho", 7: "julho", 8: "agosto",
+    9: "setembro", 10: "outubro", 11: "novembro", 12: "dezembro",
+}
+
+
+def _build_revalidation_paths(result: dict) -> list[str]:
+    """Derive frontend ISR paths to revalidate from an ingestion result dict.
+
+    Covers the programmatic SEO routes that embed ingestion data:
+    - /observatorio/raio-x-{mes}-{ano} (monthly observatory pages)
+    - /licitacoes/{setor}             (sector listing pages)
+    - /alertas-publicos/{setor}/{uf}  (per-sector/uf alert pages)
+
+    Returns a deduplicated list of URL paths suitable for `revalidatePath`.
+    """
+    import datetime
+
+    today = datetime.date.today()
+    mes_nome = _MONTH_NAMES.get(today.month, "")
+    paths: list[str] = []
+
+    # Monthly observatory page for the current month
+    if mes_nome:
+        paths.append(f"/observatorio/raio-x-{mes_nome}-{today.year}")
+
+    # Sector listing pages (always stale after a crawl — low-cost to revalidate all)
+    setor_ids: list[str] = []
+    try:
+        from sectors import SECTORS  # local import to avoid circular deps at module load
+
+        setor_ids = list(SECTORS.keys())
+        for setor_id in setor_ids:
+            paths.append(f"/licitacoes/{setor_id}")
+    except Exception:
+        pass
+
+    # Per-(setor, uf) alert pages for UFs that were crawled
+    ufs_processed: list[str] = result.get("ufs_processed", [])
+    if ufs_processed and setor_ids:
+        for setor_id in setor_ids:
+            for uf in ufs_processed:
+                paths.append(f"/alertas-publicos/{setor_id}/{uf.lower()}")
+
+    return list(dict.fromkeys(paths))  # deduplicate, preserve order
+
+
 async def _notify_failure(
     job_name: str, error: str, duration_s: float, extra: dict | None = None
 ) -> None:
@@ -89,6 +137,14 @@ async def ingestion_full_crawl_job(ctx: dict) -> dict:
         f"[Ingestion:FullCrawl] Completed in {duration_s}s — "
         f"records={result.get('records_upserted', 0)}"
     )
+
+    # Fire-and-forget ISR revalidation — never blocks/fails the job.
+    try:
+        from utils.revalidate_client import revalidate_paths
+        await revalidate_paths(_build_revalidation_paths(result))
+    except Exception as _rev_exc:
+        logger.debug("[Ingestion:FullCrawl] revalidate_paths error (non-fatal): %s", _rev_exc)
+
     return {**result, "duration_s": duration_s}
 
 
@@ -130,6 +186,14 @@ async def ingestion_incremental_job(ctx: dict) -> dict:
         f"[Ingestion:Incremental] Completed in {duration_s}s — "
         f"records={result.get('records_upserted', 0)}"
     )
+
+    # Fire-and-forget ISR revalidation — never blocks/fails the job.
+    try:
+        from utils.revalidate_client import revalidate_paths
+        await revalidate_paths(_build_revalidation_paths(result))
+    except Exception as _rev_exc:
+        logger.debug("[Ingestion:Incremental] revalidate_paths error (non-fatal): %s", _rev_exc)
+
     return {**result, "duration_s": duration_s}
 
 

--- a/backend/routes/seo_admin.py
+++ b/backend/routes/seo_admin.py
@@ -301,3 +301,42 @@ async def get_gsc_summary(
         phase="route",
         source="seo_admin.get_gsc_summary",
     )
+
+
+# ---------------------------------------------------------------------------
+# On-demand ISR revalidation — #1037
+# ---------------------------------------------------------------------------
+
+
+class RevalidateSEORequest(BaseModel):
+    paths: list[str]
+
+
+class RevalidateSEOResponse(BaseModel):
+    status: str
+    paths: list[str]
+
+
+@router.post("/admin/revalidate-seo", response_model=RevalidateSEOResponse)
+async def admin_revalidate_seo(
+    body: RevalidateSEORequest,
+    user=Depends(require_auth),
+    _admin=Depends(require_admin),
+):
+    """Manually trigger ISR revalidation for the given frontend paths.
+
+    Calls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).
+    Fire-and-forget — the HTTP call is made but result is not awaited for
+    user-facing errors.  Any failure is logged as a warning.
+
+    Requires admin role.  Raises HTTP 400 if ``paths`` is empty.
+    """
+    if not body.paths:
+        from fastapi import HTTPException as _HTTPException
+
+        raise _HTTPException(status_code=400, detail="paths must not be empty")
+
+    from utils.revalidate_client import revalidate_paths
+
+    await revalidate_paths(body.paths)
+    return RevalidateSEOResponse(status="ok", paths=body.paths)

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -11732,6 +11732,43 @@
         "title": "ResumoLicitacoes",
         "type": "object"
       },
+      "RevalidateSEORequest": {
+        "properties": {
+          "paths": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Paths",
+            "type": "array"
+          }
+        },
+        "required": [
+          "paths"
+        ],
+        "title": "RevalidateSEORequest",
+        "type": "object"
+      },
+      "RevalidateSEOResponse": {
+        "properties": {
+          "paths": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Paths",
+            "type": "array"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "paths"
+        ],
+        "title": "RevalidateSEOResponse",
+        "type": "object"
+      },
       "ReverseSyncRequest": {
         "properties": {
           "i_understand_this_modifies_stripe": {
@@ -17447,6 +17484,53 @@
         "summary": "Trigger Reconciliation",
         "tags": [
           "admin"
+        ]
+      }
+    },
+    "/v1/admin/revalidate-seo": {
+      "post": {
+        "description": "Manually trigger ISR revalidation for the given frontend paths.\n\nCalls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).\nFire-and-forget \u2014 the HTTP call is made but result is not awaited for\nuser-facing errors.  Any failure is logged as a warning.\n\nRequires admin role.  Raises HTTP 400 if ``paths`` is empty.",
+        "operationId": "admin_revalidate_seo_v1_admin_revalidate_seo_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RevalidateSEORequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevalidateSEOResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Revalidate Seo",
+        "tags": [
+          "seo_admin"
         ]
       }
     },

--- a/backend/tests/test_revalidate_client.py
+++ b/backend/tests/test_revalidate_client.py
@@ -1,0 +1,139 @@
+"""Tests for utils/revalidate_client.py — fire-and-forget ISR revalidation client.
+
+Covers:
+- Happy path: sends correct POST with secret header.
+- Silent skip when env vars are missing.
+- HTTP error → logs warning, does not propagate exception.
+- Empty paths → no HTTP call.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import httpx
+
+
+@pytest.mark.asyncio
+async def test_happy_path_sends_correct_post(monkeypatch):
+    """revalidate_paths sends POST with json body and x-revalidate-secret header."""
+    monkeypatch.setenv("FRONTEND_REVALIDATE_URL", "https://smartlic.tech/api/revalidate")
+    monkeypatch.setenv("REVALIDATE_SECRET", "test-secret-xyz")
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        from utils.revalidate_client import revalidate_paths
+
+        await revalidate_paths(["/licitacoes/saude", "/observatorio/raio-x-maio-2026"])
+
+    mock_client.post.assert_called_once_with(
+        "https://smartlic.tech/api/revalidate",
+        json={"paths": ["/licitacoes/saude", "/observatorio/raio-x-maio-2026"]},
+        headers={"x-revalidate-secret": "test-secret-xyz"},
+    )
+    mock_response.raise_for_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_url_env_var_skips_silently(monkeypatch):
+    """When FRONTEND_REVALIDATE_URL is unset, no HTTP call is made and no exception raised."""
+    monkeypatch.delenv("FRONTEND_REVALIDATE_URL", raising=False)
+    monkeypatch.setenv("REVALIDATE_SECRET", "test-secret-xyz")
+
+    with patch("httpx.AsyncClient") as mock_cls:
+        from utils.revalidate_client import revalidate_paths
+
+        # Should not raise
+        await revalidate_paths(["/licitacoes/saude"])
+
+    mock_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_env_var_skips_silently(monkeypatch):
+    """When REVALIDATE_SECRET is unset, no HTTP call is made and no exception raised."""
+    monkeypatch.setenv("FRONTEND_REVALIDATE_URL", "https://smartlic.tech/api/revalidate")
+    monkeypatch.delenv("REVALIDATE_SECRET", raising=False)
+
+    with patch("httpx.AsyncClient") as mock_cls:
+        from utils.revalidate_client import revalidate_paths
+
+        # Should not raise
+        await revalidate_paths(["/licitacoes/saude"])
+
+    mock_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_error_logs_warning_does_not_raise(monkeypatch, caplog):
+    """When the HTTP call raises an exception, a warning is logged and no exception propagates."""
+    monkeypatch.setenv("FRONTEND_REVALIDATE_URL", "https://smartlic.tech/api/revalidate")
+    monkeypatch.setenv("REVALIDATE_SECRET", "test-secret-xyz")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger="utils.revalidate_client"):
+            from utils.revalidate_client import revalidate_paths
+
+            # Must not raise
+            await revalidate_paths(["/licitacoes/saude"])
+
+    assert any("seo_revalidate failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_http_4xx_error_logs_warning_does_not_raise(monkeypatch, caplog):
+    """When the HTTP response is a 4xx/5xx, raise_for_status raises but does not propagate."""
+    monkeypatch.setenv("FRONTEND_REVALIDATE_URL", "https://smartlic.tech/api/revalidate")
+    monkeypatch.setenv("REVALIDATE_SECRET", "test-secret-xyz")
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=MagicMock(),
+            response=MagicMock(status_code=401),
+        )
+    )
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger="utils.revalidate_client"):
+            from utils.revalidate_client import revalidate_paths
+
+            # Must not raise
+            await revalidate_paths(["/licitacoes/saude"])
+
+    assert any("seo_revalidate failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_empty_paths_skips_http_call(monkeypatch):
+    """When paths is an empty list, no HTTP call is made."""
+    monkeypatch.setenv("FRONTEND_REVALIDATE_URL", "https://smartlic.tech/api/revalidate")
+    monkeypatch.setenv("REVALIDATE_SECRET", "test-secret-xyz")
+
+    with patch("httpx.AsyncClient") as mock_cls:
+        from utils.revalidate_client import revalidate_paths
+
+        await revalidate_paths([])
+
+    mock_cls.assert_not_called()

--- a/backend/utils/revalidate_client.py
+++ b/backend/utils/revalidate_client.py
@@ -1,0 +1,81 @@
+"""Fire-and-forget ISR revalidation client for Next.js on-demand cache busting.
+
+Calls `POST <FRONTEND_REVALIDATE_URL>` with the shared `REVALIDATE_SECRET` to
+trigger Next.js `revalidatePath` for the given paths.
+
+Usage (from ARQ ingestion job or admin endpoint)::
+
+    from utils.revalidate_client import revalidate_paths
+
+    # Non-blocking — never raises, never delays ingestion
+    await revalidate_paths(["/observatorio/raio-x-marco-2026"])
+
+Environment variables:
+    FRONTEND_REVALIDATE_URL  Full URL to the Next.js revalidate handler
+                             (e.g. https://smartlic.tech/api/revalidate).
+                             When unset the call is silently skipped.
+    REVALIDATE_SECRET        Shared secret sent as x-revalidate-secret header.
+                             When unset the call is silently skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Sequence
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+async def revalidate_paths(paths: Sequence[str]) -> None:
+    """Fire-and-forget POST to Next.js /api/revalidate endpoint.
+
+    Never raises — all errors are logged as warnings.  The caller must NOT
+    await this function inside a ``try/except`` that would re-raise.
+
+    Args:
+        paths: URL paths to revalidate (e.g. ``["/licitacoes/saude"]``).
+    """
+    url = os.environ.get("FRONTEND_REVALIDATE_URL")
+    secret = os.environ.get("REVALIDATE_SECRET")
+
+    if not url or not secret:
+        logger.debug(
+            "revalidate_paths: FRONTEND_REVALIDATE_URL or REVALIDATE_SECRET not set, skipping"
+        )
+        return
+
+    paths_list = list(paths)
+    if not paths_list:
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                url,
+                json={"paths": paths_list},
+                # NOTE: REVALIDATE_SECRET is intentionally never logged.
+                headers={"x-revalidate-secret": secret},
+            )
+            resp.raise_for_status()
+        logger.info(
+            "seo_revalidate ok",
+            extra={"event": "seo_revalidate", "paths": paths_list, "status": "ok"},
+        )
+    except Exception as exc:
+        logger.warning(
+            "seo_revalidate failed: %s",
+            exc,
+            extra={"event": "seo_revalidate", "paths": paths_list, "status": "failed"},
+        )
+        # Non-blocking Sentry breadcrumb — never re-raises.
+        try:
+            import sentry_sdk  # noqa: PLC0415
+
+            sentry_sdk.add_breadcrumb(
+                message=f"revalidate_paths failed: {exc}", level="warning"
+            )
+        except Exception:
+            pass

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -35,6 +35,14 @@ NEXT_PUBLIC_TRIAL_REQUIRE_CARD_ROLLOUT_PCT=0
 NEXT_PUBLIC_FOUNDING_CALENDLY_URL=
 
 # --------------------------------------------
+# On-demand ISR revalidation (#1037)
+# --------------------------------------------
+# Shared secret used by POST /api/revalidate to accept backend-triggered cache busts.
+# Must match REVALIDATE_SECRET set in the backend service.
+# Generate with: openssl rand -hex 32
+REVALIDATE_SECRET=
+
+# --------------------------------------------
 # Observability
 # --------------------------------------------
 NEXT_PUBLIC_SENTRY_DSN=

--- a/frontend/__tests__/api/revalidate.test.ts
+++ b/frontend/__tests__/api/revalidate.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for POST /api/revalidate — on-demand ISR cache revalidation handler.
+ */
+import { NextRequest } from 'next/server';
+
+// Mock next/cache before importing the route so the module sees the mock.
+const mockRevalidatePath = jest.fn();
+jest.mock('next/cache', () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+// Lazy import so the mock above is installed first.
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let POST: (req: NextRequest) => Promise<Response>;
+
+beforeAll(async () => {
+  const mod = await import('@/app/api/revalidate/route');
+  POST = mod.POST;
+});
+
+const VALID_SECRET = 'test-secret-abc123';
+
+function makeRequest(
+  body: unknown,
+  secret: string | null = VALID_SECRET,
+): NextRequest {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (secret !== null) {
+    headers['x-revalidate-secret'] = secret;
+  }
+  return new NextRequest('http://localhost/api/revalidate', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/revalidate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.REVALIDATE_SECRET = VALID_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.REVALIDATE_SECRET;
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when REVALIDATE_SECRET env var is not set', async () => {
+      delete process.env.REVALIDATE_SECRET;
+      const req = makeRequest({ paths: ['/test'] });
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+      const data = await res.json();
+      expect(data).toMatchObject({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 when x-revalidate-secret header is missing', async () => {
+      const req = makeRequest({ paths: ['/test'] }, null);
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when x-revalidate-secret header is wrong', async () => {
+      const req = makeRequest({ paths: ['/test'] }, 'wrong-secret');
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('validation', () => {
+    it('returns 400 when paths array is missing', async () => {
+      const req = makeRequest({});
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data).toMatchObject({ error: 'paths required' });
+    });
+
+    it('returns 400 when paths is an empty array', async () => {
+      const req = makeRequest({ paths: [] });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const req = new NextRequest('http://localhost/api/revalidate', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-revalidate-secret': VALID_SECRET,
+        },
+        body: 'not json {{',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns 200 with revalidated count and calls revalidatePath for each path', async () => {
+      const paths = ['/licitacoes/saude', '/observatorio/raio-x-maio-2026'];
+      const req = makeRequest({ paths });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toEqual({ revalidated: 2, paths });
+
+      expect(mockRevalidatePath).toHaveBeenCalledTimes(2);
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/licitacoes/saude');
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/observatorio/raio-x-maio-2026');
+    });
+
+    it('returns revalidated=1 for a single path', async () => {
+      const req = makeRequest({ paths: ['/test-path'] });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.revalidated).toBe(1);
+      expect(mockRevalidatePath).toHaveBeenCalledWith('/test-path');
+    });
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -890,6 +890,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/revalidate-seo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Admin Revalidate Seo
+         * @description Manually trigger ISR revalidation for the given frontend paths.
+         *
+         *     Calls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).
+         *     Fire-and-forget — the HTTP call is made but result is not awaited for
+         *     user-facing errors.  Any failure is logged as a warning.
+         *
+         *     Requires admin role.  Raises HTTP 400 if ``paths`` is empty.
+         */
+        post: operations["admin_revalidate_seo_v1_admin_revalidate_seo_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/schema-contract-status": {
         parameters: {
             query?: never;
@@ -10606,6 +10632,18 @@ export interface components {
              */
             valor_total: number;
         };
+        /** RevalidateSEORequest */
+        RevalidateSEORequest: {
+            /** Paths */
+            paths: string[];
+        };
+        /** RevalidateSEOResponse */
+        RevalidateSEOResponse: {
+            /** Paths */
+            paths: string[];
+            /** Status */
+            status: string;
+        };
         /** ReverseSyncRequest */
         ReverseSyncRequest: {
             /**
@@ -13406,6 +13444,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    admin_revalidate_seo_v1_admin_revalidate_seo_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RevalidateSEORequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RevalidateSEOResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/app/api/revalidate/route.ts
+++ b/frontend/app/api/revalidate/route.ts
@@ -1,0 +1,46 @@
+/**
+ * POST /api/revalidate — on-demand ISR cache revalidation (Next.js 16 Route Handler).
+ *
+ * Accepts a JSON body `{ paths: string[] }` and calls `revalidatePath` for each
+ * path. Protected by a shared secret (`REVALIDATE_SECRET` env var).
+ *
+ * Called by the backend `revalidate_client.py` after a successful ingestion run,
+ * and by the admin endpoint `POST /v1/admin/revalidate-seo`.
+ *
+ * Fixes: stale ISR cache (revalidate=3600/86400) after backend ingestion populates
+ * missing data — reduces stale window from up to 24h to <60s.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+export async function POST(req: NextRequest) {
+  const secret = req.headers.get('x-revalidate-secret');
+  if (!process.env.REVALIDATE_SECRET || secret !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const paths: string[] =
+    body !== null &&
+    typeof body === 'object' &&
+    'paths' in (body as object) &&
+    Array.isArray((body as { paths: unknown }).paths)
+      ? (body as { paths: string[] }).paths
+      : [];
+
+  if (paths.length === 0) {
+    return NextResponse.json({ error: 'paths required' }, { status: 400 });
+  }
+
+  for (const path of paths) {
+    revalidatePath(path);
+  }
+
+  return NextResponse.json({ revalidated: paths.length, paths });
+}


### PR DESCRIPTION
## Summary

Implements on-demand ISR cache revalidation pipeline: Next.js Route Handler `POST /api/revalidate` (secret-gated) + backend `revalidate_client.py` (fire-and-forget) + hook in ARQ ingestion job + admin manual-trigger endpoint.

- `frontend/app/api/revalidate/route.ts` — Next.js 16 Route Handler; validates `x-revalidate-secret` header, calls `revalidatePath` for each path, returns `{revalidated: N, paths}`
- `backend/utils/revalidate_client.py` — fire-and-forget `httpx.AsyncClient` POST; silently skips when env vars unset; logs warning on failure, never raises
- `backend/ingestion/scheduler.py` — `_build_revalidation_paths()` helper + hook after both `ingestion_full_crawl_job` and `ingestion_incremental_job` success
- `backend/routes/seo_admin.py` — `POST /v1/admin/revalidate-seo` (admin-only) for manual triggering
- Env vars: `FRONTEND_REVALIDATE_URL` + `REVALIDATE_SECRET` documented in root `.env.example` and `frontend/.env.example`

## Context

ISR `revalidate=3600/86400` caused up to 24h stale cache after backend ingestion populated missing data. Users would see `EmptyState` even when backend had fresh data. This fix triggers immediate revalidation after ingestion completes, reducing stale window from 24h to <60s.

## Testing Plan

- [x] `cd frontend && npm test -- --testPathPattern="revalidate"` — 8 tests pass
- [x] `cd backend && python3 -m pytest tests/test_revalidate_client.py -v` — 6 tests pass
- [ ] Manual: `curl -X POST /api/revalidate -H "x-revalidate-secret: $SECRET" -d '{"paths":["/test"]}'` → `{"revalidated":1}`
- [ ] Invalid secret → 401
- [ ] Missing `FRONTEND_REVALIDATE_URL` env → silent skip (no crash in ARQ job)
- [ ] `POST /v1/admin/revalidate-seo` with admin token + valid paths → `{"status":"ok"}`

## Closes

Closes #1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand cache revalidation capability for frontend content
  * Added admin endpoint to manually trigger cache revalidation
  * Backend automatically triggers cache revalidation following data updates

* **Tests**
  * Added test coverage for revalidation client functionality
  * Added test coverage for revalidation API endpoint

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1051)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->