### PR TITLE
fix(ci): filter .down.sql from migration check to prevent false positives

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -60,6 +60,8 @@ jobs:
               local = $1; gsub(/^[ \t]+|[ \t]+$/, "", local)
               remote = $2; gsub(/^[ \t]+|[ \t]+$/, "", remote)
               if (local == "") next
+              # Skip .down.sql rollback scripts — Supabase CLI 2.x lists them as separate migrations
+              if (local ~ /\.down/) next
               # Filter out stderr leakage (e.g. "Connecting to remote database...",
               # "Skipping migration README.md...") that lack pipe separators —
               # real migration rows always have a 14-digit timestamp in Local.

--- a/.github/workflows/migration-gate.yml
+++ b/.github/workflows/migration-gate.yml
@@ -44,7 +44,10 @@ jobs:
             NR > 2 {
               local = $1; gsub(/^[ \t]+|[ \t]+$/, "", local)
               remote = $2; gsub(/^[ \t]+|[ \t]+$/, "", remote)
-              if (local != "" && remote == "") print local
+              if (local == "") next
+              # Skip .down.sql rollback scripts — Supabase CLI 2.x lists them as separate migrations
+              if (local ~ /\.down/) next
+              if (remote == "") print local
             }
           ')
 


### PR DESCRIPTION
## Summary/Context

Supabase CLI 2.x trata arquivos `.down.sql` como migrations separadas, causando falso-positivo no CI "Migration Check (Post-Merge Alert)" e "Migration Gate (PR Warning)". O step "Check for unapplied migrations" reporta migrations não aplicadas que na verdade são rollback scripts.

**Fix:** Adiciona filtro `/.down/` no awk parser de ambos os workflows para ignorar arquivos `.down.sql` na listagem de migrations.

## Testing Plan

- [ ] CI "Migration Check" para de reportar `.down.sql` como unapplied
- [ ] CI "Migration Gate" para de warnar sobre `.down.sql` em PRs
- [ ] Migrations reais (`.sql` sem `.down`) continuam sendo detectadas

## Closes

Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated migration detection logic to correctly skip rollback script entries when validating applied migrations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1143)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->