### PR TITLE
feat(frontend): CTA secundario 'So quero ver os dados' em pSEO pages (#1009)

### DIFF
--- a/frontend/app/components/programmatic/PSEOTemplate.tsx
+++ b/frontend/app/components/programmatic/PSEOTemplate.tsx
@@ -16,6 +16,7 @@
  * robusta, ecossistema, stakeholders.
  */
 import Link from "next/link";
+import PreviewCTA from "./PreviewCTA";
 
 export type PSEOContext = {
   setor: string;              // "Pavimentação asfáltica"
@@ -194,6 +195,15 @@ export default function PSEOTemplate({ ctx, dataBlock }: Props) {
           </div>
         </div>
       </section>
+
+      {/* Preview CTA secundário (#1009 COPY-PSEO-CTA-010): "Ver 3 editais grátis" com blurred premium */}
+      <PreviewCTA
+        setor={ctx.setorSlug}
+        uf={ctx.ufSigla}
+        setorLabel={ctx.setor}
+        ufLabel={ctx.ufNome ?? ""}
+        totalOpen={total}
+      />
 
       {/* Como o SmartLic encontra editais antes de você (AC: educativo problem/solution aware) */}
       <section className="max-w-5xl mx-auto py-12 px-4">

--- a/frontend/app/components/programmatic/PreviewCTA.tsx
+++ b/frontend/app/components/programmatic/PreviewCTA.tsx
@@ -1,0 +1,372 @@
+"use client";
+/**
+ * PreviewCTA — Issue #1009 (COPY-PSEO-CTA-010)
+ *
+ * Secondary CTA for pSEO pages: "Só quero ver os dados — Ver 3 editais grátis"
+ * Opens an inline preview showing 3 free bid cards + 2-3 premium blurred cards
+ * with a signup banner for the remaining count.
+ *
+ * Drugay UX Ethics — visitor SEO research mode: show value before paywall.
+ * No auth required for the preview state.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface EditalItem {
+  orgao: string;
+  objeto: string;
+  valor_estimado: number | null;
+  data_limite: string | null;
+  data_publicacao: string | null;
+  link_interno: string;
+}
+
+interface RecentEditaisResponse {
+  items: EditalItem[];
+  total: number;
+}
+
+export interface PreviewCTAProps {
+  setor: string; // URL slug, e.g. "pavimentacao-asfaltica"
+  uf?: string; // UF code, e.g. "SC"
+  setorLabel: string; // Human label, e.g. "Pavimentacao asfaltica"
+  ufLabel: string; // Human label, e.g. "Santa Catarina"
+  totalOpen?: number; // Total open editais for the banner label
+}
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const VISIBLE_COUNT = 3;
+const PREMIUM_COUNT = 3; // blurred
+const FETCH_LIMIT = VISIBLE_COUNT + PREMIUM_COUNT; // 6
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function formatBRL(value: number | null): string {
+  if (value === null || value === undefined) return "N/I";
+  if (value >= 1_000_000) {
+    return `R$ ${(value / 1_000_000).toFixed(1)} M`;
+  }
+  if (value >= 1_000) {
+    return `R$ ${(value / 1_000).toFixed(0)} mil`;
+  }
+  return value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  try {
+    return new Date(dateStr).toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+/** Check if `?preview=true` is in the current URL (for auto-open). */
+function hasPreviewParam(): boolean {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("preview") === "true";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Skeleton card shown while loading                                  */
+/* ------------------------------------------------------------------ */
+
+function SkeletonCard({ delay }: { delay: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, delay }}
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+    >
+      <div className="h-4 w-3/5 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-3" />
+      <div className="h-3 w-full bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-2" />
+      <div className="h-3 w-4/5 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-3" />
+      <div className="flex justify-between">
+        <div className="h-3 w-1/4 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        <div className="h-3 w-1/3 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+      </div>
+    </motion.div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Bid card — fully visible or blurred (premium)                     */
+/* ------------------------------------------------------------------ */
+
+function BidCard({
+  item,
+  isPremium,
+  index,
+}: {
+  item: EditalItem;
+  isPremium: boolean;
+  index: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay: index * 0.08 }}
+      className={`rounded-xl border p-4 transition-colors ${
+        isPremium
+          ? "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+          : "border-brand-blue/20 dark:border-brand-blue/30 bg-white dark:bg-gray-800"
+      }`}
+    >
+      {/* Órgão */}
+      <p
+        className={`text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1 ${
+          isPremium ? "blur-[3px] select-none" : ""
+        }`}
+      >
+        {item.orgao}
+      </p>
+
+      {/* Objeto */}
+      <p
+        className={`text-sm font-medium text-gray-900 dark:text-white line-clamp-2 mb-3 leading-snug ${
+          isPremium ? "blur-[2px] select-none" : ""
+        }`}
+      >
+        {item.objeto}
+      </p>
+
+      {/* Valor + Data */}
+      <div className="flex items-center justify-between text-xs">
+        <span
+          className={`text-gray-600 dark:text-gray-400 ${
+            isPremium ? "blur-[4px] select-none" : ""
+          }`}
+        >
+          {formatBRL(item.valor_estimado)}
+        </span>
+        <span
+          className={`text-gray-500 dark:text-gray-500 ${
+            isPremium ? "blur-[3px] select-none" : ""
+          }`}
+        >
+          {formatDate(item.data_limite)}
+        </span>
+      </div>
+
+      {/* Detail link (blurred for premium) */}
+      {isPremium ? (
+        <div className="mt-3 h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded blur-[2px]" />
+      ) : (
+        <Link
+          href={item.link_interno}
+          className="mt-3 inline-block text-xs text-brand-blue hover:underline font-medium"
+        >
+          Ver detalhes →
+        </Link>
+      )}
+    </motion.div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Component                                                     */
+/* ------------------------------------------------------------------ */
+
+export default function PreviewCTA({
+  setor,
+  uf,
+  setorLabel,
+  ufLabel,
+  totalOpen,
+}: PreviewCTAProps) {
+  const [isOpen, setIsOpen] = useState(hasPreviewParam);
+  const [data, setData] = useState<RecentEditaisResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+
+    const params = new URLSearchParams({ setor, limit: String(FETCH_LIMIT) });
+    if (uf) params.set("uf", uf);
+
+    try {
+      const res = await fetch(`/api/pseo/recent-editais?${params.toString()}`);
+      if (!res.ok) throw new Error("Fetch failed");
+      const json: RecentEditaisResponse = await res.json();
+      setData(json);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [setor, uf]);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+
+    // Track click
+    if (typeof window !== "undefined" && (window as unknown as Record<string, unknown>).mixpanel) {
+      (window as unknown as Record<string, unknown>).mixpanel.track("pseo_preview_cta_click", {
+        setor,
+        uf: uf ?? null,
+      });
+    }
+
+    fetchData();
+  }, [setor, uf, fetchData]);
+
+  // Auto-open if ?preview=true was in the URL on mount
+  useEffect(() => {
+    if (hasPreviewParam() && !data && !loading && !error) {
+      fetchData();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const visibleItems = data?.items.slice(0, VISIBLE_COUNT) ?? [];
+  const premiumItems = data?.items.slice(VISIBLE_COUNT, FETCH_LIMIT) ?? [];
+  const remaining = totalOpen
+    ? Math.max(0, totalOpen - VISIBLE_COUNT)
+    : data
+      ? Math.max(0, data.total - VISIBLE_COUNT)
+      : 0;
+
+  /* ---- CTA button (closed state) ---- */
+  if (!isOpen) {
+    return (
+      <section
+        aria-label="Preview gratuito de editais"
+        className="max-w-5xl mx-auto px-4"
+      >
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="
+            w-full sm:w-auto
+            inline-flex items-center justify-center
+            px-6 py-3
+            bg-white dark:bg-gray-800
+            text-brand-blue dark:text-brand-blue
+            font-semibold text-sm sm:text-base
+            rounded-xl
+            border-2 border-brand-blue/40 dark:border-brand-blue/60
+            hover:bg-brand-blue/5 hover:border-brand-blue
+            transition-all duration-200
+            shadow-sm hover:shadow-md
+            cursor-pointer
+          "
+          data-testid="preview-cta-button"
+        >
+          Só quero ver os dados — Ver {VISIBLE_COUNT} editais grátis →
+        </button>
+      </section>
+    );
+  }
+
+  /* ---- Preview state ---- */
+  return (
+    <AnimatePresence mode="wait">
+      <section
+        aria-label="Preview de editais"
+        className="max-w-5xl mx-auto px-4"
+        data-testid="preview-section"
+      >
+        {/* Loading */}
+        {loading && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: FETCH_LIMIT }).map((_, i) => (
+              <SkeletonCard key={i} delay={i * 0.06} />
+            ))}
+          </div>
+        )}
+
+        {/* Error */}
+        {error && !loading && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="rounded-xl border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-6 text-center"
+            data-testid="preview-error"
+          >
+            <p className="text-sm text-red-700 dark:text-red-400 mb-3">
+              Não foi possível carregar os editais no momento.
+            </p>
+            <button
+              type="button"
+              onClick={fetchData}
+              className="px-4 py-2 text-sm font-medium text-red-700 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors"
+            >
+              Tentar novamente
+            </button>
+          </motion.div>
+        )}
+
+        {/* Data */}
+        {!loading && !error && data && (
+          <>
+            {/* Section heading */}
+            <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-4">
+              Últimos editais de {setorLabel}{uf ? ` em ${ufLabel}` : ""}
+            </h3>
+
+            {/* Cards grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {/* Visible (free) */}
+              {visibleItems.map((item, idx) => (
+                <BidCard key={`free-${idx}`} item={item} isPremium={false} index={idx} />
+              ))}
+
+              {/* Premium (blurred) */}
+              {premiumItems.map((item, idx) => (
+                <BidCard
+                  key={`premium-${idx}`}
+                  item={item}
+                  isPremium={true}
+                  index={VISIBLE_COUNT + idx}
+                />
+              ))}
+            </div>
+
+            {/* Signup banner */}
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, delay: 0.4 }}
+              className="mt-6 rounded-xl border border-brand-blue/30 bg-gradient-to-r from-brand-blue/5 to-blue-50 dark:from-brand-blue/10 dark:to-blue-950/20 p-5 sm:p-6 text-center"
+              data-testid="preview-signup-banner"
+            >
+              <p className="text-base font-semibold text-gray-900 dark:text-white mb-2">
+                {remaining > 0
+                  ? `Cadastre-se grátis para ver os ${remaining} editais restantes →`
+                  : "Cadastre-se grátis para monitorar novos editais →"}
+              </p>
+              <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 mb-4 max-w-md mx-auto">
+                14 dias grátis, sem cartão de crédito. Alertas por email e análise de viabilidade com IA.
+              </p>
+              <Link
+                href={`/signup?ref=pseo-preview-${setor}${uf ? `-${uf.toLowerCase()}` : ""}`}
+                className="inline-block px-6 py-2.5 bg-brand-blue text-white font-semibold text-sm rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
+              >
+                Cadastre-se grátis →
+              </Link>
+            </motion.div>
+          </>
+        )}
+      </section>
+    </AnimatePresence>
+  );
+}

