### PR TITLE
fix(ci): add -c flag to jq in LOC gate to prevent multi-line JSON SyntaxError

### DIFF
--- a/.github/workflows/audit-godmodule-loc.yml
+++ b/.github/workflows/audit-godmodule-loc.yml
@@ -162,8 +162,8 @@ jobs:
           echo "has_failures=${HAS_FAILURES}" >> "$GITHUB_OUTPUT"
           echo "has_warnings=${HAS_WARNINGS}" >> "$GITHUB_OUTPUT"
 
-          FAILURES_JSON=$(printf '%s\n' "${FAILURES[@]+"${FAILURES[@]}"}" | jq -Rs 'split("\n") | map(select(length > 0))')
-          WARNINGS_JSON=$(printf '%s\n' "${WARNINGS[@]+"${WARNINGS[@]}"}" | jq -Rs 'split("\n") | map(select(length > 0))')
+          FAILURES_JSON=$(printf '%s\n' "${FAILURES[@]+"${FAILURES[@]}"}" | jq -Rsc 'split("\n") | map(select(length > 0))')
+          WARNINGS_JSON=$(printf '%s\n' "${WARNINGS[@]+"${WARNINGS[@]}"}" | jq -Rsc 'split("\n") | map(select(length > 0))')
           echo "failures_json<<EOF" >> "$GITHUB_OUTPUT"
           echo "${FAILURES_JSON}" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

`jq` without `-c` produces pretty-printed multi-line JSON. When substituted into a JavaScript single-quoted string literal in `github-script`, this causes `SyntaxError: Invalid or unexpected token`.

Adding `-c` (compact) flag forces single-line JSON that embeds correctly.

## Testing Plan

- [x] Verified `jq -Rsc` produces single-line compact output
- [x] Workflow syntax valid (no YAML parse errors)

## Closes

N/A — CI infrastructure fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal workflow configuration for more efficient JSON output generation in automated processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1141)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->