### PR TITLE
feat(frontend): ban notFound() in pSEO routes — EmptyStateSEO + allow markers (#1035)

### DIFF
--- a/.github/workflows/audit-seo-notfound.yml
+++ b/.github/workflows/audit-seo-notfound.yml
@@ -125,6 +125,8 @@ jobs:
 
           # Classify each hit: allowed if `adr-seo-001-allow:` is on the same
           # line OR on the immediately preceding line.
+          # Comment-only lines (trimmed starts with // /* or *) are skipped —
+          # they appear in JSDoc descriptions referencing notFound() in prose.
           : > /tmp/seo_notfound_violations.txt
           while IFS= read -r hit; do
             [ -z "$hit" ] && continue
@@ -132,6 +134,12 @@ jobs:
             rest="${hit#*:}"
             lineno="${rest%%:*}"
             content="${rest#*:}"
+
+            # Skip pure comment lines (JSDoc / inline comments that mention notFound() in prose).
+            trimmed="$(printf '%s' "$content" | sed 's/^[[:space:]]*//')"
+            case "$trimmed" in
+              "//"*|"/*"*|"*"*) continue ;;
+            esac
 
             # Same-line marker?
             if printf '%s' "$content" | grep -q "adr-seo-001-allow:"; then

--- a/frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx
+++ b/frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * ADR-SEO-001 compliance test — programmatic SEO routes must not call
+ * notFound() on data gaps. This test mirrors the CI gate logic in
+ * .github/workflows/audit-seo-notfound.yml so violations are caught
+ * locally before push.
+ *
+ * Rules:
+ * - notFound() calls in code lines are allowed only if the same line OR the
+ *   immediately preceding line contains `adr-seo-001-allow:`.
+ * - Pure comment lines (trimmed starts with //, /*, or *) are exempt.
+ * - Routes that received EmptyStateSEO replacements must not import notFound
+ *   unless they also have format-guard calls marked with adr-seo-001-allow.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { globSync } from 'glob';
+
+const FRONTEND_ROOT = path.resolve(__dirname, '../../');
+
+const PROTECTED_PREFIXES = [
+  'app/observatorio',
+  'app/cnpj',
+  'app/fornecedores',
+  'app/orgaos',
+  'app/municipios',
+  'app/licitacoes',
+  'app/contratos',
+  'app/alertas-publicos',
+  'app/itens',
+  'app/blog',
+  'app/casos',
+  'app/glossario',
+  'app/guia',
+  'app/masterclass',
+  'app/perguntas',
+  'app/compliance',
+];
+
+function collectFiles(): string[] {
+  const results: string[] = [];
+  for (const prefix of PROTECTED_PREFIXES) {
+    const pattern = path.join(FRONTEND_ROOT, prefix, '**/*.{ts,tsx}');
+    const files = globSync(pattern, { nodir: true });
+    results.push(...files);
+  }
+  return results;
+}
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return (
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('/*') ||
+    trimmed.startsWith('*')
+  );
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  content: string;
+}
+
+function scanFile(filePath: string): Violation[] {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const violations: Violation[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.match(/notFound\s*\(/)) continue;
+
+    // Skip comment-only lines
+    if (isCommentLine(line)) continue;
+
+    // Same-line allow marker?
+    if (line.includes('adr-seo-001-allow:')) continue;
+
+    // Preceding-line allow marker?
+    if (i > 0 && lines[i - 1].includes('adr-seo-001-allow:')) continue;
+
+    violations.push({
+      file: path.relative(FRONTEND_ROOT, filePath),
+      line: i + 1,
+      content: line,
+    });
+  }
+  return violations;
+}
+
+describe('ADR-SEO-001: No unmarked notFound() in programmatic SEO routes', () => {
+  const files = collectFiles();
+
+  test('should find at least one protected route file to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  test('all notFound() calls in protected routes carry adr-seo-001-allow marker', () => {
+    const allViolations: Violation[] = [];
+
+    for (const file of files) {
+      const violations = scanFile(file);
+      allViolations.push(...violations);
+    }
+
+    if (allViolations.length > 0) {
+      const details = allViolations
+        .map((v) => `  ${v.file}:${v.line}: ${v.content.trim()}`)
+        .join('\n');
+      fail(
+        `Found ${allViolations.length} unmarked notFound() call(s) in protected SEO routes.\n` +
+          `Add "// adr-seo-001-allow: <reason>" on the same line or preceding line.\n\n` +
+          `Violations:\n${details}`
+      );
+    }
+
+    expect(allViolations).toHaveLength(0);
+  });
+
+  test('data-absence routes render EmptyStateSEO instead of calling notFound()', () => {
+    // Spot-check: routes that fetch backend data must NOT have bare notFound()
+    // for the data-absence case. We verify the key routes have EmptyStateSEO import.
+    const dataAbsenceRoutes = [
+      'app/cnpj/[cnpj]/page.tsx',
+      'app/fornecedores/[cnpj]/page.tsx',
+      'app/orgaos/[slug]/page.tsx',
+      'app/municipios/[slug]/page.tsx',
+      'app/contratos/orgao/[cnpj]/page.tsx',
+      'app/itens/[catmat]/page.tsx',
+      'app/compliance/[cnpj]/page.tsx',
+    ];
+
+    for (const route of dataAbsenceRoutes) {
+      const filePath = path.join(FRONTEND_ROOT, route);
+      if (!fs.existsSync(filePath)) continue;
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('EmptyStateSEO');
+    }
+  });
+});

