### PR TITLE
fix(frontend): remover sufixo "| SmartLic" duplicado no title de páginas blog (#1190)

### DIFF
--- a/frontend/app/blog/author/[slug]/page.tsx
+++ b/frontend/app/blog/author/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   const author = getAuthorBySlug(slug);
   if (!author) return {};
 
-  const title = `${author.name} — ${author.role} | SmartLic`;
+  const title = `${author.name} — ${author.role}`;
   const description = author.shortBio;
 
   return {

--- a/frontend/app/blog/licitacoes-do-dia/[date]/page.tsx
+++ b/frontend/app/blog/licitacoes-do-dia/[date]/page.tsx
@@ -124,7 +124,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!data) {
     const isValidDate = /^\d{4}-\d{2}-\d{2}$/.test(date);
     return {
-      title: isValidDate ? `Sem licitacoes publicadas em ${date} | SmartLic` : 'Digest Diario',
+      title: isValidDate ? `Sem licitacoes publicadas em ${date}` : 'Digest Diario',
       robots: { index: false, follow: false },
       alternates: isValidDate ? { canonical: buildCanonical(`/blog/licitacoes-do-dia/${date}`) } : undefined,
     };

--- a/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
@@ -145,7 +145,7 @@ export async function generateMetadata({
   );
   if (total === 0 && totalContracts === 0) {
     return {
-      title: `Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} | SmartLic`,
+      title: `Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`,
       description: `Licitações de ${sector.name.toLowerCase()} ${getUfPrep(ufUpper)} ${ufName}.`,
       robots: { index: false, follow: false },
       alternates: { canonical: canonicalUrl },

--- a/frontend/app/blog/licitacoes/cidade/[cidade]/[setor]/page.tsx
+++ b/frontend/app/blog/licitacoes/cidade/[cidade]/[setor]/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({
   const { cidade, setor } = await params;
   const city = getCityBySlug(cidade);
   const sector = getSectorBySlug(setor);
-  if (!city || !sector) return { title: 'Página não encontrada | SmartLic' };
+  if (!city || !sector) return { title: 'Página não encontrada' };
 
   const stats = await fetchCidadeSectorStats(city.slug, sector.id);
   const total = stats?.total_editais ?? 0;
@@ -74,7 +74,7 @@ export async function generateMetadata({
 
   const title = `Licitações de ${sector.name} em ${city.name}/${city.uf}${
     total > 0 ? ` — ${total} editais` : ''
-  } | SmartLic`;
+  }`;
   const description =
     `Encontre licitações de ${sector.name.toLowerCase()} em ${city.name} (${ufName}). ` +
     `${total > 0 ? `${total} editais ativos nos últimos 10 dias. ` : ''}` +

--- a/frontend/app/blog/licitacoes/cidade/[cidade]/page.tsx
+++ b/frontend/app/blog/licitacoes/cidade/[cidade]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { cidade } = await params;
   const city = getCityBySlug(cidade);
-  if (!city) return { title: 'Cidade não encontrada | SmartLic' };
+  if (!city) return { title: 'Cidade não encontrada' };
 
   // AC1: fetch bids + contracts in parallel
   const [stats, contractsMeta] = await Promise.all([
@@ -66,7 +66,7 @@ export async function generateMetadata({
 
   const title = `Licitações em ${city.name}/${city.uf}${
     total > 0 ? ` — ${total} editais abertos ${year}` : ` — Editais ${year}`
-  } | SmartLic`;
+  }`;
 
   // AC7: enrich description with contract count when available
   let description =

--- a/frontend/app/blog/programmatic/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/[uf]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata({
   const minBids = parseInt(process.env.MIN_ACTIVE_BIDS_FOR_INDEX ?? '5', 10);
   if (total < minBids) {
     return {
-      title: `Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName} | SmartLic`,
+      title: `Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}`,
       description: `Licitações de ${sector.name} ${getUfPrep(ufUpper)} ${ufName}. Dados do PNCP atualizados diariamente.`,
       robots: { index: false, follow: false },
       // SEO-440: canonical self-referencial evita herdar o canonical da homepage (layout.tsx)


### PR DESCRIPTION
## Summary
Remove `| SmartLic` hardcoded dos títulos em `generateMetadata()` de 6 páginas blog/pSEO. O layout template (`%s | SmartLic.tech`) já aplica o sufixo automaticamente, eliminando a duplicação.

## Testing Plan
- [ ] Verificar que nenhum `generateMetadata()` nas 6 páginas contém `| SmartLic` no campo `title`
- [ ] Rodar `npm run lint` no frontend
- [ ] Deploy e verificar `<title>` sem duplicação

## Closes
Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)