### PR TITLE
feat(backend/sql): CNPJ alfanumérico-ready — utilitário + migration + rotas (#1055)

### DIFF
--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from metrics import record_sitemap_count
 from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
+from utils.cnpj_validator import is_valid_cnpj_format
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
@@ -185,7 +186,7 @@ def _fetch_top_cnpjs() -> dict:
                 raw = resp.data if isinstance(resp.data, list) else []
                 buyer_list = [
                     c for c in raw
-                    if c and isinstance(c, str) and len(c) >= 11
+                    if isinstance(c, str) and is_valid_cnpj_format(c)
                 ]
                 cnpj_list = _merge_with_seed(buyer_list)
                 logger.info(
@@ -223,7 +224,7 @@ def _fetch_top_cnpjs() -> dict:
                 break
             for row in resp.data:
                 cnpj = (row.get("orgao_cnpj") or "").strip()
-                if cnpj and len(cnpj) >= 11:
+                if is_valid_cnpj_format(cnpj):
                     counts[cnpj] = counts.get(cnpj, 0) + 1
             if len(resp.data) < page_size:
                 break
@@ -330,8 +331,7 @@ def _fetch_top_fornecedores_cnpjs() -> dict:
                 break
             for row in resp.data:
                 cnpj = (row.get("ni_fornecedor") or "").strip()
-                # Aceitar apenas CNPJs de 14 digitos numericos
-                if cnpj and len(cnpj) == 14 and cnpj.isdigit():
+                if is_valid_cnpj_format(cnpj):
                     counts[cnpj] = counts.get(cnpj, 0) + 1
             if len(resp.data) < page_size:
                 break

--- a/backend/routes/sitemap_orgaos.py
+++ b/backend/routes/sitemap_orgaos.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 
 from metrics import record_sitemap_count
 from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
+from utils.cnpj_validator import is_valid_cnpj_format
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["sitemap"])
@@ -118,7 +119,7 @@ def _fetch_top_orgaos() -> dict:
                 raw = resp.data if isinstance(resp.data, list) else []
                 orgao_list = [
                     c for c in raw
-                    if c and isinstance(c, str) and len(c) >= 11
+                    if isinstance(c, str) and is_valid_cnpj_format(c)
                 ][:_MAX_ORGAOS]
                 logger.info(
                     "sitemap_orgaos (JSON RPC): %d órgãos returned", len(orgao_list)
@@ -152,7 +153,7 @@ def _fetch_top_orgaos() -> dict:
                 break
             for row in resp.data:
                 cnpj = (row.get("orgao_cnpj") or "").strip()
-                if cnpj and len(cnpj) >= 11:
+                if is_valid_cnpj_format(cnpj):
                     counts[cnpj] = counts.get(cnpj, 0) + 1
             if len(resp.data) < page_size:
                 break
@@ -271,7 +272,7 @@ def _fetch_contratos_orgao_indexable() -> dict:
                 break
             for row in resp.data:
                 cnpj = (row.get("orgao_cnpj") or "").strip()
-                if cnpj and len(cnpj) == 14 and cnpj.isdigit():
+                if is_valid_cnpj_format(cnpj):
                     counts[cnpj] = counts.get(cnpj, 0) + 1
             if len(resp.data) < page_size:
                 break

--- a/backend/tests/test_cnpj_validator.py
+++ b/backend/tests/test_cnpj_validator.py
@@ -1,0 +1,46 @@
+"""Tests for utils/cnpj_validator — alfanumérico-ready (IN 2.229/2024)."""
+
+import pytest
+
+from utils.cnpj_validator import is_valid_cnpj_format, normalize_cnpj
+
+
+@pytest.mark.parametrize("cnpj,expected", [
+    # Válidos — numérico sem máscara
+    ("12345678000195", True),
+    ("00000000000191", True),   # BNDES
+    # Válidos — alfanumérico futuro (12 alnum + 2 dígitos)
+    ("AB3DEF78000195", True),
+    ("ab3def78000195", True),   # lowercase deve ser normalizado
+    ("AAAAAAAAAAAA12", True),   # 12 letras + 2 dígitos
+    ("000000000A0A12", True),   # mix
+    # Válidos — com máscara padrão
+    ("12.345.678/0001-95", True),
+    ("00.000.000/0001-91", True),
+    # Inválidos — CPF (11 dígitos)
+    ("93513712553", False),
+    ("00000000000", False),
+    # Inválidos — tamanho errado
+    ("570731320001602", False),  # 15 dígitos
+    ("1234567800019", False),    # 13 dígitos
+    ("123456780001", False),     # 12 dígitos
+    # Inválidos — vazio / None / tipo errado
+    ("", False),
+    (None, False),   # type: ignore[arg-type]
+    (12345678000195, False),  # type: ignore[arg-type]  # int
+    # Inválidos — caracteres especiais restantes após remoção de máscara
+    ("12345678 0001 95", False),  # espaço → 16 chars → mismatch
+])
+def test_is_valid_cnpj_format(cnpj, expected):
+    assert is_valid_cnpj_format(cnpj) == expected, f"cnpj={cnpj!r} expected={expected}"
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("12.345.678/0001-95", "12345678000195"),
+    ("ab3def78000195", "AB3DEF78000195"),
+    ("", ""),
+    (None, ""),
+    ("AB-CD/EF.12", "ABCDEF12"),
+])
+def test_normalize_cnpj(raw, expected):
+    assert normalize_cnpj(raw) == expected, f"raw={raw!r} expected={expected!r}"