--- a/frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx
+++ b/frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx
@@ -117,17 +117,6 @@ describe('ADR-SEO-001: No unmarked notFound() in programmatic SEO routes', () =>
       allViolations.push(...violations);
     }
 
-    if (allViolations.length > 0) {
-      const details = allViolations
-        .map((v) => `  ${v.file}:${v.line}: ${v.content.trim()}`)
-        .join('\n');
-      fail(
-        `Found ${allViolations.length} unmarked notFound() call(s) in protected SEO routes.\n` +
-          `Add "// adr-seo-001-allow: <reason>" on the same line or preceding line.\n\n` +
-          `Violations:\n${details}`
-      );
-    }
-
     expect(allViolations).toHaveLength(0);
   });
 

--- a/frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx
+++ b/frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx
@@ -14,7 +14,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { globSync } from 'glob';
 
 const FRONTEND_ROOT = path.resolve(__dirname, '../../');
 
@@ -37,12 +36,26 @@ const PROTECTED_PREFIXES = [
   'app/compliance',
 ];
 
+function collectFilesRecursive(dir: string, exts: string[]): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFilesRecursive(fullPath, exts));
+    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
 function collectFiles(): string[] {
   const results: string[] = [];
   for (const prefix of PROTECTED_PREFIXES) {
-    const pattern = path.join(FRONTEND_ROOT, prefix, '**/*.{ts,tsx}');
-    const files = globSync(pattern, { nodir: true });
-    results.push(...files);
+    const dir = path.join(FRONTEND_ROOT, prefix);
+    results.push(...collectFilesRecursive(dir, ['.ts', '.tsx']));
   }
   return results;
 }

--- a/frontend/app/alertas-publicos/[setor]/[uf]/page.tsx
+++ b/frontend/app/alertas-publicos/[setor]/[uf]/page.tsx
@@ -81,10 +81,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function AlertasPage({ params }: Props) {
   const { setor, uf } = await params;
   const sector = getSectorFromSlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const ufUpper = uf.toUpperCase();
-  if (!ALL_UFS.includes(ufUpper)) notFound();
+  if (!ALL_UFS.includes(ufUpper)) notFound(); // adr-seo-001-allow: uf not in canonical UF list — true 404
 
   const ufName = UF_NAMES[ufUpper] || ufUpper;
   const data = await fetchAlertasPublicos(setor, ufUpper);

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function BlogArticlePage({
         redirect(`/blog/${normalized}`);
       }
     }
-    notFound();
+    notFound(); // adr-seo-001-allow: slug not in static blog article catalog — true 404
   }
 
   const relatedArticles = getRelatedArticles(slug);

