### PR TITLE
refactor(backend): LLM arbiter strategy pattern (REF-VAL-002)

### DIFF
--- a/backend/llm_arbiter/classification.py
+++ b/backend/llm_arbiter/classification.py
@@ -17,9 +17,9 @@ from pydantic import BaseModel, Field, field_validator
 
 from openai import OpenAI
 from metrics import (
-    LLM_CALLS, LLM_DURATION, EVIDENCE_PREFIX_STRIPPED, ARBITER_CACHE_SIZE,
-    ARBITER_CACHE_HITS, ARBITER_CACHE_MISSES, ARBITER_CACHE_EVICTIONS,
-    LLM_FALLBACK_REJECTS_TOTAL,
+    EVIDENCE_PREFIX_STRIPPED,
+    ARBITER_CACHE_SIZE,
+    ARBITER_CACHE_EVICTIONS,
 )
 
 logger = logging.getLogger(__name__)
@@ -384,247 +384,53 @@ def classify_contract_primary_match(
 ) -> dict:
     """Classify if contract is PRIMARILY about sector/terms.
 
+    REF-VAL-002: Thin dispatcher — delegates to a ``ClassificationStrategy``
+    selected by ``prompt_level``. The real work lives in
+    ``llm_arbiter.strategies.*``. Pre-flight guards (LLM disabled / missing
+    context) stay here so behaviour is bit-for-bit equivalent to the legacy
+    monolithic function.
+
     D-02: Returns structured dict with confidence, evidence, and rejection reason.
     """
-    from middleware import search_id_var
-    _search_id = search_id_var.get("-")
-
-    structured_enabled = True
-
     # Lazy import via facade so patch("llm_arbiter.LLM_ENABLED", False) works in tests (AC2)
     import llm_arbiter as _lm
+
     if not _lm.LLM_ENABLED:
         logger.warning(
             "LLM arbiter disabled (LLM_ARBITER_ENABLED=false). "
             "Accepting ambiguous contract by default."
         )
-        return {"is_primary": True, "confidence": 50, "evidence": [],
-                "rejection_reason": None, "needs_more_data": False}
+        return {
+            "is_primary": True,
+            "confidence": 50,
+            "evidence": [],
+            "rejection_reason": None,
+            "needs_more_data": False,
+        }
 
     if not setor_name and not termos_busca:
         logger.error(
             "classify_contract_primary_match called without setor_name or termos_busca"
         )
