### PR TITLE
feat(ci): reading level Flesch-Kincaid PT-BR gate (warn-only) (#1012)

### DIFF
--- a/.github/workflows/reading-level.yml
+++ b/.github/workflows/reading-level.yml
@@ -1,0 +1,88 @@
+name: Reading Level (PT-BR)
+
+# Issue #1012 — Flesch-Kincaid PT-BR adaptation gate.
+# Currently runs in WARN-ONLY mode (does not fail PRs). Threshold gating
+# is implemented in scripts/seo/reading_level_pt.py and can be enabled
+# by adding --strict to the run step.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/app/page.tsx'
+      - 'frontend/app/planos/**'
+      - 'frontend/app/pricing/**'
+      - 'frontend/app/fundadores/**'
+      - 'frontend/app/consultoria-b2g/**'
+      - 'frontend/app/observatorio/**'
+      - 'scripts/seo/reading_level_pt.py'
+      - '.github/workflows/reading-level.yml'
+  pull_request:
+    paths:
+      - 'frontend/app/page.tsx'
+      - 'frontend/app/planos/**'
+      - 'frontend/app/pricing/**'
+      - 'frontend/app/fundadores/**'
+      - 'frontend/app/consultoria-b2g/**'
+      - 'frontend/app/observatorio/**'
+      - 'scripts/seo/reading_level_pt.py'
+      - '.github/workflows/reading-level.yml'
+
+concurrency:
+  group: reading-level-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  measure:
+    name: Measure reading level
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Run reading level scorer
+        id: score
+        run: |
+          python scripts/seo/reading_level_pt.py --root . --format markdown \
+            --output reading-level-report.md
+          {
+            echo "report<<EOF"
+            cat reading-level-report.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Append to step summary
+        run: cat reading-level-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR (sticky)
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('reading-level-report.md', 'utf8');
+            const marker = '<!-- reading-level-pt:1012 -->';
+            const fullBody = `${marker}\n${body}\n\n_Issue #1012 — warn-only mode._`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: fullBody,
+              });
+            }

--- a/docs/copywriting-guidelines.md
+++ b/docs/copywriting-guidelines.md
@@ -175,9 +175,75 @@ Antes de publicar qualquer copy, verifique:
 
 ---
 