--- a/frontend/app/blog/author/[slug]/page.tsx
+++ b/frontend/app/blog/author/[slug]/page.tsx
@@ -48,7 +48,7 @@ export default async function AuthorPage({
 }) {
   const { slug } = await params;
   const author = getAuthorBySlug(slug);
-  if (!author) notFound();
+  if (!author) notFound(); // adr-seo-001-allow: slug not in static author catalog — true 404
 
   const articles = getArticlesByAuthor(slug);
 

--- a/frontend/app/blog/contratos/[setor]/page.tsx
+++ b/frontend/app/blog/contratos/[setor]/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ContratosSetorPillarPage({ params }: Props) {
   const { setor } = await params;
   const sector = getSectorFromSlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const stats = await fetchContratosSetorStats(setor);
   const editorial = getContratosEditorialContent(sector.id);

--- a/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
@@ -191,7 +191,7 @@ export default async function LicitacoesSectorUfPage({
 
   const ufUpper = uf.toUpperCase();
   const sector = getSectorFromSlug(setor);
-  if (!sector || !ALL_UFS.includes(ufUpper)) notFound();
+  if (!sector || !ALL_UFS.includes(ufUpper)) notFound(); // adr-seo-001-allow: sector or uf not in static catalog — true 404
 
   // AC1+AC2: busca paralela — sem aumento de latência de ISR
   const [stats, contractsFallback] = await Promise.all([

--- a/frontend/app/blog/licitacoes/cidade/[cidade]/[setor]/page.tsx
+++ b/frontend/app/blog/licitacoes/cidade/[cidade]/[setor]/page.tsx
@@ -107,7 +107,7 @@ export default async function LicitacoesCidadeSetorPage({
   const { cidade, setor } = await params;
   const city = getCityBySlug(cidade);
   const sector = getSectorBySlug(setor);
-  if (!city || !sector) notFound();
+  if (!city || !sector) notFound(); // adr-seo-001-allow: city or sector not in static catalog — true 404
 
   const stats = await fetchCidadeSectorStats(city.slug, sector.id);
   const ufName = UF_NAMES[city.uf] || city.uf;

--- a/frontend/app/blog/licitacoes/cidade/[cidade]/page.tsx
+++ b/frontend/app/blog/licitacoes/cidade/[cidade]/page.tsx
@@ -104,7 +104,7 @@ export default async function LicitacoesCidadePage({
 }) {
   const { cidade } = await params;
   const city = getCityBySlug(cidade);
-  if (!city) notFound();
+  if (!city) notFound(); // adr-seo-001-allow: cidade not in static city catalog — true 404
 
   // AC1: fetch bids + contracts in parallel; AC8: graceful — contractsFallback stays null on failure
   const [stats, contractsFallback] = await Promise.all([

--- a/frontend/app/blog/panorama/[setor]/page.tsx
+++ b/frontend/app/blog/panorama/[setor]/page.tsx
@@ -87,7 +87,7 @@ export default async function PanoramaSectorPage({
 }) {
   const { setor } = await params;
   const sector = getSectorFromSlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const stats = await fetchPanoramaStats(setor);
   const editorial = getEditorialContent(sector.id);

--- a/frontend/app/blog/programmatic/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/[uf]/page.tsx
@@ -82,7 +82,7 @@ export default async function SectorUfProgrammaticPage({
   const { setor, uf } = await params;
   const ufUpper = uf.toUpperCase();
   const sector = getSectorFromSlug(setor);
-  if (!sector || !ALL_UFS.includes(ufUpper)) notFound();
+  if (!sector || !ALL_UFS.includes(ufUpper)) notFound(); // adr-seo-001-allow: sector or uf not in static catalog — true 404
 
   const stats = await fetchSectorUfBlogStats(setor, ufUpper);
   const ufName = UF_NAMES[ufUpper] || ufUpper;

--- a/frontend/app/blog/programmatic/[setor]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/page.tsx
@@ -75,7 +75,7 @@ export default async function SectorProgrammaticPage({
 }) {
   const { setor } = await params;
   const sector = getSectorFromSlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const stats = await fetchSectorBlogStats(setor);
   const editorial = getEditorialContent(sector.id);

--- a/frontend/app/blog/weekly/[slug]/page.tsx
+++ b/frontend/app/blog/weekly/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import { buildCanonical, SITE_URL } from '@/lib/seo';
 import { getAuthorBySlug, DEFAULT_AUTHOR_SLUG } from '@/lib/authors';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
@@ -215,10 +216,21 @@ export default async function WeeklyDigestPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const data = await fetchWeeklyData(slug);
 
+  // adr-seo-001-allow: slug fails YYYY-Www format — not a valid weekly digest identifier
+  if (!/^\d{4}-w\d{1,2}$/i.test(slug)) notFound();
+
+  const data = await fetchWeeklyData(slug);
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
   if (!data) {
-    notFound();
+    return (
+      <EmptyStateSEO
+        title="Digest semanal ainda não disponível"
+        description="O digest desta semana ainda não foi publicado. Os dados são processados semanalmente — volte em breve ou explore outros digests."
+        ctaHref="/blog"
+        ctaLabel="Ver todos os artigos"
+      />
+    );
   }
 
   const canonicalUrl = buildCanonical(`/blog/weekly/${slug}`);

--- a/frontend/app/casos/[slug]/page.tsx
+++ b/frontend/app/casos/[slug]/page.tsx
@@ -55,7 +55,7 @@ export default async function CaseDetailPage({
 }) {
   const { slug } = await params;
   const c = getCaseBySlug(slug);
-  if (!c) notFound();
+  if (!c) notFound(); // adr-seo-001-allow: slug not in static casos catalog — true 404
 
   const articleSchema = {
     '@context': 'https://schema.org',

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import CnpjPerfilClient from './CnpjPerfilClient';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import InlineTrialCTA from '../../components/InlineTrialCTA';
 import IntelReportCTA from './IntelReportCTA';
 import { LeadCapture } from '@/components/LeadCapture';
@@ -131,8 +131,16 @@ export default async function CnpjPerfilPage({
   const { cnpj } = await params;
   const perfil = await fetchPerfil(cnpj);
 
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
   if (!perfil) {
-    notFound();
+    return (
+      <EmptyStateSEO
+        title="CNPJ sem contratos registrados ainda"
+        description="Este CNPJ não possui contratos públicos registrados nas fontes oficiais no momento. Os dados são indexados diariamente — volte em breve."
+        ctaHref="/cnpj"
+        ctaLabel="Consultar outro CNPJ"
+      />
+    );
   }
 
   const { empresa } = perfil;

--- a/frontend/app/compliance/[cnpj]/page.tsx
+++ b/frontend/app/compliance/[cnpj]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
 
@@ -101,10 +102,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ComplianceCnpjPage({ params }: Props) {
   const { cnpj } = await params;
 
-  if (!/^\d{14}$/.test(cnpj)) notFound();
+  if (!/^\d{14}$/.test(cnpj)) notFound(); // adr-seo-001-allow: cnpj fails 14-digit format check — not a valid CNPJ
 
   const profile = await fetchProfile(cnpj);
-  if (!profile) notFound();
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
+  if (!profile) {
+    return (
+      <EmptyStateSEO
+        title="CNPJ sem registros de sanções ou contratos ainda"
+        description="Este CNPJ não possui registros nas bases de compliance (CEIS/CNEP) no momento. Os dados são atualizados regularmente — volte em breve."
+        ctaHref="/compliance"
+        ctaLabel="Ver due diligence B2G"
+      />
+    );
+  }
 
   const cnpjFmt = cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5');
 

--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -109,10 +109,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ContratosSetorUfPage({ params }: Props) {
   const { setor, uf } = await params;
   const sector = getSectorFromSlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const ufUpper = uf.toUpperCase();
-  if (!ALL_UFS.includes(ufUpper)) notFound();
+  if (!ALL_UFS.includes(ufUpper)) notFound(); // adr-seo-001-allow: uf not in canonical UF list — true 404
 
   const ufName = UF_NAMES[ufUpper] || ufUpper;
 

--- a/frontend/app/contratos/orgao/[cnpj]/page.tsx
+++ b/frontend/app/contratos/orgao/[cnpj]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import { buildCanonical } from '@/lib/seo';
 import { LeadCapture } from '@/components/LeadCapture';
 import TrackingLink from '@/components/TrackingLink';
@@ -117,8 +117,16 @@ export default async function OrgaoContratosPage({ params }: Props) {
   const { cnpj } = await params;
   const stats = await fetchOrgaoContratosStats(cnpj);
 
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
   if (!stats) {
-    notFound();
+    return (
+      <EmptyStateSEO
+        title="Órgão sem contratos registrados ainda"
+        description="Este órgão não possui contratos públicos registrados nas fontes oficiais no momento. Os dados são indexados diariamente — volte em breve."
+        ctaHref="/contratos"
+        ctaLabel="Ver contratos por setor"
+      />
+    );
   }
 
   const orgSchema = {

--- a/frontend/app/fornecedores/[cnpj]/[uf]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/[uf]/page.tsx
@@ -79,10 +79,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function FornecedoresSetorUfPage({ params }: Props) {
   const { cnpj: setor, uf } = await params;
   const sector = getSectorFromSlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const ufUpper = uf.toUpperCase();
-  if (!ALL_UFS.includes(ufUpper)) notFound();
+  if (!ALL_UFS.includes(ufUpper)) notFound(); // adr-seo-001-allow: uf not in canonical UF list — true 404
 
   const ufName = UF_NAMES[ufUpper] || ufUpper;
   const data = await fetchFornecedoresStats(setor, ufUpper.toLowerCase());

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
 import FornecedorPseoCTA from './FornecedorPseoCTA';
@@ -124,10 +125,20 @@ export default async function FornecedorCnpjPage({ params }: Props) {
   const { cnpj } = await params;
 
   // Validacao basica de formato antes de chamar o backend
-  if (!/^\d{14}$/.test(cnpj)) notFound();
+  if (!/^\d{14}$/.test(cnpj)) notFound(); // adr-seo-001-allow: cnpj fails 14-digit format check — not a valid CNPJ
 
   const profile = await fetchProfile(cnpj);
-  if (!profile) notFound();
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
+  if (!profile) {
+    return (
+      <EmptyStateSEO
+        title="Fornecedor sem contratos registrados ainda"
+        description="Este CNPJ não possui contratos públicos registrados nas fontes oficiais no momento. Os dados são indexados diariamente — volte em breve."
+        ctaHref="/fornecedores"
+        ctaLabel="Ver outros fornecedores"
+      />
+    );
+  }
 
   const breadcrumbs = [
     { name: 'SmartLic', url: '/' },

--- a/frontend/app/glossario/[termo]/page.tsx
+++ b/frontend/app/glossario/[termo]/page.tsx
@@ -86,9 +86,7 @@ export default async function GlossaryTermPage({
   const { termo } = await params;
   const term = GLOSSARY_TERMS.find((t) => t.slug === termo);
 
-  if (!term) {
-    notFound();
-  }
+  if (!term) notFound(); // adr-seo-001-allow: termo not in static GLOSSARY_TERMS catalog — true 404
 
   const relatedTermObjects = (term.relatedTerms ?? [])
     .map((slug) => GLOSSARY_TERMS.find((t) => t.slug === slug))

--- a/frontend/app/guia/[slug]/page.tsx
+++ b/frontend/app/guia/[slug]/page.tsx
@@ -66,10 +66,10 @@ export default async function PillarPage({
 }) {
   const { slug } = await params;
   const pillar = getPillarBySlug(slug);
-  if (!pillar) notFound();
+  if (!pillar) notFound(); // adr-seo-001-allow: slug not in static pillars catalog — true 404
 
   const entry = CONTENT[pillar.slug as PillarSlug];
-  if (!entry) notFound();
+  if (!entry) notFound(); // adr-seo-001-allow: no content component for this pillar slug — true 404
 
   const Content = entry.Component;
   return (

--- a/frontend/app/itens/[catmat]/page.tsx
+++ b/frontend/app/itens/[catmat]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 
 const BACKEND_URL = getBackendUrl();
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
@@ -106,10 +107,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ItemCatmatPage({ params }: Props) {
   const { catmat } = await params;
 
-  if (!/^\d{1,9}$/.test(catmat)) notFound();
+  if (!/^\d{1,9}$/.test(catmat)) notFound(); // adr-seo-001-allow: catmat fails digit-only format — not a valid CATMAT code
 
   const profile = await fetchProfile(catmat);
-  if (!profile) notFound();
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
+  if (!profile) {
+    return (
+      <EmptyStateSEO
+        title="Código CATMAT sem dados de benchmark ainda"
+        description="Este código CATMAT não possui dados de benchmark de preços nas fontes oficiais no momento. Os dados são indexados diariamente — volte em breve."
+        ctaHref="/itens"
+        ctaLabel="Ver benchmark de preços"
+      />
+    );
+  }
 
   const breadcrumbs = [
     { name: 'SmartLic', url: '/' },

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -96,7 +96,7 @@ export default async function SectorPage({
 }) {
   const { setor } = await params;
   const sector = getSectorBySlug(setor);
-  if (!sector) notFound();
+  if (!sector) notFound(); // adr-seo-001-allow: setor not in static sector catalog — true 404
 
   const stats = await fetchSectorStats(setor);
   const faqs = getSectorFaqs(sector.id);

--- a/frontend/app/masterclass/[tema]/page.tsx
+++ b/frontend/app/masterclass/[tema]/page.tsx
@@ -64,7 +64,7 @@ export default async function MasterclassPage({
 }) {
   const { tema } = await params;
   const mc = getMasterclassByTema(tema);
-  if (!mc) notFound();
+  if (!mc) notFound(); // adr-seo-001-allow: tema not in static masterclass catalog — true 404
 
   const author = getAuthorBySlug(mc.instructor);
   const canonical = buildCanonical(`/masterclass/${tema}`);

--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import { getUfPrep } from '@/lib/programmatic';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
@@ -121,10 +122,20 @@ export default async function MunicipioSlugPage({ params }: Props) {
   const { slug } = await params;
 
   // Validação básica de formato: apenas letras minúsculas, números e hífens
-  if (!/^[a-z0-9-]+$/.test(slug)) notFound();
+  if (!/^[a-z0-9-]+$/.test(slug)) notFound(); // adr-seo-001-allow: slug fails basic format check — not a valid municipio identifier
 
   const profile = await fetchProfile(slug);
-  if (!profile) notFound();
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
+  if (!profile) {
+    return (
+      <EmptyStateSEO
+        title="Município sem licitações registradas ainda"
+        description="Este município não possui licitações públicas registradas nas fontes oficiais no momento. Os dados são indexados diariamente — volte em breve."
+        ctaHref="/municipios"
+        ctaLabel="Ver outros municípios"
+      />
+    );
+  }
 
   const breadcrumbs = [
     { name: 'SmartLic', url: '/' },

--- a/frontend/app/observatorio/[slug]/page.tsx
+++ b/frontend/app/observatorio/[slug]/page.tsx
@@ -145,7 +145,7 @@ export default async function RelatorioPage({
   const { slug } = await params;
   // STORY-431 AC13: malformed slug → 404 (page itself, plus noindex metadata).
   const parsed = parseSlug(slug);
-  if (!parsed) notFound();
+  if (!parsed) notFound(); // adr-seo-001-allow: slug fails raio-x-{mes}-{ano} format — not a valid observatorio period
 
   const { mes, ano } = parsed;
   const mesDisplay = MONTH_NAMES_DISPLAY[mes] ?? String(mes);

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import OrgaoPerfilClient from './OrgaoPerfilClient';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import InlineTrialCTA from '../../components/InlineTrialCTA';
 import { LeadCapture } from '@/components/LeadCapture';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
@@ -130,8 +130,16 @@ export default async function OrgaoPerfilPage({
   const { slug } = await params;
   const stats = await fetchOrgaoStats(slug);
 
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
   if (!stats) {
-    notFound();
+    return (
+      <EmptyStateSEO
+        title="Órgão público sem licitações registradas ainda"
+        description="Este órgão não possui licitações públicas registradas nas fontes oficiais no momento. Os dados são indexados diariamente — volte em breve."
+        ctaHref="/orgaos"
+        ctaLabel="Ver outros órgãos"
+      />
+    );
   }
 
   const orgSchema = {


### PR DESCRIPTION
## Summary

Implements ADR-SEO-001 across all 16 protected programmatic SEO path prefixes (~28 route files). Closes #1035.

**Root cause:** ISR caches `notFound()` responses for the full `revalidate` window (1h–24h). A single transient backend blip during an ISR regen wave produces a hard 404 that Googlebot reads, drops the URL from the index, and cascades de-indexation to sibling URLs. Recovery takes weeks.

**Changes:**

- **8 data-absence `notFound()` calls → `<EmptyStateSEO>` (HTTP 200 + noindex,follow)**
  - `cnpj/[cnpj]`, `fornecedores/[cnpj]`, `orgaos/[slug]`, `municipios/[slug]`
  - `contratos/orgao/[cnpj]`, `itens/[catmat]`, `compliance/[cnpj]`, `blog/weekly/[slug]`

- **24 legitimate `notFound()` calls annotated with `// adr-seo-001-allow: <reason>`**
  - Malformed slug format checks (regex fails before any fetch)
  - Static catalog misses (sector, UF, city, author, glossary term, guide pillar, masterclass, question, case study)

- **CI workflow update** (`.github/workflows/audit-seo-notfound.yml`): skip comment-only lines that mention `notFound()` in JSDoc prose — eliminates false positives from `/observatorio/[slug]` page comments

- **Local gate test** (`frontend/__tests__/app/programmatic-routes-no-notfound.test.tsx`): mirrors CI gate logic so violations are caught pre-push without waiting for CI

## Testing Plan

- [ ] CI gate `audit-seo-notfound.yml` passes with 0 violations
- [ ] Local gate simulation (`grep` + marker check) confirms 0 violations (verified in dev)
- [ ] `EmptyStateSEO` renders correctly for data-absent paths — HTTP 200, `<meta robots="noindex,follow">`
- [ ] Format-invalid slugs (e.g. `/cnpj/abc`, `/itens/xyz`) still return 404 (allow-marked paths)
- [ ] Static catalog misses (unknown sector, UF, glossary term) still return 404

## Closes

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)