### PR TITLE
refactor(backend): webhook handlers ABC base — idempotency unification (REF-MON-002)

### DIFF
--- a/backend/tests/webhooks/test_webhook_base.py
+++ b/backend/tests/webhooks/test_webhook_base.py
@@ -1,0 +1,239 @@
+"""
+Tests for WebhookHandler ABC base + registry (REF-MON-002).
+
+Coverage:
+- WebhookHandler.handle() invokes process() exactly once for a new event.
+- WebhookHandler.handle() skips process() on idempotency replay (2nd call
+  with same key returns immediately, no double side-effect).
+- HANDLERS_REGISTRY is populated by the @webhook_handler decorator.
+- idempotency_key() default returns event.id; subclass override works.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from webhooks.handlers._base import (
+    HANDLERS_REGISTRY,
+    WebhookHandler,
+    webhook_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(event_id: str = "evt_test_base_001", event_type: str = "test.event"):
+    event = Mock()
+    event.id = event_id
+    event.type = event_type
+    event.data = Mock()
+    event.data.object = {"id": event_id}
+    return event
+
+
+class _UpsertResult:
+    def __init__(self, data):
+        self.data = data
+
+
+def _make_sb(claim_results: list):
+    """Build a mock Supabase client where each call to
+    sb.table('stripe_webhook_events').upsert(...).execute() returns the next
+    item from ``claim_results`` (a list of _UpsertResult).
+    """
+    iterator = iter(claim_results)
+
+    def _execute_side_effect(*args, **kwargs):
+        return next(iterator)
+
+    table_mock = MagicMock()
+    table_mock.upsert.return_value.execute.side_effect = _execute_side_effect
+
+    sb = MagicMock()
+    sb.table.return_value = table_mock
+    return sb
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_populated_by_decorator():
+    """@webhook_handler must instantiate the class and register it."""
+
+    sentinel_type = "test.registry.populated"
+
+    @webhook_handler(sentinel_type)
+    class _Handler(WebhookHandler):
+        event_type = sentinel_type
+
+        async def process(self, sb, event):
+            return None
+
+    assert sentinel_type in HANDLERS_REGISTRY
+    assert isinstance(HANDLERS_REGISTRY[sentinel_type], _Handler)
+
+    # cleanup so we don't pollute the global registry for other tests
+    del HANDLERS_REGISTRY[sentinel_type]
+
+
+def test_decorator_rejects_non_subclass():
+    with pytest.raises(TypeError):
+
+        @webhook_handler("test.not.a.subclass")
+        class _NotAHandler:  # noqa: D401
+            pass
+
+
+# ---------------------------------------------------------------------------
+# idempotency_key
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_key_default_returns_event_id():
+    class _H(WebhookHandler):
+        event_type = "x"
+
+        async def process(self, sb, event):
+            pass
+
+    h = _H()
+    event = _make_event(event_id="evt_KEY_abc")
+    assert h.idempotency_key(event) == "evt_KEY_abc"
+
+
+def test_idempotency_key_override():
+    class _H(WebhookHandler):
+        event_type = "x"
+
+        def idempotency_key(self, event):
+            return event.data.object["id"] + ":custom"
+
+        async def process(self, sb, event):
+            pass
+
+    h = _H()
+    event = _make_event(event_id="evt_outer")
+    event.data.object = {"id": "biz_inner"}
+    assert h.idempotency_key(event) == "biz_inner:custom"
+
+
+# ---------------------------------------------------------------------------
+# handle() template method — idempotency replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_runs_process_once_for_new_event():
+    """First call: upsert returns data (claimed), process() must run."""
+
+    calls = []
+
+    class _H(WebhookHandler):
+        event_type = "test.new.event"
+
+        async def process(self, sb, event):
+            calls.append(event.id)
+
+    sb = _make_sb([_UpsertResult([{"id": "evt_new_001"}])])
+    h = _H()
+    event = _make_event(event_id="evt_new_001", event_type="test.new.event")
+
+    await h.handle(sb, event)
+
+    assert calls == ["evt_new_001"], "process() should run exactly once for a new event"
+
+
+@pytest.mark.asyncio
+async def test_handle_skips_process_on_replay():
+    """Second call with same key: upsert returns empty data (ON CONFLICT),
+    process() must NOT run.
+    """
+
+    calls = []
+
+    class _H(WebhookHandler):
+        event_type = "test.replay.event"
+
+        async def process(self, sb, event):
+            calls.append(event.id)
+
+    # Two sequential events with same id:
+    # - 1st claim: returns data (new) → process runs
+    # - 2nd claim: returns empty (duplicate) → process skipped
+    sb = _make_sb(
+        [
+            _UpsertResult([{"id": "evt_replay_001"}]),
+            _UpsertResult([]),  # ON CONFLICT DO NOTHING — empty result
+        ]
+    )
+    h = _H()
+    event = _make_event(event_id="evt_replay_001", event_type="test.replay.event")
+
+    await h.handle(sb, event)
+    await h.handle(sb, event)
+
+    assert calls == ["evt_replay_001"], (
+        "process() must run once across 2 deliveries of the same event_id "
+        f"(got {calls})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_proceeds_when_idempotency_claim_raises():
+    """If the DB claim raises, fail open and still process (dispatcher is the
+    authoritative gate; in-handler claim is best-effort).
+    """
+
+    calls = []
+
+    class _H(WebhookHandler):
+        event_type = "test.failopen.event"
+
+        async def process(self, sb, event):
+            calls.append(event.id)
+
+    sb = MagicMock()
+    # Make the upsert.execute() raise
+    sb.table.return_value.upsert.return_value.execute.side_effect = RuntimeError("db down")
+
+    h = _H()
+    event = _make_event(event_id="evt_failopen_001", event_type="test.failopen.event")
+
+    await h.handle(sb, event)
+
+    assert calls == ["evt_failopen_001"], (
+        "process() must still run when idempotency claim raises (fail-open)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_skips_process_when_idempotency_key_empty_but_claim_returns_empty():
+    """Edge: if idempotency_key returns empty string, we cannot dedup —
+    process() should still run (allow path).
+    """
+
+    calls = []
+
+    class _H(WebhookHandler):
+        event_type = "test.empty.key"
+
+        def idempotency_key(self, event):
+            return ""
+
+        async def process(self, sb, event):
+            calls.append("ran")
+
+    sb = MagicMock()
+    h = _H()
+    await h.handle(sb, _make_event())
+
+    assert calls == ["ran"]
+    # sb.table should not have been called (no claim attempted on empty key)
+    sb.table.assert_not_called()

--- a/backend/webhooks/handlers/__init__.py
+++ b/backend/webhooks/handlers/__init__.py
@@ -1,28 +1,45 @@
 """
 Stripe webhook event handlers — decomposed from webhooks/stripe.py (DEBT-307).
 
