### PR TITLE
fix(frontend): zero data on programmatic blog pages (#1191)

### DIFF
--- a/backend/routes/blog_stats.py
+++ b/backend/routes/blog_stats.py
@@ -528,7 +528,11 @@ async def get_sector_blog_stats(setor_id: str):
         "trend_90d": trend_90d,
         "last_updated": now.isoformat(),
     }
-    _cache_set(cache_key, data)
+    # ISSUE-1191: empty results (e.g. from _SEO_SEMAPHORE timeout inside
+    # query_datalake) MUST use negative-cache TTL — the full 6h TTL would
+    # bake a stale-zero into _blog_cache and make blog programmatic pages
+    # show zero editais for hours despite the data existing.
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not results else _CACHE_TTL_SECONDS)
     return SectorBlogStats(**data)
 
 
@@ -645,7 +649,10 @@ async def get_sector_uf_stats(setor_id: str, uf: str):
         "vs_media_nacional_pct": vs_media_nacional_pct,
         "top_compradores": top_compradores,
     }
-    _cache_set(cache_key, data)
+    # ISSUE-1191: empty results MUST use negative-cache TTL — the full 6h TTL
+    # would bake a stale-zero into _blog_cache and make blog programmatic pages
+    # show zero editais for hours despite the data existing.
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not uf_results else _CACHE_TTL_SECONDS)
     return SectorUfStats(**data)
 
 
@@ -723,7 +730,8 @@ async def get_cidade_stats(cidade: str):
         "avg_value": round(avg_val, 2),
         "last_updated": now.isoformat(),
     }
-    _cache_set(cache_key, data)
+    # ISSUE-1191: empty results MUST use negative-cache TTL
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not city_results else _CACHE_TTL_SECONDS)
     return CidadeStats(**data)
 
 
@@ -797,7 +805,8 @@ async def get_cidade_sector_stats(cidade: str, setor_id: str):
         "has_sufficient_data": len(city_results) >= 5,
         "last_updated": now.isoformat(),
     }
-    _cache_set(cache_key, data)
+    # ISSUE-1191: empty results MUST use negative-cache TTL
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not city_results else _CACHE_TTL_SECONDS)
     return CidadeSectorStats(**data)
 
 
@@ -859,7 +868,8 @@ async def get_panorama_stats(setor_id: str):
         "crescimento_estimado_pct": crescimento,
         "last_updated": now.isoformat(),
     }
-    _cache_set(cache_key, data)
+    # ISSUE-1191: empty results MUST use negative-cache TTL
+    _cache_set(cache_key, data, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not results else _CACHE_TTL_SECONDS)
     return PanoramaStats(**data)
 
 

