### PR TITLE
fix(frontend): prevent zero data on blog programmatic pages (#1191)

### DIFF
--- a/frontend/app/blog/contratos/[setor]/page.tsx
+++ b/frontend/app/blog/contratos/[setor]/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/lib/programmatic';
 import { buildCanonical } from '@/lib/seo';
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   return generateSectorParams();

--- a/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
@@ -80,7 +80,7 @@ const MODALIDADE_MAP: Record<number, { name: string; slug: string; description: 
   },
 };
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   return generateLicitacoesParams();

--- a/frontend/app/blog/licitacoes/cidade/[cidade]/[setor]/page.tsx
+++ b/frontend/app/blog/licitacoes/cidade/[cidade]/[setor]/page.tsx
@@ -36,7 +36,7 @@ import { getFreshnessLabel } from '@/lib/seo';
  * or "editais engenharia salvador".
  */
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   const params: { cidade: string; setor: string }[] = [];

--- a/frontend/app/blog/licitacoes/cidade/[cidade]/page.tsx
+++ b/frontend/app/blog/licitacoes/cidade/[cidade]/page.tsx
@@ -26,7 +26,7 @@ import { SECTORS } from '@/lib/sectors';
  * displays a generic fallback and lets the build succeed.
  */
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   return CITIES.map((c) => ({ cidade: c.slug }));

--- a/frontend/app/blog/panorama/[setor]/page.tsx
+++ b/frontend/app/blog/panorama/[setor]/page.tsx
@@ -28,7 +28,7 @@ import { SECTORS } from '@/lib/sectors';
  * Schema: FAQPage + Dataset + Article + HowTo.
  */
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   return generateSectorParams(); // 15 sectors

