### PR TITLE
fix(pseo): funnel attribution + municipios ISR build timeout

### DIFF
--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -133,7 +133,14 @@ export default async function MunicipioSlugPage({ params }: Props) {
   // Validação básica de formato: apenas letras minúsculas, números e hífens
   if (!/^[a-z0-9-]+$/.test(slug)) notFound(); // adr-seo-001-allow: slug fails basic format check — not a valid municipio identifier
 
-  const profile = await fetchProfile(slug);
+  let profile: MunicipioProfile | null;
+  try {
+    profile = await fetchProfile(slug);
+  } catch {
+    // Transient fetch failure (timeout/5xx) during SSG build or ISR revalidation —
+    // render EmptyStateSEO so the build succeeds and ISR retries on next request.
+    profile = null;
+  }
   // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
   if (!profile) {
     return (


### PR DESCRIPTION
## Summary

- Adds funnel attribution: ref params, trial_created event, LeadCapture instrumentation
- Fixes frontend SSG build failure on Railway: transient fetch timeout in `/municipios/[slug]` page kills the entire build
- Email template + signup page copy updates for fundadores

## Testing Plan

- [x] Backend tests pass (stripe, trial emails, founders welcome)
- [x] Frontend tests pass (signup, fundadores, partners)
- [ ] Railway frontend build succeeds after merge
- [ ] `/municipios/uruguaiana-rs` renders EmptyStateSEO on transient timeout instead of crashing build

## Closes

fix/pseo-funnel-attribution-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of municipio profile pages by adding graceful error handling for transient network failures (timeouts, temporary server errors). The page now displays a fallback view instead of failing completely when fetch operations encounter these issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->