### PR TITLE
feat(frontend): cross-sell Founders em /planos e dashboard trial Day 3+ (#1006)

### DIFF
--- a/frontend/__mocks__/framer-motion.js
+++ b/frontend/__mocks__/framer-motion.js
@@ -52,4 +52,5 @@ module.exports = {
   useTransform: (value) => value,
   useSpring: (value) => value,
   useInView: () => [null, true],
+  useReducedMotion: () => false,
 };

--- a/frontend/__tests__/components/FoundersCrossSellBanner.test.tsx
+++ b/frontend/__tests__/components/FoundersCrossSellBanner.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Issue #1006 (COPY-CROSS-007): FoundersCrossSellBanner tests.
+ *
+ * Covers:
+ *  - Variant 'planos': render with seats counter; non-dismissable when seats <= 10;
+ *    dismissable persistence in localStorage; copy fidelity.
+ *  - Variant 'dashboard': hidden when trial_day < 3; hidden when trial_day >= 12;
+ *    rendered for 3..11; sessionStorage dismiss; 24h click anti-fatigue.
+ *  - Common: hidden when isFounder; hidden when sold_out (seats=0);
+ *    hidden when API returns available=false; fallback copy when API errors.
+ */
+
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Stub framer-motion to a passthrough <div> + useReducedMotion
+jest.mock("framer-motion", () => ({
+  motion: { div: (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} /> },
+  useReducedMotion: () => false,
+}));
+
+// Mock Mixpanel wrappers (verify they fire without external SDK)
+const trackView = jest.fn();
+const trackClick = jest.fn();
+const trackDismiss = jest.fn();
+jest.mock("../../lib/analytics/founders", () => ({
+  trackFoundersBannerView: (p: unknown) => trackView(p),
+  trackFoundersBannerClick: (p: unknown) => trackClick(p),
+  trackFoundersBannerDismiss: (p: unknown) => trackDismiss(p),
+}));
+
+// Mock the SWR hook directly so we control availability state per test
+const mockUseAvailability = jest.fn();
+jest.mock("../../hooks/useFoundersAvailability", () => ({
+  useFoundersAvailability: () => mockUseAvailability(),
+}));
+
+import { FoundersCrossSellBanner } from "../../app/components/FoundersCrossSellBanner";
+
+const futureDeadline = "2099-06-30T23:59:59Z";
+
+const dataAvailable = (seats: number) => ({
+  data: { available: true, seats_remaining: seats, deadline_at: futureDeadline },
+  isLoading: false,
+  error: null,
+});
+
+const dataSoldOut = {
+  data: { available: true, seats_remaining: 0, deadline_at: futureDeadline },
+  isLoading: false,
+  error: null,
+};
+
+const dataUnavailable = {
+  data: { available: false, seats_remaining: 0, deadline_at: futureDeadline },
+  isLoading: false,
+  error: null,
+};
+
+const dataError = {
+  data: null,
+  isLoading: false,
+  error: new Error("boom"),
+};
+
+const dataLoading = {
+  data: null,
+  isLoading: true,
+  error: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+  mockUseAvailability.mockReset();
+});
+
+describe("FoundersCrossSellBanner — variant=planos", () => {
+  it("renders with seats counter when API returns availability", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(42));
+    render(<FoundersCrossSellBanner variant="planos" />);
+    const banner = screen.getByTestId("founders-cross-sell-banner-planos");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/42 vagas vitalícias por R\$997/);
+    expect(banner).toHaveTextContent(/Encerra 30\/06/);
+    expect(screen.getByTestId("founders-cross-sell-cta-planos")).toHaveTextContent(/Ver Plano Fundadores/);
+  });
+
+  it("hides dismiss button when seats <= 10 (real scarcity)", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(8));
+    render(<FoundersCrossSellBanner variant="planos" dismissable />);
+    expect(screen.queryByTestId("founders-cross-sell-dismiss-planos")).not.toBeInTheDocument();
+  });
+
+  it("dismissable above scarcity threshold; click persists to localStorage", async () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    const user = userEvent.setup();
+    const { rerender } = render(<FoundersCrossSellBanner variant="planos" dismissable />);
+    const btn = screen.getByTestId("founders-cross-sell-dismiss-planos");
+    await user.click(btn);
+    expect(trackDismiss).toHaveBeenCalledWith({ route: "planos" });
+    expect(localStorage.getItem("founders_cross_sell_planos_dismissed")).not.toBeNull();
+
+    rerender(<FoundersCrossSellBanner variant="planos" dismissable />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-planos")).not.toBeInTheDocument();
+  });
+
+  it("hides when isFounder", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    render(<FoundersCrossSellBanner variant="planos" isFounder />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-planos")).not.toBeInTheDocument();
+  });
+
+  it("hides when sold out (seats_remaining=0)", () => {
+    mockUseAvailability.mockReturnValue(dataSoldOut);
+    render(<FoundersCrossSellBanner variant="planos" />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-planos")).not.toBeInTheDocument();
+  });
+
+  it("hides when API returns available=false", () => {
+    mockUseAvailability.mockReturnValue(dataUnavailable);
+    render(<FoundersCrossSellBanner variant="planos" />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-planos")).not.toBeInTheDocument();
+  });
+
+  it("renders fallback copy without number when API errors", () => {
+    mockUseAvailability.mockReturnValue(dataError);
+    render(<FoundersCrossSellBanner variant="planos" />);
+    const banner = screen.getByTestId("founders-cross-sell-banner-planos");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/vagas vitalícias por R\$997/);
+    expect(banner).not.toHaveTextContent(/^\d+ vagas/); // no specific number in fallback
+  });
+
+  it("renders nothing while still loading and no data", () => {
+    mockUseAvailability.mockReturnValue(dataLoading);
+    const { container } = render(<FoundersCrossSellBanner variant="planos" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("FoundersCrossSellBanner — variant=dashboard", () => {
+  it.each([0, 1, 2])("hides when trial_day=%i (< 3)", (day) => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={day} />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-dashboard")).not.toBeInTheDocument();
+  });
+
+  it.each([12, 13, 14])("hides when trial_day=%i (>= 12, urgent TrialProgressBar own)", (day) => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={day} />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-dashboard")).not.toBeInTheDocument();
+  });
+
+  it.each([3, 7, 11])("renders for trial_day=%i (3..11) with CTA copy", (day) => {
+    mockUseAvailability.mockReturnValue(dataAvailable(25));
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={day} />);
+    const banner = screen.getByTestId("founders-cross-sell-banner-dashboard");
+    expect(banner).toHaveTextContent(/Já está vendo valor\?/);
+    expect(banner).toHaveTextContent(/25 vagas restantes/);
+    expect(screen.getByTestId("founders-cross-sell-cta-dashboard")).toHaveTextContent(/Pegar minha vaga R\$997/);
+  });
+
+  it("dismiss is session-scoped (sessionStorage), not localStorage", async () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(25));
+    const user = userEvent.setup();
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={5} dismissable />);
+    await user.click(screen.getByTestId("founders-cross-sell-dismiss-dashboard"));
+    expect(sessionStorage.getItem("founders_cross_sell_dashboard_dismissed_session")).toBe("1");
+    expect(localStorage.getItem("founders_cross_sell_dashboard_dismissed_session")).toBeNull();
+  });
+
+  it("hides when 24h click anti-fatigue is active", () => {
+    localStorage.setItem("founders_cross_sell_dashboard_clicked_at", String(Date.now()));
+    mockUseAvailability.mockReturnValue(dataAvailable(25));
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={5} />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-dashboard")).not.toBeInTheDocument();
+  });
+
+  it("CTA click writes 24h anti-fatigue timestamp + fires analytics", async () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(25));
+    const user = userEvent.setup();
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={5} />);
+    await user.click(screen.getByTestId("founders-cross-sell-cta-dashboard"));
+    expect(localStorage.getItem("founders_cross_sell_dashboard_clicked_at")).not.toBeNull();
+    expect(trackClick).toHaveBeenCalledWith({ route: "dashboard" });
+  });
+
+  it("hides when isFounder", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(25));
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={5} isFounder />);
+    expect(screen.queryByTestId("founders-cross-sell-banner-dashboard")).not.toBeInTheDocument();
+  });
+
+  it("renders fallback copy without number when API errors", () => {
+    mockUseAvailability.mockReturnValue(dataError);
+    render(<FoundersCrossSellBanner variant="dashboard" trialDay={5} />);
+    const banner = screen.getByTestId("founders-cross-sell-banner-dashboard");
+    expect(banner).toHaveTextContent(/Já está vendo valor\?/);
+    expect(banner).not.toHaveTextContent(/\d+ vagas restantes/);
+  });
+});
+
+describe("FoundersCrossSellBanner — analytics", () => {
+  it("fires founders_banner_view once on mount when eligible", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    render(<FoundersCrossSellBanner variant="planos" />);
+    expect(trackView).toHaveBeenCalledWith({ route: "planos", dismissed_count: undefined });
+  });
+
+  it("does not fire view event when banner is hidden", () => {
+    mockUseAvailability.mockReturnValue(dataSoldOut);
+    render(<FoundersCrossSellBanner variant="planos" />);
+    expect(trackView).not.toHaveBeenCalled();
+  });
+});
+
+describe("FoundersCrossSellBanner — accessibility", () => {
+  it("dismiss button has accessible name + min 44px tap target classes", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    render(<FoundersCrossSellBanner variant="planos" dismissable />);
+    const btn = screen.getByLabelText(/Fechar banner Plano Fundadores/);
+    expect(btn).toHaveClass("min-w-[44px]");
+    expect(btn).toHaveClass("min-h-[44px]");
+  });
+
+  it("CTA link has min 44px tap target", () => {
+    mockUseAvailability.mockReturnValue(dataAvailable(50));
+    render(<FoundersCrossSellBanner variant="planos" />);
+    const cta = screen.getByTestId("founders-cross-sell-cta-planos");
+    expect(cta).toHaveClass("min-h-[44px]");
+  });
+});