-Each module handles a group of related Stripe event types:
-- checkout: checkout.session.completed, async_payment_succeeded, async_payment_failed
-- subscription: customer.subscription.updated, customer.subscription.deleted
-- invoice: invoice.payment_succeeded, invoice.payment_failed, invoice.payment_action_required
+REF-MON-002 — Refactored to use ABC base + registry pattern. Each module
+handles a group of related Stripe event types:
+
+- checkout: checkout.session.completed, async_payment_succeeded/failed,
+  checkout.session.expired
+- subscription: customer.subscription.created/updated/deleted/trial_will_end
+- invoice: invoice.payment_succeeded/failed/action_required
+- stripe_product_price: product.updated, price.created/updated/deleted
+- founding: BIZ-FOUND-002 lifetime entitlement side-effects
+
+The ABC base + registry lives in ``_base.py`` and ``_registry.py``. Importing
+``_registry`` triggers handler registration via the ``@webhook_handler``
+decorator.
 """
 
+from webhooks.handlers._base import HANDLERS_REGISTRY, WebhookHandler, webhook_handler
+
+# Eager import of _registry populates HANDLERS_REGISTRY via decorators.
+# Side-effect import; the names aren't used directly here.
+from webhooks.handlers import _registry  # noqa: F401
+
 from webhooks.handlers.checkout import (
-    handle_checkout_session_completed,
-    handle_async_payment_succeeded,
     handle_async_payment_failed,
-)
-from webhooks.handlers.subscription import (
-    handle_subscription_updated,
-    handle_subscription_deleted,
+    handle_async_payment_succeeded,
+    handle_checkout_session_completed,
 )
 from webhooks.handlers.invoice import (
-    handle_invoice_payment_succeeded,
     handle_invoice_payment_failed,
+    handle_invoice_payment_succeeded,
     handle_payment_action_required,
 )
+from webhooks.handlers.subscription import (
+    handle_subscription_deleted,
+    handle_subscription_updated,
+)
 
-# Event type -> handler mapping for dispatcher
+# Legacy: event-type -> handler-function mapping. Preserved for backward
+# compatibility with any caller importing ``EVENT_HANDLERS`` directly. New
+# code SHOULD use ``HANDLERS_REGISTRY`` (returns ``WebhookHandler`` instances).
 EVENT_HANDLERS: dict[str, object] = {
     "checkout.session.completed": handle_checkout_session_completed,
     "checkout.session.async_payment_succeeded": handle_async_payment_succeeded,
@@ -36,6 +53,9 @@ EVENT_HANDLERS: dict[str, object] = {
 
 __all__ = [
     "EVENT_HANDLERS",
+    "HANDLERS_REGISTRY",
+    "WebhookHandler",
+    "webhook_handler",
     "handle_checkout_session_completed",
     "handle_async_payment_succeeded",
     "handle_async_payment_failed",

--- a/backend/webhooks/handlers/_base.py
+++ b/backend/webhooks/handlers/_base.py
@@ -1,0 +1,219 @@
+"""
+Webhook Handler ABC Base + Registry (REF-MON-002).
+
+Provides a unified contract for Stripe webhook event handlers:
+
+- ``WebhookHandler``: abstract base class with a template-method ``handle()``
+  that wraps idempotency around the subclass's ``process()`` implementation.
+- ``HANDLERS_REGISTRY``: dict mapping ``event_type`` -> handler instance.
+- ``@webhook_handler(event_type)``: class decorator that instantiates the
+  handler and registers it.
+
+DESIGN NOTES
+============
+The actual atomic idempotency for Stripe webhooks lives at the *dispatcher*
+level in ``webhooks/stripe.py`` (``stripe_webhook_events`` table + INSERT ON
+CONFLICT DO NOTHING). This is the load-bearing mechanism — duplicate Stripe
+retries are filtered before any handler runs.
+
+The ``handle()`` template method here provides a **second, in-handler**
+idempotency layer using the same table. This is useful for:
+
+1. Handlers invoked outside the standard dispatcher (e.g. background
+   reconciliation jobs that replay events).
+2. Sub-handler steps that want their own idempotency key (override
+   ``idempotency_key()`` to use e.g. ``invoice.id`` instead of ``event.id``).
+3. New handlers added in the future that should self-protect.
+
+For existing handlers wrapped via the registry, the dispatcher already gates
+them; ``handle()`` is functionally a passthrough to ``process()`` because the
+event will not reach ``handle()`` twice via the dispatcher path.
+
+USAGE
+=====
+
+    from webhooks.handlers._base import WebhookHandler, webhook_handler
+
+    @webhook_handler("customer.subscription.updated")
+    class SubscriptionUpdatedHandler(WebhookHandler):
+        event_type = "customer.subscription.updated"
+
+        async def process(self, sb, event) -> None:
+            # business logic here
+            ...
+
+The registry is then consumed by ``webhooks/stripe.py``::
+
+    from webhooks.handlers._base import HANDLERS_REGISTRY
+    handler = HANDLERS_REGISTRY.get(event.type)
+    if handler:
+        await handler.handle(sb, event)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+
+from log_sanitizer import get_sanitized_logger
+from pipeline.budget import _run_with_budget
+
+logger = get_sanitized_logger(__name__)
+
+# Per-query budget for in-handler idempotency writes. Matches the dispatcher
+# constant in ``webhooks/stripe.py`` to keep both layers consistent.
+_HANDLER_IDEMPOTENCY_BUDGET_S = 5.0
+
+
+class WebhookHandler(ABC):
+    """Abstract base for a single Stripe event-type handler.
+
+    Subclasses MUST:
+    - Set the ``event_type`` class attribute (string, e.g. ``"invoice.payment_succeeded"``).
+    - Implement ``process(sb, event)`` with the actual business logic.
+
+    Subclasses MAY:
+    - Override ``idempotency_key(event)`` to use a stable business key
+      (e.g. ``invoice.id``) instead of the default Stripe ``event.id``.
+    """
+
+    event_type: ClassVar[str] = ""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def handle(self, sb, event: Any) -> None:
+        """Template method: claim idempotency -> process -> log.
+
+        The dispatcher in ``webhooks/stripe.py`` already gates duplicates via
+        ``stripe_webhook_events``. This method's claim is a best-effort second
+        layer — if the claim fails (DB unavailable, table missing in tests),
+        we still proceed to ``process()`` rather than dropping the event.
+        """
+        claimed = await self._claim_idempotency(sb, event)
+        if not claimed:
+            logger.info(
+                "WebhookHandler.handle: duplicate idempotency_key, skipping process "
+                f"event_type={self.event_type}"
+            )
+            return
+        await self.process(sb, event)
+
+    @abstractmethod
+    async def process(self, sb, event: Any) -> None:
+        """Implement the handler's business logic here. MUST be async."""
+        raise NotImplementedError
+
+    def idempotency_key(self, event: Any) -> str:
+        """Return a stable string key for this event.
+
+        Default: Stripe ``event.id`` (``evt_...``). Subclasses can override to
+        use a business-level key (e.g. ``payment_intent.id`` or
+        ``invoice.id``) when that gives stronger replay protection.
+        """
+        # Support both stripe.Event objects (attribute access) and plain dicts.
+        if hasattr(event, "id"):
+            return getattr(event, "id")
+        if isinstance(event, dict):
+            return event.get("id", "")
+        return ""
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _claim_idempotency(self, sb, event: Any) -> bool:
+        """Best-effort INSERT ON CONFLICT DO NOTHING into stripe_webhook_events.
+
+        Returns True if this is the first time we see this key, False if it
+        was already claimed by a previous run. On any DB error returns True
+        (fail-open) so the handler still runs — the dispatcher layer is the
+        authoritative idempotency gate.
+        """
+        key = self.idempotency_key(event)
+        if not key:
+            # Nothing to dedup against; allow process() to run.
+            return True
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        event_type = self.event_type or getattr(event, "type", "") or ""
+
+        def _sync_claim():
+            return sb.table("stripe_webhook_events").upsert(
+                {
+                    "id": key,
+                    "type": event_type,
+                    "status": "processing",
+                    "received_at": now_iso,
+                },
+                on_conflict="id",
+                ignore_duplicates=True,
+            ).execute()
+
+        try:
+            result = await _run_with_budget(
+                asyncio.to_thread(_sync_claim),
+                budget=_HANDLER_IDEMPOTENCY_BUDGET_S,
+                phase="route",
+                source=f"webhook.handler.{self.event_type}.idempotency_claim",
+            )
+        except Exception as e:
+            logger.warning(
+                f"Idempotency claim failed (non-fatal, will process anyway): {e}"
+            )
+            return True
+
+        data = getattr(result, "data", None)
+        # upsert with ignore_duplicates=True returns empty data when the row
+        # already existed.
+        if not data:
+            return False
+        return True
+
+
+# ----------------------------------------------------------------------
+# Registry + decorator
+# ----------------------------------------------------------------------
+
+HANDLERS_REGISTRY: dict[str, WebhookHandler] = {}
+
+
+def webhook_handler(event_type: str):
+    """Class decorator: instantiate the handler and register it under event_type.
+
+    Example::
+
+        @webhook_handler("invoice.payment_succeeded")
+        class InvoicePaymentSucceededHandler(WebhookHandler):
+            event_type = "invoice.payment_succeeded"
+            async def process(self, sb, event):
+                ...
+    """
+
+    def decorator(cls):
+        if not issubclass(cls, WebhookHandler):
+            raise TypeError(
+                f"@webhook_handler requires a WebhookHandler subclass, got {cls!r}"
+            )
+        # Ensure the class-level attribute is set even if the subclass omitted it.
+        if not getattr(cls, "event_type", ""):
+            cls.event_type = event_type
+        instance = cls()
+        if event_type in HANDLERS_REGISTRY:
+            logger.warning(
+                f"webhook_handler: overriding existing registration for {event_type}"
+            )
+        HANDLERS_REGISTRY[event_type] = instance
+        return cls
+
+    return decorator
+
+
+__all__ = [
+    "WebhookHandler",
+    "HANDLERS_REGISTRY",
+    "webhook_handler",
+]