--- a/backend/utils/cnpj_validator.py
+++ b/backend/utils/cnpj_validator.py
@@ -1,0 +1,62 @@
+"""CNPJ format validation — alfanumérico-ready para IN 2.229/2024.
+
+A Receita Federal IN 2.229/2024 introduz CNPJs alfanuméricos (12 chars [A-Z0-9]
++ 2 dígitos verificadores) com vigência a partir de 01/07/2026. Este módulo
+centraliza a validação de formato para backend e sitemap, eliminando o uso de
+`isdigit()` e `length >= 11` que (a) rejeitariam CNPJs futuros e (b) aceitam
+CPFs (11 dígitos) e strings inválidas, causando páginas 404 no GSC.
+
+Uso:
+    from utils.cnpj_validator import is_valid_cnpj_format, normalize_cnpj
+
+    if is_valid_cnpj_format("12.345.678/0001-95"):
+        ...  # True — CNPJ numérico com máscara
+    if is_valid_cnpj_format("AB3DEF78000195"):
+        ...  # True — CNPJ alfanumérico futuro (01/07/2026)
+"""
+
+import re
+
+# CNPJ sem máscara: 12 chars alfanuméricos (A-Z0-9) + 2 dígitos verificadores
+_CNPJ_PATTERN = re.compile(r'^[A-Z0-9]{12}\d{2}$', re.IGNORECASE)
+
+# CPF sem máscara: exatamente 11 dígitos — deve ser rejeitado
+_CPF_PATTERN = re.compile(r'^\d{11}$')
+
+# Caracteres de máscara CNPJ: pontos, barras, hífens
+_STRIP_MASK = re.compile(r'[.\-/]')
+
+# Remove qualquer char não alfanumérico (genérico, para normalize_cnpj)
+_STRIP_NON_ALNUM = re.compile(r'[^A-Z0-9]')
+
+
+def is_valid_cnpj_format(c: str) -> bool:
+    """Valida formato CNPJ — alfanumérico-ready para 01/07/2026 (IN 2.229/2024).
+
+    Aceita:
+    - CNPJ numérico sem máscara: "12345678000195" (14 dígitos)
+    - CNPJ alfanumérico futuro: "AB3DEF78000195" (12 alnum + 2 dígitos)
+    - CNPJ com máscara padrão: "12.345.678/0001-95"
+
+    Rejeita:
+    - CPF (11 dígitos puramente numéricos)
+    - Strings com menos ou mais de 14 caracteres úteis
+    - None, vazio, tipos não-string
+    """
+    if not c or not isinstance(c, str):
+        return False
+    normalized = _STRIP_MASK.sub('', c.upper())
+    # Deve ter exatamente 14 chars após remoção de máscara, ser alfanumérico
+    # no padrão CNPJ, e não ser um CPF (11 dígitos)
+    return bool(_CNPJ_PATTERN.match(normalized)) and not bool(_CPF_PATTERN.match(normalized))
+
+
+def normalize_cnpj(c: str) -> str:
+    """Remove formatação, retorna string limpa uppercase.
+
+    "12.345.678/0001-95" → "12345678000195"
+    "ab3def78000195" → "AB3DEF78000195"
+    "" → ""
+    None → ""
+    """
+    return _STRIP_NON_ALNUM.sub('', (c or '').upper())