-        return {"is_primary": True, "confidence": 50, "evidence": [],
-                "rejection_reason": None, "needs_more_data": False}
-
-    objeto_truncated = objeto[:500]
-
-    from llm_arbiter.prompt_builder import (
-        _build_zero_match_prompt,
-        _build_conservative_prompt,
-        _build_standard_sector_prompt,
-    )
-
-    if setor_name:
-        mode = "setor"
-        context = setor_name
-
-        if prompt_level == "zero_match":
-            user_prompt = _build_zero_match_prompt(
-                setor_id=setor_id, setor_name=setor_name,
-                objeto_truncated=objeto_truncated, valor=valor,
-                structured=structured_enabled,
-            )
-        elif prompt_level == "conservative":
-            user_prompt = _build_conservative_prompt(
-                setor_id=setor_id, setor_name=setor_name,
-                objeto_truncated=objeto_truncated, valor=valor,
-                structured=structured_enabled,
-            )
-        else:
-            user_prompt = _build_standard_sector_prompt(
-                setor_name=setor_name, objeto_truncated=objeto_truncated,
-                valor=valor, structured=structured_enabled,
-            )
-    else:
-        mode = "termos"
-        context = ", ".join(termos_busca) if termos_busca else ""
-        from llm_arbiter.prompt_builder import _STRUCTURED_JSON_INSTRUCTION
-        suffix = _STRUCTURED_JSON_INSTRUCTION if structured_enabled else "\nResponda APENAS: SIM ou NAO"
-        user_prompt = f"""Termos buscados: {context}
-Valor: R$ {valor:,.2f}
-Objeto: {objeto_truncated}
-
-Os termos buscados descrevem o OBJETO PRINCIPAL deste contrato (não itens secundários)?{suffix}"""
-
-    prompt_version = "v2" if structured_enabled else "v1"
-    cache_key = hashlib.md5(
-        f"{prompt_version}:{mode}:{context}:{valor}:{objeto_truncated}:{prompt_level}:{setor_id or ''}".encode()
-    ).hexdigest()
-
-    if cache_key in _arbiter_cache:
-        _arbiter_cache.move_to_end(cache_key)
-        ARBITER_CACHE_HITS.labels(level="l1").inc()
-        logger.debug(
-            f"LLM arbiter cache L1 HIT: mode={mode} "
-            f"context={context[:50]}... valor={valor}"
-        )
-        return _arbiter_cache[cache_key]
-
-    redis_cached = _arbiter_cache_get_redis(cache_key)
-    if redis_cached is not None:
-        ARBITER_CACHE_HITS.labels(level="l2").inc()
-        return redis_cached
-
-    ARBITER_CACHE_MISSES.inc()
-
-    # STORY-2.11 (EPIC-TD-2026Q2 P0): Budget cap — se o teto mensal foi atingido,
-    # curto-circuita antes de chamar a OpenAI. Retorna PENDING_REVIEW (gray zone),
-    # evitando hard-reject silencioso em caso de burst de custo.
-    try:
-        from llm_budget import is_budget_exceeded_sync
-
-        if is_budget_exceeded_sync():
-            logger.warning(
-                f"STORY-2.11: LLM monthly budget exceeded — returning PENDING_REVIEW | "
-                f"search={_search_id} mode={mode} prompt_level={prompt_level}"
-            )
-            try:
-                from metrics import LLM_BUDGET_REJECTIONS
-                LLM_BUDGET_REJECTIONS.labels(caller="arbiter").inc()
-            except Exception:
-                pass
-            return {
-                "is_primary": False,
-                "confidence": 0,
-                "evidence": [],
-                "rejection_reason": "llm_budget_exceeded",
-                "needs_more_data": False,
-                "pending_review": True,
-                "_classification_source": "budget_cap",
-            }
-    except Exception:
-        # Nunca bloqueia por erro em budget check
-        pass
-
-    try:
-        if structured_enabled:
-            system_prompt = (
-                "Você é um classificador conservador de licitações públicas. "
-                "Em caso de dúvida, responda NAO. "
-                "Apenas responda SIM se o contrato é CLARAMENTE e PRIMARIAMENTE sobre o setor. "
-                "Responda em formato JSON válido conforme a estrutura solicitada."
-            )
-            effective_max_tokens = LLM_STRUCTURED_MAX_TOKENS
-        else:
-            system_prompt = (
-                "Você é um classificador conservador de licitações. "
-                "Em caso de dúvida, responda NAO. "
-                "Apenas responda SIM se o contrato é CLARAMENTE e PRIMARIAMENTE sobre o setor. "
-                "Responda APENAS 'SIM' ou 'NAO'."
-            )
-            effective_max_tokens = LLM_MAX_TOKENS
-
-        api_kwargs: dict[str, Any] = {
-            "model": LLM_MODEL,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            "max_tokens": effective_max_tokens,
-            "temperature": LLM_TEMPERATURE,
-        }
-        if structured_enabled:
-            api_kwargs["response_format"] = {"type": "json_object"}
-
-        _llm_start = _time_module.time()
-        # Lazy import via facade so patch("llm_arbiter._get_client") works in tests (AC2)
-        import llm_arbiter as _lm
-        response = _lm._get_client().chat.completions.create(**api_kwargs)
-        _llm_elapsed = _time_module.time() - _llm_start
-
-        raw_content = response.choices[0].message.content.strip()
-
-        usage = getattr(response, "usage", None)
-        if usage and search_id:
-            _log_token_usage(
-                search_id,
-                input_tokens=getattr(usage, "prompt_tokens", 0),
-                output_tokens=getattr(usage, "completion_tokens", 0),
-            )
-
-        if structured_enabled:
-            classification = _parse_structured_response(raw_content, objeto, search_id)
-            is_primary = classification.classe == "SIM"
-            result = {
-                "is_primary": is_primary,
-                "confidence": classification.confianca,
-                "evidence": classification.evidencias,
-                "rejection_reason": classification.motivo_exclusao,
-                "needs_more_data": classification.precisa_mais_dados,
-            }
-        else:
-            llm_response = raw_content.upper()
-            is_primary = llm_response == "SIM"
-            result = {
-                "is_primary": is_primary,
-                "confidence": 100 if is_primary else 0,
-                "evidence": [],
-                "rejection_reason": None,
-                "needs_more_data": False,
-            }
-
-        _decision = "SIM" if is_primary else "NAO"
-        LLM_DURATION.labels(model=LLM_MODEL, decision=_decision).observe(_llm_elapsed)
-        LLM_CALLS.labels(model=LLM_MODEL, decision=_decision, zone=prompt_level).inc()
-
-        _arbiter_cache_set(cache_key, result)
-        _arbiter_cache_set_redis(cache_key, result)
-
-        logger.info(
-            f"LLM arbiter decision: {_decision} conf={result['confidence']}% | "
-            f"search={_search_id} mode={mode} prompt_level={prompt_level} structured={structured_enabled} "
-            f"context={context[:50]}... valor=R${valor:,.2f}"
-        )
-
-        return result
-
-    except Exception as e:
-        LLM_CALLS.labels(model=LLM_MODEL, decision="ERROR", zone=prompt_level).inc()
-
-        from config import LLM_FALLBACK_PENDING_ENABLED
-        _gray_zone_levels = {"zero_match", "standard", "conservative"}
-        if LLM_FALLBACK_PENDING_ENABLED and prompt_level in _gray_zone_levels:
-            logger.warning(
-                f"LLM arbiter FAILED (PENDING_REVIEW fallback): {e} | "
-                f"search={_search_id} mode={mode} prompt_level={prompt_level} "
-                f"context={context[:50]}... valor={valor:,.2f}"
-            )
-            from metrics import LLM_FALLBACK_PENDING
-            _sector_label = context[:50] if mode == "setor" else "termos"
-            _reason = type(e).__name__
-            LLM_FALLBACK_PENDING.labels(sector=_sector_label, reason=_reason).inc()
-            _pending_confidence = 40 if prompt_level in {"standard", "conservative"} else 0
-            result = {
-                "is_primary": False,
-                "confidence": _pending_confidence,
-                "evidence": [],
-                "rejection_reason": "LLM unavailable",
-                "needs_more_data": False,
-                "pending_review": True,
-                "_classification_source": "llm_fallback_pending",
-            }
-            return result
-
-        logger.error(
-            f"LLM arbiter FAILED (defaulting to REJECT): {e} | "
-            f"search={_search_id} mode={mode} context={context[:50]}... valor={valor:,.2f}"
-        )
-        try:
-            _setor_label = setor_id or "unknown"
-            _reason = type(e).__name__
-            LLM_FALLBACK_REJECTS_TOTAL.labels(setor=_setor_label, reason=_reason).inc()
-        except Exception:
-            pass
-        result = {
-            "is_primary": False,
-            "confidence": 0,
+        return {
+            "is_primary": True,
+            "confidence": 50,
             "evidence": [],
-            "rejection_reason": "LLM unavailable",
+            "rejection_reason": None,
             "needs_more_data": False,
         }
-        return result
+
+    from llm_arbiter.strategies import get_strategy
+
+    strategy = get_strategy(prompt_level)
+    return strategy.classify(
+        objeto=objeto,
+        valor=valor,
+        setor_name=setor_name,
+        termos_busca=termos_busca,
+        setor_id=setor_id,
+        search_id=search_id,
+    )
 
 
 # ============================================================================

--- a/backend/llm_arbiter/strategies/__init__.py
+++ b/backend/llm_arbiter/strategies/__init__.py
@@ -1,0 +1,73 @@
+"""Classification strategies package (REF-VAL-002).
+
+Strategy pattern for LLM arbiter classification. Each strategy encapsulates
+one density tier:
+
+  - KeywordStrategy        — high keyword density (>5%), no LLM call
+  - LLMStandardStrategy    — medium density (2-5%), standard LLM prompt
+  - LLMConservativeStrategy — low density (1-2%), conservative LLM prompt
+  - LLMZeroMatchStrategy   — zero density (<1%), zero-match LLM prompt
+
+Prompts remain centralized in ``llm_arbiter.prompt_builder``. Strategies
+only orchestrate prompt selection, LLM call, cache, and parsing.
+
+Public entry points live in ``llm_arbiter.classification`` (back-compat).
+"""
+
+from llm_arbiter.strategies._base import ClassificationStrategy
+from llm_arbiter.strategies.keyword import KeywordStrategy
+from llm_arbiter.strategies.llm_standard import LLMStandardStrategy
+from llm_arbiter.strategies.llm_conservative import LLMConservativeStrategy
+from llm_arbiter.strategies.llm_zero_match import LLMZeroMatchStrategy
+
+
+# Registry by canonical name. Mirrors the ``prompt_level`` string used by
+# upstream callers in ``filter/pipeline.py`` and ``jobs/queue/jobs.py``.
+STRATEGY_REGISTRY: dict[str, type[ClassificationStrategy]] = {
+    "keyword": KeywordStrategy,
+    "standard": LLMStandardStrategy,
+    "conservative": LLMConservativeStrategy,
+    "zero_match": LLMZeroMatchStrategy,
+}
+
+
+def get_strategy(name: str) -> ClassificationStrategy:
+    """Look up and instantiate a strategy by name.
+
+    Falls back to LLMStandardStrategy on unknown name to preserve the
+    legacy "default to standard" behaviour of ``classify_contract_primary_match``.
+    """
+    cls = STRATEGY_REGISTRY.get(name, LLMStandardStrategy)
+    return cls()
+
+
+def select_strategy_by_density(density: float) -> ClassificationStrategy:
+    """Pick a strategy from a keyword-density score.
+
+    Tiers mirror the upstream logic in ``filter/pipeline.py`` so callers that
+    have not yet adopted ``prompt_level`` can still use this helper.
+
+      - density > 0.05 → KeywordStrategy
+      - 0.02 < density ≤ 0.05 → LLMStandardStrategy
+      - 0.01 < density ≤ 0.02 → LLMConservativeStrategy
+      - density ≤ 0.01 → LLMZeroMatchStrategy
+    """
+    if density > 0.05:
+        return KeywordStrategy()
+    if density > 0.02:
+        return LLMStandardStrategy()
+    if density > 0.01:
+        return LLMConservativeStrategy()
+    return LLMZeroMatchStrategy()
+
+
+__all__ = [
+    "ClassificationStrategy",
+    "KeywordStrategy",
+    "LLMStandardStrategy",
+    "LLMConservativeStrategy",
+    "LLMZeroMatchStrategy",
+    "STRATEGY_REGISTRY",
+    "get_strategy",
+    "select_strategy_by_density",
+]

--- a/backend/llm_arbiter/strategies/_base.py
+++ b/backend/llm_arbiter/strategies/_base.py
@@ -1,0 +1,334 @@
+"""Base ABC and shared LLM-call helper for classification strategies (REF-VAL-002).
+
+The shared helper ``run_llm_classification`` factors out the common machinery
+that all LLM-using strategies need:
+
+  - L1 (in-memory) + L2 (Redis) cache read
+  - Monthly budget cap short-circuit
+  - OpenAI chat.completions call
+  - Structured / binary response parsing
+  - Token logging + cache write
+  - Error fallback (PENDING_REVIEW or hard REJECT)
+
+It calls back into ``llm_arbiter.classification`` for the cache/parse/log
+primitives so behaviour is bit-for-bit equivalent to the pre-refactor
+``classify_contract_primary_match`` function.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time as _time_module
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ClassificationStrategy(ABC):
+    """ABC for a single density-tier classification strategy."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Canonical name of this strategy (matches legacy ``prompt_level``)."""
+
+    @abstractmethod
+    def classify(
+        self,
+        *,
+        objeto: str,
+        valor: float,
+        setor_name: Optional[str] = None,
+        termos_busca: Optional[list[str]] = None,
+        setor_id: Optional[str] = None,
+        search_id: str = "",
+    ) -> dict:
+        """Return the legacy classification dict.
+
+        Shape mirrors ``classify_contract_primary_match`` exactly::
+
+            {
+                "is_primary": bool,
+                "confidence": int,           # 0..100
+                "evidence": list[str],
+                "rejection_reason": Optional[str],
+                "needs_more_data": bool,
+                # optional keys present only on some paths:
+                "pending_review": bool,
+                "_classification_source": str,
+            }
+        """
+
+
+def run_llm_classification(
+    *,
+    user_prompt: str,
+    mode: str,
+    context: str,
+    objeto: str,
+    valor: float,
+    objeto_truncated: str,
+    prompt_level: str,
+    setor_id: Optional[str],
+    search_id: str,
+    structured_enabled: bool = True,
+) -> dict:
+    """Shared LLM-call core extracted from ``classify_contract_primary_match``.
+
+    All LLM-using strategies funnel through this helper so cache key shape,
+    metrics labels, budget gating and parsing remain identical.
+    """
+    # Late imports to avoid circulars with the facade re-export module.
+    from llm_arbiter import classification as _cls
+    from metrics import (
+        ARBITER_CACHE_HITS,
+        ARBITER_CACHE_MISSES,
+        LLM_CALLS,
+        LLM_DURATION,
+        LLM_FALLBACK_REJECTS_TOTAL,
+    )
+    from middleware import search_id_var
+
+    _search_id = search_id_var.get("-")
+
+    prompt_version = "v2" if structured_enabled else "v1"
+    cache_key = hashlib.md5(
+        f"{prompt_version}:{mode}:{context}:{valor}:{objeto_truncated}:{prompt_level}:{setor_id or ''}".encode()
+    ).hexdigest()
+
+    if cache_key in _cls._arbiter_cache:
+        _cls._arbiter_cache.move_to_end(cache_key)
+        ARBITER_CACHE_HITS.labels(level="l1").inc()
+        logger.debug(
+            f"LLM arbiter cache L1 HIT: mode={mode} "
+            f"context={context[:50]}... valor={valor}"
+        )
+        return _cls._arbiter_cache[cache_key]
+
+    redis_cached = _cls._arbiter_cache_get_redis(cache_key)
+    if redis_cached is not None:
+        ARBITER_CACHE_HITS.labels(level="l2").inc()
+        return redis_cached
+
+    ARBITER_CACHE_MISSES.inc()
+
+    # STORY-2.11 (EPIC-TD-2026Q2 P0): Budget cap short-circuit.
+    try:
+        from llm_budget import is_budget_exceeded_sync
+
+        if is_budget_exceeded_sync():
+            logger.warning(
+                f"STORY-2.11: LLM monthly budget exceeded — returning PENDING_REVIEW | "
+                f"search={_search_id} mode={mode} prompt_level={prompt_level}"
+            )
+            try:
+                from metrics import LLM_BUDGET_REJECTIONS
+
+                LLM_BUDGET_REJECTIONS.labels(caller="arbiter").inc()
+            except Exception:
+                pass
+            return {
+                "is_primary": False,
+                "confidence": 0,
+                "evidence": [],
+                "rejection_reason": "llm_budget_exceeded",
+                "needs_more_data": False,
+                "pending_review": True,
+                "_classification_source": "budget_cap",
+            }
+    except Exception:
+        pass
+
+    try:
+        if structured_enabled:
+            system_prompt = (
+                "Você é um classificador conservador de licitações públicas. "
+                "Em caso de dúvida, responda NAO. "
+                "Apenas responda SIM se o contrato é CLARAMENTE e PRIMARIAMENTE sobre o setor. "
+                "Responda em formato JSON válido conforme a estrutura solicitada."
+            )
+            effective_max_tokens = _cls.LLM_STRUCTURED_MAX_TOKENS
+        else:
+            system_prompt = (
+                "Você é um classificador conservador de licitações. "
+                "Em caso de dúvida, responda NAO. "
+                "Apenas responda SIM se o contrato é CLARAMENTE e PRIMARIAMENTE sobre o setor. "
+                "Responda APENAS 'SIM' ou 'NAO'."
+            )
+            effective_max_tokens = _cls.LLM_MAX_TOKENS
+
+        api_kwargs: dict[str, Any] = {
+            "model": _cls.LLM_MODEL,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "max_tokens": effective_max_tokens,
+            "temperature": _cls.LLM_TEMPERATURE,
+        }
+        if structured_enabled:
+            api_kwargs["response_format"] = {"type": "json_object"}
+
+        _llm_start = _time_module.time()
+        # Lazy import via facade so tests can patch ``llm_arbiter._get_client``.
+        import llm_arbiter as _lm
+
+        response = _lm._get_client().chat.completions.create(**api_kwargs)
+        _llm_elapsed = _time_module.time() - _llm_start
+
+        raw_content = response.choices[0].message.content.strip()
+
+        usage = getattr(response, "usage", None)
+        if usage and search_id:
+            _cls._log_token_usage(
+                search_id,
+                input_tokens=getattr(usage, "prompt_tokens", 0),
+                output_tokens=getattr(usage, "completion_tokens", 0),
+            )
+
+        if structured_enabled:
+            classification = _cls._parse_structured_response(raw_content, objeto, search_id)
+            is_primary = classification.classe == "SIM"
+            result = {
+                "is_primary": is_primary,
+                "confidence": classification.confianca,
+                "evidence": classification.evidencias,
+                "rejection_reason": classification.motivo_exclusao,
+                "needs_more_data": classification.precisa_mais_dados,
+            }
+        else:
+            llm_response = raw_content.upper()
+            is_primary = llm_response == "SIM"
+            result = {
+                "is_primary": is_primary,
+                "confidence": 100 if is_primary else 0,
+                "evidence": [],
+                "rejection_reason": None,
+                "needs_more_data": False,
+            }
+
+        _decision = "SIM" if is_primary else "NAO"
+        LLM_DURATION.labels(model=_cls.LLM_MODEL, decision=_decision).observe(_llm_elapsed)
+        LLM_CALLS.labels(model=_cls.LLM_MODEL, decision=_decision, zone=prompt_level).inc()
+
+        _cls._arbiter_cache_set(cache_key, result)
+        _cls._arbiter_cache_set_redis(cache_key, result)
+
+        logger.info(
+            f"LLM arbiter decision: {_decision} conf={result['confidence']}% | "
+            f"search={_search_id} mode={mode} prompt_level={prompt_level} structured={structured_enabled} "
+            f"context={context[:50]}... valor=R${valor:,.2f}"
+        )
+
+        return result
+
+    except Exception as e:
+        LLM_CALLS.labels(model=_cls.LLM_MODEL, decision="ERROR", zone=prompt_level).inc()
+
+        from config import LLM_FALLBACK_PENDING_ENABLED
+
+        _gray_zone_levels = {"zero_match", "standard", "conservative"}
+        if LLM_FALLBACK_PENDING_ENABLED and prompt_level in _gray_zone_levels:
+            logger.warning(
+                f"LLM arbiter FAILED (PENDING_REVIEW fallback): {e} | "
+                f"search={_search_id} mode={mode} prompt_level={prompt_level} "
+                f"context={context[:50]}... valor={valor:,.2f}"
+            )
+            from metrics import LLM_FALLBACK_PENDING
+
+            _sector_label = context[:50] if mode == "setor" else "termos"
+            _reason = type(e).__name__
+            LLM_FALLBACK_PENDING.labels(sector=_sector_label, reason=_reason).inc()
+            _pending_confidence = 40 if prompt_level in {"standard", "conservative"} else 0
+            return {
+                "is_primary": False,
+                "confidence": _pending_confidence,
+                "evidence": [],
+                "rejection_reason": "LLM unavailable",
+                "needs_more_data": False,
+                "pending_review": True,
+                "_classification_source": "llm_fallback_pending",
+            }
+
+        logger.error(
+            f"LLM arbiter FAILED (defaulting to REJECT): {e} | "
+            f"search={_search_id} mode={mode} context={context[:50]}... valor={valor:,.2f}"
+        )
+        try:
+            _setor_label = setor_id or "unknown"
+            _reason = type(e).__name__
+            LLM_FALLBACK_REJECTS_TOTAL.labels(setor=_setor_label, reason=_reason).inc()
+        except Exception:
+            pass
+        return {
+            "is_primary": False,
+            "confidence": 0,
+            "evidence": [],
+            "rejection_reason": "LLM unavailable",
+            "needs_more_data": False,
+        }
+
+
+def build_user_prompt(
+    *,
+    prompt_level: str,
+    setor_name: Optional[str],
+    termos_busca: Optional[list[str]],
+    objeto_truncated: str,
+    valor: float,
+    setor_id: Optional[str],
+    structured_enabled: bool = True,
+) -> tuple[str, str, str]:
+    """Build the user prompt + return (user_prompt, mode, context).
+
+    Centralises the prompt-builder dispatch so each LLM strategy only declares
+    which builder to use.
+    """
+    from llm_arbiter.prompt_builder import (
+        _STRUCTURED_JSON_INSTRUCTION,
+        _build_conservative_prompt,
+        _build_standard_sector_prompt,
+        _build_zero_match_prompt,
+    )
+
+    if setor_name:
+        mode = "setor"
+        context = setor_name
+        if prompt_level == "zero_match":
+            user_prompt = _build_zero_match_prompt(
+                setor_id=setor_id,
+                setor_name=setor_name,
+                objeto_truncated=objeto_truncated,
+                valor=valor,
+                structured=structured_enabled,
+            )
+        elif prompt_level == "conservative":
+            user_prompt = _build_conservative_prompt(
+                setor_id=setor_id,
+                setor_name=setor_name,
+                objeto_truncated=objeto_truncated,
+                valor=valor,
+                structured=structured_enabled,
+            )
+        else:
+            user_prompt = _build_standard_sector_prompt(
+                setor_name=setor_name,
+                objeto_truncated=objeto_truncated,
+                valor=valor,
+                structured=structured_enabled,
+            )
+    else:
+        mode = "termos"
+        context = ", ".join(termos_busca) if termos_busca else ""
+        suffix = _STRUCTURED_JSON_INSTRUCTION if structured_enabled else "\nResponda APENAS: SIM ou NAO"
+        user_prompt = (
+            f"Termos buscados: {context}\n"
+            f"Valor: R$ {valor:,.2f}\n"
+            f"Objeto: {objeto_truncated}\n\n"
+            f"Os termos buscados descrevem o OBJETO PRINCIPAL deste contrato "
+            f"(não itens secundários)?{suffix}"
+        )
+
+    return user_prompt, mode, context

--- a/backend/llm_arbiter/strategies/keyword.py
+++ b/backend/llm_arbiter/strategies/keyword.py
@@ -1,0 +1,48 @@
+"""High-density keyword strategy (>5% density) — no LLM call (REF-VAL-002).
+
+When keyword density is high enough, the upstream filter pipeline has already
+established sector match deterministically. We short-circuit without invoking
+the LLM and return the legacy "keyword accept" payload (confidence=95, matching
+the documented benchmark behaviour in ``test_llm_arbiter.py`` and the D-02
+comment: "keyword=95, LLM=varies, zero_match<=70").
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from llm_arbiter.strategies._base import ClassificationStrategy
+
+logger = logging.getLogger(__name__)
+
+
+class KeywordStrategy(ClassificationStrategy):
+    """High keyword density: accept without an LLM call."""
+
+    @property
+    def name(self) -> str:
+        return "keyword"
+
+    def classify(
+        self,
+        *,
+        objeto: str,
+        valor: float,
+        setor_name: Optional[str] = None,
+        termos_busca: Optional[list[str]] = None,
+        setor_id: Optional[str] = None,
+        search_id: str = "",
+    ) -> dict:
+        logger.debug(
+            "REF-VAL-002 KeywordStrategy ACCEPT (no LLM) | "
+            f"setor={setor_name} valor=R${valor:,.2f}"
+        )
+        return {
+            "is_primary": True,
+            "confidence": 95,
+            "evidence": [],
+            "rejection_reason": None,
+            "needs_more_data": False,
+            "_classification_source": "keyword",
+        }

--- a/backend/llm_arbiter/strategies/llm_conservative.py
+++ b/backend/llm_arbiter/strategies/llm_conservative.py
@@ -1,0 +1,51 @@
+"""Low-density conservative LLM strategy (1-2% density) — REF-VAL-002."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from llm_arbiter.strategies._base import (
+    ClassificationStrategy,
+    build_user_prompt,
+    run_llm_classification,
+)
+
+
+class LLMConservativeStrategy(ClassificationStrategy):
+    """Conservative LLM prompt for low keyword density (1-2%)."""
+
+    @property
+    def name(self) -> str:
+        return "conservative"
+
+    def classify(
+        self,
+        *,
+        objeto: str,
+        valor: float,
+        setor_name: Optional[str] = None,
+        termos_busca: Optional[list[str]] = None,
+        setor_id: Optional[str] = None,
+        search_id: str = "",
+    ) -> dict:
+        objeto_truncated = objeto[:500]
+        user_prompt, mode, context = build_user_prompt(
+            prompt_level=self.name,
+            setor_name=setor_name,
+            termos_busca=termos_busca,
+            objeto_truncated=objeto_truncated,
+            valor=valor,
+            setor_id=setor_id,
+            structured_enabled=True,
+        )
+        return run_llm_classification(
+            user_prompt=user_prompt,
+            mode=mode,
+            context=context,
+            objeto=objeto,
+            valor=valor,
+            objeto_truncated=objeto_truncated,
+            prompt_level=self.name,
+            setor_id=setor_id,
+            search_id=search_id,
+        )

