### PR TITLE
fix(backend): migrar sitemap_fornecedores queries para sb_execute() (#1176)

### DIFF
--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -289,7 +289,7 @@ async def sitemap_fornecedores_cnpj(response: Response):
     _fresh_fetch = True
     try:
         data = await _run_with_budget(
-            asyncio.to_thread(_fetch_top_fornecedores_cnpjs),
+            _fetch_top_fornecedores_cnpjs(),
             budget=_BUDGET_S,
             phase="route",
             source="sitemap_cnpjs.sitemap_fornecedores_cnpj",
@@ -353,26 +353,27 @@ async def sitemap_fornecedores_cnpj(response: Response):
     return SitemapFornecedoresCnpjResponse(**data)
 
 
-def _fetch_top_fornecedores_cnpjs() -> dict:
+async def _fetch_top_fornecedores_cnpjs() -> dict:
     """Busca os CNPJs de fornecedores mais ativos em mv_sitemap_fornecedores.
 
     SEO-SITEMAP-MV-001: MV pré-agregada substitui paginated scan de
     pncp_supplier_contracts. Query < 50ms.
+
+    Async com sb_execute() para retry HTTP/2 (SEN-BE-004).
     """
     try:
-        from supabase_client import get_supabase
+        from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
 
         rows: list[str] = []
         page_size = 1000
         offset = 0
         while True:
-            resp = (
+            resp = await sb_execute(
                 sb.table("mv_sitemap_fornecedores")
                 .select("cnpj")
                 .order("cnpj")
                 .range(offset, offset + page_size - 1)
-                .execute()
             )
             if not resp.data:
                 break


### PR DESCRIPTION
## Summary
Migra `_fetch_top_fornecedores_cnpjs()` de sync `.execute()` para async `sb_execute()` com retry HTTP/2 (SEN-BE-004), eliminando falhas por `ConnectionTerminated` no sitemap de fornecedores.

## Testing Plan
- [ ] `pytest tests/ -k "sitemap"` passa (85 passed)
- [ ] Verificar que a função é async e usa sb_execute
- [ ] Deploy e validar que `/v1/sitemap/fornecedores-cnpj` retorna dados

## Closes
Closes #1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JavaScript bundle size limit for upcoming enhancements.

* **Refactor**
  * Optimized sitemap generation with improved data-fetching performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1195)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->