### PR TITLE
fix: replace tiago@smartlic.tech with tiago.sasaki@confenge.com.br

### DIFF
--- a/.github/workflows/health-alert.yml
+++ b/.github/workflows/health-alert.yml
@@ -3,7 +3,7 @@ name: "Health alert (OPS-MTTR-001)"
 # Operationalises AC4 of issue #970: proactive alert when /health/ready returns
 # 5xx for >5min consecutively. Pragmatic implementation — runs every 5min and
 # emails on each failure (memory `reference_resend_personal_tone_send`: domain
-# smartlic.tech verified, from tiago@smartlic.tech).
+# confenge.com.br verified, from tiago.sasaki@confenge.com.br).
 #
 # Production rollout note: requires RESEND_API_KEY secret in repo settings.
 # Without it, the email step is skipped (workflow still flags the failure in logs).
@@ -48,7 +48,7 @@ jobs:
         run: |
           BODY=$(cat <<EOF
           {
-            "from": "tiago@smartlic.tech",
+            "from": "tiago.sasaki@confenge.com.br",
             "to": ["tiago.sasaki@gmail.com"],
             "reply_to": "tiago.sasaki@gmail.com",
             "subject": "[SmartLic] /health/ready returned ${STATUS}",

--- a/backend/services/trial_email_sequence.py
+++ b/backend/services/trial_email_sequence.py
@@ -28,9 +28,9 @@ _UNSUBSCRIBE_SECRET = os.getenv("WEBHOOK_SECRET", os.getenv("SECRET_KEY", "smart
 TIMEZONE_SCHEDULING_ENABLED = os.getenv("TIMEZONE_SCHEDULING_ENABLED", "true").lower() == "true"
 
 # EMAIL-TRIAL-006 (#1005): personal-tone send for trial sequence
-# Memory: Resend personal tone — tiago@smartlic.tech (verified domain) + reply-to gmail
+# Memory: Resend personal tone — tiago.sasaki@confenge.com.br (verified domain) + reply-to gmail
 TRIAL_EMAIL_FROM = os.getenv(
-    "TRIAL_EMAIL_FROM", "Tiago do SmartLic <tiago@smartlic.tech>"
+    "TRIAL_EMAIL_FROM", "Tiago do SmartLic <tiago.sasaki@confenge.com.br>"
 )
 TRIAL_EMAIL_REPLY_TO = os.getenv("TRIAL_EMAIL_REPLY_TO", "tiago.sasaki@gmail.com")
 
@@ -504,7 +504,7 @@ async def process_trial_emails(batch_size: int = 50) -> dict:
                         )
 
                         # Fire-and-forget send
-                        # EMAIL-TRIAL-006 (#1005): personal tone — from tiago@smartlic.tech
+                        # EMAIL-TRIAL-006 (#1005): personal tone — from tiago.sasaki@confenge.com.br
                         # + reply-to gmail (memory: reference_resend_personal_tone_send).
                         send_email_async(
                             to=email_addr,

--- a/backend/templates/emails/founders_welcome.py
+++ b/backend/templates/emails/founders_welcome.py
@@ -95,7 +95,7 @@ def render_founders_welcome_email(user_name: str) -> str:
           </p>
           <p style="color: #555; font-size: 14px; line-height: 1.6; margin: 0;">
             Sem letra miuda: e so responder este email (ou escrever para
-            <a href="mailto:tiago@smartlic.tech" style="color: {SMARTLIC_GREEN};">tiago@smartlic.tech</a>)
+            <a href="mailto:tiago.sasaki@confenge.com.br" style="color: {SMARTLIC_GREEN};">tiago.sasaki@confenge.com.br</a>)
             com o assunto <strong>"reembolso"</strong>. Retorno em ate 5 dias uteis.
           </p>
         </td>
@@ -157,7 +157,7 @@ de pagamento com o desconto aplicado direto para voce.
 
 Garantia de 60 dias - incondicional.
 Voce tem 60 dias pra usar a vontade. Se nao fizer sentido, devolvo R$997 cheios.
-Sem letra miuda: responda este email (ou escreva para tiago@smartlic.tech)
+Sem letra miuda: responda este email (ou escreva para tiago.sasaki@confenge.com.br)
 com o assunto "reembolso". Retorno em ate 5 dias uteis.
 
 Faca sua primeira busca agora: {FRONTEND_URL}/buscar

--- a/backend/tests/test_founders_welcome_email.py
+++ b/backend/tests/test_founders_welcome_email.py
@@ -73,7 +73,7 @@ class TestRenderFoundersWelcomeEmail:
         assert "reembolso" in html
         assert "5 dias uteis" in html
         # Contact channel
-        assert "tiago@smartlic.tech" in html
+        assert "tiago.sasaki@confenge.com.br" in html
         # No drift back to the legacy 7-day promise
         assert "garantia de 7 dias" not in html
 
@@ -87,7 +87,7 @@ class TestRenderFoundersWelcomeEmail:
         assert "R$997" in text
         assert "reembolso" in text
         assert "5 dias uteis" in text
-        assert "tiago@smartlic.tech" in text
+        assert "tiago.sasaki@confenge.com.br" in text
         assert "garantia de 7 dias" not in text
 
     def test_subject_constant(self):

--- a/backend/tests/test_trial_email_sequence.py
+++ b/backend/tests/test_trial_email_sequence.py
@@ -768,13 +768,13 @@ class TestEmailTrial006FoundersFetch:
 
 
 class TestEmailTrial006PersonalTone:
-    """EMAIL-TRIAL-006 (#1005): personal-tone send — from tiago@smartlic.tech + reply-to gmail."""
+    """EMAIL-TRIAL-006 (#1005): personal-tone send — from tiago.sasaki@confenge.com.br + reply-to gmail."""
 
     def test_constants_use_personal_tone(self):
         """Memory: reference_resend_personal_tone_send."""
         from services import trial_email_sequence
 
-        assert "smartlic.tech" in trial_email_sequence.TRIAL_EMAIL_FROM
+        assert "confenge.com.br" in trial_email_sequence.TRIAL_EMAIL_FROM
         assert "Tiago" in trial_email_sequence.TRIAL_EMAIL_FROM
         # Reply-to is gmail (where the founder actually answers)
         assert "@gmail.com" in trial_email_sequence.TRIAL_EMAIL_REPLY_TO

--- a/frontend/__tests__/fundadores/FundadoresClient.test.tsx
+++ b/frontend/__tests__/fundadores/FundadoresClient.test.tsx
@@ -97,9 +97,9 @@ describe('FundadoresClient', () => {
     });
   });
 
-  it('exposes the personal email tiago@smartlic.tech for refund + contact', () => {
+  it('exposes the personal email tiago.sasaki@confenge.com.br for refund + contact', () => {
     render(<FundadoresClient />);
-    const mailtos = screen.getAllByRole('link', { name: /tiago@smartlic\.tech/i });
+    const mailtos = screen.getAllByRole('link', { name: /tiago\.sasaki@confenge\.com\.br/i });
     expect(mailtos.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/app/fundadores/components/FundadoresFounderLetter.tsx
+++ b/frontend/app/fundadores/components/FundadoresFounderLetter.tsx
@@ -24,8 +24,8 @@ export default function FundadoresFounderLetter() {
               LinkedIn
             </a>
             {' · '}
-            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
-              tiago@smartlic.tech
+            <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 underline">
+              tiago.sasaki@confenge.com.br
             </a>
           </p>
         </div>
@@ -54,8 +54,7 @@ export default function FundadoresFounderLetter() {
           a CONFENGE. Hoje a plataforma indexa{' '}
           <strong>mais de 3,4 milhões de contratos públicos</strong>, monitora{' '}
           <strong>27 UFs em tempo real</strong>, classifica em{' '}
-          <strong>20 setores</strong> com IA, e está em produção (Railway + Supabase,
-          não é demo).
+          <strong>20 setores</strong> com IA, e está em produção.
         </p>
         <p className="mt-4">
           Eu poderia esperar mais 6 meses, dar polimento, lançar com pricing tradicional

--- a/frontend/app/fundadores/components/FundadoresGuarantee.tsx
+++ b/frontend/app/fundadores/components/FundadoresGuarantee.tsx
@@ -27,10 +27,10 @@ export default function FundadoresGuarantee() {
             <li>
               Envie um email para{' '}
               <a
-                href="mailto:tiago@smartlic.tech?subject=reembolso"
+                href="mailto:tiago.sasaki@confenge.com.br?subject=reembolso"
                 className="text-blue-700 underline font-medium"
               >
-                tiago@smartlic.tech
+                tiago.sasaki@confenge.com.br
               </a>{' '}
               com assunto <code className="bg-white px-1.5 py-0.5 rounded border border-slate-200">reembolso</code>.
             </li>

--- a/frontend/app/fundadores/components/FundadoresLegalFooter.tsx
+++ b/frontend/app/fundadores/components/FundadoresLegalFooter.tsx
@@ -11,8 +11,8 @@ export default function FundadoresLegalFooter() {
           Política de Privacidade
         </a>
         . Em caso de dúvida, escreva para{' '}
-        <a href="mailto:tiago@smartlic.tech" className="text-blue-600 underline">
-          tiago@smartlic.tech
+        <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 underline">
+          tiago.sasaki@confenge.com.br
         </a>
         .
       </p>

--- a/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
+++ b/frontend/app/fundadores/obrigado/FundadoresObrigadoClient.tsx
@@ -214,8 +214,8 @@ export function FundadoresObrigadoClient() {
           </p>
           <p className="text-sm text-gray-500 dark:text-gray-500">
             Dúvidas?{' '}
-            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 dark:text-blue-400 hover:underline">
-              tiago@smartlic.tech
+            <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 dark:text-blue-400 hover:underline">
+              tiago.sasaki@confenge.com.br
             </a>
           </p>
         </div>
@@ -237,8 +237,8 @@ export function FundadoresObrigadoClient() {
           </p>
           <p className="text-sm text-gray-500 dark:text-gray-500">
             Dúvidas? Fale conosco:{' '}
-            <a href="mailto:tiago@smartlic.tech" className="text-blue-600 dark:text-blue-400 hover:underline">
-              tiago@smartlic.tech
+            <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 dark:text-blue-400 hover:underline">
+              tiago.sasaki@confenge.com.br
             </a>
           </p>
         </div>
@@ -252,8 +252,8 @@ export function FundadoresObrigadoClient() {
       <div className="max-w-md text-center">
         <p className="text-gray-600 dark:text-gray-400">
           Algo deu errado. Entre em contato:{' '}
-          <a href="mailto:tiago@smartlic.tech" className="text-blue-600 hover:underline">
-            tiago@smartlic.tech
+          <a href="mailto:tiago.sasaki@confenge.com.br" className="text-blue-600 hover:underline">
+            tiago.sasaki@confenge.com.br
           </a>
         </p>
       </div>

--- a/frontend/app/termos/page.tsx
+++ b/frontend/app/termos/page.tsx
@@ -173,7 +173,7 @@ export default function TermosPage() {
                 <li>Você pode cancelar sua assinatura a qualquer momento através das configurações de conta</li>
                 <li>Cancelamentos terão efeito ao final do período de cobrança atual (não há reembolso proporcional)</li>
                 <li><strong>Garantia de Reembolso (assinaturas mensais e anuais):</strong> Planos pagos recorrentes têm garantia de 7 dias (reembolso integral se solicitado dentro deste período)</li>
-                <li><strong>Plano Fundadores (acesso vitalício):</strong> garantia incondicional de 60 dias a partir da data da compra. Para solicitar reembolso, envie um email para <a href="mailto:tiago@smartlic.tech" className="text-brand-blue underline">tiago@smartlic.tech</a> com o assunto <em>&quot;reembolso&quot;</em>. Retorno em até 5 dias úteis com devolução integral de R$ 997.</li>
+                <li><strong>Plano Fundadores (acesso vitalício):</strong> garantia incondicional de 60 dias a partir da data da compra. Para solicitar reembolso, envie um email para <a href="mailto:tiago.sasaki@confenge.com.br" className="text-brand-blue underline">tiago.sasaki@confenge.com.br</a> com o assunto <em>&quot;reembolso&quot;</em>. Retorno em até 5 dias úteis com devolução integral de R$ 997.</li>
                 <li>Fora dos períodos de garantia acima, não oferecemos reembolsos, exceto em casos excepcionais a nosso critério</li>
               </ul>
 


### PR DESCRIPTION
## Summary
- Replace all user-facing `tiago@smartlic.tech` → `tiago.sasaki@confenge.com.br`
- Pages: /fundadores, /fundadores/obrigado, /termos
- Email templates: founders_welcome (HTML + plain text), trial sequence FROM address
- Health alert workflow: from address updated
- Remove "(Railway + Supabase, não é demo)" from founder letter

## Testing Plan
- [ ] Verify /fundadores page renders with new email
- [ ] Verify /fundadores/obrigado page renders with new email
- [ ] Verify /termos page renders with new email
- [ ] Backend tests pass: `pytest tests/test_founders_welcome_email.py tests/test_trial_email_sequence.py -k "email or founders or personal"`
- [ ] Frontend tests pass: `npm test -- --testPathPattern="FundadoresClient"`

## Closes
- Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)