--- a/frontend/app/blog/programmatic/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/[uf]/page.tsx
@@ -23,7 +23,7 @@ import {
  * ISR 24h. Generates 15 sectors × 27 UFs = 405 pages.
  */
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   return generateSectorUfParams();

--- a/frontend/app/blog/programmatic/[setor]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/page.tsx
@@ -29,7 +29,7 @@ import {
  * - Contextual CTA
  */
 
-export const revalidate = 3600; // 24h ISR
+export const revalidate = 3600; // 1h ISR
 
 export function generateStaticParams() {
   return generateSectorParams();

--- a/frontend/lib/cities.ts
+++ b/frontend/lib/cities.ts
@@ -120,7 +120,7 @@ export async function fetchCidadeStats(citySlug: string): Promise<CidadeStats | 
   try {
     const res = await fetch(
       `${backendUrl}/v1/blog/stats/cidade/${encodeURIComponent(citySlug)}`,
-      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) },
+      { signal: AbortSignal.timeout(25000) },
     );
     if (!res.ok) return null;
     return (await res.json()) as CidadeStats;
@@ -169,7 +169,7 @@ export async function fetchCidadeSectorStats(
   try {
     const res = await fetch(
       `${backendUrl}/v1/blog/stats/cidade/${encodeURIComponent(citySlug)}/setor/${encodeURIComponent(sectorId)}`,
-      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) },
+      { signal: AbortSignal.timeout(25000) },
     );
     if (!res.ok) return null;
     return (await res.json()) as CidadeSectorStats;

--- a/frontend/lib/contracts-fallback.ts
+++ b/frontend/lib/contracts-fallback.ts
@@ -87,7 +87,7 @@ export async function fetchContratosSetorUfStats(
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(
       `${backendUrl}/v1/blog/stats/contratos/${sectorId}/uf/${uf.toUpperCase()}`,
-      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) },
+      { signal: AbortSignal.timeout(25000) },
     );
     if (!res.ok) return null;
     return await res.json();
@@ -105,7 +105,7 @@ export async function fetchContratosCidadeStats(
   try {
     const res = await ssgLimitedFetch(
       `${backendUrl}/v1/blog/stats/contratos/cidade/${encodeURIComponent(cidadeSlug)}`,
-      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) },
+      { signal: AbortSignal.timeout(25000) },
     );
     if (!res.ok) return null;
     return await res.json();
@@ -125,7 +125,7 @@ export async function fetchContratosCidadeSetorStats(
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(
       `${backendUrl}/v1/blog/stats/contratos/cidade/${encodeURIComponent(cidadeSlug)}/setor/${sectorId}`,
-      { next: { revalidate: 86400 }, signal: AbortSignal.timeout(10000) },
+      { signal: AbortSignal.timeout(25000) },
     );
     if (!res.ok) return null;
     return await res.json();

--- a/frontend/lib/programmatic.ts
+++ b/frontend/lib/programmatic.ts
@@ -186,8 +186,7 @@ export async function fetchSectorBlogStats(sectorSlug: string): Promise<SectorBl
   try {
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(`${backendUrl}/v1/blog/stats/setor/${sectorId}`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(25000),
     });
     if (!res.ok) return null;
     return await res.json();
@@ -209,8 +208,7 @@ export async function fetchSectorUfBlogStats(
   try {
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(`${backendUrl}/v1/blog/stats/setor/${sectorId}/uf/${uf.toUpperCase()}`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(25000),
     });
     if (!res.ok) return null;
     return await res.json();
@@ -229,8 +227,7 @@ export async function fetchPanoramaStats(sectorSlug: string): Promise<PanoramaSt
   try {
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(`${backendUrl}/v1/blog/stats/panorama/${sectorId}`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(25000),
     });
     if (!res.ok) return null;
     return await res.json();
@@ -580,8 +577,7 @@ export async function fetchAlertasPublicos(
   try {
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(`${backendUrl}/v1/alertas/${sectorId}/uf/${uf.toUpperCase()}`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(25000),
     });
     if (!res.ok) return null;
     return await res.json();
@@ -835,8 +831,7 @@ export async function fetchContratosSetorStats(sectorSlug: string): Promise<Cont
   try {
     const sectorId = SECTOR_SLUG_TO_BACKEND_ID[sectorSlug] ?? sectorSlug.replace(/-/g, '_');
     const res = await ssgLimitedFetch(`${backendUrl}/v1/blog/stats/contratos/${sectorId}`, {
-      next: { revalidate: 86400 },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(25000),
     });
     if (!res.ok) return null;
     return res.json();


### PR DESCRIPTION
## Summary

Fix persistent zero-data issue on blog programmatic pages (`/blog/programmatic/*`, `/blog/licitacoes/*`) where pages displayed 0 editais while `/licitacoes/*` showed correct data for the same sectors/UFs.

## Root Cause

Two interacting issues:

1. **Fetch-level ISR override (24h)**: `ssgLimitedFetch` calls specified `next: { revalidate: 86400 }` (24h) which overrides the page-level `revalidate = 3600` (1h). Stale empty data persisted for 24 hours even though the page revalidated hourly.

2. **Timeout mismatch**: Frontend `AbortSignal.timeout(10000)` (10s) was below backend `_run_with_budget(15s)` budget. Under load, the frontend aborted before the backend could respond, returning `null` which the page rendered as zero.

## Changes

- Remove `next: { revalidate: 86400 }` from 10 fetch call sites across `programmatic.ts`, `cities.ts`, `contracts-fallback.ts`
- Increase `AbortSignal.timeout` from 10s → 25s (above backend 15s budget)
- Fix ISR comments: `3600; // 24h ISR` → `3600; // 1h ISR` across 7 blog templates

## Testing Plan

- [ ] TypeScript compilation passes
- [ ] Blog programmatic pages render with non-zero data after next ISR cycle
- [ ] Cache invalidation works correctly at 1h intervals

## Closes

Closes #1191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected cache revalidation documentation across blog pages to accurately reflect 1-hour intervals.

* **Performance Improvements**
  * Extended request timeouts for backend data fetches from 10 to 25 seconds to enhance reliability and reduce timeout errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->