--- a/frontend/app/components/programmatic/PreviewCTA.tsx
+++ b/frontend/app/components/programmatic/PreviewCTA.tsx
@@ -128,6 +128,7 @@ function BidCard({
           ? "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
           : "border-brand-blue/20 dark:border-brand-blue/30 bg-white dark:bg-gray-800"
       }`}
+      aria-hidden={isPremium ? "true" : undefined}
     >
       {/* Órgão */}
       <p
@@ -204,7 +205,9 @@ export default function PreviewCTA({
     if (uf) params.set("uf", uf);
 
     try {
-      const res = await fetch(`/api/pseo/recent-editais?${params.toString()}`);
+      const res = await fetch(`/api/pseo/recent-editais?${params.toString()}`, {
+        signal: AbortSignal.timeout(8000),
+      });
       if (!res.ok) throw new Error("Fetch failed");
       const json: RecentEditaisResponse = await res.json();
       setData(json);
@@ -219,8 +222,8 @@ export default function PreviewCTA({
     setIsOpen(true);
 
     // Track click
-    if (typeof window !== "undefined" && (window as unknown as Record<string, unknown>).mixpanel) {
-      (window as unknown as Record<string, unknown>).mixpanel.track("pseo_preview_cta_click", {
+    if (typeof window !== "undefined") {
+      window.mixpanel?.track("pseo_preview_cta_click", {
         setor,
         uf: uf ?? null,
       });

--- a/frontend/app/components/programmatic/__tests__/PSEOTemplate.test.tsx
+++ b/frontend/app/components/programmatic/__tests__/PSEOTemplate.test.tsx
@@ -150,7 +150,11 @@ describe("PSEOTemplate render", () => {
       screen.getByText(/12 editais de Pavimentação asfáltica em Santa Catarina/)
     ).toBeInTheDocument();
     expect(screen.getByText(/Receber alertas grátis 14 dias/)).toBeInTheDocument();
-    expect(screen.getByText(/Só quero ver os dados/)).toBeInTheDocument();
+    // #1009: novo PreviewCTA também contém "Só quero ver os dados" — usamos o link exato
+    const soQueroDadosLinks = screen.getAllByText(/Só quero ver os dados/);
+    expect(soQueroDadosLinks.length).toBeGreaterThanOrEqual(1);
+    // Link original para /observatorio
+    expect(soQueroDadosLinks[0]).toHaveAttribute("href", expect.stringContaining("/observatorio"));
   });
 
   it("renderiza sticky CTA mobile com total + setor", () => {

--- a/frontend/app/components/programmatic/__tests__/PreviewCTA.test.tsx
+++ b/frontend/app/components/programmatic/__tests__/PreviewCTA.test.tsx
@@ -1,0 +1,338 @@
+/**
+ * Tests for PreviewCTA (#1009 COPY-PSEO-CTA-010).
+ *
+ * Covers:
+ *  - CTA button renders below main CTA
+ *  - Click reveals 3 visible bid cards
+ *  - Premium (blurred) bid cards show with blurred state
+ *  - Signup banner shows correct remaining count
+ *  - Loading skeleton state
+ *  - Error state with retry
+ *  - Mobile responsive (grid columns)
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import PreviewCTA from "../PreviewCTA";
+
+/* ------------------------------------------------------------------ */
+/*  Test data                                                         */
+/* ------------------------------------------------------------------ */
+
+const MOCK_ITEMS = [
+  {
+    orgao: "Prefeitura de Joinville",
+    objeto: "Pavimentação asfáltica da Rua XV de Novembro - trecho 1",
+    valor_estimado: 450000,
+    data_limite: "2026-06-15",
+    data_publicacao: "2026-05-01",
+    link_interno: "/licitacoes/pavimentacao-asfaltica?query=Prefeitura%20de%20Joinville",
+  },
+  {
+    orgao: "Prefeitura de Florianópolis",
+    objeto: "Recapeamento asfáltico da Av. Beira Mar Norte",
+    valor_estimado: 1200000,
+    data_limite: "2026-06-20",
+    data_publicacao: "2026-05-02",
+    link_interno: "/licitacoes/pavimentacao-asfaltica?query=Prefeitura%20de%20Florian%C3%B3polis",
+  },
+  {
+    orgao: "DER SC",
+    objeto: "Manutenção de pavimento asfáltico BR-101 trecho sul",
+    valor_estimado: 2800000,
+    data_limite: "2026-07-01",
+    data_publicacao: "2026-05-03",
+    link_interno: "/licitacoes/pavimentacao-asfaltica?query=DER%20SC",
+  },
+  {
+    orgao: "Prefeitura de Blumenau",
+    objeto: "Sinalização viária e recapeamento centro",
+    valor_estimado: 380000,
+    data_limite: "2026-06-25",
+    data_publicacao: "2026-05-04",
+    link_interno: "/licitacoes/pavimentacao-asfaltica?query=Prefeitura%20de%20Blumenau",
+  },
+  {
+    orgao: "Prefeitura de São José",
+    objeto: "Recapeamento asfáltico do bairro Kobrasol",
+    valor_estimado: 520000,
+    data_limite: "2026-06-30",
+    data_publicacao: "2026-05-05",
+    link_interno: "/licitacoes/pavimentacao-asfaltica?query=Prefeitura%20de%20S%C3%A3o%20Jos%C3%A9",
+  },
+  {
+    orgao: "Prefeitura de Palhoça",
+    objeto: "Pavimentação asfáltica da Rua do Comércio",
+    valor_estimado: 290000,
+    data_limite: "2026-07-05",
+    data_publicacao: "2026-05-06",
+    link_interno: "/licitacoes/pavimentacao-asfaltica?query=Prefeitura%20de%20Palho%C3%A7a",
+  },
+];
+
+const MOCK_RESPONSE = {
+  items: MOCK_ITEMS,
+  total: 47,
+};
+
+const BASE_PROPS = {
+  setor: "pavimentacao-asfaltica",
+  uf: "SC",
+  setorLabel: "Pavimentação asfáltica",
+  ufLabel: "Santa Catarina",
+  totalOpen: 47,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Setup                                                              */
+/* ------------------------------------------------------------------ */
+
+let mockFetch: jest.Mock;
+
+beforeEach(() => {
+  mockFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => MOCK_RESPONSE,
+  } as unknown as Response);
+  global.fetch = mockFetch;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("PreviewCTA — CTA button (closed state)", () => {
+  it("renderiza botão CTA abaixo da CTA principal", () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    expect(
+      screen.getByTestId("preview-cta-button")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Ver 3 editais grátis/)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Só quero ver os dados/)
+    ).toBeInTheDocument();
+  });
+
+  it("não renderiza preview section antes do clique", () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    expect(screen.queryByTestId("preview-section")).not.toBeInTheDocument();
+  });
+});
+
+describe("PreviewCTA — click reveals preview", () => {
+  it("abre preview e carrega dados ao clicar no CTA", async () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    // Deve mostrar loading primeiro
+    expect(screen.getByTestId("preview-section")).toBeInTheDocument();
+
+    // Aguarda os dados carregarem
+    await waitFor(() => {
+      expect(screen.getByText(/Últimos editais de/)).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/pseo/recent-editais")
+    );
+  });
+
+  it("mostra 3 cards visíveis com dados completos", async () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      // Os 3 primeiros órgãos devem estar visíveis (não-blurred)
+      expect(screen.getByText("Prefeitura de Joinville")).toBeInTheDocument();
+      expect(screen.getByText("Prefeitura de Florianópolis")).toBeInTheDocument();
+      expect(screen.getByText("DER SC")).toBeInTheDocument();
+    });
+
+    // Links "Ver detalhes" dos cards visíveis existem
+    const visibleLinks = screen.getAllByText("Ver detalhes →");
+    expect(visibleLinks).toHaveLength(3);
+  });
+
+  it("mostra 3 cards premium com blur", async () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      // Os 3 últimos órgãos devem estar presentes no DOM (mesmo com blur)
+      expect(screen.getByText("Prefeitura de Blumenau")).toBeInTheDocument();
+      expect(screen.getByText("Prefeitura de São José")).toBeInTheDocument();
+      expect(screen.getByText("Prefeitura de Palhoça")).toBeInTheDocument();
+    });
+  });
+
+  it("mostra banner de cadastro com contagem correta de restantes", async () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-signup-banner")).toBeInTheDocument();
+    });
+
+    // totalOpen=47, VISIBLE_COUNT=3 => remaining=44
+    expect(
+      screen.getByText(/Cadastre-se grátis para ver os 44 editais restantes/)
+    ).toBeInTheDocument();
+
+    // Link de cadastro
+    const signupLink = screen.getByText("Cadastre-se grátis →");
+    expect(signupLink).toHaveAttribute("href", expect.stringContaining("/signup"));
+    expect(signupLink).toHaveAttribute("href", expect.stringContaining("ref=pseo-preview-pavimentacao-asfaltica-sc"));
+  });
+
+  it("chama fetch com setor e uf corretos", async () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("setor=pavimentacao-asfaltica")
+      );
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("uf=SC")
+    );
+  });
+});
+
+describe("PreviewCTA — loading state", () => {
+  it("mostra skeleton durante carregamento", async () => {
+    // Não resolve o fetch imediatamente
+    mockFetch.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    // Verifica que a seção de preview está visível
+    expect(screen.getByTestId("preview-section")).toBeInTheDocument();
+
+    // Verifica que skeletons estão sendo renderizados (via animate-pulse class)
+    await waitFor(() => {
+      const skeletons = document.querySelectorAll(".animate-pulse");
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("PreviewCTA — error state", () => {
+  it("mostra mensagem de erro quando fetch falha", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-error")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Não foi possível carregar os editais/)
+    ).toBeInTheDocument();
+  });
+
+  it("botão de retry no erro tenta novamente", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-error")).toBeInTheDocument();
+    });
+
+    // Mock resolve agora
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => MOCK_RESPONSE,
+    } as unknown as Response);
+
+    fireEvent.click(screen.getByText(/Tentar novamente/));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("preview-error")).not.toBeInTheDocument();
+      expect(screen.getByText(/Últimos editais de/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("PreviewCTA — mobile responsive", () => {
+  it("usa grid responsivo 1/2/3 colunas", async () => {
+    render(<PreviewCTA {...BASE_PROPS} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Últimos editais de/)).toBeInTheDocument();
+    });
+
+    // O grid container deve ter as classes responsivas
+    const previewSection = screen.getByTestId("preview-section");
+    const grids = previewSection.querySelectorAll(".grid");
+    expect(grids.length).toBeGreaterThan(0);
+
+    // Verifica se há pelo menos um elemento com classes de grid responsivo
+    const hasResponsiveGrid = previewSection.innerHTML.includes(
+      "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+    );
+    expect(hasResponsiveGrid).toBe(true);
+  });
+});
+
+describe("PreviewCTA — sem UF (apenas setor)", () => {
+  const propsSemUf = {
+    setor: "pavimentacao-asfaltica",
+    setorLabel: "Pavimentação asfáltica",
+    ufLabel: "",
+    totalOpen: 10,
+  };
+
+  it("funciona sem UF", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: MOCK_ITEMS.slice(0, 4),
+        total: 10,
+      }),
+    } as unknown as Response);
+
+    render(<PreviewCTA {...propsSemUf} />);
+
+    fireEvent.click(screen.getByTestId("preview-cta-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Últimos editais de/)).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.not.stringContaining("uf=")
+    );
+
+    // remaining: totalOpen=10 - VISIBLE_COUNT=3 = 7
+    expect(
+      screen.getByText(/Cadastre-se grátis para ver os 7 editais restantes/)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/programmatic/__tests__/PreviewCTA.test.tsx
+++ b/frontend/app/components/programmatic/__tests__/PreviewCTA.test.tsx
@@ -144,7 +144,8 @@ describe("PreviewCTA — click reveals preview", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/pseo/recent-editais")
+      expect.stringContaining("/api/pseo/recent-editais"),
+      expect.objectContaining({ signal: expect.anything() })
     );
   });
 
@@ -205,12 +206,14 @@ describe("PreviewCTA — click reveals preview", () => {
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("setor=pavimentacao-asfaltica")
+        expect.stringContaining("setor=pavimentacao-asfaltica"),
+        expect.objectContaining({ signal: expect.anything() })
       );
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("uf=SC")
+      expect.stringContaining("uf=SC"),
+      expect.objectContaining({ signal: expect.anything() })
     );
   });
 });
@@ -327,7 +330,8 @@ describe("PreviewCTA — sem UF (apenas setor)", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.not.stringContaining("uf=")
+      expect.not.stringContaining("uf="),
+      expect.objectContaining({ signal: expect.anything() })
     );
 
     // remaining: totalOpen=10 - VISIBLE_COUNT=3 = 7


### PR DESCRIPTION
## Summary

- Secondary CTA "So quero ver os dados — Ver 3 editais gratis ->" below main CTA in pSEO pages
- Preview state: 3 visible bids + 3 blurred premium + signup banner
- Framer Motion staggered animation
- Mixpanel tracking on CTA click
- `?preview=true` URL param support for deep-link
- 12 tests for PreviewCTA, 32/32 passing

## Closes

Closes #1009

## Testing Plan

- [ ] Smoke: click CTA shows 3 bids without auth
- [ ] Premium bids show blurred values
- [ ] Signup banner shows correct remaining count
- [ ] Mobile responsive