--- a/backend/routes/sectors_public.py
+++ b/backend/routes/sectors_public.py
@@ -37,6 +37,10 @@ router = APIRouter(
 
 # AC2: 6h InMemory cache
 _CACHE_TTL_SECONDS = 6 * 60 * 60
+# 5min negative cache (DB timeout / failure path) — same pattern as blog_stats.
+# Stops Googlebot retry-storm from re-saturating Supabase pool while letting the
+# next crawl wave probe again after a short window.
+_NEGATIVE_CACHE_TTL_SECONDS = 5 * 60
 _stats_cache: dict[str, tuple[dict, float]] = {}
 
 
@@ -188,7 +192,12 @@ async def get_sector_stats(slug: str):
 
     # Generate on-demand if cache miss
     stats = await _generate_sector_stats(sector_id, sector)
-    _set_cached_stats(sector_id, stats)
+    # ISSUE-1191: empty results (from _SEO_SEMAPHORE timeout inside
+    # query_datalake) MUST use negative-cache TTL — the full 6h TTL would
+    # bake a stale-zero into _stats_cache and make /licitacoes/* pages
+    # show zero editais for hours despite the data existing.
+    has_data = stats.get("total_open", 0) > 0
+    _set_cached_stats(sector_id, stats, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not has_data else _CACHE_TTL_SECONDS)
 
     return SectorStatsResponse(**stats)
 
@@ -201,15 +210,15 @@ def _get_cached_stats(sector_id: str) -> Optional[dict]:
     """Return cached stats if still fresh (< 6h)."""
     if sector_id not in _stats_cache:
         return None
-    data, ts = _stats_cache[sector_id]
-    if time.time() - ts >= _CACHE_TTL_SECONDS:
+    data, ts, ttl = _stats_cache[sector_id]
+    if time.time() - ts >= ttl:
         del _stats_cache[sector_id]
         return None
     return data
 
 
-def _set_cached_stats(sector_id: str, data: dict) -> None:
-    _stats_cache[sector_id] = (data, time.time())
+def _set_cached_stats(sector_id: str, data: dict, ttl: float = _CACHE_TTL_SECONDS) -> None:
+    _stats_cache[sector_id] = (data, time.time(), ttl)
 
 
 def invalidate_all_stats() -> None:
@@ -346,7 +355,9 @@ async def refresh_all_sector_stats() -> int:
     for sector_id, sector in SECTORS.items():
         try:
             stats = await _generate_sector_stats(sector_id, sector)
-            _set_cached_stats(sector_id, stats)
+            # ISSUE-1191: same negative-cache guard as get_sector_stats
+            has_data = stats.get("total_open", 0) > 0
+            _set_cached_stats(sector_id, stats, ttl=_NEGATIVE_CACHE_TTL_SECONDS if not has_data else _CACHE_TTL_SECONDS)
             refreshed += 1
             logger.info("Refreshed sector stats: %s (%d items)", sector_id, stats["total_open"])
         except Exception as e:

--- a/backend/tests/test_sectors_public.py
+++ b/backend/tests/test_sectors_public.py
@@ -126,7 +126,7 @@ class TestStatsCache:
         assert result["total_open"] == 42
 
     def test_cache_expired_returns_none(self, sample_stats):
-        _stats_cache["medicamentos"] = (sample_stats, time.time() - _CACHE_TTL_SECONDS - 1)
+        _stats_cache["medicamentos"] = (sample_stats, time.time() - _CACHE_TTL_SECONDS - 1, _CACHE_TTL_SECONDS)
         assert _get_cached_stats("medicamentos") is None
 
     def test_invalidate_all(self, sample_stats):


### PR DESCRIPTION
## Summary

Blog programmatic pages show zero editais while `/licitacoes/*` pages show correct data for the same sectors/UF because the two page families use different backend endpoints. When `query_datalake` hits the `_SEO_SEMAPHORE` timeout (2s acquire), it returns `[]`, which gets cached for **6 hours** in both `_blog_cache` and `_stats_cache`.

## Root Cause

- `backend/datalake_query.py:149` — `asyncio.wait_for(_SEO_SEMAPHORE.acquire(), timeout=2.0)` returns `[]` on timeout
- Empty results cached for full 6h TTL in blog_stats + sectors_public InMemory caches
- Subsequent requests served stale-zero until cache expires

## Fix

Negative-cache pattern: use **5-minute TTL** when query results are empty instead of the default 6h TTL.

### Files changed

| File | Change |
|------|--------|
| `backend/routes/blog_stats.py` | 5 endpoints — use `_NEGATIVE_CACHE_TTL_SECONDS` when no results |
| `backend/routes/sectors_public.py` | Added negative-cache constant, per-entry TTL support, same guard in `get_sector_stats` + `refresh_all_sector_stats` |
| `backend/tests/test_sectors_public.py` | Cache tuple format updated for new 3-tuple `(data, ts, ttl)` |

## Testing

- 120 backend tests pass (96 blog_stats + 24 sectors_public)
- Manual: `_set_cached_stats` now stores `(data, ts, ttl)` — old 2-tuple format is rejected by `_get_cached_stats`

## Closes

Closes #1191