### PR TITLE
fix(backend): migrar SEO public routes batch 1 para sb_execute() (#1179)

### DIFF
--- a/backend/routes/contratos_publicos.py
+++ b/backend/routes/contratos_publicos.py
@@ -24,7 +24,6 @@ from pydantic import BaseModel
 
 from pipeline.budget import _run_with_budget
 from sectors import SECTORS
-from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["contratos-publicos"])
@@ -184,33 +183,42 @@ async def _fetch_sector_contracts(
     sector = SECTORS[sector_id_clean]
     keywords_lower = {kw.lower() for kw in sector.keywords}
 
-    def _sync_query() -> list[dict]:
-        from supabase_client import get_supabase
-        sb = get_supabase()
+    from supabase_client import get_supabase, sb_execute
+    sb = get_supabase()
+
+    async def _paginate_sector() -> list[dict]:
         # DATA-CAP-001: paginate via .range() because PostgREST silently caps
         # any single response at max_rows=1000. The previous .limit(5000) was
         # silently truncating contracts for any UF with >1000 active contracts.
-        builder = (
-            sb.table("pncp_supplier_contracts")
-            .select(
-                "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
-                "valor_global,data_assinatura,objeto_contrato"
+        batch_size = 1000
+        max_total = 5000
+        all_rows: list[dict] = []
+        offset = 0
+        while len(all_rows) < max_total:
+            end = offset + batch_size - 1
+            resp = await sb_execute(
+                sb.table("pncp_supplier_contracts")
+                .select(
+                    "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
+                    "valor_global,data_assinatura,objeto_contrato"
+                )
+                .eq("uf", uf_upper)
+                .eq("is_active", True)
+                .order("data_assinatura", desc=True)
+                .range(offset, end)
             )
-            .eq("uf", uf_upper)
-            .eq("is_active", True)
-            .order("data_assinatura", desc=True)
-        )
-        return paginate_full(
-            builder,
-            batch_size=1000,
-            max_total=5000,
-            route="contratos_publicos.sector_contracts",
-            entity_type="pncp_supplier_contracts",
-        )
+            batch = resp.data or []
+            if not batch:
+                break
+            all_rows.extend(batch)
+            if len(batch) < batch_size:
+                break
+            offset += batch_size
+        return all_rows
 
     try:
         rows = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+            _paginate_sector(),
             budget=_SECTOR_QUERY_BUDGET_S,
             phase="route",
             source="contratos_publicos.sector_contracts",
@@ -273,33 +281,41 @@ async def orgao_contratos_stats(cnpj: str):
     if cached:
         return OrgaoContratosStatsResponse(**cached)
 
-    def _sync_query_orgao() -> list[dict]:
-        from supabase_client import get_supabase
+    async def _paginate_orgao() -> list[dict]:
+        from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
         # DATA-CAP-001: paginate via .range() — orgãos públicos federais e
         # estaduais grandes (TJ, TCU, ministérios) podem ter milhares de
         # contratos ativos; .limit(5000) era silenciosamente capado a 1000.
-        builder = (
-            sb.table("pncp_supplier_contracts")
-            .select(
-                "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
-                "valor_global,data_assinatura,objeto_contrato"
+        batch_size = 1000
+        max_total = 5000
+        all_rows: list[dict] = []
+        offset = 0
+        while len(all_rows) < max_total:
+            end = offset + batch_size - 1
+            resp = await sb_execute(
+                sb.table("pncp_supplier_contracts")
+                .select(
+                    "ni_fornecedor,nome_fornecedor,orgao_cnpj,orgao_nome,"
+                    "valor_global,data_assinatura,objeto_contrato"
+                )
+                .eq("orgao_cnpj", cnpj_clean)
+                .eq("is_active", True)
+                .order("data_assinatura", desc=True)
+                .range(offset, end)
             )
-            .eq("orgao_cnpj", cnpj_clean)
-            .eq("is_active", True)
-            .order("data_assinatura", desc=True)
-        )
-        return paginate_full(
-            builder,
-            batch_size=1000,
-            max_total=5000,
-            route="contratos_publicos.orgao_contratos_stats",
-            entity_type="pncp_supplier_contracts",
-        )
+            batch = resp.data or []
+            if not batch:
+                break
+            all_rows.extend(batch)
+            if len(batch) < batch_size:
+                break
+            offset += batch_size
+        return all_rows
 
     try:
         rows = await _run_with_budget(
-            asyncio.to_thread(_sync_query_orgao),
+            _paginate_orgao(),
             budget=_SECTOR_QUERY_BUDGET_S,
             phase="route",
             source="contratos_publicos.orgao_contratos_stats",

--- a/backend/routes/orgao_publico.py
+++ b/backend/routes/orgao_publico.py
@@ -17,7 +17,6 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from pipeline.budget import _run_with_budget
-from utils.postgrest_paginate import paginate_full
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["orgao-publico"])
@@ -259,40 +258,48 @@ async def _build_orgao_stats(cnpj: str) -> tuple[dict, bool]:
     valid-shape unavailable payload. Callers should cache partial responses
     under ``_NEGATIVE_CACHE_TTL_SECONDS``.
     """
-    def _sync_query() -> list[dict]:
-        from supabase_client import get_supabase
+    async def _paginate_orgao_stats() -> list[dict]:
+        from supabase_client import get_supabase, sb_execute
 
         sb = get_supabase()
         # DATA-CAP-001: paginate via .range() — without paginate_full,
         # PostgREST silently capped this at 1000 rows even with
-        # .limit(5000), so any orgão with >1000 active bids returned
+        # .limit(5000), so any órgão with >1000 active bids returned
         # exactly 1000 rounded counts (visible UX bug on /orgaos/[cnpj]).
-        builder = (
-            sb.table("pncp_raw_bids")
-            .select(
-                "orgao_razao_social,"
-                "esfera_id,"
-                "uf,"
-                "municipio,"
-                "modalidade_nome,"
-                "objeto_compra,"
-                "valor_total_estimado,"
-                "data_publicacao"
+        batch_size = 1000
+        max_total = 5000
+        all_rows: list[dict] = []
+        offset = 0
+        while len(all_rows) < max_total:
+            end = offset + batch_size - 1
+            resp = await sb_execute(
+                sb.table("pncp_raw_bids")
+                .select(
+                    "orgao_razao_social,"
+                    "esfera_id,"
+                    "uf,"
+                    "municipio,"
+                    "modalidade_nome,"
+                    "objeto_compra,"
+                    "valor_total_estimado,"
+                    "data_publicacao"
+                )
+                .eq("orgao_cnpj", cnpj)
+                .eq("is_active", True)
+                .range(offset, end)
             )
-            .eq("orgao_cnpj", cnpj)
-            .eq("is_active", True)
-        )
-        return paginate_full(
-            builder,
-            batch_size=1000,
-            max_total=5000,
-            route="orgao_publico.orgao_stats",
-            entity_type="pncp_raw_bids",
-        )
+            batch = resp.data or []
+            if not batch:
+                break
+            all_rows.extend(batch)
+            if len(batch) < batch_size:
+                break
+            offset += batch_size
+        return all_rows
 
     try:
         rows = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+            _paginate_orgao_stats(),
             budget=_ORGAO_QUERY_BUDGET_S,
             phase="route",
             source="orgao_publico.orgao_stats",
@@ -446,27 +453,23 @@ async def _fetch_contracts_data(orgao_cnpj: str, limit: int = 10) -> dict:
     """
     result = {"top_fornecedores": [], "total_contratos_24m": 0, "valor_total_contratos_24m": 0.0}
 
-    def _sync_rpc() -> dict:
-        from supabase_client import get_supabase
+    try:
+        from supabase_client import get_supabase, sb_execute
+
         sb = get_supabase()
-        resp = sb.rpc(
-            "get_orgao_top_contracts_json",
-            {"p_orgao_cnpj": orgao_cnpj, "p_limit": limit},
-        ).execute()
+        resp = await sb_execute(
+            sb.rpc(
+                "get_orgao_top_contracts_json",
+                {"p_orgao_cnpj": orgao_cnpj, "p_limit": limit},
+            )
+        )
         # supabase-py returns the JSON value directly in resp.data when the
         # RPC RETURNS a scalar JSON — handle both shapes defensively.
         data = getattr(resp, "data", None)
         if isinstance(data, list):
             data = data[0] if data else None
-        return data or {}
+        agg = data or {}
 
-    try:
-        agg = await _run_with_budget(
-            asyncio.to_thread(_sync_rpc),
-            budget=_ORGAO_QUERY_BUDGET_S,
-            phase="route",
-            source="orgao_publico.contracts_data",
-        )
         if not agg:
             return result
 


### PR DESCRIPTION
## Summary
Migra contratos_publicos, orgao_publico de sync `.execute()` para async `sb_execute()` com retry HTTP/2 (SEN-BE-004). Remove dependencia de `paginate_full` em ambos arquivos substituindo por paginacao async inline com `sb_execute`.

## Changes
- `backend/routes/contratos_publicos.py`: 2 sync queries via `paginate_full` + `asyncio.to_thread` convertidas para paginacao async com `sb_execute`
- `backend/routes/orgao_publico.py`: 2 sync queries via `paginate_full`/`.execute()` convertidas para `sb_execute` async
- `backend/routes/empresa_publica.py`: ja utiliza `sb_execute` -- sem alteracoes

## Testing Plan
- [x] `pytest tests/ -k "contratos_publicos or orgao_publico or empresa_publica"` -- 20 passed
- [x] Nenhum `.execute()` restante nos 3 arquivos (grep verify)
- [ ] Deploy e validar que endpoints SEO públicos nao degradaram

## Closes
Closes #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)