### PR TITLE
fix(backend): improve CronMonitor diagnostics with schedule-aware stale thresholds

### DIFF
--- a/backend/jobs/cron/cron_monitor.py
+++ b/backend/jobs/cron/cron_monitor.py
@@ -26,6 +26,12 @@ logger = logging.getLogger(__name__)
 # Stale threshold: a daily cron that has not succeeded in >25h is suspect.
 STALE_AFTER_HOURS = 25
 
+# Schedule-aware thresholds for non-daily cron jobs.
+# The cron_job_health view retains a 7-day window of run_details, so weekly
+# and monthly jobs need proportionally longer windows to avoid false positives.
+_WEEKLY_STALE_HOURS = 8 * 24       # ~weekly + 1 day grace
+_MONTHLY_STALE_HOURS = 35 * 24     # ~monthly + grace
+
 # Run monitor every hour (3600s). Override via CRON_MONITOR_INTERVAL_S env var.
 CRON_MONITOR_INTERVAL_SECONDS = 3600
 
@@ -78,6 +84,56 @@ def _emit_sentry_alert(jobname: str, reason: str, row: dict[str, Any]) -> None:
         logger.warning("Failed to emit Sentry alert for %s: %s", jobname, exc)
 
 
+def _compute_stale_threshold_hours(schedule: str | None) -> float:
+    """Return a stale threshold proportional to the cron schedule interval.
+
+    Defaults to ``STALE_AFTER_HOURS`` (25h) for daily or more-frequent
+    schedules.  Returns larger thresholds for weekly and monthly cron jobs so
+    that the monitor does not fire false-positive ``stale`` alerts between
+    intended runs.
+
+    Recognised patterns (all others fall back to the default):
+    * ``dom != '*'`` (specific day-of-month) → monthly
+    * ``dom startswith '*/'`` (every N days) → N days
+    * ``dow != '*'`` (specific day-of-week) → weekly
+    * ``dow startswith '*/'`` (every N weeks) → N weeks
+    """
+    if not schedule:
+        return STALE_AFTER_HOURS
+
+    parts = schedule.strip().split()
+    if len(parts) != 5:
+        return STALE_AFTER_HOURS
+
+    _minute, _hour, dom, _month, dow = parts
+
+    # Specific day-of-month (e.g. ``0 2 1 * *`` → 1st of month).
+    if dom != "*" and not dom.startswith("*/") and "," not in dom:
+        return _MONTHLY_STALE_HOURS
+
+    # Every-N-days (e.g. ``0 2 */3 * *``).
+    if dom.startswith("*/"):
+        try:
+            n = int(dom[2:])
+            return float((n + 1) * 24)
+        except ValueError:
+            pass
+
+    # Specific day-of-week (e.g. ``30 6 * * 0`` → Sundays only).
+    if dow != "*" and not dow.startswith("*/") and "," not in dow:
+        return _WEEKLY_STALE_HOURS
+
+    # Every-N-weeks (e.g. ``30 6 * * */2``).
+    if dow.startswith("*/"):
+        try:
+            n = int(dow[2:])
+            return float((n * 7 + 1) * 24)
+        except ValueError:
+            pass
+
+    return STALE_AFTER_HOURS
+
+
 def evaluate_jobs(rows: Iterable[dict[str, Any]], *, now: datetime | None = None) -> list[dict[str, Any]]:
     """Return a list of ``{jobname, reason, row}`` entries for offending jobs.
 
@@ -90,6 +146,12 @@ def evaluate_jobs(rows: Iterable[dict[str, Any]], *, now: datetime | None = None
         if not isinstance(row, dict):
             continue
         jobname = row.get("jobname") or "<unknown>"
+
+        # Skip intentionally disabled jobs (active = False).
+        active = row.get("active")
+        if active is False:
+            continue
+
         last_status = (row.get("last_status") or "").lower()
         last_run_at = _parse_ts(row.get("last_run_at"))
 
@@ -97,7 +159,22 @@ def evaluate_jobs(rows: Iterable[dict[str, Any]], *, now: datetime | None = None
             problems.append({"jobname": jobname, "reason": "last_status=failed", "row": row})
             continue
 
-        if _is_stale(last_run_at, current):
+        # Schedule-aware stale threshold prevents false positives for
+        # weekly / monthly jobs (e.g. bloat-check-pncp-raw-bids runs
+        # Sundays only; cleanup-trial-email-log runs on the 1st of month).
+        stale_hours = _compute_stale_threshold_hours(row.get("schedule"))
+        if last_run_at is None:
+            # No runs in the 7-day health view window.
+            # For daily+ jobs = definitely stale.  For longer-interval
+            # jobs the 7-day window may simply not contain a run that
+            # happened within the expected interval → skip to avoid
+            # false-positive alerts.
+            if stale_hours <= STALE_AFTER_HOURS:
+                problems.append({"jobname": jobname, "reason": "stale", "row": row})
+            continue
+
+        delta_hours = (current - last_run_at).total_seconds() / 3600.0
+        if delta_hours > stale_hours:
             problems.append({"jobname": jobname, "reason": "stale", "row": row})
 
     return problems
@@ -128,6 +205,11 @@ async def run_cron_monitor() -> dict:
         len(rows),
         len(problems),
     )
+    if problems:
+        logger.warning(
+            "[CronMonitor] Problem jobs: %s",
+            [{"jobname": p["jobname"], "reason": p["reason"]} for p in problems],
+        )
     return {
         "status": "ok",
         "jobs_checked": len(rows),
@@ -183,16 +265,25 @@ async def cron_monitoring_job(ctx: dict) -> dict:
         _fire_sentry_alert(p["jobname"], p["reason"], p["row"])
 
     duration_s = round(time.monotonic() - start, 2)
-    logger.info(
-        "[CronMonitor] Evaluated %d jobs, %d problems in %ss",
-        len(rows),
-        len(problems),
-        duration_s,
-    )
+    problem_names = [p["jobname"] for p in problems]
+    if problems:
+        logger.warning(
+            "[CronMonitor] Evaluated %d jobs, %d problems in %ss: %s",
+            len(rows),
+            len(problems),
+            duration_s,
+            problem_names,
+        )
+    else:
+        logger.info(
+            "[CronMonitor] Evaluated %d jobs, 0 problems in %ss",
+            len(rows),
+            duration_s,
+        )
     return {
         "status": "completed",
         "evaluated": len(rows),
         "problems": len(problems),
-        "problem_jobs": [p["jobname"] for p in problems],
+        "problem_jobs": problem_names,
         "duration_s": duration_s,
     }


### PR DESCRIPTION
## Summary/Context

Worker ARQ log: `'evaluated': 24, 'problems': 7, 'problem_jobs': ['bloat...` (truncado). CronMonitor reportava 7 jobs problemáticos — mas pelo menos 3 eram falso-positivos do threshold fixo de 25h para jobs não-diários.

**Diagnóstico dos 7 jobs reportados:**
- `bloat-check-pncp-raw-bids` — job semanal, threshold 25h flaggava ~6/7 dias entre execuções
- `cleanup-trial-email-log` — job mensal (dia 1), janela de 7d do `cron_job_health` não continha última execução
- `cleanup-audit-events` — job mensal (dia 1), mesmo padrão
- Demais 4: possíveis falhas reais ou outros jobs não-diários

**Fix (99 linhas):**
1. `_compute_stale_threshold_hours()` — parse do cron expression para thresholds adaptativos: diário=25h, semanal=8d, mensal=35d
2. Filtro de jobs inativos (`active=False`) — jobs desabilitados não geram mais alerta
3. Lógica view-window-aware — jobs sem `last_run_at` na janela de 7d não são flaggados como stale
4. Logging melhorado — `WARNING` com nome e motivo individual de cada job problemático (antes era `INFO` truncado)

## Testing Plan

- [ ] CronMonitor próximo ciclo reporta ≤4 problemas (não 7)
- [ ] Jobs semanais/mensais não são mais flaggados como stale entre execuções
- [ ] ARQ logs mostram nomes completos dos jobs problemáticos (sem truncamento)
- [ ] `cron_monitoring_job` continua reportando jobs realmente falhos

## Closes

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Cron job health monitoring now applies schedule-aware thresholds when evaluating job staleness, accounting for different scheduling frequencies
* Inactive jobs are now properly excluded from health monitoring
* Enhanced logging provides detailed warnings about problematic jobs and specific conditions detected

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->