--- a/backend/webhooks/handlers/_registry.py
+++ b/backend/webhooks/handlers/_registry.py
@@ -1,0 +1,239 @@
+"""
+Webhook handler registry adapters (REF-MON-002).
+
+Wraps the existing free-function handlers in ``WebhookHandler`` subclasses
+and registers them under ``HANDLERS_REGISTRY``. The dispatcher in
+``webhooks/stripe.py`` consumes this registry instead of an if-elif chain.
+
+The adapter classes deliberately delegate to the existing functions via
+``webhooks.stripe`` module attributes (e.g. ``_handle_subscription_updated``)
+so test patches of the form::
+
+    @patch("webhooks.stripe._handle_subscription_updated")
+
+continue to work unchanged. This preserves the entire blast radius of the
+brownfield test suite while introducing the ABC + registry pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from log_sanitizer import get_sanitized_logger
+from webhooks.handlers._base import WebhookHandler, webhook_handler
+
+logger = get_sanitized_logger(__name__)
+
+
+def _resolve(attr_name: str):
+    """Late-bind the dispatcher-level function reference.
+
+    Imported lazily inside each ``process()`` call so that test patches of
+    ``webhooks.stripe.<attr_name>`` take effect (Python's @patch replaces
+    the name in that module's namespace; resolving late picks up the patch).
+    """
+    import webhooks.stripe as ws  # local import to avoid circulars at module load
+    return getattr(ws, attr_name)
+
+
+# ---------------------------------------------------------------------------
+# Checkout family
+# ---------------------------------------------------------------------------
+
+
+@webhook_handler("checkout.session.completed")
+class CheckoutSessionCompletedHandler(WebhookHandler):
+    event_type = "checkout.session.completed"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_checkout_session_completed")
+        await fn(sb, event)
+
+
+@webhook_handler("checkout.session.async_payment_succeeded")
+class CheckoutAsyncPaymentSucceededHandler(WebhookHandler):
+    event_type = "checkout.session.async_payment_succeeded"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_async_payment_succeeded")
+        await fn(sb, event)
+
+
+@webhook_handler("checkout.session.async_payment_failed")
+class CheckoutAsyncPaymentFailedHandler(WebhookHandler):
+    event_type = "checkout.session.async_payment_failed"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_async_payment_failed")
+        await fn(sb, event)
+
+
+@webhook_handler("checkout.session.expired")
+class CheckoutSessionExpiredHandler(WebhookHandler):
+    """STORY-BIZ-001: mark founding lead as abandoned when Stripe session expires.
+
+    No-op for non-founding sessions (metadata filter inside the function).
+    The underlying function is synchronous; wrap it in an async shim here.
+    """
+
+    event_type = "checkout.session.expired"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_founding_checkout_expired_raw")
+        fn(sb, event.data.object)
+
+
+# ---------------------------------------------------------------------------
+# Subscription family
+# ---------------------------------------------------------------------------
+
+
+@webhook_handler("customer.subscription.created")
+class SubscriptionCreatedHandler(WebhookHandler):
+    event_type = "customer.subscription.created"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_subscription_created")
+        await fn(sb, event)
+
+
+@webhook_handler("customer.subscription.updated")
+class SubscriptionUpdatedHandler(WebhookHandler):
+    event_type = "customer.subscription.updated"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_subscription_updated")
+        await fn(sb, event)
+
+
+@webhook_handler("customer.subscription.deleted")
+class SubscriptionDeletedHandler(WebhookHandler):
+    event_type = "customer.subscription.deleted"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_subscription_deleted")
+        await fn(sb, event)
+
+
+@webhook_handler("customer.subscription.trial_will_end")
+class SubscriptionTrialWillEndHandler(WebhookHandler):
+    """STORY-CONV-003a AC4: Stripe fires 3d before trial_end."""
+
+    event_type = "customer.subscription.trial_will_end"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_subscription_trial_will_end")
+        await fn(sb, event)
+
+
+# ---------------------------------------------------------------------------
+# Invoice family
+# ---------------------------------------------------------------------------
+
+
+@webhook_handler("invoice.payment_succeeded")
+class InvoicePaymentSucceededHandler(WebhookHandler):
+    event_type = "invoice.payment_succeeded"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_invoice_payment_succeeded")
+        await fn(sb, event)
+
+
+@webhook_handler("invoice.payment_failed")
+class InvoicePaymentFailedHandler(WebhookHandler):
+    event_type = "invoice.payment_failed"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_invoice_payment_failed")
+        await fn(sb, event)
+
+
+@webhook_handler("invoice.payment_action_required")
+class InvoicePaymentActionRequiredHandler(WebhookHandler):
+    event_type = "invoice.payment_action_required"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_payment_action_required")
+        await fn(sb, event)
+
+
+# ---------------------------------------------------------------------------
+# Product / Price family (BILL-SYNC-001)
+# ---------------------------------------------------------------------------
+
+
+@webhook_handler("product.updated")
+class ProductUpdatedHandler(WebhookHandler):
+    event_type = "product.updated"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_product_updated")
+        await fn(sb, event)
+
+
+@webhook_handler("price.created")
+class PriceCreatedHandler(WebhookHandler):
+    event_type = "price.created"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_price_created")
+        await fn(sb, event)
+
+
+@webhook_handler("price.updated")
+class PriceUpdatedHandler(WebhookHandler):
+    event_type = "price.updated"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_price_updated")
+        await fn(sb, event)
+
+
+@webhook_handler("price.deleted")
+class PriceDeletedHandler(WebhookHandler):
+    event_type = "price.deleted"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_price_deleted")
+        await fn(sb, event)
+
+
+# ---------------------------------------------------------------------------
+# Intel Report one-time payment failure (#630)
+# ---------------------------------------------------------------------------
+
+
+@webhook_handler("payment_intent.payment_failed")
+class IntelReportPaymentFailedHandler(WebhookHandler):
+    """#630: Intel Report one-time payment failure.
+
+    NOTE: Stripe Dashboard webhook config must include
+    ``payment_intent.payment_failed``.
+    """
+
+    event_type = "payment_intent.payment_failed"
+
+    async def process(self, sb, event: Any) -> None:
+        fn = _resolve("_handle_intel_report_payment_failed")
+        await fn(sb, event)
+
+
+__all__ = [
+    "CheckoutSessionCompletedHandler",
+    "CheckoutAsyncPaymentSucceededHandler",
+    "CheckoutAsyncPaymentFailedHandler",
+    "CheckoutSessionExpiredHandler",
+    "SubscriptionCreatedHandler",
+    "SubscriptionUpdatedHandler",
+    "SubscriptionDeletedHandler",
+    "SubscriptionTrialWillEndHandler",
+    "InvoicePaymentSucceededHandler",
+    "InvoicePaymentFailedHandler",
+    "InvoicePaymentActionRequiredHandler",
+    "ProductUpdatedHandler",
+    "PriceCreatedHandler",
+    "PriceUpdatedHandler",
+    "PriceDeletedHandler",
+    "IntelReportPaymentFailedHandler",
+]

--- a/backend/webhooks/stripe.py
+++ b/backend/webhooks/stripe.py
@@ -71,6 +71,11 @@ from webhooks.handlers.stripe_product_price import (  # noqa: F401
     handle_price_deleted as _handle_price_deleted,
 )
 
+# REF-MON-002: eager import populates HANDLERS_REGISTRY via @webhook_handler
+# decorators in webhooks.handlers._registry. The dispatcher uses this registry
+# below in place of the legacy if-elif chain.
+from webhooks.handlers import HANDLERS_REGISTRY  # noqa: F401
+
 logger = get_sanitized_logger(__name__)
 router = APIRouter()
 
@@ -271,51 +276,23 @@ async def stripe_webhook(request: Request):
                     )
                     return {"status": "already_processed", "event_id": event.id}
 
-        # SYS-024: Wrap event routing in asyncio.wait_for() to prevent DB hangs
-        # NOTE: References module-level names so @patch('webhooks.stripe._handle_*') works
+        # SYS-024: Wrap event routing in asyncio.wait_for() to prevent DB hangs.
+        #
+        # REF-MON-002: Registry lookup replaces the legacy if-elif chain. The
+        # adapter classes in webhooks/handlers/_registry.py delegate to the
+        # same module-level _handle_* names re-exported above, so test patches
+        # of the form @patch('webhooks.stripe._handle_*') continue to work.
         async def _process_event():
-            """Route event to appropriate handler."""
-            if event.type == "checkout.session.completed":
-                await _handle_checkout_session_completed(sb, event)
-            elif event.type == "checkout.session.async_payment_succeeded":
-                await _handle_async_payment_succeeded(sb, event)
-            elif event.type == "checkout.session.async_payment_failed":
-                await _handle_async_payment_failed(sb, event)
-            elif event.type == "checkout.session.expired":
-                # STORY-BIZ-001: mark founding lead as abandoned when Stripe
-                # session times out (Stripe default is 24h). No-op for non-
-                # founding sessions (metadata filter inside the handler).
-                _handle_founding_checkout_expired_raw(sb, event.data.object)
-            elif event.type == "customer.subscription.created":
-                await _handle_subscription_created(sb, event)
-            elif event.type == "customer.subscription.updated":
-                await _handle_subscription_updated(sb, event)
-            elif event.type == "customer.subscription.deleted":
-                await _handle_subscription_deleted(sb, event)
-            elif event.type == "customer.subscription.trial_will_end":
-                # STORY-CONV-003a AC4: Stripe fires 3d before trial_end.
-                await _handle_subscription_trial_will_end(sb, event)
-            elif event.type == "invoice.payment_succeeded":
-                await _handle_invoice_payment_succeeded(sb, event)
-            elif event.type == "invoice.payment_failed":
-                await _handle_invoice_payment_failed(sb, event)
-            elif event.type == "invoice.payment_action_required":
-                await _handle_payment_action_required(sb, event)
-            # BILL-SYNC-001: Stripe -> DB forward sync for plan_billing_periods.
-            elif event.type == "product.updated":
-                await _handle_product_updated(sb, event)
-            elif event.type == "price.created":
-                await _handle_price_created(sb, event)
-            elif event.type == "price.updated":
-                await _handle_price_updated(sb, event)
-            elif event.type == "price.deleted":
-                await _handle_price_deleted(sb, event)
-            # #630: Intel Report one-time payment failure
-            # NOTE: Stripe Dashboard webhook config must include payment_intent.payment_failed
-            elif event.type == "payment_intent.payment_failed":
-                await _handle_intel_report_payment_failed(sb, event)
-            else:
+            """Route event to appropriate handler via HANDLERS_REGISTRY."""
+            handler = HANDLERS_REGISTRY.get(event.type)
+            if handler is None:
                 logger.info(f"Unhandled event type: {event.type}")
+                return
+            # NOTE: invoke process() directly (not handle()) — the dispatcher
+            # above has already claimed stripe_webhook_events for this
+            # event.id, so calling handle() would double-claim and skip the
+            # processing. handle() is for callers outside this dispatcher.
+            await handler.process(sb, event)
 
         try:
             await asyncio.wait_for(_process_event(), timeout=WEBHOOK_DB_TIMEOUT_S)

--- a/docs/architecture/webhook-handlers.md
+++ b/docs/architecture/webhook-handlers.md
@@ -1,0 +1,180 @@
+# Webhook Handlers — ABC Base + Registry Pattern (REF-MON-002)
+
+## Status
+
+Active — introduced in REF-MON-002 (2026-05-11). Replaces the legacy if-elif
+dispatch chain in `webhooks/stripe.py` while preserving 100% test
+backward-compatibility (existing `@patch("webhooks.stripe._handle_*")` patches
+continue to work).
+
+## Motivation
+
+The original `webhooks/stripe.py` mixed three concerns in a single dispatcher
+function:
+
+1. Signature validation (Stripe `construct_event` + envelope sanity).
+2. Idempotency (atomic `INSERT ON CONFLICT DO NOTHING` into
+   `stripe_webhook_events` + stuck-event recovery).
+3. Routing (15+ branch if-elif chain calling one async function per event
+   type).
+
+Adding a new event type required editing the dispatcher; handler functions
+varied in shape (async vs sync, dict vs `event` object) and there was no
+common contract for cross-cutting concerns (logging, error envelope, retry
+hooks).
+
+## Design
+
+### Layers
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  webhooks/stripe.py  — HTTP entrypoint                       │
+│  • signature verification                                    │
+│  • dispatcher-level idempotency (stripe_webhook_events)      │
+│  • registry lookup: HANDLERS_REGISTRY[event.type].process()  │
+└──────────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌──────────────────────────────────────────────────────────────┐
+│  webhooks/handlers/_base.py                                  │
+│  • WebhookHandler (ABC)                                      │
+│  • @webhook_handler(event_type) decorator                    │
+│  • HANDLERS_REGISTRY                                         │
+└──────────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌──────────────────────────────────────────────────────────────┐
+│  webhooks/handlers/_registry.py                              │
+│  • thin adapter classes per event type                       │
+│  • each delegates to a free function in checkout.py/         │
+│    subscription.py/invoice.py/founding.py/                   │
+│    stripe_product_price.py                                   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### `WebhookHandler` contract
+
+```python
+class WebhookHandler(ABC):
+    event_type: ClassVar[str]                          # set per subclass
+
+    async def handle(self, sb, event) -> None:         # template method
+        # 1. claim idempotency (best-effort)
+        # 2. await self.process(sb, event)
+
+    @abstractmethod
+    async def process(self, sb, event) -> None: ...   # subclass logic
+
+    def idempotency_key(self, event) -> str:           # overridable
+        return event.id                                # Stripe evt_... default
+```
+
+### Registry
+
+`HANDLERS_REGISTRY: dict[str, WebhookHandler]` is populated at module-import
+time via the `@webhook_handler(event_type)` decorator. Importing
+`webhooks.handlers` triggers eager import of `_registry`, which registers all
+adapter classes.
+
+### Dispatcher integration
+
+The if-elif chain in `webhooks/stripe.py:_process_event` is replaced by:
+
+```python
+handler = HANDLERS_REGISTRY.get(event.type)
+if handler is None:
+    logger.info(f"Unhandled event type: {event.type}")
+    return
+# Skip handle()'s own idempotency claim — the dispatcher above has already
+# claimed stripe_webhook_events for this event.id. Calling handle() here
+# would double-claim and skip processing.
+await handler.process(sb, event)
+```
+
+`handle()` is reserved for callers **outside** the standard webhook
+dispatcher (e.g. background reconciliation jobs that replay events from S3
+backup) where the dispatcher-level claim does not apply.
+
+## Two layers of idempotency — why?
+
+| Layer            | Where                  | Mechanism                                 | Authoritative? |
+|------------------|------------------------|-------------------------------------------|----------------|
+| **Dispatcher**   | `webhooks/stripe.py`   | INSERT ON CONFLICT DO NOTHING + stuck>5m | YES            |
+| **Handler ABC**  | `_base.WebhookHandler` | Same table, same mechanism, best-effort  | NO             |
+
+The dispatcher layer is the production gate. Stripe retries hit the HTTP
+endpoint, the claim fails atomically, and the second delivery returns
+`{"status": "already_processed"}` without invoking any handler.
+
+The ABC-layer claim exists to protect handlers that may be invoked from
+*non-HTTP* code paths (reconciliation, manual replay tools, future event
+queues). On any DB error during the ABC claim, the layer fails open and
+allows `process()` to run — the dispatcher layer is still in front.
+
+## Adding a new handler
+
+1. Implement the business logic as an async function in one of the topical
+   handler modules (`subscription.py`, `invoice.py`, ...). Keep it side-
+   effect-free aside from the intended DB / Stripe / cache writes.
+
+2. Re-export the function in `webhooks/stripe.py` with the conventional
+   `_handle_<name>` alias so existing test patch points keep working:
+
+   ```python
+   from webhooks.handlers.subscription import (
+       handle_my_new_event as _handle_my_new_event,
+   )
+   ```
+
+3. Add a thin adapter class in `webhooks/handlers/_registry.py`:
+
+   ```python
+   @webhook_handler("customer.subscription.my_new_event")
+   class MyNewEventHandler(WebhookHandler):
+       event_type = "customer.subscription.my_new_event"
+
+       async def process(self, sb, event):
+           fn = _resolve("_handle_my_new_event")
+           await fn(sb, event)
+   ```
+
+4. No dispatcher edit required — the registry pick-up is automatic.
+
+## Test strategy
+
+- `backend/tests/webhooks/test_webhook_base.py` — covers the ABC base in
+  isolation: registry registration, idempotency_key override, replay
+  skipping, fail-open on DB error.
+- All existing tests in `test_stripe_webhook*.py`, `test_payment_failed_webhook.py`,
+  `test_founding_webhook_*.py`, etc. continue to pass unchanged because:
+  - Module-level `_handle_*` names in `webhooks/stripe.py` are preserved
+    (re-exports unchanged).
+  - The adapter classes resolve those names *lazily* inside `process()`, so
+    `@patch("webhooks.stripe._handle_*")` decorators take effect.
+  - The dispatcher-level idempotency table and flow are unchanged.
+
+## File map
+
+| Path                                            | Role                                          |
+|-------------------------------------------------|-----------------------------------------------|
+| `backend/webhooks/stripe.py`                    | HTTP route + dispatcher idempotency + registry lookup |
+| `backend/webhooks/handlers/_base.py`            | `WebhookHandler` ABC + decorator + registry   |
+| `backend/webhooks/handlers/_registry.py`        | Adapter classes (one per event type)          |
+| `backend/webhooks/handlers/_shared.py`          | Shared helpers (`resolve_user_id`, cache invalidation) |
+| `backend/webhooks/handlers/checkout.py`         | Checkout-family business logic                |
+| `backend/webhooks/handlers/subscription.py`     | Subscription-family business logic            |
+| `backend/webhooks/handlers/invoice.py`          | Invoice-family business logic                 |
+| `backend/webhooks/handlers/founding.py`         | BIZ-FOUND-002 lifetime entitlement side-effects |
+| `backend/webhooks/handlers/stripe_product_price.py` | BILL-SYNC-001 product/price sync         |
+| `backend/tests/webhooks/test_webhook_base.py`   | ABC + registry unit tests                     |
+| `docs/architecture/webhook-handlers.md`         | This document                                 |
+
+## Related
+
+- REF-MON-002 (this refactor)
+- DEBT-307 (initial decomposition of webhooks/stripe.py into handler modules)
+- SYS-024 (30s asyncio.wait_for timeout)
+- STORY-CONV-003a (trial_will_end handling)
+- BIZ-FOUND-002 (founding race guard)
+- #630 (Intel Report payment_intent.payment_failed)

--- a/docs/stories/2026-04/REF-MON-002-stripe-webhook-handlers-abc-base.story.md
+++ b/docs/stories/2026-04/REF-MON-002-stripe-webhook-handlers-abc-base.story.md
@@ -3,7 +3,7 @@
 **Priority:** P2
 **Effort:** M (3-5 dias)
 **Squad:** @dev + @architect
-**Status:** Ready
+**Status:** InReview
 **Epic:** [EPIC-TD-2026Q2](EPIC-TD-2026Q2/)
 **Sprint:** Sprint 3
 **Dependências bloqueadoras:** story-debt-0-webhook-audit Done (DEBT-324 single registration confirmed)


### PR DESCRIPTION
## Summary
- Extract shared idempotency boilerplate into `WebhookHandler` ABC base class (`webhooks/handlers/_base.py`) with template-method `handle()` and overridable `idempotency_key()`.
- Add `@webhook_handler(event_type)` decorator + `HANDLERS_REGISTRY` for declarative routing.
- Wrap existing free-function handlers (checkout / subscription / invoice / founding / stripe_product_price) in thin adapter classes (`webhooks/handlers/_registry.py`) that lazy-resolve names from `webhooks.stripe` so `@patch("webhooks.stripe._handle_*")` test patches continue to work unchanged.
- Replace ~40-line if-elif chain in `webhooks/stripe.py:_process_event` with a single registry lookup. Dispatcher-level idempotency (`stripe_webhook_events` INSERT ON CONFLICT DO NOTHING) preserved as the authoritative gate; ABC-level claim is a best-effort second layer for non-HTTP callers (replay tools, reconciliation jobs).

## Context
- Brownfield refactor; test surface is large (15+ webhook test files, 255 tests).
- Backward compatibility achieved by keeping all `_handle_*` re-exports in `webhooks/stripe.py` and resolving them lazily inside each adapter's `process()`.
- Two idempotency layers documented in `docs/architecture/webhook-handlers.md` — dispatcher = authoritative, handler ABC = fail-open second layer.

## Testing Plan
- [x] `pytest backend/tests/ -k "webhook"` — 255/255 pass (8 new + 247 existing).
- [x] New `backend/tests/webhooks/test_webhook_base.py` — covers registry registration, idempotency_key override, replay skipping (2x → 1 effect), fail-open on DB error.
- [ ] Manual: verify `HANDLERS_REGISTRY` populated at startup (covered indirectly by integration tests `test_stripe_webhook_matrix.py`).
- [ ] Production: monitor `stripe_webhook_events` for any change in dedup hit rate post-deploy.

## Closes
Closes REF-MON-002