-## 7. Referências
+## 7. Reading Level (Flesch-Kincaid PT-BR)
+
+**Referência:** issue [#1012](https://github.com/tjsasakifln/pncp-poc/issues/1012) (CI-READING-014).
+
+### Princípio
+
+Diretriz Universal #11 do consenso de copy: landing pages devem ler em nível **6ª-7ª série**. Research 2026: conteúdo nesse nível converte +109% vs nível faculdade. Mantemos um gate em CI para evitar drift.
+
+### Fórmulas
+
+O scorer (`scripts/seo/reading_level_pt.py`) reporta dois números por página:
+
+1. **Índice Flesch PT-BR (Martins et al. 1996):**
+   `IF = 248.835 − 1.015·ASL − 84.6·ASW`
+   - Range 0–100, **maior = mais fácil**.
+   - Referência: ~75 = 6ª série; ~50 = ensino médio; <30 = faculdade.
+
+2. **Flesch-Kincaid Grade (Kincaid 1975) sobre contagem PT-BR:**
+   `FKGL = 0.39·ASL + 11.8·ASW − 15.59`
+   - Aproxima o "grade level" americano. Mapeamos para série brasileira via `ceil(FKGL)`.
+
+`ASL` = palavras / frases. `ASW` = sílabas / palavras (heurística de grupo vocálico).
+
+### Threshold
+
+| Faixa | Status |
+|-------|--------|
+| `grade ≤ 7` | OK |
+| `7 < grade ≤ 9` | WARN |
+| `grade > 9` | FAIL (gate desligado inicialmente) |
+
+CI roda atualmente em **modo warn-only** (não bloqueia merge). Para ativar enforcement, adicionar `--strict` ao step de execução em `.github/workflows/reading-level.yml`.
+
+### Allowlist de termos técnicos
+
+Termos do domínio B2G não penalizam ASW (são forçados a 1 sílaba):
+`CNPJ, PNCP, ComprasGov, Comprasnet, SmartLic, TCU, TCE, STJ, STF, AGU, CGU, Pix, PJ, PF, SaaS, API, CSV, XLSX, PDF, URL, RFP, RFB, SICAF, SIASG, BNC, BBMNet, dispensa, pregão, concorrência, credenciamento, habilitação, edital, ata, SRP, ARO`.
+
+A lista é editável em `scripts/seo/reading_level_pt.py` (constante `ALLOWLIST_TERMS`). Critério para inclusão: termo é (a) jargão obrigatório do domínio, (b) usado em ≥2 landing pages, e (c) não tem sinônimo mais simples sem perder precisão.
+
+### Páginas auditadas
+
+- `/` (homepage)
+- `/planos`, `/pricing`
+- `/fundadores` (+ `FundadoresClient.tsx`)
+- `/consultoria-b2g`
+- `/observatorio` + sample `/observatorio/[slug]` (PSEO)
+
+### Como rodar local
+
+```bash
+python3 scripts/seo/reading_level_pt.py --root . --format markdown
+python3 scripts/seo/reading_level_pt.py --root . --strict   # exit code != 0 acima de FAIL
+```
+
+CI publica um sticky comment no PR com a tabela e atualiza o `$GITHUB_STEP_SUMMARY`.
+
+### Limitação documentada
+
+A extração de texto de `.tsx` é heurística (regex sobre JSX text + string literals filtrados por prosa). Aceita ~10 % de ruído. Para reduzir falsos positivos, atualizar `_looks_like_human_text()` em vez de relaxar o threshold.
+
+---
+
+## 8. Referências
 
 - Plano de reposicionamento: `docs/sessions/2026-05/2026-05-07-reposicionamento-b2g-issues-plan.md`
 - Issue: [#754](https://github.com/tjsasakifln/pncp-poc/issues/754)
+- CI gate reading level: [#1012](https://github.com/tjsasakifln/pncp-poc/issues/1012)
+- Martins, T. B. F. et al. (1996). _Readability formulas applied to textbooks in Brazilian Portuguese._
+- Kincaid, J. P. et al. (1975). _Derivation of new readability formulas for Navy enlisted personnel._
 - CONAR: https://www.conar.org.br/codigo/codigo.php
 - CDC art. 37: Lei 8.078/90

--- a/scripts/seo/reading_level_pt.py
+++ b/scripts/seo/reading_level_pt.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Reading level (Flesch-Kincaid PT-BR adaptation) for SmartLic landing pages.
+
+Issue: #1012 [CI-READING-014]
+
+## Formula
+
+We compute two metrics and report both:
+
+1. **Índice Flesch (PT-BR, Martins et al. 1996):**
+       IF = 248.835 - 1.015 * ASL - 84.6 * ASW
+   - ASL = average sentence length (words / sentences)
+   - ASW = average syllables per word
+   - Range: 0..100, higher = easier
+
+2. **Flesch-Kincaid Grade Level (Kincaid et al. 1975, applied to PT-BR
+   syllable counts):**
+       FKGL = 0.39 * ASL + 11.8 * ASW - 15.59
+   - Output approximates US grade level. We map to Brazilian "série"
+     by ceil(FKGL) (5.x -> 5a/6a serie, 9.x -> 9a serie...).
+
+Both are reported per page; the **grade** is what the threshold gates on.
+
+## Threshold (issue #1012 AC)
+
+- warn  if grade > 7  (>7a serie)
+- fail  if grade > 9  (>9a serie)
+
+**Per task instruction the workflow runs warn-only initially**
+(no fail exit). Threshold stays in code but wrapped behind --strict flag.
+
+## Allowlist semantics
+
+Technical terms (CNPJ, PNCP, ComprasGov, etc.) still count as 1 word
+but are forced to a syllable count of 1 — so they don't penalize ASW.
+ASL still includes them. Documented in code: this is choice (b) from
+the advisor review.
+
+## Text extraction (.tsx / .ts / .md)
+
+Pragmatic regex extractor: pulls JSX text nodes, single/double/template
+string literals, and markdown body text. Strips HTML/JSX tags, code
+fences, URLs. Accepts ~10% noise — documented limitation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Allowlist (technical terms that should not penalize ASW).
+# ---------------------------------------------------------------------------
+ALLOWLIST_TERMS: set[str] = {
+    "cnpj",
+    "pncp",
+    "comprasgov",
+    "comprasnet",
+    "smartlic",
+    "lc",
+    "lei",
+    "decreto",
+    "art",
+    "tcu",
+    "tce",
+    "stj",
+    "stf",
+    "agu",
+    "cgu",
+    "pix",
+    "pf",
+    "pj",
+    "saas",
+    "api",
+    "csv",
+    "xlsx",
+    "pdf",
+    "url",
+    "rfp",
+    "rfb",
+    "sicaf",
+    "siasg",
+    "bnc",
+    "bbmnet",
+    "licitacoes",  # técnico no contexto B2G
+    # Termos compostos do domínio:
+    "dispensa",
+    "pregao",
+    "concorrencia",
+    "credenciamento",
+    "habilitacao",
+    "edital",
+    "edital-tipo",
+    "ata",
+    "srp",
+    "aro",
+}
+
+
+# ---------------------------------------------------------------------------
+# Syllable counter (PT-BR, vowel-group heuristic).
+#
+# Approach: lowercase, strip diacritics for grouping, count maximal vowel
+# groups. Treats hiatos as single group (over-count slightly) but is
+# stable & deterministic — sufficient for Flesch averaging.
+# ---------------------------------------------------------------------------
+
+_DIACRITIC_MAP = str.maketrans(
+    {
+        "á": "a", "à": "a", "ã": "a", "â": "a", "ä": "a",
+        "é": "e", "ê": "e", "è": "e", "ë": "e",
+        "í": "i", "î": "i", "ï": "i",
+        "ó": "o", "ô": "o", "õ": "o", "ö": "o",
+        "ú": "u", "û": "u", "ü": "u",
+        "ç": "c",
+        "Á": "a", "À": "a", "Ã": "a", "Â": "a",
+        "É": "e", "Ê": "e",
+        "Í": "i",
+        "Ó": "o", "Ô": "o", "Õ": "o",
+        "Ú": "u",
+        "Ç": "c",
+    }
+)
+
+_VOWELS = "aeiouy"
+
+_VOWEL_GROUP_RE = re.compile(rf"[{_VOWELS}]+")
+
+
+def count_syllables_pt(word: str) -> int:
+    """Count syllables in a Portuguese word using vowel-group heuristic."""
+    w = word.lower().translate(_DIACRITIC_MAP)
+    w = re.sub(r"[^a-z]", "", w)
+    if not w:
+        return 0
+    groups = _VOWEL_GROUP_RE.findall(w)
+    n = len(groups)
+    return max(n, 1)
+
+
+# ---------------------------------------------------------------------------
+# Sentence / word tokenization
+# ---------------------------------------------------------------------------
+
+_SENT_SPLIT_RE = re.compile(r"[.!?]+(?:\s+|$)")
+_WORD_RE = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ]+(?:[-'][A-Za-zÀ-ÖØ-öø-ÿ]+)*")
+
+
+def split_sentences(text: str) -> list[str]:
+    parts = [p.strip() for p in _SENT_SPLIT_RE.split(text)]
+    return [p for p in parts if p]
+
+
+def extract_words(text: str) -> list[str]:
+    return _WORD_RE.findall(text)
+
+
+# ---------------------------------------------------------------------------
+# Text extraction from .tsx / .ts / .md / .mdx
+# ---------------------------------------------------------------------------
+
+# Strings inside JSX/TS: '...', "...", `...` (no nested template support)
+_STRING_LITERAL_RE = re.compile(
+    r"""(?<![A-Za-z0-9_])(?:                       # not part of identifier
+        '([^'\\\n]*(?:\\.[^'\\\n]*)*)'             # 'single'
+      | "([^"\\\n]*(?:\\.[^"\\\n]*)*)"             # "double"
+      | `([^`\\]*(?:\\.[^`\\]*)*)`                 # `template`
+    )""",
+    re.VERBOSE,
+)
+# JSX text between > and < that contains at least one letter
+_JSX_TEXT_RE = re.compile(r">([^<>{}\n]*[A-Za-zÀ-ÖØ-öø-ÿ][^<>{}\n]*)<")
+_IMPORT_RE = re.compile(r"^\s*import\s.+?from\s+['\"][^'\"]+['\"];?\s*$", re.MULTILINE)
+_REQUIRE_RE = re.compile(r"require\s*\(\s*['\"][^'\"]+['\"]\s*\)")
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_URL_RE = re.compile(r"https?://\S+|www\.\S+|[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}")
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MD_HEADING_HASHES_RE = re.compile(r"^#+\s*", re.MULTILINE)
+_MD_EMPHASIS_RE = re.compile(r"[*_]{1,3}([^*_]+)[*_]{1,3}")
+
+
+def _looks_like_human_text(s: str) -> bool:
+    """Heuristic: keep only prose-like strings.
+
+    To minimize noise from JSX/Tailwind/identifiers, we require:
+    - >= 6 words OR contains sentence-ending punctuation
+    - not a path, URL, classname, or identifier
+    """
+    s = s.strip()
+    if len(s) < 12:
+        return False
+    if " " not in s:
+        return False
+    if s.startswith(("http://", "https://", "/", "./", "../", "#", "data:", "mailto:")):
+        return False
+    if "/" in s and " " not in s.split("/", 1)[0]:
+        return False
+    if not re.search(r"[aeiouAEIOU]", s):
+        return False
+
+    tokens = s.split()
+    has_sentence_punct = bool(re.search(r"[.!?](?:\s|$)", s))
+
+    # Need either real punctuation (a sentence) or many words (a paragraph).
+    if not has_sentence_punct and len(tokens) < 6:
+        return False
+
+    # Filter className-like strings.
+    css_like = sum(
+        1 for t in tokens if len(t) <= 3 or ":" in t or t.startswith("-")
+    )
+    if css_like / max(len(tokens), 1) > 0.5:
+        return False
+
+    return True
+
+
+def extract_text_from_tsx(source: str) -> str:
+    src = _IMPORT_RE.sub("", source)
+    src = _REQUIRE_RE.sub("", src)
+
+    chunks: list[str] = []
+
+    for m in _JSX_TEXT_RE.finditer(src):
+        chunks.append(m.group(1))
+
+    for m in _STRING_LITERAL_RE.finditer(src):
+        s = m.group(1) or m.group(2) or m.group(3) or ""
+        # remove JSX expressions inside template literals: ${...}
+        s = re.sub(r"\$\{[^}]*\}", " ", s)
+        if _looks_like_human_text(s):
+            chunks.append(s)
+
+    return " ".join(chunks)
+
+
+def extract_text_from_md(source: str) -> str:
+    s = _CODE_FENCE_RE.sub(" ", source)
+    s = _INLINE_CODE_RE.sub(" ", s)
+    s = _MD_LINK_RE.sub(r"\1", s)
+    s = _HTML_TAG_RE.sub(" ", s)
+    s = _MD_HEADING_HASHES_RE.sub("", s)
+    s = _MD_EMPHASIS_RE.sub(r"\1", s)
+    s = _URL_RE.sub("", s)
+    return s
+
+
+def extract_text(path: Path) -> str:
+    raw = path.read_text(encoding="utf-8", errors="ignore")
+    suffix = path.suffix.lower()
+    if suffix in {".tsx", ".ts", ".jsx", ".js"}:
+        return extract_text_from_tsx(raw)
+    if suffix in {".md", ".mdx"}:
+        return extract_text_from_md(raw)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Reading level metrics
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReadingLevelReport:
+    label: str
+    words: int
+    sentences: int
+    syllables: int
+    flesch_index_pt: float  # 0..100, higher = easier
+    flesch_kincaid_grade: float  # ~ US grade level
+    estimated_serie: int  # ceil of grade, clamp 1..15
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+def compute_reading_level(text: str, label: str = "") -> ReadingLevelReport | None:
+    sentences = split_sentences(text)
+    if not sentences:
+        return None
+    words = extract_words(text)
+    if not words:
+        return None
+
+    n_sentences = len(sentences)
+    n_words = len(words)
+
+    syllables = 0
+    for w in words:
+        wl = w.lower()
+        if wl in ALLOWLIST_TERMS:
+            syllables += 1  # neutralize technical jargon
+        else:
+            syllables += count_syllables_pt(w)
+
+    asl = n_words / n_sentences
+    asw = syllables / n_words
+
+    flesch_index = 248.835 - 1.015 * asl - 84.6 * asw
+    fkgl = 0.39 * asl + 11.8 * asw - 15.59
+
+    serie = max(1, min(15, math.ceil(fkgl)))
+
+    return ReadingLevelReport(
+        label=label,
+        words=n_words,
+        sentences=n_sentences,
+        syllables=syllables,
+        flesch_index_pt=round(flesch_index, 2),
+        flesch_kincaid_grade=round(fkgl, 2),
+        estimated_serie=serie,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+# Default targets per issue #1012 AC.
+DEFAULT_TARGETS: list[str] = [
+    "frontend/app/page.tsx",
+    "frontend/app/planos/page.tsx",
+    "frontend/app/pricing/page.tsx",
+    "frontend/app/fundadores/page.tsx",
+    "frontend/app/fundadores/FundadoresClient.tsx",
+    "frontend/app/consultoria-b2g/page.tsx",
+    "frontend/app/observatorio/page.tsx",
+    "frontend/app/observatorio/[slug]/page.tsx",
+    "frontend/app/observatorio/[slug]/ObservatorioRelatorioClient.tsx",
+]
+
+
+WARN_GRADE = 7
+FAIL_GRADE = 9
+
+
+def format_markdown_report(reports: list[ReadingLevelReport]) -> str:
+    lines = [
+        "## Reading Level (Flesch-Kincaid PT-BR)",
+        "",
+        f"Threshold: warn `grade > {WARN_GRADE}`, fail `grade > {FAIL_GRADE}` "
+        "(currently warn-only).",
+        "",
+        "| Página | Palavras | Frases | IF (0-100) | Grade | Série | Status |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for r in reports:
+        if r.flesch_kincaid_grade > FAIL_GRADE:
+            status = "FAIL"
+        elif r.flesch_kincaid_grade > WARN_GRADE:
+            status = "WARN"
+        else:
+            status = "OK"
+        lines.append(
+            f"| `{r.label}` | {r.words} | {r.sentences} "
+            f"| {r.flesch_index_pt:.1f} | {r.flesch_kincaid_grade:.2f} "
+            f"| {r.estimated_serie}a | {status} |"
+        )
+    lines.append("")
+    lines.append(
+        "_Higher Flesch Index (IF) = easier. Grade approximates US grade level; "
+        "Série is `ceil(grade)`._"
+    )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Reading level (Flesch-Kincaid PT-BR) for SmartLic pages."
+    )
+    p.add_argument(
+        "paths",
+        nargs="*",
+        help="Files or globs. Defaults to issue #1012 target list.",
+    )
+    p.add_argument(
+        "--root",
+        default=".",
+        help="Repository root (default: cwd).",
+    )
+    p.add_argument(
+        "--format",
+        choices=("markdown", "json", "text"),
+        default="markdown",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on grade > FAIL_GRADE (default: warn-only).",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Write report to this file in addition to stdout.",
+    )
+    return p.parse_args(argv)
+
+
+def resolve_targets(root: Path, paths: Iterable[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for p in paths:
+        path = (root / p).resolve()
+        if path.exists():
+            resolved.append(path)
+    return resolved
+
+
+def run(argv: list[str] | None = None) -> int:
+    ns = parse_args(argv)
+    root = Path(ns.root).resolve()
+
+    targets = ns.paths if ns.paths else DEFAULT_TARGETS
+    files = resolve_targets(root, targets)
+
+    if not files:
+        print("No target files found.", file=sys.stderr)
+        return 0
+
+    reports: list[ReadingLevelReport] = []
+    for f in files:
+        text = extract_text(f)
+        try:
+            rel = f.relative_to(root)
+        except ValueError:
+            rel = f
+        report = compute_reading_level(text, label=str(rel))
+        if report is None:
+            continue
+        reports.append(report)
+
+    if not reports:
+        print("No measurable text extracted.", file=sys.stderr)
+        return 0
+
+    if ns.format == "json":
+        out = json.dumps([r.as_dict() for r in reports], indent=2, ensure_ascii=False)
+    elif ns.format == "text":
+        out = "\n".join(
+            f"{r.label}\twords={r.words}\tsent={r.sentences}\t"
+            f"IF={r.flesch_index_pt:.1f}\tgrade={r.flesch_kincaid_grade:.2f}"
+            for r in reports
+        )
+    else:
+        out = format_markdown_report(reports)
+
+    print(out)
+    if ns.output:
+        Path(ns.output).write_text(out + "\n", encoding="utf-8")
+
+    if ns.strict:
+        if any(r.flesch_kincaid_grade > FAIL_GRADE for r in reports):
+            return 2
+        if any(r.flesch_kincaid_grade > WARN_GRADE for r in reports):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/scripts/tests/test_reading_level_pt.py
+++ b/scripts/tests/test_reading_level_pt.py
@@ -1,0 +1,201 @@
+"""Issue #1012 — unit tests for scripts/seo/reading_level_pt.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load():
+    here = Path(__file__).resolve().parents[2]
+    mod_path = here / "scripts" / "seo" / "reading_level_pt.py"
+    spec = importlib.util.spec_from_file_location("reading_level_pt", mod_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["reading_level_pt"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def rl():
+    return _load()
+
+
+# ---------- Syllable counter ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "word,expected",
+    [
+        ("casa", 2),
+        ("computador", 4),
+        ("a", 1),
+        ("e", 1),
+        ("Brasil", 2),
+        ("Joao", 2),  # "joao" -> two vowel groups (jo-ao) per heuristic
+        ("dia", 1),  # hiato collapsed (heuristic limit)
+        ("rua", 1),
+        ("contratação", 4),  # con-tra-ta-cao
+        ("inteligência", 4),  # in-te-li-gen-cia (heuristic ~4)
+    ],
+)
+def test_syllable_count_reasonable(rl, word, expected):
+    got = rl.count_syllables_pt(word)
+    # Allow ±1 for heuristic variation; this is averaged over many words.
+    assert abs(got - expected) <= 1, f"{word}: got {got}, expected ~{expected}"
+
+
+def test_syllable_empty_returns_zero(rl):
+    assert rl.count_syllables_pt("") == 0
+    assert rl.count_syllables_pt("123") == 0
+
+
+# ---------- Sentence / word tokenization --------------------------------------
+
+
+def test_split_sentences_basic(rl):
+    text = "Olá mundo. Tudo bem? Sim! Continue."
+    assert len(rl.split_sentences(text)) == 4
+
+
+def test_extract_words(rl):
+    text = "O CNPJ 12.345/0001-99 está ativo."
+    words = rl.extract_words(text)
+    assert "CNPJ" in words
+    assert "ativo" in words
+    assert "12" not in words  # numbers excluded
+
+
+# ---------- Directional formula sanity ----------------------------------------
+
+
+SIMPLE_TEXT = (
+    "O céu é azul. A flor é bela. O sol brilha. O dia é bom. "
+    "A casa é grande. O gato dorme. O pão é gostoso. A água é fria."
+)
+
+# Dense academic-style PT prose
+COMPLEX_TEXT = (
+    "A operacionalização sistemática dos paradigmas epistemológicos "
+    "contemporâneos demanda uma reconfiguração metodológica abrangente, "
+    "considerando especialmente as interdependências hermenêuticas "
+    "subjacentes aos processos comunicacionais multidimensionais que "
+    "permeiam a infraestrutura sociotécnica contemporânea, conforme "
+    "demonstrado pela bibliografia especializada referente à temática "
+    "em questão."
+)
+
+
+def test_simple_text_grade_lower_than_complex(rl):
+    simple = rl.compute_reading_level(SIMPLE_TEXT, label="simple")
+    complex_ = rl.compute_reading_level(COMPLEX_TEXT, label="complex")
+    assert simple is not None
+    assert complex_ is not None
+    assert simple.flesch_kincaid_grade < complex_.flesch_kincaid_grade
+    # Higher Flesch Index = easier
+    assert simple.flesch_index_pt > complex_.flesch_index_pt
+
+
+def test_simple_text_within_target_range(rl):
+    """Simple PT-BR prose should land at ~5a-7a serie."""
+    r = rl.compute_reading_level(SIMPLE_TEXT, label="simple")
+    assert r is not None
+    assert r.estimated_serie <= 7, (
+        f"Simple text estimated_serie={r.estimated_serie}, expected <= 7"
+    )
+
+
+def test_complex_text_above_warn_threshold(rl):
+    r = rl.compute_reading_level(COMPLEX_TEXT, label="complex")
+    assert r is not None
+    assert r.flesch_kincaid_grade > rl.WARN_GRADE
+
+
+def test_empty_text_returns_none(rl):
+    assert rl.compute_reading_level("", label="empty") is None
+    assert rl.compute_reading_level("   ", label="ws") is None
+
+
+# ---------- Allowlist -----------------------------------------------------------
+
+
+def test_allowlist_neutralizes_jargon(rl):
+    """A text with many technical terms should not score worse than the same
+    text with those terms replaced by a 1-syllable filler — by construction
+    of the allowlist semantics."""
+    text_with_jargon = "O CNPJ é necessário. O PNCP publica editais. O TCU fiscaliza."
+    text_neutral = "O CEP é necessário. O CEP publica editais. O CEP fiscaliza."
+    a = rl.compute_reading_level(text_with_jargon, label="jargon")
+    b = rl.compute_reading_level(text_neutral, label="neutral")
+    assert a is not None and b is not None
+    # Both should score the same since CNPJ/PNCP/TCU each forced to 1 syllable.
+    # CEP is not in allowlist but has 1 vowel group anyway.
+    assert abs(a.flesch_kincaid_grade - b.flesch_kincaid_grade) < 0.5
+
+
+# ---------- Text extractors ----------------------------------------------------
+
+
+def test_extract_text_from_tsx_pulls_jsx_and_strings(rl):
+    src = """
+    import React from 'react';
+    export default function Page() {
+      return (
+        <div className="px-4 py-2">
+          <h1>Bem-vindo ao SmartLic</h1>
+          <p>{'Plataforma de inteligência B2G para empresas brasileiras.'}</p>
+        </div>
+      );
+    }
+    """
+    text = rl.extract_text_from_tsx(src)
+    assert "Bem-vindo ao SmartLic" in text
+    assert "inteligência" in text
+    # className tailwind tokens should not appear
+    assert "px-4" not in text
+
+
+def test_extract_text_from_md(rl):
+    src = """
+# Título
+
+Este é um parágrafo com [link](https://exemplo.com) e `código inline`.
+
+```python
+x = 1
+```
+
+Outro parágrafo final.
+    """
+    text = rl.extract_text_from_md(src)
+    assert "parágrafo" in text
+    assert "código inline" not in text  # stripped
+    assert "x = 1" not in text  # code fence stripped
+
+
+# ---------- CLI ----------------------------------------------------------------
+
+
+def test_run_with_explicit_file(tmp_path, capsys, rl):
+    f = tmp_path / "sample.md"
+    f.write_text(SIMPLE_TEXT, encoding="utf-8")
+    rc = rl.run([str(f), "--root", str(tmp_path), "--format", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    import json as _json
+
+    data = _json.loads(out)
+    assert len(data) == 1
+    assert data[0]["words"] > 0
+
+
+def test_run_strict_fails_on_complex(tmp_path, rl):
+    # Build a text guaranteed above FAIL_GRADE
+    f = tmp_path / "complex.md"
+    f.write_text(COMPLEX_TEXT * 3, encoding="utf-8")
+    rc = rl.run([str(f), "--root", str(tmp_path), "--strict", "--format", "text"])
+    assert rc in (1, 2)


### PR DESCRIPTION
## Summary

CI gate que mede nível de leitura Flesch-Kincaid para PT-BR em cópia de frontend. Warn-only nesta fase.

## Testing Plan

- [ ] Tests pass locally (`npm test` / `pytest`)
- [ ] No regressions in CI (`ci`)
- [ ] Manual smoke test on staging

## Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)