--- a/backend/llm_arbiter/strategies/llm_standard.py
+++ b/backend/llm_arbiter/strategies/llm_standard.py
@@ -1,0 +1,51 @@
+"""Standard-density LLM strategy (2-5% density) — REF-VAL-002."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from llm_arbiter.strategies._base import (
+    ClassificationStrategy,
+    build_user_prompt,
+    run_llm_classification,
+)
+
+
+class LLMStandardStrategy(ClassificationStrategy):
+    """Standard LLM arbiter prompt for medium keyword density."""
+
+    @property
+    def name(self) -> str:
+        return "standard"
+
+    def classify(
+        self,
+        *,
+        objeto: str,
+        valor: float,
+        setor_name: Optional[str] = None,
+        termos_busca: Optional[list[str]] = None,
+        setor_id: Optional[str] = None,
+        search_id: str = "",
+    ) -> dict:
+        objeto_truncated = objeto[:500]
+        user_prompt, mode, context = build_user_prompt(
+            prompt_level=self.name,
+            setor_name=setor_name,
+            termos_busca=termos_busca,
+            objeto_truncated=objeto_truncated,
+            valor=valor,
+            setor_id=setor_id,
+            structured_enabled=True,
+        )
+        return run_llm_classification(
+            user_prompt=user_prompt,
+            mode=mode,
+            context=context,
+            objeto=objeto,
+            valor=valor,
+            objeto_truncated=objeto_truncated,
+            prompt_level=self.name,
+            setor_id=setor_id,
+            search_id=search_id,
+        )

--- a/backend/llm_arbiter/strategies/llm_zero_match.py
+++ b/backend/llm_arbiter/strategies/llm_zero_match.py
@@ -1,0 +1,56 @@
+"""Zero-density LLM strategy (<1% density) — single-bid zero-match (REF-VAL-002).
+
+Wraps the single-bid zero-match arbiter call. Batch zero-match recovery
+remains in ``llm_arbiter.zero_match`` (different code path: bulk YES/NO list
+over many bids) and is not within the scope of this strategy.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from llm_arbiter.strategies._base import (
+    ClassificationStrategy,
+    build_user_prompt,
+    run_llm_classification,
+)
+
+
+class LLMZeroMatchStrategy(ClassificationStrategy):
+    """Zero-match LLM prompt for very low keyword density (<1%)."""
+
+    @property
+    def name(self) -> str:
+        return "zero_match"
+
+    def classify(
+        self,
+        *,
+        objeto: str,
+        valor: float,
+        setor_name: Optional[str] = None,
+        termos_busca: Optional[list[str]] = None,
+        setor_id: Optional[str] = None,
+        search_id: str = "",
+    ) -> dict:
+        objeto_truncated = objeto[:500]
+        user_prompt, mode, context = build_user_prompt(
+            prompt_level=self.name,
+            setor_name=setor_name,
+            termos_busca=termos_busca,
+            objeto_truncated=objeto_truncated,
+            valor=valor,
+            setor_id=setor_id,
+            structured_enabled=True,
+        )
+        return run_llm_classification(
+            user_prompt=user_prompt,
+            mode=mode,
+            context=context,
+            objeto=objeto,
+            valor=valor,
+            objeto_truncated=objeto_truncated,
+            prompt_level=self.name,
+            setor_id=setor_id,
+            search_id=search_id,
+        )