--- a/frontend/app/components/FoundersCrossSellBanner.tsx
+++ b/frontend/app/components/FoundersCrossSellBanner.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+/**
+ * Issue #1006 (COPY-CROSS-007): Cross-sell Founders banner — shared component.
+ *
+ * Variants:
+ *  - 'planos'    : top of /planos pricing table; non-dismissable when seats ≤ 10 (real scarcity)
+ *  - 'dashboard' : trial Day 3–11 dashboard cross-sell; session-scoped dismiss + 24h click anti-fatigue
+ *  - 'pseo'      : programmatic SEO footer (referenced by COPY-PSEO-005)
+ *
+ * Hide rules (all variants):
+ *  - User is already a founder (`isFounder`)
+ *  - Offer sold out (seats_remaining = 0) or unavailable
+ *  - Deadline passed
+ *
+ * Variant-specific hides:
+ *  - 'planos'    : dismissed via localStorage UNLESS seats ≤ 10
+ *  - 'dashboard' : trial_day < 3 OR trial_day >= 12 (Day 12+ has urgent TrialProgressBar);
+ *                  session-dismissed; 24h-anti-fatigue after CTA click
+ *
+ * Animation: Framer Motion fade, respects prefers-reduced-motion.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import { useFoundersAvailability } from "../../hooks/useFoundersAvailability";
+import {
+  trackFoundersBannerView,
+  trackFoundersBannerClick,
+  trackFoundersBannerDismiss,
+} from "../../lib/analytics/founders";
+
+const PLANOS_DISMISS_KEY = "founders_cross_sell_planos_dismissed";
+const PLANOS_DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const DASHBOARD_SESSION_DISMISS_KEY = "founders_cross_sell_dashboard_dismissed_session";
+const DASHBOARD_CLICK_KEY = "founders_cross_sell_dashboard_clicked_at";
+const DASHBOARD_CLICK_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const SCARCITY_THRESHOLD = 10;
+
+export interface FoundersCrossSellBannerProps {
+  variant: "planos" | "dashboard" | "pseo";
+  dismissable?: boolean;
+  position?: "top" | "bottom" | "sticky";
+  /** Required for 'dashboard' variant — pulled from useTrialPhase().day */
+  trialDay?: number;
+  /** Hide entirely if user is already a Founder */
+  isFounder?: boolean;
+  className?: string;
+}
+
+function isPlanosDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = localStorage.getItem(PLANOS_DISMISS_KEY);
+    if (!raw) return false;
+    const ts = parseInt(raw, 10);
+    if (Number.isNaN(ts)) return false;
+    return Date.now() - ts < PLANOS_DISMISS_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+function isDashboardSessionDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return sessionStorage.getItem(DASHBOARD_SESSION_DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function isDashboardClickAntiFatigueActive(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = localStorage.getItem(DASHBOARD_CLICK_KEY);
+    if (!raw) return false;
+    const ts = parseInt(raw, 10);
+    if (Number.isNaN(ts)) return false;
+    return Date.now() - ts < DASHBOARD_CLICK_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+export function FoundersCrossSellBanner({
+  variant,
+  dismissable = true,
+  position = "top",
+  trialDay,
+  isFounder = false,
+  className = "",
+}: FoundersCrossSellBannerProps) {
+  const { data: availability, isLoading, error } = useFoundersAvailability();
+  const reducedMotion = useReducedMotion();
+
+  // Client-side dismiss state hydration
+  const [dismissed, setDismissed] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (variant === "planos") {
+      setDismissed(isPlanosDismissed());
+    } else if (variant === "dashboard") {
+      setDismissed(isDashboardSessionDismissed() || isDashboardClickAntiFatigueActive());
+    } else {
+      // pseo: never dismissable in storage — always render if eligible
+      setDismissed(false);
+    }
+    setHydrated(true);
+  }, [variant]);
+
+  const seatsRemaining = availability?.seats_remaining ?? null;
+  const deadlinePassed = useMemo(() => {
+    if (!availability?.deadline_at) return false;
+    try {
+      return new Date(availability.deadline_at) < new Date();
+    } catch {
+      return false;
+    }
+  }, [availability?.deadline_at]);
+
+  // Variant-specific eligibility (computed before render to gate analytics)
+  const variantEligible = useMemo(() => {
+    if (variant === "dashboard") {
+      if (typeof trialDay !== "number") return false;
+      if (trialDay < 3) return false;
+      if (trialDay >= 12) return false;
+    }
+    return true;
+  }, [variant, trialDay]);
+
+  // Effective dismissable: planos becomes non-dismissable under scarcity
+  const effectiveDismissable = useMemo(() => {
+    if (!dismissable) return false;
+    if (variant === "planos" && seatsRemaining !== null && seatsRemaining <= SCARCITY_THRESHOLD) {
+      return false;
+    }
+    return true;
+  }, [dismissable, variant, seatsRemaining]);
+
+  // Fire view analytics once when eligible
+  const visibilityKey = `${hydrated}-${dismissed}-${variantEligible}-${isFounder}-${availability?.available}-${seatsRemaining}-${deadlinePassed}`;
+  useEffect(() => {
+    if (!hydrated || dismissed || !variantEligible || isFounder) return;
+    if (!availability || !availability.available) return;
+    if (seatsRemaining === 0 || deadlinePassed) return;
+    trackFoundersBannerView({
+      route: variant,
+      dismissed_count: undefined,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibilityKey]);
+
+  const handleDismiss = () => {
+    try {
+      if (variant === "planos") {
+        localStorage.setItem(PLANOS_DISMISS_KEY, String(Date.now()));
+      } else if (variant === "dashboard") {
+        sessionStorage.setItem(DASHBOARD_SESSION_DISMISS_KEY, "1");
+      }
+    } catch {
+      // storage unavailable — dismiss in-memory only
+    }
+    setDismissed(true);
+    trackFoundersBannerDismiss({ route: variant });
+  };
+
+  const handleCtaClick = () => {
+    try {
+      if (variant === "dashboard") {
+        localStorage.setItem(DASHBOARD_CLICK_KEY, String(Date.now()));
+      }
+    } catch {
+      // no-op
+    }
+    trackFoundersBannerClick({ route: variant });
+  };
+
+  // Render gates
+  if (!hydrated) return null;
+  if (dismissed) return null;
+  if (isFounder) return null;
+  if (!variantEligible) return null;
+
+  // Loading: render nothing rather than "..." (per AC: "Loading state graceful")
+  if (isLoading && !availability) return null;
+
+  // Hard hides from API state
+  if (availability) {
+    if (!availability.available) return null;
+    if (availability.seats_remaining === 0) return null;
+    if (deadlinePassed) return null;
+  } else if (error) {
+    // Fallback path: API failed — render conservative copy without number
+  } else {
+    return null;
+  }
+
+  // Resolve copy by variant (with API fallback)
+  const seats = seatsRemaining;
+  const hasSeats = typeof seats === "number" && seats > 0;
+  const fallback = !availability && !!error;
+
+  let bodyText: React.ReactNode;
+  let ctaLabel: string;
+  if (variant === "planos") {
+    bodyText = fallback ? (
+      <>
+        <strong>Antes de escolher um plano mensal:</strong> existem vagas vitalícias por R$997. Pague uma vez, use pra sempre. Encerra 30/06.
+      </>
+    ) : (
+      <>
+        <strong>Antes de escolher um plano mensal: existem {seats} vagas vitalícias por R$997.</strong>{" "}
+        Pague uma vez, use pra sempre. Encerra 30/06.
+      </>
+    );
+    ctaLabel = "Ver Plano Fundadores →";
+  } else if (variant === "dashboard") {
+    bodyText = fallback || !hasSeats ? (
+      <>Já está vendo valor? Pague R$997 uma vez e nunca mais veja boleto do SmartLic.</>
+    ) : (
+      <>
+        Já está vendo valor? Pague R$997 uma vez e nunca mais veja boleto do SmartLic. {seats} vagas restantes.
+      </>
+    );
+    ctaLabel = "Pegar minha vaga R$997 →";
+  } else {
+    // pseo
+    bodyText = fallback || !hasSeats ? (
+      <>Plano Fundadores: acesso vitalício por R$997. Vagas limitadas, encerra 30/06.</>
+    ) : (
+      <>Plano Fundadores: {seats} vagas vitalícias por R$997. Encerra 30/06.</>
+    );
+    ctaLabel = "Saiba mais →";
+  }
+
+  const positionClass =
+    position === "sticky"
+      ? "sticky top-0 z-30"
+      : position === "bottom"
+        ? ""
+        : "";
+
+  const animProps = reducedMotion
+    ? { initial: false, animate: { opacity: 1 } }
+    : { initial: { opacity: 0, y: -4 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0.25 } };
+
+  return (
+    <motion.div
+      role="status"
+      aria-live="polite"
+      data-testid={`founders-cross-sell-banner-${variant}`}
+      data-variant={variant}
+      className={`w-full bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3 ${positionClass} ${className}`}
+      {...animProps}
+    >
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+        <p className="text-sm text-amber-900 dark:text-amber-100 leading-relaxed">{bodyText}</p>
+        <div className="flex items-center gap-2 flex-shrink-0 self-stretch sm:self-auto">
+          <Link
+            href="/fundadores"
+            onClick={handleCtaClick}
+            data-testid={`founders-cross-sell-cta-${variant}`}
+            className="inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium rounded-md transition-colors whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+          >
+            {ctaLabel}
+          </Link>
+          {effectiveDismissable && (
+            <button
+              type="button"
+              onClick={handleDismiss}
+              aria-label="Fechar banner Plano Fundadores"
+              data-testid={`founders-cross-sell-dismiss-${variant}`}
+              className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] p-2 text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 rounded-md"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+export default FoundersCrossSellBanner;

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -14,6 +14,9 @@ import { TrialUpsellCTA } from "../../components/billing/TrialUpsellCTA";
 import { TrialValueTracker } from "../../components/billing/TrialValueTracker";
 import { TrialExtensionCard } from "../../components/billing/TrialExtensionCard";
 import { usePlan } from "../../hooks/usePlan";
+import { useTrialPhase } from "../../hooks/useTrialPhase";
+// Issue #1006 (COPY-CROSS-007): Day 3+ Founders cross-sell on dashboard
+import { FoundersCrossSellBanner } from "../components/FoundersCrossSellBanner";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { formatCurrencyBR } from "../../lib/format-currency";
 import { Download } from "lucide-react";
@@ -81,6 +84,7 @@ export default function DashboardPage() {
   const { trackEvent } = useAnalytics();
   const { status: backendStatus } = useBackendStatusContext();
   const { planInfo } = usePlan();
+  const trialPhase = useTrialPhase();
   const isMobile = useIsMobile();
 
   const [period, setPeriod] = useState<Period>("week");
@@ -282,6 +286,18 @@ export default function DashboardPage() {
 
         {/* Zero-Churn P2 §8.2: Trial extension actions checklist */}
         <TrialExtensionCard />
+
+        {/* Issue #1006 (COPY-CROSS-007): Day 3-11 Founders cross-sell.
+            Hidden if not in trial (day=0 from useTrialPhase non-trial fallback), if user is already
+            a Founder, if seats sold out, or if user dismissed for the session / clicked CTA in last 24h.
+            Day 12+ has the urgent TrialProgressBar — banner steps aside. */}
+        <FoundersCrossSellBanner
+          variant="dashboard"
+          dismissable
+          trialDay={trialPhase.day}
+          isFounder={Boolean((planInfo as { is_founder?: boolean } | null)?.is_founder)}
+          className="mb-6"
+        />
 
         {summary && (
           <p className="text-sm text-[var(--ink-muted)] mb-6">

--- a/frontend/app/planos/page.tsx
+++ b/frontend/app/planos/page.tsx
@@ -22,6 +22,8 @@ import { PlanProCard } from "./components/PlanProCard";
 import { PlanConsultoriaCard } from "./components/PlanConsultoriaCard";
 import { PlanFAQ } from "./components/PlanFAQ";
 import { ProductSchema } from "./components/ProductSchema";
+// Issue #1006 (COPY-CROSS-007): live counter cross-sell replacing static banner
+import { FoundersCrossSellBanner } from "../components/FoundersCrossSellBanner";
 import { buttonVariants } from "../../components/ui/button";
 import { trackViewItem, trackBeginCheckout } from "../components/GoogleAnalytics";
 import { PRO_PRICING, CONSULTORIA_PRICING } from "@/lib/plan-pricing";
@@ -358,15 +360,17 @@ export default function PlanosPage() {
           </div>
         </div>
 
-        {/* Fundadores cross-sell banner — BIZ-FOUND-002 / feat/#789 */}
-        <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg flex items-center justify-between">
-          <p className="text-sm text-amber-800 dark:text-amber-200">
-            → Conheça o <strong>Plano Fundadores</strong> — R$997 vitalício, vagas limitadas
-          </p>
-          <Link href="/fundadores" className="text-sm font-medium text-amber-700 dark:text-amber-300 hover:underline ml-4 whitespace-nowrap">
-            Saiba mais →
-          </Link>
-        </div>
+        {/* Issue #1006 (COPY-CROSS-007): live counter cross-sell — replaces previous static banner (BIZ-FOUND-002 / #789).
+            Non-dismissable when seats <= 10 (real scarcity). Hidden if user is already a Founder or for active subscribers. */}
+        {userStatus !== "subscriber" && (
+          <div className="mb-6">
+            <FoundersCrossSellBanner
+              variant="planos"
+              dismissable
+              isFounder={Boolean(planInfo?.is_founder)}
+            />
+          </div>
+        )}
 
         <PlanStatusBanners
           userStatus={userStatus}

--- a/frontend/hooks/useFoundersAvailability.ts
+++ b/frontend/hooks/useFoundersAvailability.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import useSWR from "swr";
+
+/**
+ * Issue #1006 (COPY-CROSS-007): SWR wrapper around `/api/founding/availability`.
+ *
+ * Note on naming: task description references "/api/founders/availability" + PR #1014,
+ * but the actually-shipped endpoint in production is the singular form
+ * `/api/founding/availability` (proxied to `/v1/founding/availability`). We standardize
+ * on the existing endpoint to avoid duplicating infrastructure. PR #1014 hadn't merged
+ * at component implementation time.
+ *
+ * Schema (matches `frontend/app/api-types.generated.ts::FoundingAvailability`):
+ *   { available: boolean, seats_remaining: number, deadline_at: string | null }
+ *
+ * Cache strategy:
+ *  - dedupingInterval 60s (matches backend cache and ISR alignment guidance)
+ *  - revalidateOnFocus disabled — counter doesn't need sub-minute freshness
+ *  - errorRetryCount 1 — fail fast so callers can show conservative fallback copy
+ */
+
+export interface FoundingAvailability {
+  available: boolean;
+  seats_remaining: number;
+  deadline_at: string | null;
+}
+
+interface UseFoundersAvailabilityResult {
+  data: FoundingAvailability | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const fetcher = async (url: string): Promise<FoundingAvailability | null> => {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) return null;
+  return res.json();
+};
+
+export function useFoundersAvailability(): UseFoundersAvailabilityResult {
+  const { data, error, isLoading } = useSWR<FoundingAvailability | null>(
+    "/api/founding/availability",
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+      errorRetryCount: 1,
+      fallbackData: null,
+    },
+  );
+
+  return {
+    data: data ?? null,
+    isLoading,
+    error: (error as Error) ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Banner cross-sell Founders com contador de vagas ao vivo em /planos e dashboard de trial (Day 3+).

## Testing Plan

- [ ] Tests pass locally (`npm test` / `pytest`)
- [ ] No regressions in CI (`frontend`)
- [ ] Manual smoke test on staging

## Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)