### PR TITLE
fix(health): remove mv_sitemap_municipios from health check — migration not applied (#1074)

### DIFF
--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -305,7 +305,7 @@ _SITEMAP_MVS = [
     "mv_sitemap_cnpjs",
     "mv_sitemap_orgaos",
     "mv_sitemap_fornecedores",
-    "mv_sitemap_municipios",
+    # mv_sitemap_municipios: added when migration ships (SEO-SITEMAP-MV-001)
 ]
 
 


### PR DESCRIPTION
## Summary

- **Production hotfix**: `/health/sitemap` was returning 503/degraded on every call because `mv_sitemap_municipios` was added to `_SITEMAP_MVS` in #1070 but no migration creates this MV yet
- Removes `mv_sitemap_municipios` from the check list with a comment pointing to SEO-SITEMAP-MV-001 where the migration will ship

## Testing Plan

- [x] `/health/sitemap` returns 200 once `mv_sitemap_cnpjs`, `mv_sitemap_orgaos`, `mv_sitemap_fornecedores` are populated
- [ ] Re-add `mv_sitemap_municipios` when SEO-SITEMAP-MV-001 migration is applied to prod

## Closes

Addresses regression introduced by #1070 (merged 2026-05-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)