### PR TITLE
fix(sitemap): backend 503 em timeout + frontend retry exponential backoff (#1056)

### DIFF
--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
@@ -128,14 +129,17 @@ async def sitemap_cnpjs(response: Response):
         )
         _set_cached("cnpjs", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
-        logger.warning(
-            "sitemap_cnpjs: budget %.0fs exceeded — returning empty negative cache",
+        logger.error(
+            "sitemap_cnpjs: budget %.0fs exceeded — returning 503 (not caching)",
             _BUDGET_S,
         )
         sentry_sdk.capture_message('sitemap_source_timeout', level='warning',
             tags={'endpoint': 'cnpjs', 'outcome': 'timeout'})
-        data = _empty_cnpjs_response()
-        _set_cached("cnpjs", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "sitemap_source_timeout"},
+            headers={"Retry-After": "30"},
+        )
     except Exception as exc:
         logger.error("sitemap_cnpjs unexpected error: %s", exc)
         data = _empty_cnpjs_response()
@@ -325,14 +329,17 @@ async def sitemap_fornecedores_cnpj(response: Response):
         )
         _set_fornecedores_cached("fornecedores_cnpj", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
-        logger.warning(
-            "sitemap_fornecedores_cnpj: budget %.0fs exceeded — returning empty negative cache",
+        logger.error(
+            "sitemap_fornecedores_cnpj: budget %.0fs exceeded — returning 503 (not caching)",
             _BUDGET_S,
         )
         sentry_sdk.capture_message('sitemap_source_timeout', level='warning',
             tags={'endpoint': 'fornecedores-cnpj', 'outcome': 'timeout'})
-        data = _empty_cnpjs_response()
-        _set_fornecedores_cached("fornecedores_cnpj", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "sitemap_source_timeout"},
+            headers={"Retry-After": "30"},
+        )
     except Exception as exc:
         logger.error("sitemap_fornecedores_cnpj unexpected error: %s", exc)
         data = _empty_cnpjs_response()

--- a/backend/routes/sitemap_licitacoes.py
+++ b/backend/routes/sitemap_licitacoes.py
@@ -17,6 +17,7 @@ from typing import Optional
 import sentry_sdk
 
 from fastapi import APIRouter, Depends, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from admin import require_admin
@@ -84,19 +85,17 @@ async def get_licitacoes_indexable(response: Response):
         }
         _cache = (result, time.time(), _CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
-        logger.warning(
-            "get_licitacoes_indexable: budget %.0fs exceeded — returning empty negative cache",
+        logger.error(
+            "get_licitacoes_indexable: budget %.0fs exceeded — returning 503 (not caching)",
             _BUDGET_S,
         )
         sentry_sdk.capture_message('sitemap_source_timeout', level='warning',
             tags={'endpoint': 'licitacoes-indexable', 'outcome': 'timeout'})
-        result = {
-            "combos": [],
-            "total": 0,
-            "threshold": bids_threshold,
-            "updated_at": datetime.now(timezone.utc).isoformat(),
-        }
-        _cache = (result, time.time(), _NEGATIVE_CACHE_TTL_SECONDS)
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "sitemap_source_timeout"},
+            headers={"Retry-After": "30"},
+        )
     except Exception as exc:
         logger.error("get_licitacoes_indexable unexpected error: %s", exc)
         result = {

--- a/backend/routes/sitemap_licitacoes_do_dia.py
+++ b/backend/routes/sitemap_licitacoes_do_dia.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
@@ -91,14 +92,17 @@ async def sitemap_licitacoes_do_dia_indexable(response: Response):
         )
         _set_cached("dates", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
-        logger.warning(
-            "sitemap_licitacoes_do_dia: budget %.0fs exceeded — empty negative cache",
+        logger.error(
+            "sitemap_licitacoes_do_dia: budget %.0fs exceeded — returning 503 (not caching)",
             _BUDGET_S,
         )
         sentry_sdk.capture_message('sitemap_source_timeout', level='warning',
             tags={'endpoint': 'licitacoes-do-dia-indexable', 'outcome': 'timeout'})
-        data = _empty_dates_response()
-        _set_cached("dates", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "sitemap_source_timeout"},
+            headers={"Retry-After": "30"},
+        )
     except Exception as exc:
         logger.error("sitemap_licitacoes_do_dia unexpected error: %s", exc)
         data = _empty_dates_response()

--- a/backend/routes/sitemap_orgaos.py
+++ b/backend/routes/sitemap_orgaos.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
@@ -88,14 +89,17 @@ async def sitemap_orgaos(response: Response):
         )
         _set_cached("orgaos", data, ttl=_CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
-        logger.warning(
-            "sitemap_orgaos: budget %.0fs exceeded — returning empty negative cache",
+        logger.error(
+            "sitemap_orgaos: budget %.0fs exceeded — returning 503 (not caching)",
             _BUDGET_S,
         )
         sentry_sdk.capture_message('sitemap_source_timeout', level='warning',
             tags={'endpoint': 'orgaos', 'outcome': 'timeout'})
-        data = _empty_orgaos_response()
-        _set_cached("orgaos", data, ttl=_NEGATIVE_CACHE_TTL_SECONDS)
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "sitemap_source_timeout"},
+            headers={"Retry-After": "30"},
+        )
     except Exception as exc:
         logger.error("sitemap_orgaos unexpected error: %s", exc)
         data = _empty_orgaos_response()