--- a/backend/tests/test_strategy_keyword.py
+++ b/backend/tests/test_strategy_keyword.py
@@ -1,0 +1,76 @@
+"""REF-VAL-002 — KeywordStrategy unit tests.
+
+High-density keyword tier short-circuits: no LLM call, returns is_primary=True
+with confidence=95.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from llm_arbiter.strategies import KeywordStrategy, get_strategy, select_strategy_by_density
+
+
+class TestKeywordStrategyNoLLM:
+    def test_name(self) -> None:
+        assert KeywordStrategy().name == "keyword"
+
+    def test_classify_does_not_call_llm(self) -> None:
+        """KeywordStrategy must never invoke the OpenAI client."""
+        with patch("llm_arbiter._get_client") as mock_client:
+            result = KeywordStrategy().classify(
+                objeto="Construção de escola pública municipal",
+                valor=1_500_000,
+                setor_name="Construção Civil",
+                setor_id="construcao",
+                search_id="search-abc",
+            )
+            mock_client.assert_not_called()
+
+        assert result["is_primary"] is True
+        assert result["confidence"] == 95
+        assert result["evidence"] == []
+        assert result["rejection_reason"] is None
+        assert result["needs_more_data"] is False
+        assert result["_classification_source"] == "keyword"
+
+    def test_classify_with_termos_busca(self) -> None:
+        result = KeywordStrategy().classify(
+            objeto="Fornecimento de equipamentos médicos",
+            valor=500_000,
+            termos_busca=["equipamentos médicos", "hospitalar"],
+            search_id="search-xyz",
+        )
+        assert result["is_primary"] is True
+        assert result["confidence"] == 95
+
+
+class TestStrategyRegistry:
+    def test_get_strategy_by_name(self) -> None:
+        assert get_strategy("keyword").name == "keyword"
+        assert get_strategy("standard").name == "standard"
+        assert get_strategy("conservative").name == "conservative"
+        assert get_strategy("zero_match").name == "zero_match"
+
+    def test_get_strategy_unknown_falls_back_to_standard(self) -> None:
+        """Legacy default to standard for unknown prompt_level."""
+        assert get_strategy("nonexistent").name == "standard"
+
+    @pytest.mark.parametrize(
+        "density,expected",
+        [
+            (0.10, "keyword"),       # >5%
+            (0.06, "keyword"),       # >5%
+            (0.05, "standard"),      # not > 5%, but > 2%
+            (0.03, "standard"),      # 2-5%
+            (0.02, "conservative"),  # not > 2%, but > 1%
+            (0.015, "conservative"), # 1-2%
+            (0.01, "zero_match"),    # not > 1%
+            (0.005, "zero_match"),   # <1%
+            (0.0, "zero_match"),
+        ],
+    )
+    def test_select_strategy_by_density(self, density: float, expected: str) -> None:
+        assert select_strategy_by_density(density).name == expected

--- a/backend/tests/test_strategy_llm.py
+++ b/backend/tests/test_strategy_llm.py
@@ -1,0 +1,193 @@
+"""REF-VAL-002 — LLM strategy unit tests (standard / conservative / zero_match).
+
+Each LLM strategy calls into the shared ``run_llm_classification`` helper,
+mocked at the ``llm_arbiter._get_client`` boundary (CLAUDE.md test pattern).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from llm_arbiter import clear_cache
+from llm_arbiter.strategies import (
+    LLMConservativeStrategy,
+    LLMStandardStrategy,
+    LLMZeroMatchStrategy,
+)
+
+
+@pytest.fixture(autouse=True)
+def _env() -> None:
+    os.environ["LLM_ARBITER_ENABLED"] = "true"
+    os.environ["LLM_ARBITER_MODEL"] = "gpt-4.1-nano"
+    os.environ["LLM_ARBITER_MAX_TOKENS"] = "1"
+    os.environ["LLM_ARBITER_TEMPERATURE"] = "0"
+    os.environ["OPENAI_API_KEY"] = "test-key-12345"
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def _mock_response(classe: str = "SIM", confianca: int = 85, evidencias: list[str] | None = None) -> Mock:
+    payload = {
+        "classe": classe,
+        "confianca": confianca,
+        "evidencias": evidencias or [],
+        "motivo_exclusao": None,
+        "precisa_mais_dados": False,
+    }
+    msg = Mock()
+    msg.content = json.dumps(payload)
+    choice = Mock()
+    choice.message = msg
+    usage = Mock()
+    usage.prompt_tokens = 100
+    usage.completion_tokens = 10
+    resp = Mock()
+    resp.choices = [choice]
+    resp.usage = usage
+    return resp
+
+
+class TestLLMStandardStrategy:
+    def test_name(self) -> None:
+        assert LLMStandardStrategy().name == "standard"
+
+    def test_classify_sim(self) -> None:
+        with patch("llm_arbiter._get_client") as mock_get_client:
+            mock_client = Mock()
+            mock_client.chat.completions.create.return_value = _mock_response(classe="SIM", confianca=88)
+            mock_get_client.return_value = mock_client
+
+            result = LLMStandardStrategy().classify(
+                objeto="Aquisição de medicamentos para a Secretaria de Saúde",
+                valor=200_000,
+                setor_name="Saúde",
+                setor_id="saude",
+                search_id="s-std-1",
+            )
+
+        assert result["is_primary"] is True
+        assert result["confidence"] == 88
+        mock_client.chat.completions.create.assert_called_once()
+
+    def test_classify_nao(self) -> None:
+        with patch("llm_arbiter._get_client") as mock_get_client:
+            mock_client = Mock()
+            mock_client.chat.completions.create.return_value = _mock_response(classe="NAO", confianca=20)
+            mock_get_client.return_value = mock_client
+
+            result = LLMStandardStrategy().classify(
+                objeto="Compra de cadeiras escolares",
+                valor=50_000,
+                setor_name="Saúde",
+                search_id="s-std-2",
+            )
+
+        assert result["is_primary"] is False
+        assert result["confidence"] == 20
+
+
+class TestLLMConservativeStrategy:
+    def test_name(self) -> None:
+        assert LLMConservativeStrategy().name == "conservative"
+
+    def test_classify_calls_llm(self) -> None:
+        with patch("llm_arbiter._get_client") as mock_get_client:
+            mock_client = Mock()
+            mock_client.chat.completions.create.return_value = _mock_response(classe="SIM", confianca=72)
+            mock_get_client.return_value = mock_client
+
+            result = LLMConservativeStrategy().classify(
+                objeto="Serviços de manutenção predial com itens diversos",
+                valor=100_000,
+                setor_name="Construção Civil",
+                setor_id="construcao",
+                search_id="s-cons-1",
+            )
+
+        assert result["is_primary"] is True
+        assert result["confidence"] == 72
+        # Verify it used the conservative prompt path — check prompt_level metric label
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert "messages" in call_kwargs
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+class TestLLMZeroMatchStrategy:
+    def test_name(self) -> None:
+        assert LLMZeroMatchStrategy().name == "zero_match"
+
+    def test_classify_zero_match(self) -> None:
+        with patch("llm_arbiter._get_client") as mock_get_client:
+            mock_client = Mock()
+            mock_client.chat.completions.create.return_value = _mock_response(classe="NAO", confianca=10)
+            mock_get_client.return_value = mock_client
+
+            result = LLMZeroMatchStrategy().classify(
+                objeto="Aquisição de uniformes escolares",
+                valor=30_000,
+                setor_name="Saúde",
+                setor_id="saude",
+                search_id="s-zm-1",
+            )
+
+        assert result["is_primary"] is False
+        assert result["confidence"] == 10
+
+
+class TestStrategyCacheSharing:
+    """All LLM strategies share the same L1 cache via run_llm_classification."""
+
+    def test_second_call_hits_cache(self) -> None:
+        with patch("llm_arbiter._get_client") as mock_get_client:
+            mock_client = Mock()
+            mock_client.chat.completions.create.return_value = _mock_response(classe="SIM", confianca=90)
+            mock_get_client.return_value = mock_client
+
+            strat = LLMStandardStrategy()
+            r1 = strat.classify(
+                objeto="Objeto X",
+                valor=1_000,
+                setor_name="Saúde",
+                setor_id="saude",
+                search_id="s-cache-1",
+            )
+            r2 = strat.classify(
+                objeto="Objeto X",
+                valor=1_000,
+                setor_name="Saúde",
+                setor_id="saude",
+                search_id="s-cache-1",
+            )
+
+        assert r1 == r2
+        # Only one underlying API call — second was a cache hit
+        assert mock_client.chat.completions.create.call_count == 1
+
+
+class TestStrategyErrorFallback:
+    def test_api_error_pending_review(self) -> None:
+        """LLM error in gray-zone returns pending_review when LLM_FALLBACK_PENDING_ENABLED."""
+        with patch("llm_arbiter._get_client") as mock_get_client, patch(
+            "config.LLM_FALLBACK_PENDING_ENABLED", True
+        ):
+            mock_client = Mock()
+            mock_client.chat.completions.create.side_effect = RuntimeError("openai down")
+            mock_get_client.return_value = mock_client
+
+            result = LLMStandardStrategy().classify(
+                objeto="Algum objeto",
+                valor=10_000,
+                setor_name="Saúde",
+                setor_id="saude",
+                search_id="s-err-1",
+            )
+
+        assert result["is_primary"] is False
+        assert result.get("pending_review") is True
+        assert result["_classification_source"] == "llm_fallback_pending"

