### PR TITLE
fix(backend): migrar SEO public routes batch 2 para sb_execute() (#1180)

### DIFF
--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -25,7 +25,6 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from sectors import SECTORS, SectorConfig
-from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/blog/stats", tags=["blog-stats"])
@@ -907,20 +906,18 @@ def _safe_float_blog(val) -> float:
         return 0.0
 
 
-def _query_contratos_sync(
+async def _query_contratos_data(
     *,
     uf: Optional[str] = None,
     municipio_pattern: Optional[str] = None,
 ) -> list[dict]:
-    """Sync Supabase query against pncp_supplier_contracts.
+    """Async Supabase query against pncp_supplier_contracts with sb_execute.
 
-    Must run inside ``asyncio.to_thread(...)`` — the supabase-py client uses
-    blocking httpx and will wedge the event loop otherwise. The 2026-04-27
-    Stage 3 outage was caused by this function being called directly from
-    an async handler with no thread-offload; a single 30s ``ilike`` on
-    municipio froze ``/health/live`` for every Railway proxy probe.
+    Uses sb_execute for HTTP/2 retry (SEN-BE-004) and circuit breaker
+    (STORY-291/416) instead of the old synchronous paginate_full.
     """
-    from supabase_client import get_supabase
+    from supabase_client import get_supabase, sb_execute
+
     sb = get_supabase()
 
     query = (
@@ -943,14 +940,23 @@ def _query_contratos_sync(
     # silently truncating to 1000 rows, which broke /blog/stats/* pillar
     # pages for high-volume sectors / large UFs (top_orgaos, top_fornecedores
     # and monthly_trend were computed off a 1000-row sample — wrong totals).
+    # SEN-BE-004: async pagination with sb_execute (HTTP/2 retry).
     builder = query.order("data_assinatura", desc=True)
-    return paginate_full(
-        builder,
-        batch_size=1000,
-        max_total=10_000,
-        route="blog_stats.contratos",
-        entity_type="pncp_supplier_contracts",
-    )
+    rows: list[dict] = []
+    batch_size = 1000
+    max_total = 10_000
+    offset = 0
+    while len(rows) < max_total:
+        end = offset + batch_size - 1
+        resp = await sb_execute(builder.range(offset, end))
+        batch = resp.data or []
+        if not batch:
+            break
+        rows.extend(batch)
+        if len(batch) < batch_size:
+            break
+        offset += batch_size
+    return rows[:max_total]
 
 
 def _empty_contratos_stats() -> dict:
@@ -999,8 +1005,7 @@ async def _compute_contratos_stats(
 
     try:
         rows = await _run_with_budget(
-            asyncio.to_thread(
-                _query_contratos_sync,
+            _query_contratos_data(
                 uf=uf,
                 municipio_pattern=municipio_pattern,
             ),

--- a/backend/routes/comparador.py
+++ b/backend/routes/comparador.py
@@ -20,7 +20,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
-from supabase_client import get_supabase
+from supabase_client import get_supabase, sb_execute
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/comparador", tags=["comparador"])
@@ -165,12 +165,10 @@ async def get_bids_by_ids(
     # Query supabase directly for exact pncp_id matches
     try:
         sb = get_supabase()
-
-        def _sync_query():
-            return sb.table("pncp_raw_bids").select("*").in_("pncp_id", id_list).execute()
-
         result = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+            sb_execute(
+                sb.table("pncp_raw_bids").select("*").in_("pncp_id", id_list)
+            ),
             budget=5.0,
             phase="route",
             source="comparador.comparador_bids",

--- a/backend/routes/compliance_publicos.py
+++ b/backend/routes/compliance_publicos.py
@@ -171,30 +171,28 @@ async def compliance_profile(cnpj: str):
 
 async def _fetch_razao_social(cnpj: str) -> str:
     """Tenta obter a razao social de enriched_entities (Supabase) ou BrasilAPI."""
-    # 1. enriched_entities — RES-BE-015: ``_run_with_budget`` + ``to_thread``
+    # 1. enriched_entities — RES-BE-015: ``_run_with_budget`` + ``sb_execute``
     # so the sync supabase-py client never blocks the event loop and any
     # saturation increments
     # ``smartlic_pipeline_budget_exceeded_total{phase=route,source=compliance_publicos.razao_social}``.
-    def _sync_query() -> list[dict]:
-        from supabase_client import get_supabase
-        sb = get_supabase()
-        resp = (
-            sb.table("enriched_entities")
-            .select("data")
-            .eq("entity_type", "fornecedor")
-            .eq("entity_id", cnpj)
-            .limit(1)
-            .execute()
-        )
-        return resp.data or []
-
+    # SEN-BE-004: HTTP/2 retry via sb_execute.
     try:
-        rows = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        resp = await _run_with_budget(
+            sb_execute(
+                sb.table("enriched_entities")
+                .select("data")
+                .eq("entity_type", "fornecedor")
+                .eq("entity_id", cnpj)
+                .limit(1)
+            ),
             budget=_RAZAO_SOCIAL_QUERY_BUDGET_S,
             phase="route",
             source="compliance_publicos.razao_social",
         )
+        rows = resp.data or []
         if rows:
             data = rows[0].get("data") or {}
             nome = data.get("razao_social") or ""

--- a/backend/routes/indice_municipal.py
+++ b/backend/routes/indice_municipal.py
@@ -256,11 +256,11 @@ async def get_municipio(
 
     # Busca no banco primeiro
     try:
-        from supabase_client import get_supabase
-        sb = get_supabase()
+        from supabase_client import get_supabase, sb_execute
 
-        def _sync_query():
-            return (
+        sb = get_supabase()
+        resp = await _run_with_budget(
+            sb_execute(
                 sb.table("indice_municipal")
                 .select("*")
                 .eq("uf", uf)
@@ -268,11 +268,7 @@ async def get_municipio(
                 .ilike("municipio_nome", f"%{municipio_part.replace('-', '%')}%")
                 .order("score_total", desc=True)
                 .limit(1)
-                .execute()
-            )
-
-        resp = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+            ),
             budget=5.0,
             phase="route",
             source="indice_municipal.get_indice_municipio",

--- a/backend/routes/itens_publicos.py
+++ b/backend/routes/itens_publicos.py
@@ -25,8 +25,6 @@ from fastapi import APIRouter, HTTPException, Response
 from pipeline.budget import _run_with_budget
 from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
 from pydantic import BaseModel
-from utils.postgrest_paginate import paginate_full
-
 from metrics import record_sitemap_count
 
 logger = logging.getLogger(__name__)
@@ -428,15 +426,16 @@ async def _fetch_price_data(nome_item: str) -> tuple[list[float], list[dict]]:
     """Busca contratos do PNCP que contenham o nome do item no objeto.
 
     Retorna (lista_de_valores, top_10_contratos_referencia).
-    Encapsula o .execute() síncrono em asyncio.to_thread para não bloquear
-    o event loop (vide Stage 8 outage 2026-04-30).
+    Usa sb_execute async com paginação via .range() (DATA-CAP-001) e
+    retry HTTP/2 (SEN-BE-004).
     """
     palavras = [p for p in nome_item.lower().split() if len(p) >= 4][:2]
     if not palavras:
         return [], []
 
-    def _sync_fetch() -> list[dict]:
-        from supabase_client import get_supabase
+    async def _async_fetch() -> list[dict]:
+        from supabase_client import get_supabase, sb_execute
+
         sb = get_supabase()
         # DATA-CAP-001: previously a bare ``.limit(1000).execute()`` which
         # is exactly the silent-cap boundary — for very common keywords
@@ -451,17 +450,26 @@ async def _fetch_price_data(nome_item: str) -> tuple[list[float], list[dict]]:
             .eq("is_active", True)
             .order("data_assinatura", desc=True)
         )
-        return paginate_full(
-            builder,
-            batch_size=1000,
-            max_total=5000,
-            route="itens_publicos.fetch_price_data",
-            entity_type="pncp_supplier_contracts",
-        )
+        # SEN-BE-004: async pagination with sb_execute (HTTP/2 retry).
+        rows: list[dict] = []
+        batch_size = 1000
+        max_total = 5000
+        offset = 0
+        while len(rows) < max_total:
+            end = offset + batch_size - 1
+            resp = await sb_execute(builder.range(offset, end))
+            batch = resp.data or []
+            if not batch:
+                break
+            rows.extend(batch)
+            if len(batch) < batch_size:
+                break
+            offset += batch_size
+        return rows[:max_total]
 
     try:
         rows = await _run_with_budget(
-            asyncio.to_thread(_sync_fetch),
+            _async_fetch(),
             budget=_PRICE_QUERY_BUDGET_S,
             phase="route",
             source="itens_publicos.fetch_price_data",

--- a/backend/tests/test_blog_stats_budget.py
+++ b/backend/tests/test_blog_stats_budget.py
@@ -53,7 +53,7 @@ class TestContratosBudget:
 
         with patch.object(
             bs,
-            "_query_contratos_sync",
+            "_query_contratos_data",
             side_effect=_slow_sync_execute,
         ):
             # Patch budget down to keep test fast — fix still proves the
@@ -101,7 +101,7 @@ class TestContratosBudget:
             ttl=bs._CACHE_TTL_SECONDS,
         )
 
-        with patch.object(bs, "_query_contratos_sync") as mock_query:
+        with patch.object(bs, "_query_contratos_data") as mock_query:
             resp = client.get("/v1/blog/stats/contratos/informatica")
 
         assert resp.status_code == 200
@@ -116,7 +116,7 @@ class TestComputeContratosStatsAsync:
     def test_timeout_returns_partial_true(self):
         from routes import blog_stats as bs
 
-        with patch.object(bs, "_query_contratos_sync", side_effect=_slow_sync_execute):
+        with patch.object(bs, "_query_contratos_data", side_effect=_slow_sync_execute):
             with patch.object(bs, "_CONTRATOS_QUERY_BUDGET_S", 0.1):
                 data, partial = asyncio.run(bs._compute_contratos_stats())
 
@@ -129,7 +129,7 @@ class TestComputeContratosStatsAsync:
 
         with patch.object(
             bs,
-            "_query_contratos_sync",
+            "_query_contratos_data",
             side_effect=RuntimeError("supabase pool exhausted"),
         ):
             data, partial = asyncio.run(bs._compute_contratos_stats())
@@ -152,7 +152,7 @@ class TestComputeContratosStatsAsync:
                 "uf": "SP",
             },
         ]
-        with patch.object(bs, "_query_contratos_sync", return_value=rows):
+        with patch.object(bs, "_query_contratos_data", return_value=rows):
             data, partial = asyncio.run(bs._compute_contratos_stats())
 
         assert partial is False


### PR DESCRIPTION
## Summary
Migra compliance_publicos, indice_municipal, itens_publicos, comparador, blog_stats de sync `.execute()` para async `sb_execute()` com retry HTTP/2 (SEN-BE-004).

## Testing Plan
- [x] `pytest tests/ -k "compliance or indice_municipal or itens or comparador or blog_stats"` passa
- [x] Nenhum `.execute()` restante nos 5 arquivos
- [ ] Deploy e validar endpoints SEO públicos

## Closes
Closes #1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)