@@ -269,14 +273,17 @@ async def sitemap_contratos_orgao_indexable(response: Response):
         )
         _contratos_orgao_cache[key] = (data, time.time(), _CACHE_TTL_SECONDS)
     except asyncio.TimeoutError:
-        logger.warning(
-            "sitemap_contratos_orgao_indexable: budget %.0fs exceeded — empty negative cache",
+        logger.error(
+            "sitemap_contratos_orgao_indexable: budget %.0fs exceeded — returning 503 (not caching)",
             _BUDGET_S,
         )
         sentry_sdk.capture_message('sitemap_source_timeout', level='warning',
             tags={'endpoint': 'contratos-orgao-indexable', 'outcome': 'timeout'})
-        data = _empty_orgaos_response()
-        _contratos_orgao_cache[key] = (data, time.time(), _NEGATIVE_CACHE_TTL_SECONDS)
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "sitemap_source_timeout"},
+            headers={"Retry-After": "30"},
+        )
     except Exception as exc:
         logger.error("sitemap_contratos_orgao_indexable unexpected error: %s", exc)
         data = _empty_orgaos_response()

--- a/backend/tests/test_sitemap_cascade.py
+++ b/backend/tests/test_sitemap_cascade.py
@@ -1,0 +1,188 @@
+"""SEO-SITEMAP-CASCADE-001: Tests for 503 on timeout + no negative cache.
+
+Regression guard for the cascade bug where backend returned 200+[] on DB timeout,
+which poisoned the ISR cache for 5min → frontend silently cached an empty sitemap
+for 1h → Google received XML with zero URLs → GSC "Não foi possível buscar".
+
+Fix: backend now raises HTTPException(503) on asyncio.TimeoutError in all
+sitemap routes, and does NOT write to in-memory cache on timeout.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from startup.app_factory import create_app
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_all_sitemap_caches():
+    """Clear all in-memory sitemap caches before and after each test."""
+    from routes.sitemap_cnpjs import _sitemap_cache, _fornecedores_sitemap_cache
+    from routes.sitemap_licitacoes_do_dia import _cache as _dates_cache
+    from routes.sitemap_orgaos import _sitemap_cache as _orgao_cache, _contratos_orgao_cache
+    import routes.sitemap_licitacoes as _licit_mod
+
+    _sitemap_cache.clear()
+    _fornecedores_sitemap_cache.clear()
+    _dates_cache.clear()
+    _orgao_cache.clear()
+    _contratos_orgao_cache.clear()
+    _licit_mod._cache = None
+
+    yield
+
+    _sitemap_cache.clear()
+    _fornecedores_sitemap_cache.clear()
+    _dates_cache.clear()
+    _orgao_cache.clear()
+    _contratos_orgao_cache.clear()
+    _licit_mod._cache = None
+
+
+class TestSitemapCnpjsTimeout:
+    """sitemap_cnpjs: timeout → 503, cache stays empty."""
+
+    @patch("routes.sitemap_cnpjs._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_returns_503(self, _mock_budget, client):
+        """asyncio.TimeoutError in sitemap_cnpjs must return HTTP 503."""
+        response = client.get("/v1/sitemap/cnpjs")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "sitemap_source_timeout"
+
+    @patch("routes.sitemap_cnpjs._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_does_not_populate_cache(self, _mock_budget, client):
+        """503 timeout must NOT write an empty entry to the in-memory cache."""
+        from routes.sitemap_cnpjs import _sitemap_cache
+        client.get("/v1/sitemap/cnpjs")
+        # Cache must remain empty — no negative cache entry.
+        assert "cnpjs" not in _sitemap_cache
+
+    @patch("routes.sitemap_cnpjs._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_second_request_after_timeout_also_hits_db(self, mock_budget, client):
+        """Without cache poisoning, each 503 response re-queries the DB."""
+        client.get("/v1/sitemap/cnpjs")
+        client.get("/v1/sitemap/cnpjs")
+        assert mock_budget.call_count == 2
+
+
+class TestSitemapFornecedoresTimeout:
+    """sitemap_fornecedores_cnpj: timeout → 503, cache stays empty."""
+
+    @patch("routes.sitemap_cnpjs._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_returns_503(self, _mock_budget, client):
+        response = client.get("/v1/sitemap/fornecedores-cnpj")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "sitemap_source_timeout"
+
+    @patch("routes.sitemap_cnpjs._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_does_not_populate_cache(self, _mock_budget, client):
+        from routes.sitemap_cnpjs import _fornecedores_sitemap_cache
+        client.get("/v1/sitemap/fornecedores-cnpj")
+        assert "fornecedores_cnpj" not in _fornecedores_sitemap_cache
+
+
+class TestSitemapOrgaosTimeout:
+    """sitemap_orgaos: timeout → 503, cache stays empty."""
+
+    @patch("routes.sitemap_orgaos._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_returns_503(self, _mock_budget, client):
+        response = client.get("/v1/sitemap/orgaos")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "sitemap_source_timeout"
+
+    @patch("routes.sitemap_orgaos._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_does_not_populate_cache(self, _mock_budget, client):
+        from routes.sitemap_orgaos import _sitemap_cache
+        client.get("/v1/sitemap/orgaos")
+        assert "orgaos" not in _sitemap_cache
+
+
+class TestSitemapContratosOrgaoTimeout:
+    """sitemap_contratos_orgao_indexable: timeout → 503, cache stays empty."""
+
+    @patch("routes.sitemap_orgaos._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_returns_503(self, _mock_budget, client):
+        response = client.get("/v1/sitemap/contratos-orgao-indexable")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "sitemap_source_timeout"
+
+    @patch("routes.sitemap_orgaos._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_does_not_populate_cache(self, _mock_budget, client):
+        from routes.sitemap_orgaos import _contratos_orgao_cache
+        client.get("/v1/sitemap/contratos-orgao-indexable")
+        assert "contratos_orgao_indexable" not in _contratos_orgao_cache
+
+
+class TestSitemapLicitacoesDoDialTimeout:
+    """sitemap_licitacoes_do_dia: timeout → 503, cache stays empty."""
+
+    @patch("routes.sitemap_licitacoes_do_dia._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_returns_503(self, _mock_budget, client):
+        response = client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "sitemap_source_timeout"
+
+    @patch("routes.sitemap_licitacoes_do_dia._run_with_budget", side_effect=asyncio.TimeoutError())
+    def test_timeout_does_not_populate_cache(self, _mock_budget, client):
+        from routes.sitemap_licitacoes_do_dia import _cache
+        client.get("/v1/sitemap/licitacoes-do-dia-indexable")
+        assert "dates" not in _cache
+
+
+class TestSitemapLicitacoesIndexableTimeout:
+    """sitemap_licitacoes_indexable: timeout → 503, cache stays None.
+
+    Note: this route uses asyncio.wait_for directly (not _run_with_budget).
+    The route-level timeout middleware (RES-BE-016 AC4, 60s) may intercept
+    the TimeoutError before the route handler. Either way the response is 503
+    — the key invariant is that the in-memory cache is NOT poisoned.
+    """
+
+    @patch("routes.sitemap_licitacoes.asyncio.wait_for", side_effect=asyncio.TimeoutError())
+    def test_timeout_returns_503(self, _mock_wait, client):
+        response = client.get("/v1/sitemap/licitacoes-indexable")
+        # Both the route handler and the middleware produce 503 on timeout.
+        assert response.status_code == 503
+
+    @patch("routes.sitemap_licitacoes.asyncio.wait_for", side_effect=asyncio.TimeoutError())
+    def test_timeout_does_not_populate_cache(self, _mock_wait, client):
+        import routes.sitemap_licitacoes as mod
+        client.get("/v1/sitemap/licitacoes-indexable")
+        assert mod._cache is None
+
+
+class TestSitemapSuccessPath:
+    """Verify that successful requests still cache and return 200."""
+
+    @patch("routes.sitemap_cnpjs._SEED_SUPPLIER_CNPJS", [])
+    @patch("routes.sitemap_cnpjs._run_with_budget")
+    def test_success_returns_200_and_caches(self, mock_budget, client):
+        """Successful DB response returns 200 and stores in cache."""
+        from datetime import datetime, timezone
+        mock_budget.return_value = {
+            "cnpjs": ["11111111000100"],
+            "total": 1,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        # mock_budget is an async-compatible MagicMock via TestClient sync context
+        # but _run_with_budget is awaited — wrap return in coroutine
+        async def fake_budget(*args, **kwargs):
+            return mock_budget.return_value
+        mock_budget.side_effect = fake_budget
+
+        response = client.get("/v1/sitemap/cnpjs")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert "11111111000100" in body["cnpjs"]
+
+        from routes.sitemap_cnpjs import _sitemap_cache
+        assert "cnpjs" in _sitemap_cache

--- a/frontend/__tests__/app/sitemap-cascade-503.test.ts
+++ b/frontend/__tests__/app/sitemap-cascade-503.test.ts
@@ -74,19 +74,20 @@ describe('fetchSitemapJsonWithRetry — 503 cascade fix (SEO-SITEMAP-CASCADE-001
   });
 
   it('503 exhausted after 3 attempts throws error (ISR preserves stale sitemap)', async () => {
-    // Backend returns 503 on all 3 attempts
+    // Import module BEFORE activating fake timers to avoid dynamic import freeze
+    const sitemap = await importFreshFetchHelper();
+
+    // Now set up fetch mock and start the sitemap call
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
       if (url.includes('/health/live')) return makeHealthLiveOk();
       return make503Response();
     });
 
-    const sitemap = await importFreshFetchHelper();
-
     // The id:4 sitemap fetches cnpjs first; after 3×503 it should throw
     const sitemapPromise = sitemap({ id: Promise.resolve('4') });
 
     // Advance timers for exponential backoff: 1s + 2s between retries
-    jest.runAllTimers();
+    await jest.runAllTimersAsync();
 
     await expect(sitemapPromise).rejects.toThrow('sitemap_cnpjs_503_exhausted');
   });
@@ -120,6 +121,9 @@ describe('fetchSitemapJsonWithRetry — 503 cascade fix (SEO-SITEMAP-CASCADE-001
   });
 
   it('503 then 200+data → eventual success after backoff', async () => {
+    // Import module BEFORE activating fake timers to avoid dynamic import freeze
+    const sitemap = await importFreshFetchHelper();
+
     let cnpjsCallCount = 0;
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
       if (url.includes('/health/live')) return makeHealthLiveOk();
@@ -136,9 +140,8 @@ describe('fetchSitemapJsonWithRetry — 503 cascade fix (SEO-SITEMAP-CASCADE-001
       return make200Response({});
     });
 
-    const sitemap = await importFreshFetchHelper();
     const sitemapPromise = sitemap({ id: Promise.resolve('4') });
-    jest.runAllTimers();
+    await jest.runAllTimersAsync();
 
     const result = await sitemapPromise;
     // Should succeed with the CNPJ data from second attempt

--- a/frontend/__tests__/app/sitemap-cascade-503.test.ts
+++ b/frontend/__tests__/app/sitemap-cascade-503.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment node
+ *
+ * SEO-SITEMAP-CASCADE-001: Regression tests for 503-aware retry logic.
+ *
+ * Root cause: backend returned 200+[] on DB timeout → frontend treated as
+ * legitimate empty → ISR cached empty sitemap for 1h → Google GSC error.
+ *
+ * Fix: backend now raises 503 on timeout; frontend retries 503 with exponential
+ * backoff (up to 3×) and THROWS on exhaustion so ISR preserves last known-good.
+ *
+ * Tests:
+ *  - 503 → retry 3× → throw (ISR stale-while-revalidate kicks in)
+ *  - 200+[] → return [] immediately (legitimate empty, no retry)
+ *  - 503 × 2 then 200+data → eventual success after backoff
+ *  - non-503 http_error → return null (callers default to [])
+ */
+
+// Mock fetch globally
+global.fetch = jest.fn();
+// Disable real setTimeout delays in tests
+jest.useFakeTimers();
+
+process.env.BACKEND_URL = 'http://mock-backend';
+process.env.NEXT_PUBLIC_CANONICAL_URL = 'https://smartlic.tech';
+
+// Helper: fresh module import with all filesystem deps mocked
+async function importFreshFetchHelper() {
+  jest.resetModules();
+  jest.mock('@/lib/blog', () => ({ getAllSlugs: () => [], getArticleBySlug: () => null }));
+  jest.mock('@/lib/sectors', () => ({ SECTORS: [] }));
+  jest.mock('@/lib/programmatic', () => ({
+    generateSectorParams: () => [],
+    generateLicitacoesParams: () => [],
+    generateSectorUfParams: () => [],
+    backendIdToFrontendSlug: (s: string) => s,
+  }));
+  jest.mock('@/lib/cases', () => ({ getAllCaseSlugs: () => [] }));
+  jest.mock('@/lib/cities', () => ({ CITIES: [] }));
+  jest.mock('@/lib/glossary-terms', () => ({ GLOSSARY_TERMS: [] }));
+  jest.mock('@/lib/authors', () => ({ getAllAuthorSlugs: () => [] }));
+  jest.mock('@/lib/questions', () => ({ getAllQuestionSlugs: () => [] }));
+  jest.mock('@/lib/masterclasses', () => ({ getAllMasterclassTemas: () => [] }));
+  jest.mock('@/lib/seo/noindex', () => ({ filterNoindexedSitemap: (urls: unknown[]) => urls }));
+
+  const mod = await import('../../app/sitemap');
+  return mod.default;
+}
+
+function make503Response() {
+  return Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({ detail: 'sitemap_source_timeout' }) } as Response);
+}
+
+function make200Response(payload: object) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(payload) } as Response);
+}
+
+function make404Response() {
+  return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) } as Response);
+}
+
+function makeHealthLiveOk() {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) } as Response);
+}
+
+describe('fetchSitemapJsonWithRetry — 503 cascade fix (SEO-SITEMAP-CASCADE-001)', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockReset();
+    jest.clearAllTimers();
+  });
+
+  afterEach(() => {
+    jest.runAllTimers();
+  });
+
+  it('503 exhausted after 3 attempts throws error (ISR preserves stale sitemap)', async () => {
+    // Backend returns 503 on all 3 attempts
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/health/live')) return makeHealthLiveOk();
+      return make503Response();
+    });
+
+    const sitemap = await importFreshFetchHelper();
+
+    // The id:4 sitemap fetches cnpjs first; after 3×503 it should throw
+    const sitemapPromise = sitemap({ id: Promise.resolve('4') });
+
+    // Advance timers for exponential backoff: 1s + 2s between retries
+    jest.runAllTimers();
+
+    await expect(sitemapPromise).rejects.toThrow('sitemap_cnpjs_503_exhausted');
+  });
+
+  it('200+[] returns empty array immediately without retry', async () => {
+    // Backend returns 200 with empty cnpjs — legitimate (no data yet)
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/health/live')) return makeHealthLiveOk();
+      if (url.includes('/v1/sitemap/cnpjs')) return make200Response({ cnpjs: [], total: 0 });
+      if (url.includes('/v1/sitemap/contratos-orgao-indexable')) return make200Response({ orgaos: [] });
+      if (url.includes('/v1/sitemap/orgaos')) return make200Response({ orgaos: [] });
+      if (url.includes('/v1/sitemap/fornecedores-cnpj')) return make200Response({ cnpjs: [] });
+      if (url.includes('/v1/sitemap/municipios')) return make200Response({ slugs: [] });
+      if (url.includes('/v1/sitemap/itens')) return make200Response({ catmats: [] });
+      return make200Response({});
+    });
+
+    const sitemap = await importFreshFetchHelper();
+    jest.runAllTimers();
+
+    const result = await sitemap({ id: Promise.resolve('4') });
+    // Result is an empty sitemap array (no URLs) — not an error
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(0);
+
+    // Verify fetch was called exactly once per endpoint (no retry)
+    const cnpjsCalls = (global.fetch as jest.Mock).mock.calls.filter(([url]: [string]) =>
+      url.includes('/v1/sitemap/cnpjs'),
+    );
+    expect(cnpjsCalls).toHaveLength(1);
+  });
+
+  it('503 then 200+data → eventual success after backoff', async () => {
+    let cnpjsCallCount = 0;
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/health/live')) return makeHealthLiveOk();
+      if (url.includes('/v1/sitemap/cnpjs')) {
+        cnpjsCallCount++;
+        if (cnpjsCallCount === 1) return make503Response();
+        return make200Response({ cnpjs: ['11111111000100'], total: 1 });
+      }
+      if (url.includes('/v1/sitemap/contratos-orgao-indexable')) return make200Response({ orgaos: [] });
+      if (url.includes('/v1/sitemap/orgaos')) return make200Response({ orgaos: [] });
+      if (url.includes('/v1/sitemap/fornecedores-cnpj')) return make200Response({ cnpjs: [] });
+      if (url.includes('/v1/sitemap/municipios')) return make200Response({ slugs: [] });
+      if (url.includes('/v1/sitemap/itens')) return make200Response({ catmats: [] });
+      return make200Response({});
+    });
+
+    const sitemap = await importFreshFetchHelper();
+    const sitemapPromise = sitemap({ id: Promise.resolve('4') });
+    jest.runAllTimers();
+
+    const result = await sitemapPromise;
+    // Should succeed with the CNPJ data from second attempt
+    expect(Array.isArray(result)).toBe(true);
+    const cnpjUrls = result.filter((entry: { url: string }) => entry.url.includes('/cnpj/'));
+    expect(cnpjUrls).toHaveLength(1);
+    expect(cnpjUrls[0].url).toContain('11111111000100');
+  });
+
+  it('non-503 http error (404) returns null — callers default to empty array', async () => {
+    // id:2 uses licitacoes-indexable; test that 404 → empty array (not throw)
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/v1/sitemap/licitacoes-indexable')) return make404Response();
+      return make200Response({});
+    });
+
+    const sitemap = await importFreshFetchHelper();
+    jest.runAllTimers();
+
+    // id:2 should return [] (not throw) when endpoint returns 404
+    const result = await sitemap({ id: Promise.resolve('2') });
+    expect(Array.isArray(result)).toBe(true);
+    // No routes generated when licitacoes-indexable is unavailable
+  });
+});

--- a/frontend/__tests__/app/sitemap-cascade-503.test.ts
+++ b/frontend/__tests__/app/sitemap-cascade-503.test.ts
@@ -86,10 +86,15 @@ describe('fetchSitemapJsonWithRetry — 503 cascade fix (SEO-SITEMAP-CASCADE-001
     // The id:4 sitemap fetches cnpjs first; after 3×503 it should throw
     const sitemapPromise = sitemap({ id: Promise.resolve('4') });
 
+    // Register the rejection handler BEFORE advancing timers to avoid unhandled rejection.
+    // If the handler is registered after runAllTimersAsync(), the promise may already have
+    // rejected by the time the .rejects assertion is attached, causing an UnhandledRejection.
+    const assertion = expect(sitemapPromise).rejects.toThrow('sitemap_cnpjs_503_exhausted');
+
     // Advance timers for exponential backoff: 1s + 2s between retries
     await jest.runAllTimersAsync();
 
-    await expect(sitemapPromise).rejects.toThrow('sitemap_cnpjs_503_exhausted');
+    await assertion;
   });
 
   it('200+[] returns empty array immediately without retry', async () => {

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -17,70 +17,87 @@ import { filterNoindexedSitemap } from '@/lib/seo/noindex';
 // STORY-SEO-001 AC3: Observable fetch wrapper. Replaces the silent `catch { return []; }`
 // pattern that hid ECONNREFUSED / DNS / 5xx errors at build time — which is exactly how
 // `sitemap/4.xml` went empty in production for weeks without Sentry or Prometheus alerting.
-// The wrapper still returns null on failure (callers default to []), so build never breaks.
+//
+// SEO-SITEMAP-CASCADE-001: wrapper now returns a discriminated result so callers can
+// distinguish 503 (retriable — backend DB timeout) from 200+[] (legitimate empty) from
+// other errors. This prevents ISR from caching a backend-timeout-induced empty sitemap.
 //
 // SEN-BE-007 AC11: structured Sentry breadcrumb on every fetch (success and failure)
-// with sitemap_outcome ∈ {success, http_error, timeout, empty_data}, latency_ms, and
-// url_count. Distinguishes timeout from generic fetch_error (previously lumped together).
+// with sitemap_outcome ∈ {success, http_error, timeout, empty_data, service_unavailable},
+// latency_ms, and url_count.
+type FetchSitemapResult<T> =
+  | { kind: 'success'; data: T }
+  | { kind: 'empty_data'; data: T }
+  | { kind: 'service_unavailable' }   // backend 503 — retriable
+  | { kind: 'http_error'; status: number }
+  | { kind: 'timeout' };
+
 async function fetchSitemapJson<T>(
   endpoint: string,
   extract: (data: unknown) => T,
   label: string,
-): Promise<T | null> {
+): Promise<FetchSitemapResult<T>> {
   const backendUrl = getBackendUrl();
   const url = `${backendUrl}${endpoint}`;
   const startedAt = Date.now();
-  let outcome: 'success' | 'http_error' | 'timeout' | 'empty_data' = 'success';
+  let outcome: 'success' | 'http_error' | 'timeout' | 'empty_data' | 'service_unavailable' = 'success';
   let statusCode = 0;
   let urlCount = 0;
-  let result: T | null = null;
-  let capturedError: unknown = null;
+  let fetchResult: FetchSitemapResult<T> = { kind: 'http_error', status: 0 };
   try {
     const resp = await fetch(url, {
       next: { revalidate: 3600 },
       signal: AbortSignal.timeout(15000),
     });
     statusCode = resp.status;
-    if (!resp.ok) {
+    if (resp.status === 503) {
+      // SEO-SITEMAP-CASCADE-001: backend returned 503 (DB timeout) — do NOT cache this.
+      outcome = 'service_unavailable';
+      console.warn(`[sitemap] ${label} returned 503 (backend timeout) url=${url}`);
+      fetchResult = { kind: 'service_unavailable' };
+    } else if (!resp.ok) {
       outcome = 'http_error';
       const err = new Error(`Sitemap fetch ${label} returned HTTP ${resp.status}`);
-      capturedError = err;
       console.error(`[sitemap] ${err.message} url=${url}`);
       Sentry.captureException(err, {
         tags: { sitemap_endpoint: label, sitemap_outcome: 'http_error' },
         contexts: { sitemap: { endpoint, url, status: resp.status } },
       });
-      result = null;
+      fetchResult = { kind: 'http_error', status: resp.status };
     } else {
       const data = (await resp.json()) as unknown;
-      result = extract(data);
+      const extracted = extract(data);
       // Count URLs in extracted payload — defensive shape check.
-      if (Array.isArray(result)) {
-        urlCount = result.length;
-      } else if (result && typeof result === 'object') {
+      if (Array.isArray(extracted)) {
+        urlCount = extracted.length;
+      } else if (extracted && typeof extracted === 'object') {
         // Shape varies per endpoint (combos/cnpjs/orgaos/slugs/catmats). Sum any array values.
-        for (const v of Object.values(result as Record<string, unknown>)) {
+        for (const v of Object.values(extracted as Record<string, unknown>)) {
           if (Array.isArray(v)) urlCount += v.length;
         }
       }
       if (urlCount === 0) {
         outcome = 'empty_data';
+        fetchResult = { kind: 'empty_data', data: extracted };
+      } else {
+        outcome = 'success';
+        fetchResult = { kind: 'success', data: extracted };
       }
     }
   } catch (err) {
-    capturedError = err;
     const errName = (err as Error)?.name || '';
     if (errName === 'TimeoutError' || errName === 'AbortError') {
       outcome = 'timeout';
+      fetchResult = { kind: 'timeout' };
     } else {
       outcome = 'http_error';
+      fetchResult = { kind: 'http_error', status: 0 };
     }
     console.error(`[sitemap] fetch ${label} failed (${outcome})`, err);
     Sentry.captureException(err, {
       tags: { sitemap_endpoint: label, sitemap_outcome: outcome },
       contexts: { sitemap: { endpoint, url } },
     });
-    result = null;
   } finally {
     Sentry.addBreadcrumb({
       category: 'sitemap',
@@ -95,33 +112,59 @@ async function fetchSitemapJson<T>(
       },
     });
   }
-  // Reference capturedError to silence unused-variable lint while keeping the
-  // explicit assignment for future structured-logging needs.
-  void capturedError;
-  return result;
+  return fetchResult;
 }
 
-// SEN-BE-007 AC12: 1× retry with 2s backoff. Retries on null result (timeout or
-// http_error). Does NOT retry on `empty_data` — an empty array is a valid response
-// from the backend (e.g. no indexable combos yet). Total worst case: 15s + 2s + 15s = 32s.
+// SEO-SITEMAP-CASCADE-001: 503-aware retry with exponential backoff.
+//
+// Previous behaviour (SEN-BE-007 AC12): 1× retry with 2s flat delay, returns null on all
+// failures — callers silently defaulted to [] which ISR cached for 1h.
+//
+// New behaviour:
+//  - 503 (backend DB timeout) → retry up to maxRetries times with 2^attempt * 1000ms backoff.
+//    On exhaustion → THROW so Next.js ISR preserves last known-good sitemap (stale-while-revalidate).
+//  - 200+[] (legitimate empty) → return [] immediately (no retry, valid state).
+//  - Other http_error / timeout → return null (callers default to [], same as before).
+//
+// Worst case: 3 attempts × (15s fetch + backoff) = 15s + (1+2+4)s = ~22s. Within ISR budget.
 async function fetchSitemapJsonWithRetry<T>(
   endpoint: string,
   extract: (data: unknown) => T,
   label: string,
+  maxRetries = 3,
 ): Promise<T | null> {
-  const first = await fetchSitemapJson<T>(endpoint, extract, label);
-  if (first !== null) {
-    return first;
-  }
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  const second = await fetchSitemapJson<T>(endpoint, extract, `${label}-retry`);
-  if (second === null) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const res = await fetchSitemapJson<T>(endpoint, extract, `${label}${attempt > 0 ? `-retry${attempt}` : ''}`);
+
+    if (res.kind === 'success' || res.kind === 'empty_data') {
+      // 200+data or 200+[] — both are legitimate; return extracted value.
+      return res.data;
+    }
+
+    if (res.kind === 'service_unavailable') {
+      if (attempt < maxRetries - 1) {
+        // Exponential backoff before retry: 1s, 2s, 4s, ...
+        const delayMs = Math.pow(2, attempt) * 1000;
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+      // Final attempt still got 503 — throw so ISR preserves last known-good sitemap.
+      const exhaustedErr = new Error(`sitemap_${label}_503_exhausted`);
+      Sentry.captureException(exhaustedErr, {
+        tags: { sitemap_endpoint: label, sitemap_outcome: 'retry_exhausted_503' },
+        contexts: { sitemap: { endpoint, attempts: maxRetries } },
+      });
+      throw exhaustedErr;
+    }
+
+    // http_error or timeout on non-503 — return null (caller defaults to []).
     Sentry.captureMessage(`sitemap_retry_exhausted_${label}`, {
       level: 'warning',
       tags: { sitemap_endpoint: label, sitemap_outcome: 'retry_exhausted' },
     });
+    return null;
   }
-  return second;
+  return null;
 }
 
 /**

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -143,8 +143,11 @@ async function fetchSitemapJsonWithRetry<T>(
 
     if (res.kind === 'service_unavailable') {
       if (attempt < maxRetries - 1) {
-        // Exponential backoff before retry: 1s, 2s, 4s, ...
-        const delayMs = Math.pow(2, attempt) * 1000;
+        // Exponential backoff before retry: 1s, 2s, 4s, ... with multiplicative jitter (0.7×–1.3×)
+        // Prevents thundering herd when multiple ISR workers restart simultaneously.
+        const baseDelay = Math.pow(2, attempt) * 1000;
+        const jitter = Math.random() * 0.6 + 0.7; // 0.7x to 1.3x
+        const delayMs = Math.round(baseDelay * jitter);
         await new Promise((resolve) => setTimeout(resolve, delayMs));
         continue;
       }


### PR DESCRIPTION
## Summary

Backend retorna 503 (não vazio) em timeout de sitemap. Frontend faz retry com exponential backoff + jitter. Retry-After: 30.

## Testing Plan

- [ ] Tests pass locally (`npm test` / `pytest`)
- [ ] No regressions in CI (`backend,frontend`)
- [ ] Manual smoke test on staging

## Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)