--- a/docs/stories/2026-04/REF-VAL-002-llm-arbiter-classification-strategy-pattern.story.md
+++ b/docs/stories/2026-04/REF-VAL-002-llm-arbiter-classification-strategy-pattern.story.md
@@ -3,7 +3,7 @@
 **Priority:** P2
 **Effort:** M (3-5 dias)
 **Squad:** @architect + @dev
-**Status:** Ready
+**Status:** InReview
 **Epic:** [EPIC-TD-2026Q2](EPIC-TD-2026Q2/)
 **Sprint:** Sprint 4
 **Dependências bloqueadoras:** Benchmark precision/recall ≥85%/≥70% test suite estável


### PR DESCRIPTION
## Summary
- Extract 4 classification tiers (keyword, llm_standard, llm_conservative, llm_zero_match) into Strategy pattern under `backend/llm_arbiter/strategies/`
- ABC `ClassificationStrategy` base with `classify()` interface
- Shared `run_llm_classification()` helper preserves bit-for-bit behaviour (cache, budget cap, error fallback, metrics labels)
- `classification.py` reduced 648 → 454 LOC; `classify_contract_primary_match` is now a ~50-line dispatcher delegating via `get_strategy(prompt_level)`
- Prompts stay centralized in `prompt_builder.py` (no duplication)
- New helper `select_strategy_by_density(density)` for upstream callers

## Testing Plan
- [x] `pytest backend/tests/test_llm_arbiter*.py` — 158 tests pass
- [x] Wider sweep (`test_crit_flt_002_arbiter_parallel`, `test_crit058`, `test_crit059`, `test_filter_cross_sector_fp`, `test_precision_recall_benchmark`) — 243 passed, 1 pre-existing xfailed
- [x] New `test_strategy_keyword.py` + `test_strategy_llm.py` — 23 tests covering registry, density mapping, no-LLM short-circuit, cache reuse, error fallback
- [x] Precision ≥85% / recall ≥70% benchmark preserved (`test_precision_recall_benchmark.py` still green)

## Closes
Closes REF-VAL-002