### PR TITLE
fix(frontend): resumo undefined crash — optional chaining on partial_data SSE

### DIFF
--- a/frontend/app/buscar/components/SearchFormActions.tsx
+++ b/frontend/app/buscar/components/SearchFormActions.tsx
@@ -56,7 +56,7 @@ export default function SearchFormActions({
         )}
       </Button>
 
-      {result && result.resumo.total_oportunidades > 0 && (
+      {result && (result.resumo?.total_oportunidades ?? 0) > 0 && (
         <Button
           onClick={handleSaveSearch}
           disabled={isMaxCapacity}

--- a/frontend/app/buscar/components/SearchResults.tsx
+++ b/frontend/app/buscar/components/SearchResults.tsx
@@ -131,7 +131,7 @@ export default function SearchResults(props: SearchResultsProps) {
 
   // DEBT-FE-023: Move focus to results heading when search completes and results are present
   useEffect(() => {
-    if (!loading && result && result.resumo.total_oportunidades > 0 && resultsHeadingRef.current) {
+    if (!loading && result && result.resumo?.total_oportunidades > 0 && resultsHeadingRef.current) {
       resultsHeadingRef.current.focus();
     }
   }, [loading, result?.resumo?.total_oportunidades]);
@@ -188,11 +188,11 @@ export default function SearchResults(props: SearchResultsProps) {
 
       {/* Empty/error states */}
       {!loading && result && result.response_state === "empty_failure" && <SourcesUnavailable onRetry={onSearch} onLoadLastSearch={onLoadLastSearch || (() => {})} hasLastSearch={!!hasLastSearch} retrying={loading} degradationGuidance={result.degradation_guidance} />}
-      {!loading && result && result.response_state !== "empty_failure" && result.response_state !== "degraded_expired" && result.is_partial && (result.total_raw || 0) === 0 && result.resumo.total_oportunidades === 0 && !result.cached && <SourcesUnavailable onRetry={onSearch} onLoadLastSearch={onLoadLastSearch || (() => {})} hasLastSearch={!!hasLastSearch} retrying={loading} degradationGuidance={result.degradation_guidance} />}
+      {!loading && result && result.response_state !== "empty_failure" && result.response_state !== "degraded_expired" && result.is_partial && (result.total_raw || 0) === 0 && (result.resumo?.total_oportunidades ?? 0) === 0 && !result.cached && <SourcesUnavailable onRetry={onSearch} onLoadLastSearch={onLoadLastSearch || (() => {})} hasLastSearch={!!hasLastSearch} retrying={loading} degradationGuidance={result.degradation_guidance} />}
       {!loading && result && result.response_state === "degraded_expired" && result.cached_at && <ExpiredCacheBanner cachedAt={result.cached_at} onRetry={onSearch} loading={loading} />}
-      {!loading && result && result.is_partial && (result.total_raw || 0) > 0 && result.resumo.total_oportunidades === 0 && <>{renderDataQualityBanner()}<SearchEmptyState onAdjustSearch={() => window.scrollTo({ top: 0, behavior: "smooth" })} rawCount={rawCount} stateCount={ufsSelecionadas.size} filterStats={result.filter_stats} sectorName={sectorName} emptyUfs={result.coverage_metadata?.ufs_empty} /></>}
+      {!loading && result && result.is_partial && (result.total_raw || 0) > 0 && (result.resumo?.total_oportunidades ?? 0) === 0 && <>{renderDataQualityBanner()}<SearchEmptyState onAdjustSearch={() => window.scrollTo({ top: 0, behavior: "smooth" })} rawCount={rawCount} stateCount={ufsSelecionadas.size} filterStats={result.filter_stats} sectorName={sectorName} emptyUfs={result.coverage_metadata?.ufs_empty} /></>}
       {/* CRIT-053 AC5: Contextual zero results — degraded sources get degradation message, not "nenhuma corresponde" */}
-      {!loading && result && result.resumo.total_oportunidades === 0 && result.sources_degraded && result.sources_degraded.length > 0 && result.response_state !== "empty_failure" && (
+      {!loading && result && (result.resumo?.total_oportunidades ?? 0) === 0 && result.sources_degraded && result.sources_degraded.length > 0 && result.response_state !== "empty_failure" && (
         <div className="mt-6 text-center py-10" data-testid="degraded-zero-results">
           {renderDataQualityBanner()}
           <div className="mt-6">
@@ -203,9 +203,9 @@ export default function SearchResults(props: SearchResultsProps) {
           </div>
         </div>
       )}
-      {!loading && result && !result.is_partial && result.response_state !== "empty_failure" && result.resumo.total_oportunidades === 0 && (!result.sources_degraded || result.sources_degraded.length === 0) && (result.total_filtrado === 0 && (result.total_raw || 0) > 0 ? <EmptyResults totalRaw={result.total_raw} sectorName={sectorName} ufCount={ufsSelecionadas.size} onScrollToTop={() => window.scrollTo({ top: 0, behavior: "smooth" })} /> : <ZeroResultsSuggestions sectorName={sectorName} ufCount={ufsSelecionadas.size} ufNames={Array.from(ufsSelecionadas)} dayRange={30} onAdjustPeriod={props.onAdjustPeriod} onAddNeighborStates={props.onAddNeighborStates} onChangeSector={() => window.scrollTo({ top: 0, behavior: "smooth" })} nearbyResultsCount={props.nearbyResultsCount} onViewNearbyResults={props.onViewNearbyResults} totalFromSources={result.total_raw} filterStats={result.filter_stats} />)}
+      {!loading && result && !result.is_partial && result.response_state !== "empty_failure" && (result.resumo?.total_oportunidades ?? 0) === 0 && (!result.sources_degraded || result.sources_degraded.length === 0) && (result.total_filtrado === 0 && (result.total_raw || 0) > 0 ? <EmptyResults totalRaw={result.total_raw} sectorName={sectorName} ufCount={ufsSelecionadas.size} onScrollToTop={() => window.scrollTo({ top: 0, behavior: "smooth" })} /> : <ZeroResultsSuggestions sectorName={sectorName} ufCount={ufsSelecionadas.size} ufNames={Array.from(ufsSelecionadas)} dayRange={30} onAdjustPeriod={props.onAdjustPeriod} onAddNeighborStates={props.onAddNeighborStates} onChangeSector={() => window.scrollTo({ top: 0, behavior: "smooth" })} nearbyResultsCount={props.nearbyResultsCount} onViewNearbyResults={props.onViewNearbyResults} totalFromSources={result.total_raw} filterStats={result.filter_stats} />)}
       {/* DEBT-FE-004: Pre-results info banners consolidated via BannerStack */}
-      {!loading && result && result.resumo.total_oportunidades === 0 && (
+      {!loading && result && (result.resumo?.total_oportunidades ?? 0) === 0 && (
         <SearchResultsBanners
           result={result}
           loading={loading}
@@ -222,7 +222,7 @@ export default function SearchResults(props: SearchResultsProps) {
       )}
 
       {/* === Results === */}
-      {!loading && result && result.resumo.total_oportunidades > 0 && (
+      {!loading && result && (result.resumo?.total_oportunidades ?? 0) > 0 && (
         <div className={`mt-6 sm:mt-8 space-y-4 sm:space-y-6 ${!showGrid ? 'animate-fade-in-up' : ''}`}>
           {trialPhase === "limited_access" && (
             <div className="p-3 rounded-card bg-gradient-to-r from-blue-600 to-purple-600 text-white flex items-center justify-between" data-testid="trial-paywall-banner" role="banner">

--- a/frontend/app/buscar/components/SearchResultsBanners.tsx
+++ b/frontend/app/buscar/components/SearchResultsBanners.tsx
@@ -63,7 +63,7 @@ export function SearchResultsBanners({
   const showDataQuality =
     !loading &&
     result.response_state !== "degraded_expired" &&
-    result.resumo.total_oportunidades > 0;
+    (result.resumo?.total_oportunidades ?? 0) > 0;
 
   if (showDataQuality) {
     banners.push({
@@ -125,7 +125,7 @@ export function SearchResultsBanners({
               : undefined
           }
           originalCount={0}
-          relaxedCount={result.resumo.total_oportunidades}
+          relaxedCount={result.resumo?.total_oportunidades ?? 0}
         />
       ),
     });

--- a/frontend/app/buscar/components/search-results/ResultCard.tsx
+++ b/frontend/app/buscar/components/search-results/ResultCard.tsx
@@ -72,48 +72,48 @@ export function ResultCard({
       <div className="flex flex-col sm:flex-row flex-wrap gap-4 sm:gap-8 mt-4 sm:mt-6">
         <div>
           <span className="text-3xl sm:text-4xl font-bold font-data tabular-nums text-brand-navy dark:text-brand-blue">
-            {result.resumo.total_oportunidades}
+            {(result.resumo?.total_oportunidades ?? 0)}
           </span>
-          <span className="text-sm sm:text-base text-ink-secondary block mt-1">{result.resumo.total_oportunidades === 1 ? 'licitação' : 'licitações'}</span>
+          <span className="text-sm sm:text-base text-ink-secondary block mt-1">{(result.resumo?.total_oportunidades ?? 0) === 1 ? 'licitação' : 'licitações'}</span>
         </div>
         <div>
           <span className="text-3xl sm:text-4xl font-bold font-data tabular-nums text-brand-navy dark:text-brand-blue">
-            {result.resumo.valor_total > 0 ? formatCurrencyBR(result.resumo.valor_total) : "Valor não divulgado"}
+            {(result.resumo?.valor_total ?? 0) > 0 ? formatCurrencyBR((result.resumo?.valor_total ?? 0)) : "Valor não divulgado"}
           </span>
-          <span className="text-sm sm:text-base text-ink-secondary block mt-1">{result.resumo.valor_total > 0 ? "valor total" : "valor não disponível nas fontes"}</span>
+          <span className="text-sm sm:text-base text-ink-secondary block mt-1">{(result.resumo?.valor_total ?? 0) > 0 ? "valor total" : "valor não disponível nas fontes"}</span>
         </div>
       </div>
 
       {/* AC11: Insight Setorial Banner */}
-      {result.resumo.insight_setorial && (
+      {result.resumo?.insight_setorial && (
         <div className="mt-4 sm:mt-6 p-3 sm:p-4 bg-brand-blue-subtle/50 border border-accent/30 rounded-card">
           <p className="text-sm sm:text-base text-ink-secondary leading-relaxed">
             <span className="font-semibold text-brand-navy dark:text-brand-blue">Contexto do setor: </span>
-            {result.resumo.insight_setorial}
+            {result.resumo?.insight_setorial}
           </p>
         </div>
       )}
 
       {/* AC12: Multiple Urgency Alerts */}
-      {result.resumo.alertas_urgencia && result.resumo.alertas_urgencia.length > 0 ? (
+      {result.resumo?.alertas_urgencia && result.resumo?.alertas_urgencia.length > 0 ? (
         <div className="mt-4 sm:mt-6 space-y-2" role="alert">
-          {result.resumo.alertas_urgencia.map((alerta, i) => (
+          {result.resumo?.alertas_urgencia.map((alerta, i) => (
             <div key={i} className="p-3 sm:p-4 bg-warning-subtle border border-warning/20 rounded-card">
               <p className="text-sm sm:text-base font-medium text-warning">{alerta}</p>
             </div>
           ))}
         </div>
-      ) : result.resumo.alerta_urgencia ? (
+      ) : result.resumo?.alerta_urgencia ? (
         <div className="mt-4 sm:mt-6 p-3 sm:p-4 bg-warning-subtle border border-warning/20 rounded-card" role="alert">
           <p className="text-sm sm:text-base font-medium text-warning">
             <span aria-hidden="true">Atenção: </span>
-            {result.resumo.alerta_urgencia}
+            {result.resumo?.alerta_urgencia}
           </p>
         </div>
       ) : null}
 
       {/* AC10 + UX-350 AC5-AC8: Recommendation Cards with strategic context */}
-      {result.resumo.recomendacoes && result.resumo.recomendacoes.length > 0 && (
+      {result.resumo?.recomendacoes && result.resumo?.recomendacoes.length > 0 && (
         <div className="mt-4 sm:mt-6">
           <h4 className="text-base sm:text-lg font-semibold font-display text-ink mb-3 sm:mb-4">Recomendações Estratégicas:</h4>
 
@@ -149,7 +149,7 @@ export function ResultCard({
           </p>
 
           <div className="space-y-3">
-            {result.resumo.recomendacoes.map((rec, i) => {
+            {result.resumo?.recomendacoes.map((rec, i) => {
               const matchedBid = result.licitacoes.find(l =>
                 rec.oportunidade && (
                   l.orgao && rec.oportunidade.includes(l.orgao) ||
@@ -212,11 +212,11 @@ export function ResultCard({
         </div>
       )}
 
-      {result.resumo.destaques && result.resumo.destaques.length > 0 && (
+      {result.resumo?.destaques && result.resumo?.destaques.length > 0 && (
         <div className="mt-4 sm:mt-6">
           <h4 className="text-base sm:text-lg font-semibold font-display text-ink mb-2 sm:mb-3">Destaques:</h4>
           <ul className="list-disc list-inside text-sm sm:text-base space-y-2 text-ink-secondary">
-            {result.resumo.destaques.map((d, i) => (
+            {result.resumo?.destaques.map((d, i) => (
               // eslint-disable-next-line local-rules/no-inline-styles -- DYNAMIC: animationDelay computed from index
               <li key={i} className="animate-fade-in-up" style={{ animationDelay: `${i * 60}ms` }}>{d}</li>
             ))}

--- a/frontend/app/buscar/components/search-results/ResultsFooter.tsx
+++ b/frontend/app/buscar/components/search-results/ResultsFooter.tsx
@@ -92,7 +92,7 @@ export function ResultsFooter({
       <div className="text-xs sm:text-sm text-ink-muted text-center space-y-1">
         {rawCount > 0 && (
           <p>
-            {result.resumo.total_oportunidades} {result.resumo.total_oportunidades === 1 ? 'oportunidade selecionada' : 'oportunidades selecionadas'} de {rawCount.toLocaleString("pt-BR")} analisadas
+            {(result.resumo?.total_oportunidades ?? 0)} {(result.resumo?.total_oportunidades ?? 0) === 1 ? 'oportunidade selecionada' : 'oportunidades selecionadas'} de {rawCount.toLocaleString("pt-BR")} analisadas
             {searchMode === "setor" && sectorName !== "Licitações" ? ` para o setor ${sectorName.toLowerCase()}` : ''}
             {result.sources_used && result.sources_used.length > 1 && (
               <span className="ml-1 cursor-help border-b border-dotted border-ink-faint" title={result.source_stats?.filter((s: { status: string }) => s.status === "success" || s.status === "partial").map((s: { source_code: string; record_count: number }) => `${s.source_code}: ${s.record_count} registros`).join('\n') || ''}>(dados de multiplas fontes)</span>
@@ -125,7 +125,7 @@ export function ResultsFooter({
       </div>
 
       {/* Post-search/download CTAs */}
-      {result.resumo.total_oportunidades >= 10 && <TrialUpsellCTA variant="post-search" planId={planInfo?.plan_id} subscriptionStatus={planInfo?.subscription_status} contextData={{ opportunities: result.resumo.total_oportunidades }} />}
+      {(result.resumo?.total_oportunidades ?? 0) >= 10 && <TrialUpsellCTA variant="post-search" planId={planInfo?.plan_id} subscriptionStatus={planInfo?.subscription_status} contextData={{ opportunities: result.resumo?.total_oportunidades ?? 0 }} />}
       {downloadCompleted && <TrialUpsellCTA variant="post-download" planId={planInfo?.plan_id} subscriptionStatus={planInfo?.subscription_status} contextData={{ exportLimit: planInfo?.capabilities.max_requests_per_month ?? 1000 }} />}
 
       <p className="text-center text-sm text-ink-muted py-2" data-testid="return-invitation">Novas oportunidades são publicadas diariamente. Volte amanhã para conferir.</p>

--- a/frontend/app/buscar/components/search-results/ResultsHeader.tsx
+++ b/frontend/app/buscar/components/search-results/ResultsHeader.tsx
@@ -33,7 +33,7 @@ export const ResultsHeader = forwardRef<HTMLHeadingElement, ResultsHeaderProps>(
       <div>
         <div className="flex items-center gap-2 flex-wrap">
           <h2 ref={ref} className="text-lg font-semibold text-ink" data-testid="results-header" tabIndex={-1}>
-            {result.resumo.total_oportunidades} {result.resumo.total_oportunidades === 1 ? 'oportunidade selecionada' : 'oportunidades selecionadas'}{rawCount > 0 ? ` de ${rawCount.toLocaleString("pt-BR")} analisadas` : ''}
+            {(result.resumo?.total_oportunidades ?? 0)} {(result.resumo?.total_oportunidades ?? 0) === 1 ? 'oportunidade selecionada' : 'oportunidades selecionadas'}{rawCount > 0 ? ` de ${rawCount.toLocaleString("pt-BR")} analisadas` : ''}
           </h2>
           {/* STORY-5.13 AC3: "Updated X min ago" freshness badge */}
           {(() => {
@@ -43,7 +43,7 @@ export const ResultsHeader = forwardRef<HTMLHeadingElement, ResultsHeaderProps>(
             return <FreshnessIndicator timestamp={ts} freshness={freshness} />;
           })()}
           {/* STORY-260 AC17: "Análise personalizada" badge when profile is complete */}
-          {isProfileComplete && result.resumo.total_oportunidades > 0 && (
+          {isProfileComplete && (result.resumo?.total_oportunidades ?? 0) > 0 && (
             <div
               className="inline-flex items-center gap-1 px-2 py-1 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 text-xs rounded-full"
               title="Resultados otimizados para o perfil da sua empresa"
@@ -58,7 +58,7 @@ export const ResultsHeader = forwardRef<HTMLHeadingElement, ResultsHeaderProps>(
         </div>
         {filterSummary && filterSummary.totalRaw > 0 && (
           <p className="text-sm text-ink-secondary mt-0.5" data-testid="filter-context-line">
-            Analisamos {filterSummary.totalRaw.toLocaleString("pt-BR")} oportunidades e selecionamos {result.resumo.total_oportunidades} {result.resumo.total_oportunidades === 1 ? 'compatível' : 'compatíveis'} com seu perfil
+            Analisamos {filterSummary.totalRaw.toLocaleString("pt-BR")} oportunidades e selecionamos {result.resumo?.total_oportunidades ?? 0} {(result.resumo?.total_oportunidades ?? 0) === 1 ? 'compatível' : 'compatíveis'} com seu perfil
             {/* C-02 AC9: Confidence distribution counts */}
             {(() => {
               const counts = { high: 0, medium: 0, low: 0 };

--- a/frontend/app/buscar/components/search-results/ResultsToolbar.tsx
+++ b/frontend/app/buscar/components/search-results/ResultsToolbar.tsx
@@ -127,7 +127,7 @@ export function ResultsToolbar({
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
                   </svg>
-                  Relatório PDF ({result.resumo.total_oportunidades} {result.resumo.total_oportunidades === 1 ? 'oportunidade' : 'oportunidades'})
+                  Relatório PDF ({(result.resumo?.total_oportunidades ?? 0)} {(result.resumo?.total_oportunidades ?? 0) === 1 ? 'oportunidade' : 'oportunidades'})
                 </>
               )}
             </button>
@@ -136,7 +136,7 @@ export function ResultsToolbar({
 
         {/* Opportunity count — right side */}
         <span className="text-sm text-[var(--ink-secondary)] sm:ml-auto whitespace-nowrap" data-testid="sticky-count">
-          {result.resumo.total_oportunidades} {result.resumo.total_oportunidades === 1 ? 'oportunidade' : 'oportunidades'}
+          {(result.resumo?.total_oportunidades ?? 0)} {(result.resumo?.total_oportunidades ?? 0) === 1 ? 'oportunidade' : 'oportunidades'}
         </span>
       </div>
 
@@ -233,7 +233,7 @@ function ExcelButton({
                  hover:bg-[var(--brand-blue-hover)]
                  disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       data-testid="excel-download-button"
-      aria-label={`Baixar Excel com ${result.resumo.total_oportunidades} licitações`}
+      aria-label={`Baixar Excel com ${(result.resumo?.total_oportunidades ?? 0)} licitações`}
     >
       {downloadLoading ? (
         <>
@@ -248,7 +248,7 @@ function ExcelButton({
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
           </svg>
-          Baixar Excel ({result.resumo.total_oportunidades} {result.resumo.total_oportunidades === 1 ? 'licitação' : 'licitações'})
+          Baixar Excel ({(result.resumo?.total_oportunidades ?? 0)} {(result.resumo?.total_oportunidades ?? 0) === 1 ? 'licitação' : 'licitações'})
         </>
       )}
     </button>

--- a/frontend/app/buscar/hooks/useSearchSSEHandler.ts
+++ b/frontend/app/buscar/hooks/useSearchSSEHandler.ts
@@ -252,7 +252,7 @@ export function useSearchSSEHandler(params: UseSearchSSEHandlerParams) {
           if (unique.length === 0) return prev;
           const merged = [...existing, ...unique];
           return {
-            ...(prev || {} as BuscaResult),
+            ...(prev || { resumo: { total_oportunidades: merged.length, resumo_executivo: '', valor_total: 0, outlier_count: 0, valor_sanitizado: false } } as BuscaResult),
             licitacoes: merged,
             total_filtrado: merged.length,
             is_partial: !event.detail?.is_final,

--- a/frontend/app/buscar/types/searchPhase.ts
+++ b/frontend/app/buscar/types/searchPhase.ts
@@ -84,14 +84,14 @@ export function deriveSearchPhase(input: SearchPhaseInput): SearchPhase {
       result.response_state !== "degraded_expired" &&
       result.is_partial &&
       (result.total_raw || 0) === 0 &&
-      result.resumo.total_oportunidades === 0 &&
+      (result.resumo?.total_oportunidades ?? 0) === 0 &&
       !result.cached
     ) {
       return "all_sources_failed";
     }
 
     // Zero results (legitimate — not source failure)
-    if (result.resumo.total_oportunidades === 0) return "empty_results";
+    if ((result.resumo?.total_oportunidades ?? 0) === 0) return "empty_results";
 
     // Source timeout — has results but some sources failed
     if (result.is_partial || (result.failed_ufs && result.failed_ufs.length > 0)) {


### PR DESCRIPTION
## Summary
- SSE `partial_data` event fires before LLM generates `resumo`, creating `BuscaResult` without the `resumo` field
- 9 components access `result.resumo.total_oportunidades` (and other resumo fields) without optional chaining
- Crash: "Cannot read properties of undefined (reading 'total_oportunidades')"

## Root Cause
Backend pipeline emits `partial_data` (stages `execute.py:329` / `filter_stage.py:372`) with partial licitacoes before LLM generates the executive summary. Frontend SSE handler creates a partial result via `{} as BuscaResult` spread, which has no `resumo` at runtime.

## Fix
- **Structural:** `useSearchSSEHandler.ts:254` — default `resumo` fallback when `prev` is null
- **Defensive:** `?.` + `?? 0` on all `result.resumo.*` accesses across 9 files (36 sites)

## Testing Plan
- [x] 132 tests pass (SearchResults, ResultCard, ResultsHeader, ResultsFooter, ResultsToolbar, searchPhase suites)
- [x] `tsc --noEmit` clean
- [ ] Manual: perform search, verify no crash during SSE partial_data → resumo arrival gap
- [ ] Manual: verify zero-results states render correctly

## Closes
N/A — hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced stability of search results display and analysis features to prevent potential crashes when viewing results, applying filters, and exporting analyses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->