### PR TITLE
feat(backend): smartlic_seo_404_total Prometheus counter + middleware (#1041)

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -343,6 +343,16 @@ SSE_FALLBACK_SIMULATED_TOTAL = _create_counter(
     "Times frontend fell back to simulated progress after SSE failure",
 )
 
+# Issue #1041: HTTP 404 responses on programmatic SEO routes.
+# Enables Sentry rate-based alert when seo_404_rate > 0.5%/24h (Google de-indexation risk).
+# route_type: first non-version segment (observatorio, cnpj, orgao, contratos, etc.)
+# reason: malformed_slug | empty_data | timeout | unknown
+SEO_404_TOTAL = _create_counter(
+    "smartlic_seo_404_total",
+    "HTTP 404 responses on programmatic SEO routes",
+    labelnames=["route_type", "reason"],
+)
+
 # TD-004 AC4: Legacy route deprecation tracking
 LEGACY_ROUTE_CALLS = _create_counter(
     "smartlic_legacy_route_calls_total",

--- a/backend/seo_404_middleware.py
+++ b/backend/seo_404_middleware.py
@@ -1,0 +1,111 @@
+"""Issue #1041: SEO 404 Prometheus middleware.
+
+Detects HTTP 404 responses on programmatic SEO route prefixes and increments
+``smartlic_seo_404_total{route_type, reason}`` (defined in ``metrics.py``).
+
+Why a dedicated counter (instead of derived from ``HTTP_RESPONSES_TOTAL``):
+- Programmatic SEO drives the primary inbound funnel (10k+ ISR pages). 404s
+  silently raise Google de-indexation risk if not alerted before the crawler
+  re-checks. A per-route-type counter enables a Sentry rate alert
+  (``seo_404_rate > 0.5%/24h``) without slicing the global 4xx counter.
+- Labels stay deliberately low cardinality: ``route_type`` is the first non-/v1/
+  segment (~15 known prefixes); ``reason`` has 4 enum values.
+
+Operates purely on the response object so it never touches route handlers
+(avoids races with concurrent route refactors). Safe under graceful Prometheus
+fallback — ``SEO_404_TOTAL`` is a ``_NoopMetric`` when ``prometheus_client``
+isn't installed.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+
+# Programmatic SEO prefixes (whitelist). All registered under /v1/ in
+# ``startup/routes.py::register_routes`` (every router goes through
+# ``app.include_router(r, prefix="/v1")``). Public, no-auth routers that drive
+# organic inbound — see ``.claude/rules/architecture-detail.md`` SEO Programmatic.
+_SEO_ROUTE_PREFIXES: tuple[str, ...] = (
+    "/v1/observatorio",
+    "/v1/cnpj",
+    "/v1/orgao",        # covers /v1/orgao/* and /v1/orgaos/*
+    "/v1/orgaos",
+    "/v1/contratos",
+    "/v1/municipios",
+    "/v1/itens",
+    "/v1/compliance",
+    "/v1/alertas",
+    "/v1/sectors",
+    "/v1/setores",
+    "/v1/blog",
+    "/v1/dados",
+    "/v1/empresa",
+    "/v1/fornecedores",
+    "/v1/indice-municipal",
+    "/v1/calculadora",
+    "/v1/comparador",
+)
+
+_VALID_REASONS = frozenset({"malformed_slug", "empty_data", "timeout", "unknown"})
+
+
+def _route_type_for(path: str, prefixes: Iterable[str] = _SEO_ROUTE_PREFIXES) -> str | None:
+    """Return route_type label for *path* if it matches a SEO prefix, else None.
+
+    The label is the first non-version segment (e.g. ``/v1/observatorio/raio-x/123``
+    → ``observatorio``). Kept low cardinality on purpose.
+    """
+    for prefix in prefixes:
+        if path == prefix or path.startswith(prefix + "/"):
+            # First segment after /v1/ — strip leading slash and split.
+            tail = path[len("/v1/"):] if path.startswith("/v1/") else path.lstrip("/")
+            head = tail.split("/", 1)[0] if tail else ""
+            return head or None
+    return None
+
+
+def _reason_for(response: Response) -> str:
+    """Infer the reason label from response headers.
+
+    Header-based hints are preferred over body inspection (cheaper, no
+    streaming-body re-read). Routes that already classify 404s can advertise
+    via ``X-SEO-404-Reason: malformed_slug|empty_data|timeout``. Anything
+    else falls through to ``unknown`` so the counter still increments.
+    """
+    hint = response.headers.get("X-SEO-404-Reason", "").strip().lower()
+    if hint in _VALID_REASONS:
+        return hint
+    # Soft heuristics from common existing headers.
+    coverage = response.headers.get("X-Coverage-Status", "").strip().lower()
+    if coverage in {"empty", "no-data", "no_data"}:
+        return "empty_data"
+    return "unknown"
+
+
+class SEO404MetricsMiddleware(BaseHTTPMiddleware):
+    """Increment ``SEO_404_TOTAL`` on programmatic SEO 404s.
+
+    Place AFTER tracing middleware (added later → outermost runs earlier;
+    we want the *final* status code, so this should be added near the
+    response-tracking middlewares — see ``startup/middleware_setup.py``).
+    """
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        response = await call_next(request)
+        try:
+            if response.status_code == 404:
+                route_type = _route_type_for(request.url.path)
+                if route_type:
+                    reason = _reason_for(response)
+                    from metrics import SEO_404_TOTAL
+                    SEO_404_TOTAL.labels(route_type=route_type, reason=reason).inc()
+        except Exception:  # pragma: no cover — defensive, never break the response
+            logger.exception("seo_404_middleware: failed to record metric")
+        return response

--- a/backend/startup/middleware_setup.py
+++ b/backend/startup/middleware_setup.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from config import get_cors_origins, METRICS_TOKEN
 from config.pipeline import REQUEST_SLOW_THRESHOLD_S, ROUTE_TIMEOUT_S
 from middleware import CorrelationIDMiddleware, SecurityHeadersMiddleware, DeprecationMiddleware, RateLimitMiddleware
+from seo_404_middleware import SEO404MetricsMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,10 @@ def setup_middleware(app: FastAPI) -> None:
     app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(DeprecationMiddleware)
     app.add_middleware(RateLimitMiddleware)
+    # Issue #1041: Increment smartlic_seo_404_total{route_type, reason} on programmatic SEO 404s.
+    # Added AFTER tracing middlewares so this sees the final response status; pure response-side
+    # logic (no route file changes) — avoids races with concurrent route refactors.
+    app.add_middleware(SEO404MetricsMiddleware)
 
     # DEBT-124: Graceful shutdown drain — reject new requests with 503 during shutdown
     @app.middleware("http")

--- a/backend/tests/test_seo_404_middleware.py
+++ b/backend/tests/test_seo_404_middleware.py
@@ -1,0 +1,202 @@
+"""Issue #1041: Tests for ``smartlic_seo_404_total`` counter + middleware.
+
+Strategy:
+- Build a minimal Starlette app wired only with ``SEO404MetricsMiddleware``.
+- Define routes mimicking real SEO prefixes (``/v1/observatorio/...``,
+  ``/v1/cnpj/...``) and a non-SEO control route (``/v1/admin/foo``).
+- Assert the Prometheus counter is incremented exactly when expected, by
+  comparing snapshots from ``REGISTRY.get_sample_value`` before/after each
+  request. This avoids depending on the full FastAPI app and its 30+ env
+  requirements (Supabase, Stripe, etc.) — keeps the test fast (<1s) and hermetic.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("prometheus_client")
+from prometheus_client import REGISTRY  # noqa: E402
+from starlette.applications import Starlette  # noqa: E402
+from starlette.responses import JSONResponse, Response  # noqa: E402
+from starlette.routing import Route  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from seo_404_middleware import (  # noqa: E402
+    SEO404MetricsMiddleware,
+    _reason_for,
+    _route_type_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# prometheus_client strips the trailing ``_total`` from Counter names internally,
+# then re-appends ``_total`` for the sample name. So a Counter declared as
+# ``smartlic_seo_404_total`` exposes:
+#   - metric family name : "smartlic_seo_404"
+#   - cumulative sample  : "smartlic_seo_404_total"
+_METRIC_FAMILY = "smartlic_seo_404"
+_SAMPLE_NAME = "smartlic_seo_404_total"
+
+
+def _counter_value(route_type: str, reason: str) -> float:
+    """Read the current value of the counter for the given label pair.
+
+    ``REGISTRY.get_sample_value`` returns ``None`` when the labelset has not
+    been observed yet — normalise to 0.0 so deltas are arithmetic.
+    """
+    val = REGISTRY.get_sample_value(
+        _SAMPLE_NAME,
+        labels={"route_type": route_type, "reason": reason},
+    )
+    return val if val is not None else 0.0
+
+
+def _make_app() -> Starlette:
+    async def observatorio_404(request):  # malformed slug → 404
+        return JSONResponse({"detail": "not found"}, status_code=404)
+
+    async def cnpj_404_with_reason(request):
+        # Route advertises why it 404'd via header — middleware should pick it up.
+        return JSONResponse(
+            {"detail": "no rows"},
+            status_code=404,
+            headers={"X-SEO-404-Reason": "empty_data"},
+        )
+
+    async def cnpj_200(request):
+        return JSONResponse({"ok": True})
+
+    async def admin_404(request):  # non-SEO route — must NOT increment counter
+        return JSONResponse({"detail": "not found"}, status_code=404)
+
+    app = Starlette(
+        routes=[
+            Route("/v1/observatorio/relatorio/{mes}/{ano}", observatorio_404),
+            Route("/v1/cnpj/{cnpj}/missing", cnpj_404_with_reason),
+            Route("/v1/cnpj/{cnpj}", cnpj_200),
+            Route("/v1/admin/foo", admin_404),
+        ],
+    )
+    app.add_middleware(SEO404MetricsMiddleware)
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(_make_app())
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRouteTypeFor:
+    """`_route_type_for` returns the first non-version segment for SEO paths."""
+
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            ("/v1/observatorio/relatorio/3/2026", "observatorio"),
+            ("/v1/cnpj/12345678000199", "cnpj"),
+            ("/v1/orgao/abc", "orgao"),
+            ("/v1/orgaos/abc", "orgaos"),
+            ("/v1/contratos/saude/sp", "contratos"),
+            ("/v1/municipios/sao-paulo-sp", "municipios"),
+            ("/v1/blog/licitacoes/saude", "blog"),
+            ("/v1/dados/abertos", "dados"),
+        ],
+    )
+    def test_seo_prefixes_match(self, path: str, expected: str) -> None:
+        assert _route_type_for(path) == expected
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/admin/foo",
+            "/v1/buscar",
+            "/v1/pipeline",
+            "/health/live",
+            "/metrics",
+            "/v1/user/me",
+        ],
+    )
+    def test_non_seo_paths_return_none(self, path: str) -> None:
+        assert _route_type_for(path) is None
+
+
+class TestReasonFor:
+    """`_reason_for` prefers the explicit header, then heuristics, then unknown."""
+
+    def test_explicit_header_wins(self) -> None:
+        resp = Response(status_code=404, headers={"X-SEO-404-Reason": "malformed_slug"})
+        assert _reason_for(resp) == "malformed_slug"
+
+    def test_invalid_header_falls_back_to_unknown(self) -> None:
+        resp = Response(status_code=404, headers={"X-SEO-404-Reason": "lol"})
+        assert _reason_for(resp) == "unknown"
+
+    def test_coverage_status_empty_maps_to_empty_data(self) -> None:
+        resp = Response(status_code=404, headers={"X-Coverage-Status": "empty"})
+        assert _reason_for(resp) == "empty_data"
+
+    def test_no_hints_unknown(self) -> None:
+        resp = Response(status_code=404)
+        assert _reason_for(resp) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Middleware behavior — increment / no-increment
+# ---------------------------------------------------------------------------
+
+
+class TestSEO404MiddlewareIncrements:
+    def test_404_on_seo_route_increments_counter(self, client: TestClient) -> None:
+        before = _counter_value("observatorio", "unknown")
+        resp = client.get("/v1/observatorio/relatorio/99/9999")
+        assert resp.status_code == 404
+        after = _counter_value("observatorio", "unknown")
+        assert after == before + 1.0
+
+    def test_404_with_reason_header_uses_that_reason(self, client: TestClient) -> None:
+        before = _counter_value("cnpj", "empty_data")
+        resp = client.get("/v1/cnpj/00000000000000/missing")
+        assert resp.status_code == 404
+        after = _counter_value("cnpj", "empty_data")
+        assert after == before + 1.0
+
+    def test_404_on_non_seo_route_does_not_increment_any_label(
+        self, client: TestClient
+    ) -> None:
+        # Snapshot ALL existing label combos for this metric before the request.
+        before: dict[tuple[str, str], float] = {}
+        for metric in REGISTRY.collect():
+            if metric.name != _METRIC_FAMILY:
+                continue
+            for sample in metric.samples:
+                if sample.name == _SAMPLE_NAME:
+                    key = (sample.labels.get("route_type", ""), sample.labels.get("reason", ""))
+                    before[key] = sample.value
+
+        resp = client.get("/v1/admin/foo")
+        assert resp.status_code == 404
+
+        # No label combination should have grown.
+        for metric in REGISTRY.collect():
+            if metric.name != _METRIC_FAMILY:
+                continue
+            for sample in metric.samples:
+                if sample.name == _SAMPLE_NAME:
+                    key = (sample.labels.get("route_type", ""), sample.labels.get("reason", ""))
+                    assert sample.value == before.get(key, 0.0), (
+                        f"Non-SEO 404 leaked into label {key}"
+                    )
+
+    def test_2xx_on_seo_route_does_not_increment(self, client: TestClient) -> None:
+        before = _counter_value("cnpj", "unknown")
+        resp = client.get("/v1/cnpj/12345678000199")
+        assert resp.status_code == 200
+        after = _counter_value("cnpj", "unknown")
+        assert after == before


### PR DESCRIPTION
## Summary

Middleware que conta 404s por rota e expõe métrica smartlic_seo_404_total para Prometheus + alerta Sentry.

## Testing Plan

- [ ] Tests pass locally (`npm test` / `pytest`)
- [ ] No regressions in CI (`backend`)
- [ ] Manual smoke test on staging

## Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)