### PR TITLE
feat(frontend): rewrite /fundadores as founder pact (#1000)

### DIFF
--- a/frontend/__tests__/fundadores/FundadoresClient.test.tsx
+++ b/frontend/__tests__/fundadores/FundadoresClient.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Issue #786: FundadoresClient smoke tests
+ * Issue #1000: FundadoresClient smoke tests
  *
- * Verifies the /fundadores page renders without crash and contains
- * the required CTA copy. Full interaction tests live in FundadoresForm.test.tsx.
+ * Verifies the rewritten /fundadores page renders without crash and
+ * contains the founder-letter / 60d guarantee / 4-question / "quem nao
+ * deveria comprar" copy. Full interaction tests live in FundadoresForm.test.tsx.
  */
 
 import { render, screen } from '@testing-library/react';
@@ -28,37 +29,77 @@ describe('FundadoresClient', () => {
     expect(document.body).toBeTruthy();
   });
 
-  it('contains the hero headline', () => {
+  it('contains the rewritten H1 "Pague R$997 uma vez. Use o SmartLic pra sempre."', () => {
     render(<FundadoresClient />);
     expect(
-      screen.getByText(/Pare de perder licitações por falta de informação/i)
+      screen.getByRole('heading', {
+        level: 1,
+        name: /pague r\$997 uma vez\. use o smartlic pra sempre\./i,
+      })
     ).toBeInTheDocument();
   });
 
-  it('contains the CTA "Garantir acesso vitalício"', () => {
+  it('renders the form CTA "Garantir acesso vitalício"', () => {
     render(<FundadoresClient />);
     const ctaButtons = screen.getAllByText(/Garantir acesso vitalício/i);
     expect(ctaButtons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('contains urgency copy about encerra date', () => {
+  it('mentions the 30/06/2026 deadline', () => {
     render(<FundadoresClient />);
-    const matches = screen.getAllByText(/Encerra 30\/06\/2026/i);
+    const matches = screen.getAllByText(/30\/06\/2026/);
     expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('contains comparison section headline', () => {
+  it('renders the founder letter section "Uma carta de quem fez isso"', () => {
     render(<FundadoresClient />);
-    expect(screen.getByText(/Fundador vs Assinatura recorrente/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /uma carta de quem fez isso/i })
+    ).toBeInTheDocument();
   });
 
-  it('contains "Por que empresas B2G perdem licitações" section', () => {
+  it('renders the 60d guarantee section', () => {
     render(<FundadoresClient />);
-    expect(screen.getByText(/Por que empresas B2G perdem licitações/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /garantia incondicional de 60 dias/i })
+    ).toBeInTheDocument();
   });
 
-  it('contains "Ajude a financiar a próxima fase" message', () => {
+  it('renders the "Quem não deveria comprar" section', () => {
     render(<FundadoresClient />);
-    expect(screen.getByText(/Ajude a financiar a próxima fase do SmartLic/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /quem não deveria comprar/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the "As 4 perguntas que todo mundo me faz" FAQ heading', () => {
+    render(<FundadoresClient />);
+    expect(
+      screen.getByRole('heading', { name: /as 4 perguntas que todo mundo me faz/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the "A conta do uma vez vs todo mês" comparison table', () => {
+    render(<FundadoresClient />);
+    expect(
+      screen.getByRole('heading', { name: /a conta do uma vez vs todo mês/i })
+    ).toBeInTheDocument();
+    // Spot-check the 5-year economy row
+    expect(screen.getByText(/60 meses \(5 anos\)/i)).toBeInTheDocument();
+  });
+
+  it('renders the secondary "14 dias grátis" trial link to /planos', () => {
+    render(<FundadoresClient />);
+    const links = screen.getAllByRole('link', { name: /comece com 14 dias grátis/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('href', '/planos');
+    });
+  });
+
+  it('exposes the personal email tiago@smartlic.tech for refund + contact', () => {
+    render(<FundadoresClient />);
+    const mailtos = screen.getAllByRole('link', { name: /tiago@smartlic\.tech/i });
+    expect(mailtos.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/app/fundadores/FundadoresClient.tsx
+++ b/frontend/app/fundadores/FundadoresClient.tsx
@@ -98,20 +98,24 @@ export default function FundadoresClient() {
   }, []);
 
   const price = formatPrice(snapshot?.price_brl_cents);
+  const seatsRemaining = snapshot?.seats_remaining ?? null;
+  const seatsRemainingText = seatsRemaining !== null ? `${seatsRemaining}` : '50';
 
   return (
     <main className="min-h-screen bg-white">
-      {/* Hero */}
+      {/* Hero — founder pact framing */}
       <section className="bg-slate-900 text-white">
         <div className="mx-auto max-w-3xl px-4 py-16">
           <p className="text-sm uppercase tracking-widest text-blue-400 font-semibold mb-3">
-            Plano Fundadores — encerra 30/06/2026
+            Plano Fundadores · 50 vagas · Encerra 30/06/2026
           </p>
           <h1 className="text-3xl sm:text-5xl font-bold leading-tight mb-4">
-            Pare de perder licitações por falta de informação.
+            Pague {price} uma vez. Use o SmartLic pra sempre.
           </h1>
           <p className="text-lg sm:text-xl text-slate-300 mb-8">
-            IA que encontra e classifica editais do seu setor — R$997 uma única vez, sem mensalidade, para sempre.
+            50 empresas. {price} pagamento único. Acesso vitalício a tudo que existe e tudo
+            que vier. Sem mensalidade. Encerra 30 de junho de 2026 — ou quando as 50 vagas
+            acabarem (faltam {seatsRemainingText}).
           </p>
 
           <div className="mb-8">
@@ -119,101 +123,277 @@ export default function FundadoresClient() {
           </div>
 
           <div className="rounded-xl border border-blue-500/30 bg-blue-950/40 p-6">
-            <p className="text-2xl font-bold text-white mb-1">{price} <span className="text-base font-normal text-slate-400">pagamento único</span></p>
-            <p className="text-slate-300 text-sm mb-4">Sem mensalidade. Sem renovação. Acesso permanente. Encerra 30/06/2026.</p>
+            <p className="text-2xl font-bold text-white mb-1">
+              {price} <span className="text-base font-normal text-slate-400">pagamento único</span>
+            </p>
+            <p className="text-slate-300 text-sm mb-4">
+              Pagamento único no Pix ou cartão. 60 dias de garantia incondicional.
+            </p>
             <FundadoresForm availability={snapshot} price={price} />
+            <p className="mt-3 text-xs text-slate-400">
+              Prefere testar antes?{' '}
+              <a href="/planos" className="text-blue-300 underline hover:text-blue-200">
+                Comece com 14 dias grátis →
+              </a>
+            </p>
           </div>
         </div>
       </section>
 
       <div className="mx-auto max-w-3xl px-4 py-12">
-        {/* Problema */}
-        <section aria-labelledby="problema-heading" className="mb-16">
-          <h2 id="problema-heading" className="text-2xl font-semibold text-slate-900 mb-4">
-            Por que empresas B2G perdem licitações
+        {/* Carta do founder */}
+        <section aria-labelledby="carta-heading" className="mb-16">
+          <h2 id="carta-heading" className="text-2xl font-semibold text-slate-900 mb-6">
+            Uma carta de quem fez isso
           </h2>
-          <div className="prose prose-slate max-w-none">
-            <p>
-              Editais relevantes para o seu setor são publicados todos os dias — em portais
-              diferentes, com formatação inconsistente, prazos curtos. Sua equipe gasta horas
-              vasculhando PNCP, ComprasGov e portais estaduais antes de saber se vale a pena
-              participar.
+          <div className="flex items-start gap-4 mb-6">
+            <div
+              aria-hidden="true"
+              className="h-16 w-16 rounded-full bg-slate-200 flex items-center justify-center text-slate-500 font-semibold flex-shrink-0"
+            >
+              TS
+            </div>
+            <div>
+              <p className="font-semibold text-slate-900">Tiago Sasaki</p>
+              <p className="text-sm text-slate-600">Fundador, SmartLic · CONFENGE Avaliações e IA</p>
+              <p className="text-sm text-slate-600 mt-1">
+                <a
+                  href="https://www.linkedin.com/in/tiagosasaki/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  LinkedIn
+                </a>
+                {' · '}
+                <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
+                  tiago@smartlic.tech
+                </a>
+              </p>
+            </div>
+          </div>
+          <div className="prose prose-slate max-w-none text-slate-700 leading-relaxed">
+            <p>Olá. Sou o Tiago.</p>
+            <p className="mt-4">
+              Sou engenheiro civil. Passei 10 anos como servidor público no setor de obras
+              de uma prefeitura. Desse outro lado do balcão, vi duas coisas todo dia:
             </p>
             <p className="mt-4">
-              <strong>Enquanto você está pesquisando, o concorrente está elaborando a proposta.</strong>{' '}
-              O SmartLic faz a triagem automaticamente: agrega, filtra por setor e aponta os
-              editais com maior probabilidade de viabilidade — para que sua equipe foque no que
-              importa.
+              <strong>Primeiro:</strong> empresas pequenas e médias perdendo licitações
+              boas porque não viram o edital a tempo. Edital publicado terça à tarde,
+              prazo curto, abertura na sexta. Quem tinha equipe pra varrer PNCP toda hora
+              entrava. Quem não tinha, ficava de fora — não por incompetência, por falta
+              de informação no momento certo.
             </p>
             <p className="mt-4">
-              <strong>Informação certa, na hora certa.</strong> Classificação setorial por IA
-              com precisão ≥85%, análise de viabilidade em quatro fatores e histórico de 2 milhões
-              de contratos públicos para benchmark de preço.
+              <strong>Segundo:</strong> consultoria de licitação cobrando
+              R$3.000–R$8.000/mês para fazer triagem manual que uma IA bem feita resolve.
+              Empresário B2G pagando salário de gente para ler PDF.
             </p>
+            <p className="mt-4">
+              Saí em 2025 e construí o SmartLic com a CONFENGE. Hoje a plataforma indexa{' '}
+              <strong>2.187.430 contratos públicos</strong>, monitora{' '}
+              <strong>27 UFs em tempo real</strong>, classifica em{' '}
+              <strong>20 setores</strong> com IA, e está em produção (Railway + Supabase,
+              não é demo).
+            </p>
+            <p className="mt-4">
+              Eu poderia esperar mais 6 meses, dar polimento, lançar com pricing tradicional
+              R$397/mês, e tentar bootstrappar do zero. Não vou fazer isso.
+            </p>
+            <p className="mt-4">
+              Estou abrindo <strong>50 vagas</strong> de acesso vitalício por R$997
+              one-time. Em troca de quê? De runway honesto pros próximos 6 meses (50 ×
+              R$997 = R$49.850, dá pra terminar o roadmap sem captar) e de 50 parceiros
+              que vão usar de verdade, reclamar quando algo quebrar, e me dizer o que falta.
+            </p>
+            <p className="mt-4">
+              Não é &quot;early bird&quot; de marketing. É um pacto: você banca a próxima
+              fase, eu garanto que você nunca mais paga mensalidade — independentemente do
+              que aconteça com o pricing depois.
+            </p>
+            <p className="mt-4">
+              Se faz sentido pra você, está aí em cima.
+            </p>
+            <p className="mt-4">— Tiago</p>
           </div>
         </section>
 
-        {/* Features */}
-        <FundadoresFeatures />
-
-        {/* Comparação */}
-        <section aria-labelledby="comparacao-heading" className="mt-16">
-          <h2 id="comparacao-heading" className="text-2xl font-semibold text-slate-900 mb-6">
-            Fundador vs Assinatura recorrente
+        {/* A conta do uma vez vs todo mês */}
+        <section aria-labelledby="conta-heading" className="mb-16">
+          <h2 id="conta-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+            A conta do uma vez vs todo mês
           </h2>
+          <p className="text-slate-600 mb-6">
+            Pro mensal regular custa R$397/mês. Veja o que isso vira ao longo do tempo
+            comparado ao pagamento único de fundador.
+          </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm border-collapse">
               <thead>
                 <tr className="bg-slate-100">
-                  <th className="text-left px-4 py-3 font-semibold text-slate-700 border border-slate-200"></th>
-                  <th className="text-center px-4 py-3 font-semibold text-blue-700 border border-slate-200">
-                    Plano Fundadores
+                  <th className="text-left px-4 py-3 font-semibold text-slate-700 border border-slate-200">
+                    Período
                   </th>
                   <th className="text-center px-4 py-3 font-semibold text-slate-700 border border-slate-200">
-                    Pro Recorrente
+                    Pro mensal (R$397/mês)
+                  </th>
+                  <th className="text-center px-4 py-3 font-semibold text-blue-700 border border-slate-200">
+                    Fundador (R$997 único)
+                  </th>
+                  <th className="text-center px-4 py-3 font-semibold text-emerald-700 border border-slate-200">
+                    Você economiza
                   </th>
                 </tr>
               </thead>
               <tbody>
                 {[
-                  ['Modelo de cobrança', 'R$997 único', 'R$397/mês'],
-                  ['Custo em 12 meses', 'R$997', 'R$4.764'],
-                  ['Acesso', 'Vitalício', 'Enquanto pagar'],
-                  ['Todas as funcionalidades', '✓', '✓'],
-                  ['Atualizações futuras', '✓ incluídas', '✓ incluídas'],
-                  ['Encerra em', '30/06/2026', 'A qualquer momento'],
-                  ['Influência no roadmap', '✓ direto', '—'],
-                ].map(([label, founder, regular]) => (
-                  <tr key={label} className="border border-slate-200 hover:bg-slate-50">
-                    <td className="px-4 py-3 text-slate-700 border border-slate-200">{label}</td>
-                    <td className="px-4 py-3 text-center font-medium text-blue-700 border border-slate-200">{founder}</td>
-                    <td className="px-4 py-3 text-center text-slate-600 border border-slate-200">{regular}</td>
+                  { periodo: '12 meses (1 ano)', mensal: 4764, economia: 4764 - 997 },
+                  { periodo: '24 meses (2 anos)', mensal: 9528, economia: 9528 - 997 },
+                  { periodo: '60 meses (5 anos)', mensal: 23820, economia: 23820 - 997 },
+                ].map((row) => (
+                  <tr key={row.periodo} className="border border-slate-200 hover:bg-slate-50">
+                    <td className="px-4 py-3 text-slate-700 border border-slate-200 font-medium">
+                      {row.periodo}
+                    </td>
+                    <td className="px-4 py-3 text-center text-slate-600 border border-slate-200">
+                      R${row.mensal.toLocaleString('pt-BR')}
+                    </td>
+                    <td className="px-4 py-3 text-center font-medium text-blue-700 border border-slate-200">
+                      R$997
+                    </td>
+                    <td className="px-4 py-3 text-center font-semibold text-emerald-700 border border-slate-200">
+                      R${row.economia.toLocaleString('pt-BR')}
+                    </td>
                   </tr>
                 ))}
+                <tr className="bg-emerald-50 border border-slate-200">
+                  <td
+                    colSpan={4}
+                    className="px-4 py-3 text-center text-emerald-800 border border-slate-200 font-semibold"
+                  >
+                    Em 5 anos, fundadores economizam mais de R$22 mil — e seguem com acesso
+                    pra sempre.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
         </section>
 
-        {/* Sobre o SmartLic */}
-        <section aria-labelledby="sobre-heading" className="mt-16 rounded-lg border border-slate-200 bg-slate-50 p-6">
-          <h2 id="sobre-heading" className="text-xl font-semibold text-slate-900 mb-3">
-            Sobre o SmartLic (v0.5 — beta produtivo)
+        {/* O que está incluído (9 bullets) */}
+        <FundadoresFeatures />
+
+        {/* As 4 perguntas que todo mundo me faz */}
+        <FundadoresFAQ />
+
+        {/* Quem não deveria comprar */}
+        <section
+          aria-labelledby="nao-deveria-heading"
+          className="mt-16 rounded-xl border border-amber-200 bg-amber-50 p-6"
+        >
+          <h2 id="nao-deveria-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+            Quem não deveria comprar
           </h2>
-          <p className="text-slate-700 leading-relaxed">
-            2 milhões de contratos públicos indexados. 50 mil licitações abertas em tempo real.
-            20 setores com classificação por IA. Infra production-ready (Railway, Supabase).
-            Ferramenta é real — estamos abrindo acesso vitalício para os primeiros fundadores que
-            ajudam a financiar e moldar a próxima fase do produto.
+          <p className="text-slate-700 mb-4">
+            Honestidade vale mais do que conversão. Se você se encaixa em um destes três
+            perfis, não compre — vai ficar frustrado e eu vou ter que devolver na garantia
+            de 60 dias.
           </p>
-          <p className="mt-3 text-slate-700">
-            <strong>Ajude a financiar a próxima fase do SmartLic.</strong> Cada fundador é um
-            parceiro estratégico, não apenas um cliente.
-          </p>
+          <ul className="space-y-3 text-slate-700">
+            <li className="flex gap-3">
+              <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
+              <span>
+                <strong>Empresa com faturamento abaixo de R$200 mil/ano.</strong>{' '}
+                Licitação pública exige capital de giro, fluxo de caixa, capacidade
+                operacional. R$997 não vai te tornar elegível se a estrutura financeira
+                não está pronta. Cresça primeiro, automatize depois.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
+              <span>
+                <strong>Empresa sem CRC ou habilitação técnica do setor.</strong>{' '}
+                O SmartLic encontra e qualifica editais — mas não emite atestado,
+                não substitui registro profissional, não resolve falta de habilitação.
+                Resolva o cadastro antes; o software vem depois.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
+              <span>
+                <strong>Quem espera &quot;garantia de ganhar licitação&quot;.</strong>{' '}
+                Não existe. Quem te promete isso está mentindo ou cobrando ilegalmente.
+                O SmartLic aumenta a probabilidade de encontrar editais bons no momento
+                certo — quem ganha é a sua proposta.
+              </span>
+            </li>
+          </ul>
         </section>
 
-        {/* FAQ */}
-        <FundadoresFAQ />
+        {/* Garantia 60 dias */}
+        <section
+          aria-labelledby="garantia-heading"
+          className="mt-16 rounded-xl border-2 border-emerald-300 bg-emerald-50 p-6"
+        >
+          <div className="flex items-start gap-4">
+            <div
+              aria-hidden="true"
+              className="h-16 w-16 rounded-full bg-emerald-600 text-white flex items-center justify-center font-bold text-lg flex-shrink-0"
+            >
+              60d
+            </div>
+            <div>
+              <h2 id="garantia-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+                Garantia incondicional de 60 dias
+              </h2>
+              <p className="text-slate-700 leading-relaxed mb-3">
+                Use o SmartLic por 60 dias. Se em qualquer momento dos primeiros dois meses
+                você decidir que não vale, devolvo 100% do valor pago. Sem perguntas, sem
+                formulário longo, sem &quot;tem certeza?&quot; três vezes.
+              </p>
+              <p className="text-slate-700 leading-relaxed mb-2">
+                <strong>Como pedir reembolso:</strong>
+              </p>
+              <ol className="list-decimal pl-5 space-y-1 text-slate-700 mb-3">
+                <li>
+                  Envie um email para{' '}
+                  <a
+                    href="mailto:tiago@smartlic.tech?subject=reembolso"
+                    className="text-blue-700 underline font-medium"
+                  >
+                    tiago@smartlic.tech
+                  </a>{' '}
+                  com assunto <code className="bg-white px-1.5 py-0.5 rounded border border-slate-200">reembolso</code>.
+                </li>
+                <li>Não preciso saber por quê. Reembolso processado em até 5 dias úteis.</li>
+                <li>Acesso à plataforma é encerrado após o reembolso confirmar.</li>
+              </ol>
+              <p className="text-sm text-slate-600">
+                Vale para qualquer um dos primeiros 60 dias após o pagamento confirmado.
+                Eu assino embaixo.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Vagas em tempo real */}
+        <section
+          aria-labelledby="vagas-heading"
+          className="mt-16 rounded-lg border border-slate-200 bg-slate-50 p-6"
+        >
+          <h2 id="vagas-heading" className="text-xl font-semibold text-slate-900 mb-3">
+            Vagas em tempo real
+          </h2>
+          <p className="text-slate-700">
+            <strong className="text-blue-700 text-2xl">{seatsRemainingText}</strong>{' '}
+            <span className="text-slate-600">de 50 vagas restantes.</span>
+          </p>
+          <p className="text-sm text-slate-500 mt-2">
+            Contador atualiza a cada minuto direto do banco — não é counter de marketing.
+            Quando zerar, encerra antes de 30/06/2026.
+          </p>
+        </section>
 
         {/* CTA final */}
         <section
@@ -221,12 +401,19 @@ export default function FundadoresClient() {
           className="mt-16 rounded-xl border border-blue-200 bg-blue-50 p-8"
         >
           <h2 id="cta-final-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-            Garanta acesso vitalício agora
+            Quero uma das {seatsRemainingText} vagas — {price}
           </h2>
           <p className="text-slate-700 mb-6">
-            {price} uma única vez. Sem mensalidade. Sem renovação. Encerra 30/06/2026 — depois disso, apenas planos mensais.
+            Pagamento único no Pix ou cartão. 60 dias de garantia incondicional. Acesso
+            ativado na hora.
           </p>
           <FundadoresForm availability={snapshot} price={price} />
+          <p className="mt-4 text-sm text-slate-600">
+            Prefere testar antes?{' '}
+            <a href="/planos" className="text-blue-700 underline hover:text-blue-800 font-medium">
+              Comece com 14 dias grátis →
+            </a>
+          </p>
         </section>
 
         {/* Disclaimer legal */}
@@ -241,8 +428,8 @@ export default function FundadoresClient() {
               Política de Privacidade
             </a>
             . Em caso de dúvida, escreva para{' '}
-            <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 underline">
-              tiago.sasaki@confenge.com.br
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
+              tiago@smartlic.tech
             </a>
             .
           </p>

--- a/frontend/app/fundadores/FundadoresClient.tsx
+++ b/frontend/app/fundadores/FundadoresClient.tsx
@@ -7,6 +7,11 @@ import FundadoresForm from './components/FundadoresForm';
 import FundadoresFAQ from './components/FundadoresFAQ';
 import FundadoresFeatures from './components/FundadoresFeatures';
 import FundadoresCountdown, { FoundingAvailabilitySnapshot } from './components/FundadoresCountdown';
+import FundadoresFounderLetter from './components/FundadoresFounderLetter';
+import FundadoresComparisonTable from './components/FundadoresComparisonTable';
+import FundadoresDoNotBuy from './components/FundadoresDoNotBuy';
+import FundadoresGuarantee from './components/FundadoresGuarantee';
+import FundadoresLegalFooter from './components/FundadoresLegalFooter';
 
 function trackEvent(name: string, props?: Record<string, unknown>) {
   if (typeof window === 'undefined') return;
@@ -21,6 +26,17 @@ function trackEvent(name: string, props?: Record<string, unknown>) {
 
 const REFRESH_INTERVAL_MS = 60_000;
 
+const UNAVAILABLE_SNAPSHOT: FoundingAvailabilitySnapshot = {
+  available: false,
+  seats_total: 50,
+  seats_remaining: 0,
+  seats_taken: 50,
+  deadline_at: null,
+  paused: false,
+  reason: 'unavailable',
+  coupon_code: 'FOUNDING_LIFETIME',
+  discount_pct: 0,
+};
 
 // TODO: remove hardcoded fallback after #782 merges (price_brl_cents in API response)
 function formatPrice(priceBrlCents: number | undefined): string {
@@ -55,37 +71,13 @@ export default function FundadoresClient() {
       try {
         const res = await fetch('/api/founding/availability', { cache: 'no-store' });
         if (!res.ok) {
-          if (!cancelled) {
-            setSnapshot({
-              available: false,
-              seats_total: 50,
-              seats_remaining: 0,
-              seats_taken: 50,
-              deadline_at: null,
-              paused: false,
-              reason: 'unavailable',
-              coupon_code: 'FOUNDING_LIFETIME',
-              discount_pct: 0,
-            });
-          }
+          if (!cancelled) setSnapshot(UNAVAILABLE_SNAPSHOT);
           return;
         }
         const data = (await res.json()) as FoundingAvailabilitySnapshot;
         if (!cancelled) setSnapshot(data);
       } catch {
-        if (!cancelled) {
-          setSnapshot({
-            available: false,
-            seats_total: 50,
-            seats_remaining: 0,
-            seats_taken: 50,
-            deadline_at: null,
-            paused: false,
-            reason: 'unavailable',
-            coupon_code: 'FOUNDING_LIFETIME',
-            discount_pct: 0,
-          });
-        }
+        if (!cancelled) setSnapshot(UNAVAILABLE_SNAPSHOT);
       }
     }
 
@@ -141,145 +133,8 @@ export default function FundadoresClient() {
       </section>
 
       <div className="mx-auto max-w-3xl px-4 py-12">
-        {/* Carta do founder */}
-        <section aria-labelledby="carta-heading" className="mb-16">
-          <h2 id="carta-heading" className="text-2xl font-semibold text-slate-900 mb-6">
-            Uma carta de quem fez isso
-          </h2>
-          <div className="flex items-start gap-4 mb-6">
-            <div
-              aria-hidden="true"
-              className="h-16 w-16 rounded-full bg-slate-200 flex items-center justify-center text-slate-500 font-semibold flex-shrink-0"
-            >
-              TS
-            </div>
-            <div>
-              <p className="font-semibold text-slate-900">Tiago Sasaki</p>
-              <p className="text-sm text-slate-600">Fundador, SmartLic · CONFENGE Avaliações e IA</p>
-              <p className="text-sm text-slate-600 mt-1">
-                <a
-                  href="https://www.linkedin.com/in/tiagosasaki/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 underline"
-                >
-                  LinkedIn
-                </a>
-                {' · '}
-                <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
-                  tiago@smartlic.tech
-                </a>
-              </p>
-            </div>
-          </div>
-          <div className="prose prose-slate max-w-none text-slate-700 leading-relaxed">
-            <p>Olá. Sou o Tiago.</p>
-            <p className="mt-4">
-              Sou engenheiro civil. Passei 10 anos como servidor público no setor de obras
-              de uma prefeitura. Desse outro lado do balcão, vi duas coisas todo dia:
-            </p>
-            <p className="mt-4">
-              <strong>Primeiro:</strong> empresas pequenas e médias perdendo licitações
-              boas porque não viram o edital a tempo. Edital publicado terça à tarde,
-              prazo curto, abertura na sexta. Quem tinha equipe pra varrer PNCP toda hora
-              entrava. Quem não tinha, ficava de fora — não por incompetência, por falta
-              de informação no momento certo.
-            </p>
-            <p className="mt-4">
-              <strong>Segundo:</strong> consultoria de licitação cobrando
-              R$3.000–R$8.000/mês para fazer triagem manual que uma IA bem feita resolve.
-              Empresário B2G pagando salário de gente para ler PDF.
-            </p>
-            <p className="mt-4">
-              Saí em 2025 e construí o SmartLic com a CONFENGE. Hoje a plataforma indexa{' '}
-              <strong>2.187.430 contratos públicos</strong>, monitora{' '}
-              <strong>27 UFs em tempo real</strong>, classifica em{' '}
-              <strong>20 setores</strong> com IA, e está em produção (Railway + Supabase,
-              não é demo).
-            </p>
-            <p className="mt-4">
-              Eu poderia esperar mais 6 meses, dar polimento, lançar com pricing tradicional
-              R$397/mês, e tentar bootstrappar do zero. Não vou fazer isso.
-            </p>
-            <p className="mt-4">
-              Estou abrindo <strong>50 vagas</strong> de acesso vitalício por R$997
-              one-time. Em troca de quê? De runway honesto pros próximos 6 meses (50 ×
-              R$997 = R$49.850, dá pra terminar o roadmap sem captar) e de 50 parceiros
-              que vão usar de verdade, reclamar quando algo quebrar, e me dizer o que falta.
-            </p>
-            <p className="mt-4">
-              Não é &quot;early bird&quot; de marketing. É um pacto: você banca a próxima
-              fase, eu garanto que você nunca mais paga mensalidade — independentemente do
-              que aconteça com o pricing depois.
-            </p>
-            <p className="mt-4">
-              Se faz sentido pra você, está aí em cima.
-            </p>
-            <p className="mt-4">— Tiago</p>
-          </div>
-        </section>
-
-        {/* A conta do uma vez vs todo mês */}
-        <section aria-labelledby="conta-heading" className="mb-16">
-          <h2 id="conta-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-            A conta do uma vez vs todo mês
-          </h2>
-          <p className="text-slate-600 mb-6">
-            Pro mensal regular custa R$397/mês. Veja o que isso vira ao longo do tempo
-            comparado ao pagamento único de fundador.
-          </p>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm border-collapse">
-              <thead>
-                <tr className="bg-slate-100">
-                  <th className="text-left px-4 py-3 font-semibold text-slate-700 border border-slate-200">
-                    Período
-                  </th>
-                  <th className="text-center px-4 py-3 font-semibold text-slate-700 border border-slate-200">
-                    Pro mensal (R$397/mês)
-                  </th>
-                  <th className="text-center px-4 py-3 font-semibold text-blue-700 border border-slate-200">
-                    Fundador (R$997 único)
-                  </th>
-                  <th className="text-center px-4 py-3 font-semibold text-emerald-700 border border-slate-200">
-                    Você economiza
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {[
-                  { periodo: '12 meses (1 ano)', mensal: 4764, economia: 4764 - 997 },
-                  { periodo: '24 meses (2 anos)', mensal: 9528, economia: 9528 - 997 },
-                  { periodo: '60 meses (5 anos)', mensal: 23820, economia: 23820 - 997 },
-                ].map((row) => (
-                  <tr key={row.periodo} className="border border-slate-200 hover:bg-slate-50">
-                    <td className="px-4 py-3 text-slate-700 border border-slate-200 font-medium">
-                      {row.periodo}
-                    </td>
-                    <td className="px-4 py-3 text-center text-slate-600 border border-slate-200">
-                      R${row.mensal.toLocaleString('pt-BR')}
-                    </td>
-                    <td className="px-4 py-3 text-center font-medium text-blue-700 border border-slate-200">
-                      R$997
-                    </td>
-                    <td className="px-4 py-3 text-center font-semibold text-emerald-700 border border-slate-200">
-                      R${row.economia.toLocaleString('pt-BR')}
-                    </td>
-                  </tr>
-                ))}
-                <tr className="bg-emerald-50 border border-slate-200">
-                  <td
-                    colSpan={4}
-                    className="px-4 py-3 text-center text-emerald-800 border border-slate-200 font-semibold"
-                  >
-                    Em 5 anos, fundadores economizam mais de R$22 mil — e seguem com acesso
-                    pra sempre.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </section>
+        <FundadoresFounderLetter />
+        <FundadoresComparisonTable />
 
         {/* O que está incluído (9 bullets) */}
         <FundadoresFeatures />
@@ -287,95 +142,8 @@ export default function FundadoresClient() {
         {/* As 4 perguntas que todo mundo me faz */}
         <FundadoresFAQ />
 
-        {/* Quem não deveria comprar */}
-        <section
-          aria-labelledby="nao-deveria-heading"
-          className="mt-16 rounded-xl border border-amber-200 bg-amber-50 p-6"
-        >
-          <h2 id="nao-deveria-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-            Quem não deveria comprar
-          </h2>
-          <p className="text-slate-700 mb-4">
-            Honestidade vale mais do que conversão. Se você se encaixa em um destes três
-            perfis, não compre — vai ficar frustrado e eu vou ter que devolver na garantia
-            de 60 dias.
-          </p>
-          <ul className="space-y-3 text-slate-700">
-            <li className="flex gap-3">
-              <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
-              <span>
-                <strong>Empresa com faturamento abaixo de R$200 mil/ano.</strong>{' '}
-                Licitação pública exige capital de giro, fluxo de caixa, capacidade
-                operacional. R$997 não vai te tornar elegível se a estrutura financeira
-                não está pronta. Cresça primeiro, automatize depois.
-              </span>
-            </li>
-            <li className="flex gap-3">
-              <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
-              <span>
-                <strong>Empresa sem CRC ou habilitação técnica do setor.</strong>{' '}
-                O SmartLic encontra e qualifica editais — mas não emite atestado,
-                não substitui registro profissional, não resolve falta de habilitação.
-                Resolva o cadastro antes; o software vem depois.
-              </span>
-            </li>
-            <li className="flex gap-3">
-              <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
-              <span>
-                <strong>Quem espera &quot;garantia de ganhar licitação&quot;.</strong>{' '}
-                Não existe. Quem te promete isso está mentindo ou cobrando ilegalmente.
-                O SmartLic aumenta a probabilidade de encontrar editais bons no momento
-                certo — quem ganha é a sua proposta.
-              </span>
-            </li>
-          </ul>
-        </section>
-
-        {/* Garantia 60 dias */}
-        <section
-          aria-labelledby="garantia-heading"
-          className="mt-16 rounded-xl border-2 border-emerald-300 bg-emerald-50 p-6"
-        >
-          <div className="flex items-start gap-4">
-            <div
-              aria-hidden="true"
-              className="h-16 w-16 rounded-full bg-emerald-600 text-white flex items-center justify-center font-bold text-lg flex-shrink-0"
-            >
-              60d
-            </div>
-            <div>
-              <h2 id="garantia-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-                Garantia incondicional de 60 dias
-              </h2>
-              <p className="text-slate-700 leading-relaxed mb-3">
-                Use o SmartLic por 60 dias. Se em qualquer momento dos primeiros dois meses
-                você decidir que não vale, devolvo 100% do valor pago. Sem perguntas, sem
-                formulário longo, sem &quot;tem certeza?&quot; três vezes.
-              </p>
-              <p className="text-slate-700 leading-relaxed mb-2">
-                <strong>Como pedir reembolso:</strong>
-              </p>
-              <ol className="list-decimal pl-5 space-y-1 text-slate-700 mb-3">
-                <li>
-                  Envie um email para{' '}
-                  <a
-                    href="mailto:tiago@smartlic.tech?subject=reembolso"
-                    className="text-blue-700 underline font-medium"
-                  >
-                    tiago@smartlic.tech
-                  </a>{' '}
-                  com assunto <code className="bg-white px-1.5 py-0.5 rounded border border-slate-200">reembolso</code>.
-                </li>
-                <li>Não preciso saber por quê. Reembolso processado em até 5 dias úteis.</li>
-                <li>Acesso à plataforma é encerrado após o reembolso confirmar.</li>
-              </ol>
-              <p className="text-sm text-slate-600">
-                Vale para qualquer um dos primeiros 60 dias após o pagamento confirmado.
-                Eu assino embaixo.
-              </p>
-            </div>
-          </div>
-        </section>
+        <FundadoresDoNotBuy />
+        <FundadoresGuarantee />
 
         {/* Vagas em tempo real */}
         <section
@@ -416,24 +184,7 @@ export default function FundadoresClient() {
           </p>
         </section>
 
-        {/* Disclaimer legal */}
-        <footer className="mt-12 border-t border-slate-200 pt-6 text-sm text-slate-500">
-          <p>
-            Ao prosseguir, você concorda com os{' '}
-            <a href="/termos/fundadores" className="text-blue-600 underline">
-              Termos do Plano Fundadores
-            </a>{' '}
-            e a{' '}
-            <a href="/privacidade" className="text-blue-600 underline">
-              Política de Privacidade
-            </a>
-            . Em caso de dúvida, escreva para{' '}
-            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
-              tiago@smartlic.tech
-            </a>
-            .
-          </p>
-        </footer>
+        <FundadoresLegalFooter />
       </div>
     </main>
   );

--- a/frontend/app/fundadores/components/FundadoresComparisonTable.tsx
+++ b/frontend/app/fundadores/components/FundadoresComparisonTable.tsx
@@ -1,0 +1,66 @@
+const ROWS = [
+  { periodo: '12 meses (1 ano)', mensal: 4764, economia: 4764 - 997 },
+  { periodo: '24 meses (2 anos)', mensal: 9528, economia: 9528 - 997 },
+  { periodo: '60 meses (5 anos)', mensal: 23820, economia: 23820 - 997 },
+];
+
+export default function FundadoresComparisonTable() {
+  return (
+    <section aria-labelledby="conta-heading" className="mb-16">
+      <h2 id="conta-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+        A conta do uma vez vs todo mês
+      </h2>
+      <p className="text-slate-600 mb-6">
+        Pro mensal regular custa R$397/mês. Veja o que isso vira ao longo do tempo
+        comparado ao pagamento único de fundador.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="bg-slate-100">
+              <th className="text-left px-4 py-3 font-semibold text-slate-700 border border-slate-200">
+                Período
+              </th>
+              <th className="text-center px-4 py-3 font-semibold text-slate-700 border border-slate-200">
+                Pro mensal (R$397/mês)
+              </th>
+              <th className="text-center px-4 py-3 font-semibold text-blue-700 border border-slate-200">
+                Fundador (R$997 único)
+              </th>
+              <th className="text-center px-4 py-3 font-semibold text-emerald-700 border border-slate-200">
+                Você economiza
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((row) => (
+              <tr key={row.periodo} className="border border-slate-200 hover:bg-slate-50">
+                <td className="px-4 py-3 text-slate-700 border border-slate-200 font-medium">
+                  {row.periodo}
+                </td>
+                <td className="px-4 py-3 text-center text-slate-600 border border-slate-200">
+                  R${row.mensal.toLocaleString('pt-BR')}
+                </td>
+                <td className="px-4 py-3 text-center font-medium text-blue-700 border border-slate-200">
+                  R$997
+                </td>
+                <td className="px-4 py-3 text-center font-semibold text-emerald-700 border border-slate-200">
+                  R${row.economia.toLocaleString('pt-BR')}
+                </td>
+              </tr>
+            ))}
+            <tr className="bg-emerald-50 border border-slate-200">
+              <td
+                colSpan={4}
+                className="px-4 py-3 text-center text-emerald-800 border border-slate-200 font-semibold"
+              >
+                Em 5 anos, fundadores economizam mais de R$22 mil — e seguem com acesso
+                pra sempre.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresDoNotBuy.tsx
+++ b/frontend/app/fundadores/components/FundadoresDoNotBuy.tsx
@@ -1,0 +1,46 @@
+export default function FundadoresDoNotBuy() {
+  return (
+    <section
+      aria-labelledby="nao-deveria-heading"
+      className="mt-16 rounded-xl border border-amber-200 bg-amber-50 p-6"
+    >
+      <h2 id="nao-deveria-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+        Quem não deveria comprar
+      </h2>
+      <p className="text-slate-700 mb-4">
+        Honestidade vale mais do que conversão. Se você se encaixa em um destes três
+        perfis, não compre — vai ficar frustrado e eu vou ter que devolver na garantia
+        de 60 dias.
+      </p>
+      <ul className="space-y-3 text-slate-700">
+        <li className="flex gap-3">
+          <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
+          <span>
+            <strong>Empresa com faturamento abaixo de R$200 mil/ano.</strong>{' '}
+            Licitação pública exige capital de giro, fluxo de caixa, capacidade
+            operacional. R$997 não vai te tornar elegível se a estrutura financeira
+            não está pronta. Cresça primeiro, automatize depois.
+          </span>
+        </li>
+        <li className="flex gap-3">
+          <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
+          <span>
+            <strong>Empresa sem CRC ou habilitação técnica do setor.</strong>{' '}
+            O SmartLic encontra e qualifica editais — mas não emite atestado,
+            não substitui registro profissional, não resolve falta de habilitação.
+            Resolva o cadastro antes; o software vem depois.
+          </span>
+        </li>
+        <li className="flex gap-3">
+          <span aria-hidden="true" className="text-amber-700 font-bold">×</span>
+          <span>
+            <strong>Quem espera &quot;garantia de ganhar licitação&quot;.</strong>{' '}
+            Não existe. Quem te promete isso está mentindo ou cobrando ilegalmente.
+            O SmartLic aumenta a probabilidade de encontrar editais bons no momento
+            certo — quem ganha é a sua proposta.
+          </span>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresFAQ.tsx
+++ b/frontend/app/fundadores/components/FundadoresFAQ.tsx
@@ -7,30 +7,23 @@ interface FaqItem {
   a: string;
 }
 
+// 4 perguntas (Issue #1000) — as 4 que todo mundo me faz
 const FAQS: FaqItem[] = [
   {
-    q: 'R$997 é muito — e se eu não usar?',
-    a: 'Quanto vale uma licitação ganha? Para a maioria das empresas B2G, o ROI aparece no primeiro contrato obtido com informação melhor. E sem mensalidade, não existe risco de esquecer de cancelar: você paga uma vez e o acesso está lá quando precisar.',
+    q: 'E se o SmartLic acabar? Eu perco meus R$997?',
+    a: 'Não. Três compromissos formais: (1) 60 dias de garantia incondicional — não gostou em qualquer momento dos primeiros dois meses, devolvo 100%, sem perguntas. (2) Se um dia o SmartLic precisar fechar, aviso com 90 dias de antecedência por email. (3) Você consegue exportar todos os seus dados a qualquer momento (buscas, pipeline, contratos analisados) — e a busca multi-fonte é open-source, fica no GitHub para sempre. Seu trabalho não some junto com a empresa.',
   },
   {
-    q: 'Plano vitalício parece arriscado — e se a empresa fechar?',
-    a: 'O SmartLic está em produção com clientes reais e infraestrutura estável (Railway + Supabase). Mas, mais importante: seu acesso não depende de renovação — está ativado permanentemente na sua conta. Se quiser transparência sobre a saúde do produto, é só perguntar.',
+    q: 'Vocês não vão começar a cobrar mensalidade depois?',
+    a: 'Não para você. Quem entra como fundador paga R$997 uma vez e nunca mais — está escrito no contrato (Termos do Plano Fundadores). Os 50 fundadores ficam vitalícios independentemente do que aconteça com o pricing depois de 30/06/2026. Quem entrar pelo plano regular a partir de julho/2026, sim, paga mensal.',
   },
   {
-    q: 'O que exatamente está incluído no plano vitalício?',
-    a: 'Busca unificada nos três principais portais (PNCP, ComprasGov, Portal de Compras Públicas), classificação por IA para o seu setor, análise de viabilidade em 4 fatores, pipeline Kanban para acompanhar oportunidades, relatórios Excel estilizados, e todas as novas funcionalidades lançadas futuramente — sem custo adicional.',
+    q: 'Vale R$997 mesmo se eu nunca ganhar uma licitação?',
+    a: 'Pergunta honesta. Se você nunca participar de licitação, não vale — não compra. Se você participa (mesmo de vez em quando), o break-even é uma proposta a mais por ano. Uma única licitação ganha porque você viu o edital antes paga R$997 muitas vezes. E sem mensalidade não tem risco de esquecer de cancelar: paga uma vez, fica na sua conta, usa quando precisar.',
   },
   {
-    q: 'Funciona para o meu setor?',
-    a: 'O SmartLic cobre 20 setores B2G: construção civil, TI, saúde, limpeza e conservação, segurança, engenharia elétrica, hidráulica, rodoviário, entre outros. A classificação é automática por IA — você configura seu setor no onboarding e a plataforma filtra por relevância.',
-  },
-  {
-    q: 'Como funciona o pagamento?',
-    a: 'Cartão de crédito ou boleto bancário, processado com segurança via Stripe. O acesso é ativado imediatamente após a confirmação do pagamento — sem espera, sem burocracia.',
-  },
-  {
-    q: 'Posso testar antes de comprar?',
-    a: 'Sim. O plano trial está disponível em smartlic.tech — sem cartão, acesso imediato. O Plano Fundadores é para quem já testou (ou já decidiu) e quer garantir o acesso vitalício antes de 30/06/2026.',
+    q: 'Por que essa oferta existe? Onde está a pegadinha?',
+    a: 'Sem pegadinha — é matemática honesta. 50 fundadores × R$997 = R$49.850. Isso é mais ou menos 6 meses de runway para terminar o que está no roadmap (alertas WhatsApp, relatório de viabilidade PDF, integração com proposta comercial). Em troca, vocês 50 ganham acesso vitalício e influência direta no produto. Eu prefiro 50 parceiros pagantes hoje a 500 trials que talvez convertam em mensalidade. Pre-revenue, runway é tudo.',
   },
 ];
 
@@ -39,9 +32,12 @@ export default function FundadoresFAQ() {
 
   return (
     <section aria-labelledby="faq-heading" className="mt-16">
-      <h2 id="faq-heading" className="text-2xl font-semibold text-slate-900 mb-6">
-        Perguntas frequentes
+      <h2 id="faq-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+        As 4 perguntas que todo mundo me faz
       </h2>
+      <p className="text-slate-600 mb-6">
+        Recebi essas perguntas por email, LinkedIn e WhatsApp. Respondo aqui de uma vez.
+      </p>
       <div className="divide-y divide-slate-200 border border-slate-200 rounded-lg">
         {FAQS.map((item, idx) => {
           const isOpen = openIndex === idx;

--- a/frontend/app/fundadores/components/FundadoresFeatures.tsx
+++ b/frontend/app/fundadores/components/FundadoresFeatures.tsx
@@ -5,51 +5,15 @@ interface Feature {
 
 // 9 bullets — "Tudo, pra sempre" (Issue #1000)
 const FEATURES: Feature[] = [
-  {
-    title: 'Busca multi-fonte unificada',
-    description:
-      'PNCP + ComprasGov + Portal de Compras Públicas em uma busca só. Dedup automático. Sem abrir três portais.',
-  },
-  {
-    title: 'Classificação por IA (20 setores)',
-    description:
-      'GPT-4.1-nano classifica cada edital pelo seu setor. Precisão ≥85% validada em benchmark.',
-  },
-  {
-    title: 'Análise de viabilidade em 4 fatores',
-    description:
-      'Modalidade, timeline, valor e geografia pontuam cada edital antes de você abrir o PDF.',
-  },
-  {
-    title: 'Pipeline Kanban de oportunidades',
-    description:
-      'Do radar até a proposta enviada em uma tela. Drag-and-drop, sem planilha paralela.',
-  },
-  {
-    title: 'Relatórios Excel + resumo executivo IA',
-    description:
-      'Exporte resultados formatados, com resumo gerado por IA. Pronto para a reunião.',
-  },
-  {
-    title: 'Histórico de 2.187.430 contratos públicos',
-    description:
-      'Benchmark de preços, mapeamento de concorrentes, panorama setorial. Você decide com dados.',
-  },
-  {
-    title: 'Cobertura nacional (27 UFs)',
-    description:
-      'Todo o Brasil, sem custo extra por estado. De Roraima ao Rio Grande do Sul.',
-  },
-  {
-    title: 'Todas as atualizações futuras',
-    description:
-      'Cada feature nova entra automaticamente na sua conta. Sem upgrade, sem upsell, sem letra miúda.',
-  },
-  {
-    title: 'Sem mensalidade, sem renovação',
-    description:
-      'Você paga R$997 uma vez. Acesso fica na sua conta. Não precisa lembrar de cancelar nada.',
-  },
+  { title: 'Busca multi-fonte unificada', description: 'PNCP + ComprasGov + Portal de Compras Públicas em uma busca só. Dedup automático. Sem abrir três portais.' },
+  { title: 'Classificação por IA (20 setores)', description: 'GPT-4.1-nano classifica cada edital pelo seu setor. Precisão ≥85% validada em benchmark.' },
+  { title: 'Análise de viabilidade em 4 fatores', description: 'Modalidade, timeline, valor e geografia pontuam cada edital antes de você abrir o PDF.' },
+  { title: 'Pipeline Kanban de oportunidades', description: 'Do radar até a proposta enviada em uma tela. Drag-and-drop, sem planilha paralela.' },
+  { title: 'Relatórios Excel + resumo executivo IA', description: 'Exporte resultados formatados, com resumo gerado por IA. Pronto para a reunião.' },
+  { title: 'Histórico de 2.187.430 contratos públicos', description: 'Benchmark de preços, mapeamento de concorrentes, panorama setorial. Você decide com dados.' },
+  { title: 'Cobertura nacional (27 UFs)', description: 'Todo o Brasil, sem custo extra por estado. De Roraima ao Rio Grande do Sul.' },
+  { title: 'Todas as atualizações futuras', description: 'Cada feature nova entra automaticamente na sua conta. Sem upgrade, sem upsell, sem letra miúda.' },
+  { title: 'Sem mensalidade, sem renovação', description: 'Você paga R$997 uma vez. Acesso fica na sua conta. Não precisa lembrar de cancelar nada.' },
 ];
 
 export default function FundadoresFeatures() {

--- a/frontend/app/fundadores/components/FundadoresFeatures.tsx
+++ b/frontend/app/fundadores/components/FundadoresFeatures.tsx
@@ -3,36 +3,52 @@ interface Feature {
   description: string;
 }
 
+// 9 bullets — "Tudo, pra sempre" (Issue #1000)
 const FEATURES: Feature[] = [
   {
-    title: 'Encontra licitações do seu setor automaticamente',
+    title: 'Busca multi-fonte unificada',
     description:
-      'Agrega PNCP, ComprasGov e Portal de Compras Públicas em uma busca única — sem abrir três portais, sem duplicatas.',
+      'PNCP + ComprasGov + Portal de Compras Públicas em uma busca só. Dedup automático. Sem abrir três portais.',
   },
   {
-    title: 'IA classifica relevância — você só vê o que importa',
+    title: 'Classificação por IA (20 setores)',
     description:
-      'Classificação setorial com precisão ≥85%. Menos tempo em editais irrelevantes, mais tempo elaborando propostas.',
+      'GPT-4.1-nano classifica cada edital pelo seu setor. Precisão ≥85% validada em benchmark.',
   },
   {
     title: 'Análise de viabilidade em 4 fatores',
     description:
-      'Modalidade, timeline, valor e geografia pontuam cada edital antes de você abrir o PDF. Decida em segundos se vale a pena.',
+      'Modalidade, timeline, valor e geografia pontuam cada edital antes de você abrir o PDF.',
   },
   {
     title: 'Pipeline Kanban de oportunidades',
     description:
-      'Do radar até a proposta enviada em uma tela. Acompanhe cada edital com drag-and-drop sem planilha paralela.',
+      'Do radar até a proposta enviada em uma tela. Drag-and-drop, sem planilha paralela.',
   },
   {
-    title: 'Relatórios Excel prontos para apresentar',
+    title: 'Relatórios Excel + resumo executivo IA',
     description:
-      'Exporte resultados formatados com resumo executivo gerado por IA. Leve para a reunião sem trabalho extra.',
+      'Exporte resultados formatados, com resumo gerado por IA. Pronto para a reunião.',
   },
   {
-    title: 'Histórico de 2 milhões de contratos públicos',
+    title: 'Histórico de 2.187.430 contratos públicos',
     description:
-      'Benchmarke preços, mapeie concorrentes e entenda o mercado B2G antes de entrar em qualquer disputa.',
+      'Benchmark de preços, mapeamento de concorrentes, panorama setorial. Você decide com dados.',
+  },
+  {
+    title: 'Cobertura nacional (27 UFs)',
+    description:
+      'Todo o Brasil, sem custo extra por estado. De Roraima ao Rio Grande do Sul.',
+  },
+  {
+    title: 'Todas as atualizações futuras',
+    description:
+      'Cada feature nova entra automaticamente na sua conta. Sem upgrade, sem upsell, sem letra miúda.',
+  },
+  {
+    title: 'Sem mensalidade, sem renovação',
+    description:
+      'Você paga R$997 uma vez. Acesso fica na sua conta. Não precisa lembrar de cancelar nada.',
   },
 ];
 
@@ -40,10 +56,11 @@ export default function FundadoresFeatures() {
   return (
     <section aria-labelledby="features-heading" className="mt-16">
       <h2 id="features-heading" className="text-2xl font-semibold text-slate-900 mb-2">
-        O que está incluído
+        O que está incluído (tudo, pra sempre)
       </h2>
       <p className="text-slate-600 mb-8">
-        Tudo que você precisa para encontrar, qualificar e acompanhar licitações públicas.
+        Não tem &quot;plano básico&quot; vs &quot;plano avançado&quot;. Fundador pega tudo —
+        e tudo que vier também.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         {FEATURES.map((feat) => (

--- a/frontend/app/fundadores/components/FundadoresFounderLetter.tsx
+++ b/frontend/app/fundadores/components/FundadoresFounderLetter.tsx
@@ -1,0 +1,80 @@
+export default function FundadoresFounderLetter() {
+  return (
+    <section aria-labelledby="carta-heading" className="mb-16">
+      <h2 id="carta-heading" className="text-2xl font-semibold text-slate-900 mb-6">
+        Uma carta de quem fez isso
+      </h2>
+      <div className="flex items-start gap-4 mb-6">
+        <div
+          aria-hidden="true"
+          className="h-16 w-16 rounded-full bg-slate-200 flex items-center justify-center text-slate-500 font-semibold flex-shrink-0"
+        >
+          TS
+        </div>
+        <div>
+          <p className="font-semibold text-slate-900">Tiago Sasaki</p>
+          <p className="text-sm text-slate-600">Fundador, SmartLic · CONFENGE Avaliações e IA</p>
+          <p className="text-sm text-slate-600 mt-1">
+            <a
+              href="https://www.linkedin.com/in/tiagosasaki/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline"
+            >
+              LinkedIn
+            </a>
+            {' · '}
+            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
+              tiago@smartlic.tech
+            </a>
+          </p>
+        </div>
+      </div>
+      <div className="prose prose-slate max-w-none text-slate-700 leading-relaxed">
+        <p>Olá. Sou o Tiago.</p>
+        <p className="mt-4">
+          Sou engenheiro civil. Passei 10 anos como servidor público no setor de obras
+          de uma prefeitura. Desse outro lado do balcão, vi duas coisas todo dia:
+        </p>
+        <p className="mt-4">
+          <strong>Primeiro:</strong> empresas pequenas e médias perdendo licitações
+          boas porque não viram o edital a tempo. Edital publicado terça à tarde,
+          prazo curto, abertura na sexta. Quem tinha equipe pra varrer PNCP toda hora
+          entrava. Quem não tinha, ficava de fora — não por incompetência, por falta
+          de informação no momento certo.
+        </p>
+        <p className="mt-4">
+          <strong>Segundo:</strong> consultoria de licitação cobrando
+          R$3.000–R$8.000/mês para fazer triagem manual que uma IA bem feita resolve.
+          Empresário B2G pagando salário de gente para ler PDF.
+        </p>
+        <p className="mt-4">
+          Saí em 2025 e construí o SmartLic com a CONFENGE. Hoje a plataforma indexa{' '}
+          <strong>2.187.430 contratos públicos</strong>, monitora{' '}
+          <strong>27 UFs em tempo real</strong>, classifica em{' '}
+          <strong>20 setores</strong> com IA, e está em produção (Railway + Supabase,
+          não é demo).
+        </p>
+        <p className="mt-4">
+          Eu poderia esperar mais 6 meses, dar polimento, lançar com pricing tradicional
+          R$397/mês, e tentar bootstrappar do zero. Não vou fazer isso.
+        </p>
+        <p className="mt-4">
+          Estou abrindo <strong>50 vagas</strong> de acesso vitalício por R$997
+          one-time. Em troca de quê? De runway honesto pros próximos 6 meses (50 ×
+          R$997 = R$49.850, dá pra terminar o roadmap sem captar) e de 50 parceiros
+          que vão usar de verdade, reclamar quando algo quebrar, e me dizer o que falta.
+        </p>
+        <p className="mt-4">
+          Não é &quot;early bird&quot; de marketing. É um pacto: você banca a próxima
+          fase, eu garanto que você nunca mais paga mensalidade — independentemente do
+          que aconteça com o pricing depois.
+        </p>
+        <p className="mt-4">
+          Se faz sentido pra você, está aí em cima.
+        </p>
+        <p className="mt-4">— Tiago</p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresGuarantee.tsx
+++ b/frontend/app/fundadores/components/FundadoresGuarantee.tsx
@@ -1,0 +1,48 @@
+export default function FundadoresGuarantee() {
+  return (
+    <section
+      aria-labelledby="garantia-heading"
+      className="mt-16 rounded-xl border-2 border-emerald-300 bg-emerald-50 p-6"
+    >
+      <div className="flex items-start gap-4">
+        <div
+          aria-hidden="true"
+          className="h-16 w-16 rounded-full bg-emerald-600 text-white flex items-center justify-center font-bold text-lg flex-shrink-0"
+        >
+          60d
+        </div>
+        <div>
+          <h2 id="garantia-heading" className="text-2xl font-semibold text-slate-900 mb-2">
+            Garantia incondicional de 60 dias
+          </h2>
+          <p className="text-slate-700 leading-relaxed mb-3">
+            Use o SmartLic por 60 dias. Se em qualquer momento dos primeiros dois meses
+            você decidir que não vale, devolvo 100% do valor pago. Sem perguntas, sem
+            formulário longo, sem &quot;tem certeza?&quot; três vezes.
+          </p>
+          <p className="text-slate-700 leading-relaxed mb-2">
+            <strong>Como pedir reembolso:</strong>
+          </p>
+          <ol className="list-decimal pl-5 space-y-1 text-slate-700 mb-3">
+            <li>
+              Envie um email para{' '}
+              <a
+                href="mailto:tiago@smartlic.tech?subject=reembolso"
+                className="text-blue-700 underline font-medium"
+              >
+                tiago@smartlic.tech
+              </a>{' '}
+              com assunto <code className="bg-white px-1.5 py-0.5 rounded border border-slate-200">reembolso</code>.
+            </li>
+            <li>Não preciso saber por quê. Reembolso processado em até 5 dias úteis.</li>
+            <li>Acesso à plataforma é encerrado após o reembolso confirmar.</li>
+          </ol>
+          <p className="text-sm text-slate-600">
+            Vale para qualquer um dos primeiros 60 dias após o pagamento confirmado.
+            Eu assino embaixo.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/fundadores/components/FundadoresLegalFooter.tsx
+++ b/frontend/app/fundadores/components/FundadoresLegalFooter.tsx
@@ -1,0 +1,21 @@
+export default function FundadoresLegalFooter() {
+  return (
+    <footer className="mt-12 border-t border-slate-200 pt-6 text-sm text-slate-500">
+      <p>
+        Ao prosseguir, você concorda com os{' '}
+        <a href="/termos/fundadores" className="text-blue-600 underline">
+          Termos do Plano Fundadores
+        </a>{' '}
+        e a{' '}
+        <a href="/privacidade" className="text-blue-600 underline">
+          Política de Privacidade
+        </a>
+        . Em caso de dúvida, escreva para{' '}
+        <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
+          tiago@smartlic.tech
+        </a>
+        .
+      </p>
+    </footer>
+  );
+}

--- a/frontend/app/fundadores/page.tsx
+++ b/frontend/app/fundadores/page.tsx
@@ -3,15 +3,15 @@ import { Suspense } from 'react';
 import FundadoresClient from './FundadoresClient';
 
 export const metadata: Metadata = {
-  title: 'SmartLic Plano Fundadores — Acesso vitalício à inteligência B2G',
+  title: 'SmartLic Plano Fundadores — Pague R$997 uma vez. Use pra sempre.',
   description:
-    'Entre cedo na infraestrutura de inteligência B2G do SmartLic. Acesso vitalício por R$997 — pagamento único, sem mensalidade. Vagas limitadas.',
+    '50 vagas. R$997 pagamento único. Acesso vitalício à plataforma SmartLic — sem mensalidade. 60 dias de garantia incondicional. Encerra 30/06/2026.',
   robots: { index: true, follow: true },
   alternates: { canonical: 'https://smartlic.tech/fundadores' },
   openGraph: {
-    title: 'SmartLic Plano Fundadores — Acesso vitalício à inteligência B2G',
+    title: 'SmartLic Plano Fundadores — Pague R$997 uma vez. Use pra sempre.',
     description:
-      'Menos PDF. Mais decisão. A IA encontra. A inteligência decide. Acesso vitalício por R$997.',
+      '50 vagas. R$997 pagamento único. Acesso vitalício, sem mensalidade. 60 dias de garantia. Encerra 30/06/2026.',
     url: 'https://smartlic.tech/fundadores',
     siteName: 'SmartLic',
     locale: 'pt_BR',
@@ -45,26 +45,34 @@ const jsonLdFaq = {
   mainEntity: [
     {
       '@type': 'Question',
-      name: 'O que está incluído no Plano Fundadores?',
+      name: 'E se o SmartLic acabar? Eu perco meus R$997?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Acesso vitalício à plataforma SmartLic (busca multi-fonte, classificação IA, pipeline kanban, relatórios Excel, análise de viabilidade). Pagamento único de R$997 — sem mensalidade.',
+        text: 'Não. Três compromissos formais: (1) 60 dias de garantia incondicional — não gostou em qualquer momento dos primeiros dois meses, devolvemos 100%, sem perguntas. (2) Se um dia o SmartLic precisar fechar, avisamos com 90 dias de antecedência por email. (3) Você consegue exportar todos os seus dados a qualquer momento (buscas, pipeline, contratos analisados) — e a busca multi-fonte é open-source, fica no GitHub para sempre.',
       },
     },
     {
       '@type': 'Question',
-      name: 'Qual a diferença entre Fundador e assinante regular?',
+      name: 'Vocês não vão começar a cobrar mensalidade depois?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'O assinante regular paga R$397/mês recorrente. O Fundador paga R$997 uma única vez e tem acesso permanente, incluindo todas as atualizações futuras.',
+        text: 'Não para você. Quem entra como fundador paga R$997 uma vez e nunca mais — está escrito no contrato. Os 50 fundadores ficam vitalícios independentemente do que aconteça com o pricing depois de 30/06/2026. Quem entrar pelo plano regular a partir de julho/2026, sim, paga mensal.',
       },
     },
     {
       '@type': 'Question',
-      name: 'Posso cancelar ou pedir reembolso?',
+      name: 'Vale R$997 mesmo se eu nunca ganhar uma licitação?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Sim. Oferecemos 7 dias de garantia. Se não ficar satisfeito por qualquer motivo dentro deste prazo, devolvemos 100% do valor pago.',
+        text: 'Se você nunca participar de licitação, não vale. Se você participa, mesmo de vez em quando, o break-even é uma proposta a mais por ano. Uma única licitação ganha porque você viu o edital antes paga R$997 muitas vezes. E sem mensalidade não tem risco de esquecer de cancelar.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Por que essa oferta existe? Onde está a pegadinha?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Sem pegadinha. 50 fundadores × R$997 = R$49.850 — aproximadamente 6 meses de runway para terminar o roadmap (alertas WhatsApp, relatório PDF de viabilidade, integração com proposta comercial). Em troca, os 50 ganham acesso vitalício e influência direta no produto. Pre-revenue, runway é tudo.',
       },
     },
   ],


### PR DESCRIPTION
## Summary

Refatora página /fundadores em sub-componentes: FounderLetter, FAQ, Features, ComparisonTable, Guarantee, DoNotBuy, LegalFooter. Atende COPY-FOUND-001.

## Testing Plan

- [ ] Tests pass locally (`npm test` / `pytest`)
- [ ] No regressions in CI (`frontend`)
- [ ] Manual smoke test on staging

## Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)