--- a/frontend/lib/cnpj.ts
+++ b/frontend/lib/cnpj.ts
@@ -1,0 +1,46 @@
+/**
+ * CNPJ format validation — alfanumérico-ready para IN 2.229/2024.
+ *
+ * A Receita Federal IN 2.229/2024 introduz CNPJs alfanuméricos
+ * (12 chars [A-Z0-9] + 2 dígitos verificadores) com vigência a partir de 01/07/2026.
+ * Este módulo centraliza a validação de formato no frontend, eliminando checks
+ * `length === 14` que rejeitarão CNPJs alfanuméricos futuros.
+ *
+ * Uso:
+ *   import { isValidCnpjFormat, normalizeCnpj } from '@/lib/cnpj';
+ *   if (isValidCnpjFormat('12.345.678/0001-95')) { ... }
+ *   if (isValidCnpjFormat('AB3DEF78000195')) { ... }  // alfanumérico futuro
+ */
+
+const CNPJ_PATTERN = /^[A-Z0-9]{12}\d{2}$/i;
+const CPF_PATTERN = /^\d{11}$/;
+
+/**
+ * Valida formato CNPJ — alfanumérico-ready para 01/07/2026 (IN 2.229/2024).
+ *
+ * Aceita:
+ * - CNPJ numérico sem máscara: "12345678000195" (14 dígitos)
+ * - CNPJ alfanumérico futuro: "AB3DEF78000195" (12 alnum + 2 dígitos)
+ * - CNPJ com máscara padrão: "12.345.678/0001-95"
+ *
+ * Rejeita:
+ * - CPF (11 dígitos puramente numéricos)
+ * - Strings com menos ou mais de 14 chars úteis após remover máscara
+ * - Valores nulos, vazios ou não-string
+ */
+export function isValidCnpjFormat(s: string | null | undefined): boolean {
+  if (!s || typeof s !== 'string') return false;
+  const clean = s.replace(/[.\-\/]/g, '').toUpperCase();
+  return CNPJ_PATTERN.test(clean) && !CPF_PATTERN.test(clean);
+}
+
+/**
+ * Remove formatação, retorna string limpa uppercase.
+ *
+ * "12.345.678/0001-95" → "12345678000195"
+ * "ab3def78000195"     → "AB3DEF78000195"
+ * ""                   → ""
+ */
+export function normalizeCnpj(s: string | null | undefined): string {
+  return (s ?? '').replace(/[^A-Z0-9]/gi, '').toUpperCase();
+}

