### PR TITLE
feat(backend): migrate CNAE mapping to DB table + admin CRUD (DATA-CNAE-001)

### DIFF
--- a/backend/routes/admin_cnae_mapping.py
+++ b/backend/routes/admin_cnae_mapping.py
@@ -1,0 +1,222 @@
+"""DATA-CNAE-001: Admin CRUD endpoints for ``cnae_setor_mapping`` table.
+
+Allows admins to add, update, and soft-delete CNAE -> sector mappings at
+runtime without redeploys. The lookup function
+``utils.cnae_mapping.lookup_cnae_setor`` reads from this table (with
+hardcoded fallback) and is LRU-cached, so every mutation here calls
+:func:`utils.cnae_mapping.invalidate_cnae_cache` to invalidate the cache.
+
+Routes (all under ``/v1/admin``):
+
+* ``GET    /v1/admin/cnae-mapping?setor=<id>``     list (filtered).
+* ``POST   /v1/admin/cnae-mapping``                create entry.
+* ``PATCH  /v1/admin/cnae-mapping/{cnae_code}``    update entry.
+* ``DELETE /v1/admin/cnae-mapping/{cnae_code}``    soft delete.
+
+All endpoints require ``profiles.is_admin = true`` via :func:`admin.require_admin`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from admin import require_admin
+from supabase_client import get_supabase, sb_execute_direct
+from utils.cnae_mapping import invalidate_cnae_cache
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin", tags=["admin", "cnae-mapping"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CnaeMappingCreate(BaseModel):
+    cnae_code: str = Field(..., min_length=4, max_length=4, pattern=r"^\d{4}$")
+    setor_id: str = Field(..., min_length=1, max_length=64)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    fallback_setor_id: Optional[str] = Field(default=None, max_length=64)
+    notes: Optional[str] = Field(default=None, max_length=500)
+
+
+class CnaeMappingUpdate(BaseModel):
+    setor_id: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    fallback_setor_id: Optional[str] = Field(default=None, max_length=64)
+    notes: Optional[str] = Field(default=None, max_length=500)
+
+
+class CnaeMappingRow(BaseModel):
+    cnae_code: str
+    setor_id: str
+    confidence: float
+    fallback_setor_id: Optional[str] = None
+    notes: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    updated_by: Optional[str] = None
+
+
+class CnaeMappingListResponse(BaseModel):
+    count: int
+    rows: list[CnaeMappingRow]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialize(row: dict[str, Any]) -> CnaeMappingRow:
+    return CnaeMappingRow(
+        cnae_code=row["cnae_code"],
+        setor_id=row["setor_id"],
+        confidence=float(row.get("confidence") or 1.0),
+        fallback_setor_id=row.get("fallback_setor_id"),
+        notes=row.get("notes"),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+        updated_by=row.get("updated_by"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/cnae-mapping", response_model=CnaeMappingListResponse)
+async def list_cnae_mappings(
+    setor: Optional[str] = Query(default=None, description="Filter by setor_id"),
+    user: dict = Depends(require_admin),
+) -> CnaeMappingListResponse:
+    """List CNAE mappings, optionally filtered by ``setor``."""
+    try:
+        sb = get_supabase()
+        query = sb.table("cnae_setor_mapping").select("*").order("cnae_code")
+        if setor:
+            query = query.eq("setor_id", setor)
+        result = await sb_execute_direct(query)
+        rows = getattr(result, "data", None) or []
+        serialized = [_serialize(r) for r in rows if isinstance(r, dict)]
+        return CnaeMappingListResponse(count=len(serialized), rows=serialized)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("list_cnae_mappings failed: %s", exc)
+        raise HTTPException(status_code=500, detail="failed to list cnae mappings")
+
+
+@router.post("/cnae-mapping", response_model=CnaeMappingRow, status_code=201)
+async def create_cnae_mapping(
+    payload: CnaeMappingCreate,
+    user: dict = Depends(require_admin),
+) -> CnaeMappingRow:
+    """Create a new CNAE -> setor mapping."""
+    try:
+        sb = get_supabase()
+        row = {
+            "cnae_code": payload.cnae_code,
+            "setor_id": payload.setor_id,
+            "confidence": payload.confidence,
+            "fallback_setor_id": payload.fallback_setor_id,
+            "notes": payload.notes,
+            "updated_by": user.get("id") or user.get("sub"),
+        }
+        # Drop None values so DB defaults / nullable columns are respected.
+        row = {k: v for k, v in row.items() if v is not None}
+        result = await sb_execute_direct(
+            sb.table("cnae_setor_mapping").insert(row)
+        )
+        data = getattr(result, "data", None) or []
+        if not data:
+            raise HTTPException(status_code=409, detail="insert returned no row (conflict?)")
+        invalidate_cnae_cache()
+        return _serialize(data[0])
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("create_cnae_mapping failed: %s", exc)
+        msg = str(exc).lower()
+        if "duplicate" in msg or "unique" in msg or "23505" in msg:
+            raise HTTPException(status_code=409, detail="cnae_code already exists")
+        raise HTTPException(status_code=500, detail="failed to create cnae mapping")
+
+
+@router.patch("/cnae-mapping/{cnae_code}", response_model=CnaeMappingRow)
+async def update_cnae_mapping(
+    cnae_code: str,
+    payload: CnaeMappingUpdate,
+    user: dict = Depends(require_admin),
+) -> CnaeMappingRow:
+    """Patch an existing mapping. Fields not present in the body are untouched."""
+    updates: dict[str, Any] = {}
+    if payload.setor_id is not None:
+        updates["setor_id"] = payload.setor_id
+    if payload.confidence is not None:
+        updates["confidence"] = payload.confidence
+    if payload.fallback_setor_id is not None:
+        updates["fallback_setor_id"] = payload.fallback_setor_id
+    if payload.notes is not None:
+        updates["notes"] = payload.notes
+    if not updates:
+        raise HTTPException(status_code=400, detail="no fields to update")
+    updates["updated_at"] = datetime.now(timezone.utc).isoformat()
+    updates["updated_by"] = user.get("id") or user.get("sub")
+
+    try:
+        sb = get_supabase()
+        result = await sb_execute_direct(
+            sb.table("cnae_setor_mapping").update(updates).eq("cnae_code", cnae_code)
+        )
+        data = getattr(result, "data", None) or []
+        if not data:
+            raise HTTPException(status_code=404, detail="cnae_code not found")
+        invalidate_cnae_cache()
+        return _serialize(data[0])
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("update_cnae_mapping failed cnae=%s: %s", cnae_code, exc)
+        raise HTTPException(status_code=500, detail="failed to update cnae mapping")
+
+
+@router.delete("/cnae-mapping/{cnae_code}", response_model=CnaeMappingRow)
+async def delete_cnae_mapping(
+    cnae_code: str,
+    user: dict = Depends(require_admin),
+) -> CnaeMappingRow:
+    """Soft delete: marks ``notes='deleted'`` so audit trail is preserved.
+
+    The DB lookup in ``utils.cnae_mapping._db_lookup`` skips rows with
+    ``notes = 'deleted'`` and the LRU cache is invalidated so the next
+    request falls back to the hardcoded dict (if present there).
+    """
+    try:
+        sb = get_supabase()
+        updates = {
+            "notes": "deleted",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "updated_by": user.get("id") or user.get("sub"),
+        }
+        result = await sb_execute_direct(
+            sb.table("cnae_setor_mapping").update(updates).eq("cnae_code", cnae_code)
+        )
+        data = getattr(result, "data", None) or []
+        if not data:
+            raise HTTPException(status_code=404, detail="cnae_code not found")
+        invalidate_cnae_cache()
+        return _serialize(data[0])
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("delete_cnae_mapping failed cnae=%s: %s", cnae_code, exc)
+        raise HTTPException(status_code=500, detail="failed to delete cnae mapping")

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -30,6 +30,7 @@ from routes.health_core import router as health_core_router
 from routes.feedback import router as feedback_router
 from routes.admin_trace import router as admin_trace_router
 from routes.admin_cron import router as admin_cron_router
+from routes.admin_cnae_mapping import router as admin_cnae_mapping_router
 from routes.admin_llm_cost import router as admin_llm_cost_router
 from routes.admin_calibration import router as admin_calibration_router
 from routes.survey import router as survey_router
@@ -144,6 +145,7 @@ def register_routes(app: FastAPI) -> None:
     # Self-prefixed routers
     app.include_router(admin_trace_router)
     app.include_router(admin_cron_router)
+    app.include_router(admin_cnae_mapping_router)
     app.include_router(admin_llm_cost_router)
     app.include_router(admin_calibration_router)
     app.include_router(admin_billing_sync_router)

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -2897,6 +2897,215 @@
         "title": "ClearNewBidsCountResponse",
         "type": "object"
       },
+      "CnaeMappingCreate": {
+        "properties": {
+          "cnae_code": {
+            "maxLength": 4,
+            "minLength": 4,
+            "pattern": "^\\d{4}$",
+            "title": "Cnae Code",
+            "type": "string"
+          },
+          "confidence": {
+            "default": 1.0,
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence",
+            "type": "number"
+          },
+          "fallback_setor_id": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Setor Id"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "setor_id": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Setor Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cnae_code",
+          "setor_id"
+        ],
+        "title": "CnaeMappingCreate",
+        "type": "object"
+      },
+      "CnaeMappingListResponse": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/CnaeMappingRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "count",
+          "rows"
+        ],
+        "title": "CnaeMappingListResponse",
+        "type": "object"
+      },
+      "CnaeMappingRow": {
+        "properties": {
+          "cnae_code": {
+            "title": "Cnae Code",
+            "type": "string"
+          },
+          "confidence": {
+            "title": "Confidence",
+            "type": "number"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "fallback_setor_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Setor Id"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "setor_id": {
+            "title": "Setor Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
+          }
+        },
+        "required": [
+          "cnae_code",
+          "setor_id",
+          "confidence"
+        ],
+        "title": "CnaeMappingRow",
+        "type": "object"
+      },
+      "CnaeMappingUpdate": {
+        "properties": {
+          "confidence": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "fallback_setor_id": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Setor Id"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "setor_id": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Setor Id"
+          }
+        },
+        "title": "CnaeMappingUpdate",
+        "type": "object"
+      },
       "ComparadorBid": {
         "properties": {
           "data_abertura": {
@@ -16851,6 +17060,216 @@
         "summary": "Clear Contracts Checkpoints",
         "tags": [
           "admin"
+        ]
+      }
+    },
+    "/v1/admin/cnae-mapping": {
+      "get": {
+        "description": "List CNAE mappings, optionally filtered by ``setor``.",
+        "operationId": "list_cnae_mappings_v1_admin_cnae_mapping_get",
+        "parameters": [
+          {
+            "description": "Filter by setor_id",
+            "in": "query",
+            "name": "setor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by setor_id",
+              "title": "Setor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CnaeMappingListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Cnae Mappings",
+        "tags": [
+          "admin",
+          "cnae-mapping"
+        ]
+      },
+      "post": {
+        "description": "Create a new CNAE -> setor mapping.",
+        "operationId": "create_cnae_mapping_v1_admin_cnae_mapping_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CnaeMappingCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CnaeMappingRow"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Cnae Mapping",
+        "tags": [
+          "admin",
+          "cnae-mapping"
+        ]
+      }
+    },
+    "/v1/admin/cnae-mapping/{cnae_code}": {
+      "delete": {
+        "description": "Soft delete: marks ``notes='deleted'`` so audit trail is preserved.\n\nThe DB lookup in ``utils.cnae_mapping._db_lookup`` skips rows with\n``notes = 'deleted'`` and the LRU cache is invalidated so the next\nrequest falls back to the hardcoded dict (if present there).",
+        "operationId": "delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cnae_code",
+            "required": true,
+            "schema": {
+              "title": "Cnae Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CnaeMappingRow"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Cnae Mapping",
+        "tags": [
+          "admin",
+          "cnae-mapping"
+        ]
+      },
+      "patch": {
+        "description": "Patch an existing mapping. Fields not present in the body are untouched.",
+        "operationId": "update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cnae_code",
+            "required": true,
+            "schema": {
+              "title": "Cnae Code",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CnaeMappingUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CnaeMappingRow"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Cnae Mapping",
+        "tags": [
+          "admin",
+          "cnae-mapping"
         ]
       }
     },

--- a/backend/tests/test_cnae_mapping_db.py
+++ b/backend/tests/test_cnae_mapping_db.py
@@ -1,0 +1,152 @@
+"""DATA-CNAE-001: tests for DB-backed CNAE -> setor mapping.
+
+Covers:
+
+* Snapshot: every CNAE in the original hardcoded dict still resolves to the
+  same setor via :func:`utils.cnae_mapping.lookup_cnae_setor` even when the
+  DB lookup is unavailable (fallback path).
+* Edge: unknown CNAE returns ``None``; ``map_cnae_to_setor`` falls back to
+  ``"geral"`` (legacy contract preserved).
+* DB path: when the Supabase client returns a row, that value wins over
+  the hardcoded dict.
+* Cache invalidation: ``invalidate_cnae_cache`` actually clears the LRU.
+* Soft delete: rows with ``notes='deleted'`` are ignored.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils import cnae_mapping
+from utils.cnae_mapping import (
+    CNAE_TO_SETOR,
+    invalidate_cnae_cache,
+    lookup_cnae_setor,
+    map_cnae_to_setor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Ensure each test starts with a cold LRU cache."""
+    invalidate_cnae_cache()
+    yield
+    invalidate_cnae_cache()
+
+
+@pytest.fixture
+def _db_offline(monkeypatch):
+    """Force the DB lookup to behave as if Supabase is unavailable."""
+    monkeypatch.setattr(cnae_mapping, "_db_lookup", lambda code: None)
+
+
+class TestSnapshotFallback:
+    """When DB is offline every original mapping must keep working."""
+
+    def test_every_original_cnae_resolves(self, _db_offline):
+        for cnae, expected in CNAE_TO_SETOR.items():
+            assert lookup_cnae_setor(cnae) == expected, (
+                f"snapshot regression for cnae={cnae}"
+            )
+
+    def test_unknown_cnae_returns_none(self, _db_offline):
+        assert lookup_cnae_setor("9999") is None
+        assert lookup_cnae_setor("0000") is None
+
+    def test_map_cnae_to_setor_legacy_contract(self, _db_offline):
+        assert map_cnae_to_setor("9999") == "geral"
+        assert map_cnae_to_setor("") == "geral"
+        assert map_cnae_to_setor("4781") == "vestuario"
+
+
+class TestDbWinsOverHardcoded:
+    """Anything returned by the DB beats the hardcoded fallback."""
+
+    def test_db_value_wins(self, monkeypatch):
+        monkeypatch.setattr(
+            cnae_mapping, "_db_lookup", lambda code: "saude" if code == "4120" else None
+        )
+        # "4120" is hardcoded as "engenharia"; DB now says "saude".
+        assert lookup_cnae_setor("4120") == "saude"
+
+    def test_db_miss_falls_back_to_dict(self, monkeypatch):
+        monkeypatch.setattr(cnae_mapping, "_db_lookup", lambda code: None)
+        assert lookup_cnae_setor("4120") == "engenharia"
+
+    def test_db_returns_unknown_cnae(self, monkeypatch):
+        monkeypatch.setattr(
+            cnae_mapping, "_db_lookup", lambda code: "informatica" if code == "9999" else None
+        )
+        # "9999" is not in the hardcoded dict but DB exposes it now.
+        assert lookup_cnae_setor("9999") == "informatica"
+
+
+class TestCacheInvalidation:
+    """Cache must be invalidated after admin writes."""
+
+    def test_cache_holds_first_result(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake(code):
+            calls["n"] += 1
+            return "engenharia"
+
+        monkeypatch.setattr(cnae_mapping, "_db_lookup", fake)
+        assert lookup_cnae_setor("4120") == "engenharia"
+        assert lookup_cnae_setor("4120") == "engenharia"
+        assert calls["n"] == 1, "second call should have been served from LRU"
+
+    def test_invalidate_forces_refetch(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake(code):
+            calls["n"] += 1
+            return "engenharia" if calls["n"] == 1 else "saude"
+
+        monkeypatch.setattr(cnae_mapping, "_db_lookup", fake)
+        assert lookup_cnae_setor("4120") == "engenharia"
+        invalidate_cnae_cache()
+        # After invalidation the next call hits _db_lookup again and sees the
+        # new value.
+        assert lookup_cnae_setor("4120") == "saude"
+        assert calls["n"] == 2
+
+
+class TestSoftDelete:
+    """Rows with notes='deleted' must be treated as if absent."""
+
+    def test_soft_deleted_row_ignored(self, monkeypatch):
+        # Build a fake supabase client whose .execute() returns a deleted row.
+        sb = MagicMock()
+        chain = sb.table.return_value.select.return_value.eq.return_value.limit.return_value
+        chain.execute.return_value = MagicMock(
+            data=[{"setor_id": "engenharia", "notes": "deleted"}]
+        )
+        monkeypatch.setattr(
+            "supabase_client.get_supabase", lambda: sb, raising=False
+        )
+        # _db_lookup should return None because the row is soft-deleted, so
+        # the hardcoded dict ("vestuario" for 4781) takes over.
+        assert cnae_mapping._db_lookup("4781") is None
+
+    def test_active_row_returned(self, monkeypatch):
+        sb = MagicMock()
+        chain = sb.table.return_value.select.return_value.eq.return_value.limit.return_value
+        chain.execute.return_value = MagicMock(
+            data=[{"setor_id": "engenharia", "notes": None}]
+        )
+        monkeypatch.setattr(
+            "supabase_client.get_supabase", lambda: sb, raising=False
+        )
+        assert cnae_mapping._db_lookup("4781") == "engenharia"
+
+    def test_db_error_returns_none(self, monkeypatch):
+        def boom():
+            raise RuntimeError("supabase down")
+
+        monkeypatch.setattr(
+            "supabase_client.get_supabase", boom, raising=False
+        )
+        assert cnae_mapping._db_lookup("4781") is None

--- a/backend/utils/cnae_mapping.py
+++ b/backend/utils/cnae_mapping.py
@@ -4,17 +4,27 @@ CNAE to SmartLic sector mapping.
 Maps Brazilian CNAE (Classificação Nacional de Atividades Econômicas)
 codes to SmartLic sector IDs used by the search pipeline.
 
+DATA-CNAE-001 (2026-05-11): primary source of truth is now the DB table
+``public.cnae_setor_mapping`` (Supabase). The hardcoded ``CNAE_TO_SETOR``
+dict below is kept as a fallback for resilience (DB down, RLS misconfig,
+boot before migrations applied) and as documentation of the initial seed.
+
 Coverage snapshot (2026-05-07): 59 CNAEs mapped across 9 sectors.
 IBGE CNAE 2.3 has ~1300 active subclasses. Coverage = 59/1300 = ~4.5%.
-Full migration to DB tracked in story DATA-CNAE-001.
 """
 
+from __future__ import annotations
+
+import functools
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# CNAE→sector mappings
-# Format: CNAE 4-digit prefix → sector_id
+# Hardcoded fallback dict — kept in sync with the seed insert in
+# supabase/migrations/20260511120000_cnae_setor_mapping.sql. DB is the
+# source of truth at runtime; this dict only activates when the DB
+# lookup fails (transient error or cnae_code missing).
 CNAE_TO_SETOR: dict[str, str] = {
     # Engenharia / Construção Civil
     "4120": "engenharia",    # Construção de edifícios
@@ -101,6 +111,83 @@ SETOR_NAMES: dict[str, str] = {
 }
 
 
+def _extract_prefix(cnae: str) -> str:
+    """Extract the 4-digit prefix from a CNAE string in any common format.
+
+    "4781", "4781-4/00", "47814" -> "4781". Returns "" if no 4 digits found.
+    """
+    cleaned = (cnae or "").strip().replace(" ", "")
+    prefix = ""
+    for ch in cleaned:
+        if ch.isdigit():
+            prefix += ch
+            if len(prefix) == 4:
+                return prefix
+    return prefix if len(prefix) == 4 else ""
+
+
+def _db_lookup(cnae_prefix: str) -> Optional[str]:
+    """Query Supabase ``cnae_setor_mapping`` for ``cnae_prefix``.
+
+    Returns ``setor_id`` if found, ``None`` if missing, and ``None`` (after
+    logging) on any transient error so the caller can fall back to the
+    hardcoded dict.
+
+    Skips rows whose ``notes = 'deleted'`` (soft-delete convention).
+    """
+    try:
+        from supabase_client import get_supabase  # local import to avoid boot cycles
+        sb = get_supabase()
+        result = (
+            sb.table("cnae_setor_mapping")
+            .select("setor_id, notes")
+            .eq("cnae_code", cnae_prefix)
+            .limit(1)
+            .execute()
+        )
+        rows = getattr(result, "data", None) or []
+        if not rows:
+            return None
+        row = rows[0]
+        if (row.get("notes") or "").strip().lower() == "deleted":
+            return None
+        return row.get("setor_id")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("cnae_db_lookup_failed cnae=%s err=%s", cnae_prefix, exc)
+        return None
+
+
+@functools.lru_cache(maxsize=1024)
+def lookup_cnae_setor(cnae_code: str) -> Optional[str]:
+    """Resolve a CNAE code to a SmartLic sector id.
+
+    Resolution order:
+      1. DB ``public.cnae_setor_mapping`` (primary, runtime-editable).
+      2. Hardcoded ``CNAE_TO_SETOR`` dict (fallback, ships with code).
+      3. ``None`` if both miss — callers may default to "geral".
+
+    Cached via ``functools.lru_cache``; admin CRUD endpoints MUST call
+    :func:`invalidate_cnae_cache` after writes so subsequent lookups
+    re-query the DB.
+    """
+    prefix = _extract_prefix(cnae_code)
+    if not prefix:
+        return None
+    db = _db_lookup(prefix)
+    if db is not None:
+        return db
+    return CNAE_TO_SETOR.get(prefix)
+
+
+def invalidate_cnae_cache() -> None:
+    """Clear the lookup_cnae_setor LRU cache.
+
+    Admin CRUD endpoints (POST/PATCH/DELETE /v1/admin/cnae-mapping) call
+    this after writes so the next request observes the new mapping.
+    """
+    lookup_cnae_setor.cache_clear()
+
+
 def map_cnae_to_setor(cnae: str) -> str:
     """
     Map CNAE code to SmartLic sector ID.
@@ -119,21 +206,12 @@ def map_cnae_to_setor(cnae: str) -> str:
     Returns:
         Sector ID string (e.g., "vestuario", "servicos_prediais", "geral")
     """
-    # Extract 4-digit prefix: handle "4781-4/00", "4781400", "4781" formats
-    cleaned = cnae.strip().replace(" ", "")
-    # Take first 4 digits
-    prefix = ""
-    for ch in cleaned:
-        if ch.isdigit():
-            prefix += ch
-            if len(prefix) == 4:
-                break
-
-    if not prefix or len(prefix) < 4:
+    prefix = _extract_prefix(cnae)
+    if not prefix:
         logger.warning("cnae_not_mapped cnae=%r fallback=geral", cnae)
-        return "geral"  # Default fallback for unknown/unparseable CNAE
+        return "geral"
 
-    result = CNAE_TO_SETOR.get(prefix)
+    result = lookup_cnae_setor(prefix)
     if result is None:
         logger.warning("cnae_not_mapped cnae=%s fallback=geral", prefix)
         return "geral"

--- a/docs/data/cnae-coverage.md
+++ b/docs/data/cnae-coverage.md
@@ -1,0 +1,64 @@
+# CNAE → SmartLic Sector Coverage
+
+**Story:** DATA-CNAE-001
+**Source of truth:** `public.cnae_setor_mapping` (Supabase) — seeded by
+`supabase/migrations/20260511120000_cnae_setor_mapping.sql`.
+**Code fallback:** `backend/utils/cnae_mapping.py::CNAE_TO_SETOR`.
+
+## Snapshot (2026-05-11)
+
+| Sector | CNAE count |
+| --- | ---: |
+| engenharia | 25 |
+| vestuario | 5 |
+| servicos_prediais | 4 |
+| vigilancia | 2 |
+| saude | 6 |
+| alimentos | 4 |
+| informatica | 5 |
+| equipamentos | 3 |
+| transporte | 5 |
+| **Total mapped** | **59** |
+
+IBGE CNAE 2.3 publishes ~1300 active subclasses (4-digit prefixes used as
+keys here are wider — there are ~673 4-digit groups). With **59 entries
+mapped**, coverage is roughly **9 %** at the 4-digit granularity. The
+remaining ~91 % currently fall through `map_cnae_to_setor()` to the
+default sector `"geral"` and emit `cnae_not_mapped` WARN logs.
+
+## CNAEs that fall back to `geral`
+
+Notable gaps (review-report.md Gap-8 backlog):
+
+- **Educação** (CNAE 85xx): no mapping today.
+- **Construção naval / aeronáutica** (3011, 3041): no mapping.
+- **Mobiliário** (3101–3103): no mapping.
+- **Energia** (3511–3520): no mapping.
+- **Tratamento de resíduos** (3811–3839): no mapping.
+- **Comércio atacadista geral** (469x não-saúde / não-alimento): no mapping.
+- **Serviços profissionais** (69xx jurídico, contábil): no mapping.
+
+Use `SELECT * FROM cnae_setor_mapping WHERE notes ILIKE 'seed%'` to see
+the curated seed; everything outside this set is treated as `geral`.
+
+## Adding new mappings at runtime
+
+Admins can add/update without redeploys via:
+
+```bash
+curl -X POST https://api.smartlic.tech/v1/admin/cnae-mapping \
+  -H "Authorization: Bearer <admin-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"cnae_code": "8511", "setor_id": "educacao", "confidence": 0.95,
+       "notes": "Educação infantil — added 2026-05-11"}'
+```
+
+The backend LRU cache (`lookup_cnae_setor`) is invalidated by the admin
+endpoint on every write, so the new value is visible on the next request.
+
+## Soft delete
+
+`DELETE /v1/admin/cnae-mapping/{cnae_code}` does not row-delete; it sets
+`notes = 'deleted'` so the audit trail (created_at, updated_by) is
+preserved. The lookup path treats those rows as missing and falls back
+to the hardcoded dict (if any) or to `None`.

--- a/docs/stories/2026-04/DATA-CNAE-001-migrate-cnae-mapping-to-db.story.md
+++ b/docs/stories/2026-04/DATA-CNAE-001-migrate-cnae-mapping-to-db.story.md
@@ -3,7 +3,7 @@
 **Priority:** P2
 **Effort:** M (2-3 dias)
 **Squad:** @data-engineer + @dev
-**Status:** Ready
+**Status:** InReview
 **Epic:** [EPIC-TD-2026Q2](EPIC-TD-2026Q2/)
 **Sprint:** Sprint 2-3
 **Dependências bloqueadoras:** Nenhuma

--- a/supabase/migrations/20260511120000_cnae_setor_mapping.down.sql
+++ b/supabase/migrations/20260511120000_cnae_setor_mapping.down.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- DOWN: cnae_setor_mapping — reverses 20260511120000_cnae_setor_mapping.sql
+-- Date: 2026-05-11
+-- Author: @dev / @data-engineer (DATA-CNAE-001)
+-- ============================================================================
+-- Context:
+--   Up migration created public.cnae_setor_mapping table, RLS policies,
+--   index, and seeded 59 rows from backend/utils/cnae_mapping.py.
+--
+--   Reverting drops the entire table (CASCADE removes policies, index and
+--   seed data atomically). The hardcoded CNAE_TO_SETOR dict in
+--   backend/utils/cnae_mapping.py remains as fallback in code, so the
+--   lookup_cnae_setor() function continues to work after rollback.
+--
+--   NO BACKUP NEEDED: the source-of-truth dict still lives in code.
+-- ============================================================================
+
+BEGIN;
+
+DROP POLICY IF EXISTS "cnae_admin_write" ON public.cnae_setor_mapping;
+DROP POLICY IF EXISTS "cnae_public_read" ON public.cnae_setor_mapping;
+DROP INDEX IF EXISTS public.idx_cnae_setor_mapping_setor;
+DROP TABLE IF EXISTS public.cnae_setor_mapping;
+
+COMMIT;

--- a/supabase/migrations/20260511120000_cnae_setor_mapping.sql
+++ b/supabase/migrations/20260511120000_cnae_setor_mapping.sql
@@ -1,0 +1,134 @@
+-- ============================================================================
+-- Migration: 20260511120000_cnae_setor_mapping
+-- Story: DATA-CNAE-001 — Migrate utils/cnae_mapping.py hardcoded -> DB table
+-- Date: 2026-05-11
+--
+-- Purpose:
+--   Replaces hardcoded CNAE -> sector dict (backend/utils/cnae_mapping.py)
+--   with a DB-backed table so admins can update mappings at runtime without
+--   redeploying the backend. Drives onboarding wizard (US-006 Reversa) where
+--   user provides CNAE -> sector inferred -> first analysis dispatch.
+--
+--   Columns:
+--   - cnae_code:           4-digit CNAE prefix (PK).
+--   - setor_id:            SmartLic sector id (matches sectors_data.yaml).
+--   - confidence:          0.00-1.00 confidence score.
+--   - fallback_setor_id:   secondary sector if primary unmatched downstream.
+--   - notes:               free-text rationale / audit trail.
+--   - updated_by:          auth.users(id) — set by admin CRUD endpoint.
+--
+-- RLS:
+--   - Public SELECT (cnae_code is not PII; setor exposed via /setores anyway).
+--   - Write restricted to authenticated admins (profiles.is_admin = true).
+--
+-- Seed:
+--   Bulk INSERT of 59 entries (snapshot 2026-05-07) from CNAE_TO_SETOR dict.
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.cnae_setor_mapping (
+    cnae_code        TEXT PRIMARY KEY,
+    setor_id         TEXT NOT NULL,
+    confidence       NUMERIC(3, 2) NOT NULL DEFAULT 1.00,
+    fallback_setor_id TEXT,
+    notes            TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by       UUID REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cnae_setor_mapping_setor
+    ON public.cnae_setor_mapping (setor_id);
+
+COMMENT ON TABLE public.cnae_setor_mapping IS
+    'CNAE 4-digit prefix -> SmartLic sector mapping. DATA-CNAE-001.';
+COMMENT ON COLUMN public.cnae_setor_mapping.cnae_code IS
+    'CNAE 4-digit prefix (e.g. "4120"). Source of truth: IBGE CNAE 2.3.';
+COMMENT ON COLUMN public.cnae_setor_mapping.confidence IS
+    'Confidence score 0.00-1.00. 1.00 = exact match curated.';
+COMMENT ON COLUMN public.cnae_setor_mapping.notes IS
+    'Free-text audit trail. Soft-delete uses notes = ''deleted''.';
+
+ALTER TABLE public.cnae_setor_mapping ENABLE ROW LEVEL SECURITY;
+
+-- Public read: cnae_code -> sector is not sensitive.
+DROP POLICY IF EXISTS "cnae_public_read" ON public.cnae_setor_mapping;
+CREATE POLICY "cnae_public_read" ON public.cnae_setor_mapping
+    FOR SELECT USING (true);
+
+-- Admin-only write (INSERT/UPDATE/DELETE).
+DROP POLICY IF EXISTS "cnae_admin_write" ON public.cnae_setor_mapping;
+CREATE POLICY "cnae_admin_write" ON public.cnae_setor_mapping
+    FOR ALL TO authenticated
+    USING (
+        (SELECT is_admin FROM public.profiles WHERE id = auth.uid()) = true
+    )
+    WITH CHECK (
+        (SELECT is_admin FROM public.profiles WHERE id = auth.uid()) = true
+    );
+
+-- Seed: snapshot from backend/utils/cnae_mapping.py (2026-05-07, 59 entries).
+INSERT INTO public.cnae_setor_mapping (cnae_code, setor_id, notes) VALUES
+    ('4120', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4211', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4212', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4213', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4221', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4222', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4223', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4291', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4292', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4299', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4311', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4312', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4313', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4319', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4321', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4322', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4329', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4391', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4399', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('7111', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('7112', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('7119', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4781', 'vestuario',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('1412', 'vestuario',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('1413', 'vestuario',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('1421', 'vestuario',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('1422', 'vestuario',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('8121', 'servicos_prediais',  'seed 2026-05-11 DATA-CNAE-001'),
+    ('8122', 'servicos_prediais',  'seed 2026-05-11 DATA-CNAE-001'),
+    ('8129', 'servicos_prediais',  'seed 2026-05-11 DATA-CNAE-001'),
+    ('8130', 'servicos_prediais',  'seed 2026-05-11 DATA-CNAE-001'),
+    ('8011', 'vigilancia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('8012', 'vigilancia',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('3250', 'saude',              'seed 2026-05-11 DATA-CNAE-001'),
+    ('4644', 'saude',              'seed 2026-05-11 DATA-CNAE-001'),
+    ('4645', 'saude',              'seed 2026-05-11 DATA-CNAE-001'),
+    ('8610', 'saude',              'seed 2026-05-11 DATA-CNAE-001'),
+    ('8621', 'saude',              'seed 2026-05-11 DATA-CNAE-001'),
+    ('8630', 'saude',              'seed 2026-05-11 DATA-CNAE-001'),
+    ('1011', 'alimentos',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('1091', 'alimentos',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('4639', 'alimentos',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('4711', 'alimentos',          'seed 2026-05-11 DATA-CNAE-001'),
+    ('6201', 'informatica',        'seed 2026-05-11 DATA-CNAE-001'),
+    ('6202', 'informatica',        'seed 2026-05-11 DATA-CNAE-001'),
+    ('6209', 'informatica',        'seed 2026-05-11 DATA-CNAE-001'),
+    ('6311', 'informatica',        'seed 2026-05-11 DATA-CNAE-001'),
+    ('6319', 'informatica',        'seed 2026-05-11 DATA-CNAE-001'),
+    ('2710', 'equipamentos',       'seed 2026-05-11 DATA-CNAE-001'),
+    ('2759', 'equipamentos',       'seed 2026-05-11 DATA-CNAE-001'),
+    ('2861', 'equipamentos',       'seed 2026-05-11 DATA-CNAE-001'),
+    ('4921', 'transporte',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4922', 'transporte',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4924', 'transporte',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4929', 'transporte',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('4930', 'transporte',         'seed 2026-05-11 DATA-CNAE-001'),
+    ('8411', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001 admin publico'),
+    ('8412', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001 admin publico'),
+    ('8413', 'engenharia',         'seed 2026-05-11 DATA-CNAE-001 admin publico')
+ON CONFLICT (cnae_code) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- New `cnae_setor_mapping` table (Supabase migration) with RLS: public read, admin write
- Seed all 59 existing CNAE entries from the hardcoded `CNAE_TO_SETOR` dict (backward compatible)
- Refactor `utils/cnae_mapping.py` to DB lookup with LRU cache (`functools.lru_cache`) + hardcoded fallback for resilience
- Admin CRUD endpoints at `/v1/admin/cnae-mapping` (GET filter by setor, POST, PATCH, DELETE soft-delete)
- Every admin mutation calls `invalidate_cnae_cache()` so the next read sees the new value
- Soft delete sets `notes='deleted'` (preserves audit trail) — lookup ignores those rows
- Paired `.down.sql` per STORY-6.2 policy
- Coverage doc at `docs/data/cnae-coverage.md` enumerates known gaps (Educação, energia, mobiliário, etc.)
- Enables admins to add/update CNAE mappings at runtime without redeploys (drives onboarding wizard US-006)

## Testing Plan
- [x] `pytest backend/tests/test_cnae_mapping*.py` → 39/39 passing (28 legacy snapshot + 11 new DB/cache/soft-delete)
- [ ] Apply migration in staging and verify `SELECT count(*) FROM cnae_setor_mapping` = 59
- [ ] Smoke admin CRUD: POST new mapping, GET filtered, PATCH, DELETE
- [ ] Verify LRU cache invalidation: PATCH a row, next request returns new setor
- [ ] Verify RLS: anonymous SELECT works, anonymous INSERT/UPDATE/DELETE rejected

## Closes
Closes DATA-CNAE-001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin management interface for CNAE sector mappings with database persistence
  * Implemented materialized views for improved sitemap performance
  * Enabled admin dashboard access for authorized users
  * Added analytics tracking to CTA click events

* **Bug Fixes**
  * Enhanced error handling with fallback signup CTA in preview failures
  * Added BACKEND_URL fallback configuration for API routes

* **Documentation**
  * Added CNAE sector coverage documentation

* **Content Updates**
  * Updated Founder plan messaging to reflect limited availability
  * Refreshed blog article titles and descriptions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->