### PR TITLE
fix(backend): migrar sitemap routes restantes para sb_execute() (#1181)

### DIFF
--- a/backend/routes/sitemap_licitacoes.py
+++ b/backend/routes/sitemap_licitacoes.py
@@ -270,7 +270,7 @@ async def _compute_contracts_combos(threshold: int) -> list[dict]:
     event loop e causam timeout em todos os outros endpoints.
     """
     try:
-        from supabase_client import get_supabase
+        from supabase_client import get_supabase, sb_execute
         from sectors import SECTORS
     except ImportError:
         logger.warning("sitemap_licitacoes: importações de contracts não disponíveis")
@@ -290,12 +290,10 @@ async def _compute_contracts_combos(threshold: int) -> list[dict]:
         """Chama RPC count_contracts_by_setor_uf para um par (setor, uf)."""
         async with _sem:
             try:
-                resp = await asyncio.to_thread(
-                    lambda: sb.rpc(
+                resp = await sb_execute(sb.rpc(
                         "count_contracts_by_setor_uf",
                         {"p_keywords": keywords, "p_uf": uf},
-                    ).execute()
-                )
+                    ))
                 count = resp.data if isinstance(resp.data, int) else 0
                 return setor_id, uf, count
             except Exception as e:

--- a/backend/routes/sitemap_licitacoes_do_dia.py
+++ b/backend/routes/sitemap_licitacoes_do_dia.py
@@ -85,7 +85,7 @@ async def sitemap_licitacoes_do_dia_indexable(response: Response):
 
     try:
         data = await _run_with_budget(
-            asyncio.to_thread(_fetch_indexable_dates),
+            _fetch_indexable_dates(),
             budget=_BUDGET_S,
             phase="route",
             source="sitemap_licitacoes_do_dia.sitemap_licitacoes_do_dia_indexable",
@@ -127,7 +127,7 @@ async def sitemap_licitacoes_do_dia_indexable(response: Response):
     return SitemapLicitacoesDoDiaResponse(**data)
 
 
-def _fetch_indexable_dates() -> dict:
+async def _fetch_indexable_dates() -> dict:
     """Scan pncp_raw_bids janela 30d, conta por data, filtra HAVING >=5.
 
     Implementa client-side aggregation: paginated fetch de data_publicacao
@@ -137,8 +137,7 @@ def _fetch_indexable_dates() -> dict:
     cache TTL 1h reduz para 1x/h por worker.
     """
     try:
-        from supabase_client import get_supabase
-
+        from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
 
         cutoff = (datetime.now(timezone.utc) - timedelta(days=_WINDOW_DAYS)).date().isoformat()
@@ -149,14 +148,13 @@ def _fetch_indexable_dates() -> dict:
         page_count = 0
 
         while True:
-            resp = (
+            resp = await sb_execute(
                 sb.table("pncp_raw_bids")
                 .select("data_publicacao")
                 .eq("is_active", True)
                 .gte("data_publicacao", cutoff)
                 .not_.is_("data_publicacao", "null")
                 .range(offset, offset + page_size - 1)
-                .execute()
             )
             page_count += 1
             if not resp.data:

--- a/backend/routes/sitemap_orgaos.py
+++ b/backend/routes/sitemap_orgaos.py
@@ -79,7 +79,7 @@ async def sitemap_orgaos(response: Response):
     _fresh_fetch = False
     try:
         data = await _run_with_budget(
-            asyncio.to_thread(_fetch_top_orgaos),
+            _fetch_top_orgaos(),
             budget=_BUDGET_S,
             phase="route",
             source="sitemap_orgaos.sitemap_orgaos",
@@ -148,27 +148,25 @@ async def sitemap_orgaos(response: Response):
     return SitemapOrgaosResponse(**data)
 
 
-def _fetch_top_orgaos() -> dict:
+async def _fetch_top_orgaos() -> dict:
     """Query mv_sitemap_orgaos for orgao_cnpj com ≥5 licitações em 12 meses.
 
     SEO-SITEMAP-MV-001: MV pré-agregada substitui RPC + fallback paginado.
     Query < 50ms.
     """
     try:
-        from supabase_client import get_supabase
-
+        from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
 
         rows: list[str] = []
         page_size = 1000
         offset = 0
         while True:
-            resp = (
+            resp = await sb_execute(
                 sb.table("mv_sitemap_orgaos")
                 .select("cnpj")
                 .order("cnpj")
                 .range(offset, offset + page_size - 1)
-                .execute()
             )
             if not resp.data:
                 break
@@ -258,7 +256,7 @@ async def sitemap_contratos_orgao_indexable(response: Response):
 
     try:
         data = await _run_with_budget(
-            asyncio.to_thread(_fetch_contratos_orgao_indexable),
+            _fetch_contratos_orgao_indexable(),
             budget=_CONTRATOS_BUDGET_S,
             phase="route",
             source="sitemap_orgaos.sitemap_contratos_orgao_indexable",
@@ -318,7 +316,7 @@ async def sitemap_contratos_orgao_indexable(response: Response):
     return SitemapContratosOrgaoResponse(**data)
 
 
-def _fetch_contratos_orgao_indexable() -> dict:
+async def _fetch_contratos_orgao_indexable() -> dict:
     """Fetch distinct orgao_cnpj from pncp_supplier_contracts via RPC.
 
     Usa get_sitemap_contratos_orgao_json RPC (SEN-BE-005) para fazer GROUP BY
@@ -329,13 +327,13 @@ def _fetch_contratos_orgao_indexable() -> dict:
     REST) que causava 502 "JSON could not be generated" no PostgREST.
     """
     try:
-        from supabase_client import get_supabase
+        from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
 
-        resp = sb.rpc(
+        resp = await sb_execute(sb.rpc(
             "get_sitemap_contratos_orgao_json",
             {"max_results": _MAX_CONTRATOS_ORGAOS},
-        ).execute()
+        ))
 
         orgao_list = resp.data if isinstance(resp.data, list) else []
         orgao_list = [c for c in orgao_list if is_valid_cnpj_format(c)]


### PR DESCRIPTION
## Summary
Migra sitemap_orgaos, sitemap_licitacoes, sitemap_licitacoes_do_dia de sync `.execute()` para async `sb_execute()` com retry HTTP/2 (SEN-BE-004).

### Alteracoes por arquivo

| File | Change |
|------|--------|
| `backend/routes/sitemap_orgaos.py` | `_fetch_top_orgaos` e `_fetch_contratos_orgao_indexable`: sync → async, `.execute()` → `await sb_execute()` |
| `backend/routes/sitemap_licitacoes.py` | `count_contracts`: `asyncio.to_thread(lambda: ...execute())` → `await sb_execute()` |
| `backend/routes/sitemap_licitacoes_do_dia.py` | `_fetch_indexable_dates`: sync → async, `.execute()` → `await sb_execute()` |

## Testing Plan
- [x] `pytest tests/ -k "sitemap"` — 85 passed, 0 failed
- [x] Nenhum `.execute()` restante nos 3 arquivos
- [ ] Deploy e validar sitemaps retornam dados corretos

## Closes
Closes #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)