--- a/supabase/migrations/20260510120000_sitemap_cnpj_alpha_validation.down.sql
+++ b/supabase/migrations/20260510120000_sitemap_cnpj_alpha_validation.down.sql
@@ -1,0 +1,91 @@
+-- Rollback: Reverte SEO-CNPJ-ALPHA-001
+-- Restaura critério `length >= 11` nas funções RPC de sitemap.
+-- AVISO: este rollback reintroduz a aceitação de CPFs (11 dígitos) e strings
+-- inválidas no sitemap — aplicar apenas em emergência.
+
+-- get_sitemap_cnpjs_json
+CREATE OR REPLACE FUNCTION public.get_sitemap_cnpjs_json(max_results integer DEFAULT 5000)
+RETURNS json
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(json_agg(t.orgao_cnpj ORDER BY t.bid_count DESC), '[]'::json)
+  FROM (
+    SELECT orgao_cnpj, COUNT(*) AS bid_count
+    FROM pncp_raw_bids
+    WHERE is_active = true
+      AND orgao_cnpj IS NOT NULL
+      AND orgao_cnpj <> ''
+      AND length(orgao_cnpj) >= 11
+    GROUP BY orgao_cnpj
+    ORDER BY bid_count DESC
+    LIMIT max_results
+  ) t;
+$$;
+
+-- get_sitemap_orgaos_json
+CREATE OR REPLACE FUNCTION public.get_sitemap_orgaos_json(max_results integer DEFAULT 2000)
+RETURNS json
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(json_agg(t.orgao_cnpj ORDER BY t.bid_count DESC), '[]'::json)
+  FROM (
+    SELECT orgao_cnpj, COUNT(*) AS bid_count
+    FROM pncp_raw_bids
+    WHERE is_active = true
+      AND orgao_cnpj IS NOT NULL
+      AND orgao_cnpj <> ''
+      AND length(orgao_cnpj) >= 11
+    GROUP BY orgao_cnpj
+    ORDER BY bid_count DESC
+    LIMIT max_results
+  ) t;
+$$;
+
+-- get_sitemap_cnpjs
+CREATE OR REPLACE FUNCTION public.get_sitemap_cnpjs(max_results integer DEFAULT 5000)
+RETURNS TABLE(orgao_cnpj text, bid_count bigint)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT orgao_cnpj, COUNT(*) AS bid_count
+  FROM pncp_raw_bids
+  WHERE is_active = true
+    AND orgao_cnpj IS NOT NULL
+    AND orgao_cnpj <> ''
+    AND length(orgao_cnpj) >= 11
+  GROUP BY orgao_cnpj
+  ORDER BY bid_count DESC
+  LIMIT max_results;
+$$;
+
+-- get_sitemap_orgaos
+CREATE OR REPLACE FUNCTION public.get_sitemap_orgaos(max_results integer DEFAULT 2000)
+RETURNS TABLE(orgao_cnpj text, bid_count bigint)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT orgao_cnpj, COUNT(*) AS bid_count
+  FROM pncp_raw_bids
+  WHERE is_active = true
+    AND orgao_cnpj IS NOT NULL
+    AND orgao_cnpj <> ''
+    AND length(orgao_cnpj) >= 11
+  GROUP BY orgao_cnpj
+  ORDER BY bid_count DESC
+  LIMIT max_results;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_sitemap_cnpjs_json(integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_sitemap_orgaos_json(integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_sitemap_cnpjs(integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_sitemap_orgaos(integer) TO anon, authenticated, service_role;

--- a/supabase/migrations/20260510120000_sitemap_cnpj_alpha_validation.sql
+++ b/supabase/migrations/20260510120000_sitemap_cnpj_alpha_validation.sql
@@ -1,0 +1,98 @@
+-- SEO-CNPJ-ALPHA-001: Substituir length >= 11 por regex CNPJ alfanumérico
+-- nas funções RPC de sitemap.
+--
+-- Motivo: Receita Federal IN 2.229/2024 introduz CNPJs alfanuméricos
+-- (formato: 12 chars [A-Z0-9] + 2 dígitos verificadores) a partir de 01/07/2026.
+-- O critério anterior `length(orgao_cnpj) >= 11` aceitava CPFs (11 dígitos) e
+-- strings inválidas, causando ~2.962 páginas 404 no Google Search Console.
+--
+-- Regex: '^[A-Z0-9]{12}[0-9]{2}$' com flag 'i' (case insensitive)
+-- Rejeita: CPF (exatamente 11 dígitos), strings < 14 chars, strings > 14 chars
+-- Aceita: CNPJ numérico 14 dígitos, CNPJ alfanumérico futuro (12 alnum + 2 num)
+
+-- get_sitemap_cnpjs_json: returns JSON array of top CNPJs (no row-count cap)
+CREATE OR REPLACE FUNCTION public.get_sitemap_cnpjs_json(max_results integer DEFAULT 5000)
+RETURNS json
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(json_agg(t.orgao_cnpj ORDER BY t.bid_count DESC), '[]'::json)
+  FROM (
+    SELECT orgao_cnpj, COUNT(*) AS bid_count
+    FROM pncp_raw_bids
+    WHERE is_active = true
+      AND orgao_cnpj IS NOT NULL
+      AND orgao_cnpj <> ''
+      AND orgao_cnpj ~* '^[A-Z0-9]{12}[0-9]{2}$'
+    GROUP BY orgao_cnpj
+    ORDER BY bid_count DESC
+    LIMIT max_results
+  ) t;
+$$;
+
+-- get_sitemap_orgaos_json: returns JSON array of top órgãos (no row-count cap)
+CREATE OR REPLACE FUNCTION public.get_sitemap_orgaos_json(max_results integer DEFAULT 2000)
+RETURNS json
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(json_agg(t.orgao_cnpj ORDER BY t.bid_count DESC), '[]'::json)
+  FROM (
+    SELECT orgao_cnpj, COUNT(*) AS bid_count
+    FROM pncp_raw_bids
+    WHERE is_active = true
+      AND orgao_cnpj IS NOT NULL
+      AND orgao_cnpj <> ''
+      AND orgao_cnpj ~* '^[A-Z0-9]{12}[0-9]{2}$'
+    GROUP BY orgao_cnpj
+    ORDER BY bid_count DESC
+    LIMIT max_results
+  ) t;
+$$;
+
+-- get_sitemap_cnpjs: returns top CNPJs sorted by bid count, for /cnpj/{cnpj} pages
+CREATE OR REPLACE FUNCTION public.get_sitemap_cnpjs(max_results integer DEFAULT 5000)
+RETURNS TABLE(orgao_cnpj text, bid_count bigint)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT orgao_cnpj, COUNT(*) AS bid_count
+  FROM pncp_raw_bids
+  WHERE is_active = true
+    AND orgao_cnpj IS NOT NULL
+    AND orgao_cnpj <> ''
+    AND orgao_cnpj ~* '^[A-Z0-9]{12}[0-9]{2}$'
+  GROUP BY orgao_cnpj
+  ORDER BY bid_count DESC
+  LIMIT max_results;
+$$;
+
+-- get_sitemap_orgaos: returns top órgãos sorted by bid count, for /orgaos/{cnpj} pages
+CREATE OR REPLACE FUNCTION public.get_sitemap_orgaos(max_results integer DEFAULT 2000)
+RETURNS TABLE(orgao_cnpj text, bid_count bigint)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT orgao_cnpj, COUNT(*) AS bid_count
+  FROM pncp_raw_bids
+  WHERE is_active = true
+    AND orgao_cnpj IS NOT NULL
+    AND orgao_cnpj <> ''
+    AND orgao_cnpj ~* '^[A-Z0-9]{12}[0-9]{2}$'
+  GROUP BY orgao_cnpj
+  ORDER BY bid_count DESC
+  LIMIT max_results;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_sitemap_cnpjs_json(integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_sitemap_orgaos_json(integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_sitemap_cnpjs(integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_sitemap_orgaos(integer) TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

- New `backend/utils/cnpj_validator.py` with `is_valid_cnpj_format()` — suporta CNPJ alfanumérico (Receita Federal IN 2.229/2024, vigência 01/07/2026). Rejeita CPFs (11 dígitos) que causavam ~2.962 páginas 404 no GSC.
- SQL migration `20260510120000_sitemap_cnpj_alpha_validation.sql` substitui `length >= 11` pelo regex `^[A-Z0-9]{12}[0-9]{2}$` nas quatro funções RPC de sitemap. Paired `.down.sql` rollback incluído.
- `backend/routes/sitemap_cnpjs.py` e `sitemap_orgaos.py` atualizados para usar o validador centralizado (elimina `len(c) >= 11`, `len(cnpj) == 14 and cnpj.isdigit()` antipatterns).
- `frontend/lib/cnpj.ts`: utilitários TypeScript `isValidCnpjFormat()` e `normalizeCnpj()` com mesma lógica de validação.

## Testing Plan

- [x] `pytest tests/test_cnpj_validator.py` — 22 casos parametrizados: CNPJ numérico válido, alfanumérico futuro, CPF (rejeita), oversized, com máscara, None, int — todos passando
- [ ] Backend sitemap routes: verificar que slugs CPF são excluídos, CNPJs 14-char válidos incluídos
- [x] Migration: arquivo .sql + .down.sql paired presentes

## Closes

Closes #1055