### PR TITLE
fix(backend): migrate 8 remaining route files to sb_execute() (#1182)

### DIFF
--- a/backend/routes/conta.py
+++ b/backend/routes/conta.py
@@ -19,7 +19,6 @@ Design notes:
 
 from __future__ import annotations
 
-import logging
 from typing import Optional
 
 import stripe
@@ -31,7 +30,7 @@ from services.trial_cancel_token import (
     TrialCancelTokenError,
     verify_cancel_trial_token,
 )
-from supabase_client import get_supabase
+from supabase_client import get_supabase, sb_execute
 
 logger = get_sanitized_logger(__name__)
 router = APIRouter(prefix="/conta", tags=["conta"])
@@ -91,26 +90,24 @@ def _error_response_for(reason: str) -> HTTPException:
     )
 
 
-def _load_profile_and_subscription(sb, user_id: str) -> tuple[Optional[dict], Optional[dict]]:
+async def _load_profile_and_subscription(sb, user_id: str) -> tuple[Optional[dict], Optional[dict]]:
     """Fetch profile + active user_subscriptions row (may be None if user deleted)."""
-    profile_result = (
+    profile_result = await sb_execute(
         sb.table("profiles")
         .select("id, email, plan_type, subscription_status, stripe_subscription_id")
         .eq("id", user_id)
         .limit(1)
-        .execute()
     )
     if not profile_result.data:
         return None, None
     profile = profile_result.data[0]
 
-    sub_result = (
+    sub_result = await sb_execute(
         sb.table("user_subscriptions")
         .select("id, plan_id, stripe_subscription_id, is_active, subscription_status")
         .eq("user_id", user_id)
         .eq("is_active", True)
         .limit(1)
-        .execute()
     )
     subscription = sub_result.data[0] if sub_result.data else None
     return profile, subscription
@@ -135,7 +132,7 @@ def _fetch_trial_end_from_stripe(stripe_sub_id: Optional[str]) -> Optional[int]:
 
 
 @router.get("/cancelar-trial", response_model=CancelTrialInfoResponse)
-def cancel_trial_info(token: str = Query(..., min_length=20)) -> CancelTrialInfoResponse:
+async def cancel_trial_info(token: str = Query(..., min_length=20)) -> CancelTrialInfoResponse:
     """
     Return trial metadata for the confirmation UI.
 
@@ -149,7 +146,7 @@ def cancel_trial_info(token: str = Query(..., min_length=20)) -> CancelTrialInfo
         raise _error_response_for(exc.reason) from exc
 
     sb = get_supabase()
-    profile, subscription = _load_profile_and_subscription(sb, user_id)
+    profile, subscription = await _load_profile_and_subscription(sb, user_id)
     if not profile:
         raise HTTPException(
             status_code=404,
@@ -182,7 +179,7 @@ def cancel_trial_info(token: str = Query(..., min_length=20)) -> CancelTrialInfo
 
 
 @router.post("/cancelar-trial", response_model=CancelTrialResponse)
-def cancel_trial_execute(payload: CancelTrialRequest) -> CancelTrialResponse:
+async def cancel_trial_execute(payload: CancelTrialRequest) -> CancelTrialResponse:
     """
     Cancel the user's active trial subscription.
 
@@ -198,7 +195,7 @@ def cancel_trial_execute(payload: CancelTrialRequest) -> CancelTrialResponse:
         raise _error_response_for(exc.reason) from exc
 
     sb = get_supabase()
-    profile, subscription = _load_profile_and_subscription(sb, user_id)
+    profile, subscription = await _load_profile_and_subscription(sb, user_id)
     if not profile:
         raise HTTPException(
             status_code=404,
@@ -249,20 +246,26 @@ def cancel_trial_execute(payload: CancelTrialRequest) -> CancelTrialResponse:
 
     # 2) Update local state (profiles + user_subscriptions).
     try:
-        sb.table("profiles").update(
-            {
-                "subscription_status": "canceled_trial",
-                "plan_type": "free_trial",
-            }
-        ).eq("id", user_id).execute()
+        await sb_execute(
+            sb.table("profiles").update(
+                {
+                    "subscription_status": "canceled_trial",
+                    "plan_type": "free_trial",
+                }
+            ).eq("id", user_id),
+            category="write",
+        )
     except Exception as exc:
         logger.error(f"Failed to update profiles during trial cancel: {exc}")
 
     if subscription:
         try:
-            sb.table("user_subscriptions").update(
-                {"subscription_status": "canceled", "is_active": False}
-            ).eq("id", subscription["id"]).execute()
+            await sb_execute(
+                sb.table("user_subscriptions").update(
+                    {"subscription_status": "canceled", "is_active": False}
+                ).eq("id", subscription["id"]),
+                category="write",
+            )
         except Exception as exc:
             logger.error(f"Failed to update user_subscriptions during trial cancel: {exc}")
 

--- a/backend/routes/features.py
+++ b/backend/routes/features.py
@@ -14,6 +14,7 @@ from auth import require_auth
 from cache import redis_cache
 from log_sanitizer import mask_user_id
 from quota import get_plan_from_profile, SUBSCRIPTION_GRACE_DAYS
+from supabase_client import sb_execute
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class UserFeaturesResponse(BaseModel):
     cached_at: Optional[str] = None  # ISO 8601 timestamp
 
 
-def fetch_features_from_db(user_id: str) -> UserFeaturesResponse:
+async def fetch_features_from_db(user_id: str) -> UserFeaturesResponse:
     """Fetch user features from Supabase (cache miss).
 
     Args:
@@ -60,14 +61,13 @@ def fetch_features_from_db(user_id: str) -> UserFeaturesResponse:
 
     # --- Layer 1: Active subscription ---
     try:
-        sub_result = (
+        sub_result = await sb_execute(
             sb.table("user_subscriptions")
             .select("plan_id, billing_period, expires_at")
             .eq("user_id", user_id)
             .eq("is_active", True)
             .order("created_at", desc=True)
             .limit(1)
-            .execute()
         )
 
         if sub_result.data and len(sub_result.data) > 0:
@@ -85,14 +85,13 @@ def fetch_features_from_db(user_id: str) -> UserFeaturesResponse:
     if not plan_id:
         try:
             grace_cutoff = (datetime.now(timezone.utc) - timedelta(days=SUBSCRIPTION_GRACE_DAYS)).isoformat()
-            grace_result = (
+            grace_result = await sb_execute(
                 sb.table("user_subscriptions")
                 .select("plan_id, billing_period, expires_at")
                 .eq("user_id", user_id)
                 .gte("expires_at", grace_cutoff)
                 .order("expires_at", desc=True)
                 .limit(1)
-                .execute()
             )
 
             if grace_result.data and len(grace_result.data) > 0:
@@ -126,13 +125,12 @@ def fetch_features_from_db(user_id: str) -> UserFeaturesResponse:
 
     # Get features for this plan + billing_period
     try:
-        features_result = (
+        features_result = await sb_execute(
             sb.table("plan_features")
             .select("feature_key, enabled, metadata")
             .eq("plan_id", plan_id)
             .eq("billing_period", billing_period)
             .eq("enabled", True)
-            .execute()
         )
 
         features = [
@@ -192,7 +190,7 @@ async def get_my_features(user: dict = Depends(require_auth)):
 
     # Cache miss - fetch from database
     logger.debug(f"Cache MISS for user {mask_user_id(user_id)}, querying database")
-    response = fetch_features_from_db(user_id)
+    response = await fetch_features_from_db(user_id)
 
     # Add cached_at timestamp
     response.cached_at = datetime.now(timezone.utc).isoformat()

--- a/backend/routes/founding.py
+++ b/backend/routes/founding.py
@@ -27,7 +27,6 @@ BIZ-FOUND-002 changes:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 
@@ -39,7 +38,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from metrics import FOUNDING_CHECKOUTS_TOTAL
 from rate_limiter import require_rate_limit
-from supabase_client import get_supabase
+from supabase_client import get_supabase, sb_execute
 
 
 logger = logging.getLogger(__name__)
@@ -166,40 +165,41 @@ def _mask_email(email: str) -> str:
     return f"{local[:2]}****@{domain}"
 
 
-def _already_registered(sb, email: str) -> bool:
+async def _already_registered(sb, email: str) -> bool:
     """Return True if the email already owns a profile. Best-effort, non-blocking."""
     try:
-        res = sb.table("profiles").select("id").eq("email", email).limit(1).execute()
+        res = await sb_execute(
+            sb.table("profiles").select("id").eq("email", email).limit(1)
+        )
         return bool(res.data)
     except Exception as e:
         logger.warning(f"founding: profile lookup failed (non-blocking): {e}")
         return False
 
 
-def _get_session_lead(sb, session_id: str) -> dict | None:
+async def _get_session_lead(sb, session_id: str) -> dict | None:
     """Return founding_leads row for the given Stripe checkout session ID.
 
     Returns ``None`` when not found. Raises on unexpected DB errors.
     """
-    res = (
+    res = await sb_execute(
         sb.table("founding_leads")
         .select("email, checkout_status, magic_link_sent_at, created_at")
         .eq("checkout_session_id", session_id)
         .limit(1)
-        .execute()
     )
     rows = res.data or []
     return rows[0] if rows else None
 
 
-def _check_availability(sb) -> dict[str, Any]:
+async def _check_availability(sb) -> dict[str, Any]:
     """Call ``check_founding_availability()`` RPC; return normalized dict.
 
     On any DB error returns ``available=False`` with reason ``'unavailable'``
     so the route fails closed (never accidentally over-sell the cohort).
     """
     try:
-        res = sb.rpc("check_founding_availability").execute()
+        res = await sb_execute(sb.rpc("check_founding_availability"), category="rpc")
         rows = getattr(res, "data", None) or []
         if not rows:
             logger.warning("founding: check_founding_availability returned empty")
@@ -292,7 +292,7 @@ async def founding_availability(response: Response) -> Any:
 
     sb = get_supabase()
     snapshot = await _run_with_budget(
-        asyncio.to_thread(_check_availability, sb),
+        _check_availability(sb),
         budget=3.0,
         phase="route",
         source="founding.availability",
@@ -378,12 +378,9 @@ async def founding_session_status(
 
     sb = get_supabase()
 
-    def _fetch():
-        return _get_session_lead(sb, session_id)
-
     try:
         lead = await _run_with_budget(
-            asyncio.to_thread(_fetch),
+            _get_session_lead(sb, session_id),
             budget=5.0,
             phase="route",
             source="founding.session_status",
@@ -436,7 +433,7 @@ async def founding_session_status(
     has_account = False
     if email:
         try:
-            has_account = await asyncio.to_thread(_already_registered, sb, email)
+            has_account = await _already_registered(sb, email)
         except Exception as exc:
             logger.warning(
                 f"founding: session-status profile check failed (non-blocking): {exc}"
@@ -501,7 +498,7 @@ async def founding_checkout(
     # Evaluated BEFORE Stripe config checks so that 410 responses are always
     # returned correctly even in environments without Stripe configured (e.g. tests).
     snapshot = await _run_with_budget(
-        asyncio.to_thread(_check_availability, sb),
+        _check_availability(sb),
         budget=3.0,
         phase="route",
         source="founding.checkout_gate",
@@ -523,7 +520,7 @@ async def founding_checkout(
             },
         )
 
-    if await asyncio.to_thread(_already_registered, sb, payload.email):
+    if await _already_registered(sb, payload.email):
         raise HTTPException(
             status_code=409,
             detail="Este email já possui conta SmartLic. Faça login para gerenciar sua assinatura.",
@@ -561,11 +558,8 @@ async def founding_checkout(
         "user_agent": request.headers.get("user-agent", "")[:500],
     }
 
-    def _insert_lead():
-        return sb.table("founding_leads").insert(lead_row).execute()
-
     lead_insert = await _run_with_budget(
-        asyncio.to_thread(_insert_lead),
+        sb_execute(sb.table("founding_leads").insert(lead_row), category="write"),
         budget=5.0,
         phase="route",
         source="founding.checkout.insert_lead",
@@ -620,16 +614,13 @@ async def founding_checkout(
     try:
         _session_id = session.id
 
-        def _update_session_id():
-            return (
+        await _run_with_budget(
+            sb_execute(
                 sb.table("founding_leads")
                 .update({"checkout_session_id": _session_id})
-                .eq("id", lead_id)
-                .execute()
-            )
-
-        await _run_with_budget(
-            asyncio.to_thread(_update_session_id),
+                .eq("id", lead_id),
+                category="write",
+            ),
             budget=5.0,
             phase="route",
             source="founding.checkout.update_session_id",

--- a/backend/routes/lead_capture.py
+++ b/backend/routes/lead_capture.py
@@ -12,13 +12,12 @@ radar, report, intel, diagnostico) continue to be stored in the original
 ``leads`` table.
 """
 
-import asyncio
 import logging
 import re
 from datetime import datetime, timezone
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from rate_limiter import require_rate_limit
@@ -139,7 +138,7 @@ class LeadCaptureResponse(BaseModel):
 
 async def _store_in_legacy_leads(req: LeadCaptureRequest) -> None:
     """Upsert a row into the original ``leads`` table (old sources only)."""
-    from supabase_client import get_supabase
+    from supabase_client import get_supabase, sb_execute
 
     sb = get_supabase()
     lead_row = {
@@ -159,12 +158,12 @@ async def _store_in_legacy_leads(req: LeadCaptureRequest) -> None:
         "referer_path": req.referer_path,
     }
 
-    def _sync_upsert():
-        return sb.table("leads").upsert(lead_row, on_conflict="email,source").execute()
-
     try:
         await _run_with_budget(
-            asyncio.to_thread(_sync_upsert),
+            sb_execute(
+                sb.table("leads").upsert(lead_row, on_conflict="email,source"),
+                category="write",
+            ),
             budget=5.0,
             phase="route",
             source="lead_capture.legacy_upsert",
@@ -185,7 +184,7 @@ async def _store_in_lead_captures(
 
     Returns the new row id on success, ``None`` on failure (fail-open).
     """
-    from supabase_client import get_supabase
+    from supabase_client import get_supabase, sb_execute
 
     sb = get_supabase()
     row = {
@@ -207,12 +206,12 @@ async def _store_in_lead_captures(
         },
     }
 
-    def _sync_insert():
-        return sb.table("lead_captures").insert(row).execute()
-
     try:
         result = await _run_with_budget(
-            asyncio.to_thread(_sync_insert),
+            sb_execute(
+                sb.table("lead_captures").insert(row),
+                category="write",
+            ),
             budget=5.0,
             phase="route",
             source="lead_capture.insert",

--- a/backend/routes/mfa.py
+++ b/backend/routes/mfa.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from auth import require_auth
 from authorization import check_user_roles
 from log_sanitizer import mask_ip_address, mask_user_id
+from supabase_client import sb_execute
 from rate_limiter import require_rate_limit
 from schemas.user import (
     MFAEnrollResponse,
@@ -129,13 +130,12 @@ async def _check_brute_force(user_id: str) -> int:
     sb = await _get_supabase()
     one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
 
-    result = await asyncio.to_thread(
+    result = await sb_execute(
         sb.table("mfa_recovery_attempts")
         .select("id")
         .eq("user_id", user_id)
         .eq("success", False)
         .gte("attempted_at", one_hour_ago)
-        .execute
     )
 
     failed_count = len(result.data) if result.data else 0
@@ -153,11 +153,12 @@ async def _check_brute_force(user_id: str) -> int:
 async def _record_attempt(user_id: str, success: bool) -> None:
     """Record a recovery code attempt for brute force tracking."""
     sb = await _get_supabase()
-    await asyncio.to_thread(
+    await sb_execute(
         sb.table("mfa_recovery_attempts").insert({
             "user_id": user_id,
             "success": success,
-        }).execute
+        }),
+        category="write",
     )
 
 
@@ -204,11 +205,10 @@ async def get_mfa_status(user: dict = Depends(require_auth)):
     factors = []
     try:
         sb = await _get_supabase()
-        result = await asyncio.to_thread(
+        result = await sb_execute(
             sb.table("mfa_factors")
             .select("id, factor_type, friendly_name, status, created_at")
             .eq("user_id", user_id)
-            .execute
         )
 
         if result.data:
@@ -295,8 +295,9 @@ async def generate_recovery_codes(user: dict = Depends(require_auth)):
     sb = await _get_supabase()
 
     # Delete any existing codes for this user (fresh set on each enrollment)
-    await asyncio.to_thread(
-        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id).execute
+    await sb_execute(
+        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id),
+        category="write",
     )
 
     # Generate and store codes
@@ -309,8 +310,9 @@ async def generate_recovery_codes(user: dict = Depends(require_auth)):
             "code_hash": _hash_code(code),
         })
 
-    await asyncio.to_thread(
-        sb.table("mfa_recovery_codes").insert(rows).execute
+    await sb_execute(
+        sb.table("mfa_recovery_codes").insert(rows),
+        category="write",
     )
 
     logger.info(f"Generated {len(plaintext_codes)} recovery codes for user {user_id[:8]}...")
@@ -336,12 +338,11 @@ async def verify_recovery_code(
     sb = await _get_supabase()
 
     # Get unused codes for this user
-    result = await asyncio.to_thread(
+    result = await sb_execute(
         sb.table("mfa_recovery_codes")
         .select("id, code_hash")
         .eq("user_id", user_id)
         .is_("used_at", "null")
-        .execute
     )
 
     stored_codes = result.data or []
@@ -350,10 +351,11 @@ async def verify_recovery_code(
     for stored in stored_codes:
         if _verify_code(body.code, stored["code_hash"]):
             # Mark as used
-            await asyncio.to_thread(
+            await sb_execute(
                 sb.table("mfa_recovery_codes").update({
                     "used_at": datetime.now(timezone.utc).isoformat(),
-                }).eq("id", stored["id"]).execute
+                }).eq("id", stored["id"]),
+                category="write",
             )
 
             # Record successful attempt
@@ -375,14 +377,13 @@ async def verify_recovery_code(
     # No match — record failed attempt
     await _record_attempt(user_id, success=False)
 
-    _fail_query = (
+    _fail_result = await sb_execute(
         sb.table("mfa_recovery_attempts")
         .select("id")
         .eq("user_id", user_id)
         .eq("success", False)
         .gte("attempted_at", (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat())
     )
-    _fail_result = await asyncio.to_thread(_fail_query.execute)
     failed_count = len(_fail_result.data or [])
 
     remaining_attempts = MAX_FAILED_ATTEMPTS_PER_HOUR - failed_count
@@ -486,14 +487,16 @@ async def _persist_backup_codes(user_id: str) -> list[str]:
     """
     sb = await _get_supabase()
 
-    await asyncio.to_thread(
-        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id).execute
+    await sb_execute(
+        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id),
+        category="write",
     )
 
     plaintext_codes = _generate_recovery_codes()
     rows = [{"user_id": user_id, "code_hash": _hash_code(code)} for code in plaintext_codes]
-    await asyncio.to_thread(
-        sb.table("mfa_recovery_codes").insert(rows).execute
+    await sb_execute(
+        sb.table("mfa_recovery_codes").insert(rows),
+        category="write",
     )
 
     return plaintext_codes
@@ -659,13 +662,12 @@ async def verify_totp(
     # Find the user's most recent unverified factor (the one they just enrolled).
     sb = await _get_supabase()
     try:
-        result = await asyncio.to_thread(
+        result = await sb_execute(
             sb.table("mfa_factors")
             .select("id, status, created_at")
             .eq("user_id", user_id)
             .eq("factor_type", "totp")
             .order("created_at", desc=True)
-            .execute
         )
     except Exception as e:  # noqa: BLE001
         logger.warning(
@@ -756,16 +758,18 @@ async def regenerate_recovery_codes(user: dict = Depends(require_auth)):
     sb = await _get_supabase()
 
     # Delete all existing codes
-    await asyncio.to_thread(
-        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id).execute
+    await sb_execute(
+        sb.table("mfa_recovery_codes").delete().eq("user_id", user_id),
+        category="write",
     )
 
     # Generate fresh codes
     plaintext_codes = _generate_recovery_codes()
 
     rows = [{"user_id": user_id, "code_hash": _hash_code(code)} for code in plaintext_codes]
-    await asyncio.to_thread(
-        sb.table("mfa_recovery_codes").insert(rows).execute
+    await sb_execute(
+        sb.table("mfa_recovery_codes").insert(rows),
+        category="write",
     )
 
     logger.info(f"Regenerated recovery codes for user {user_id[:8]}...")

--- a/backend/routes/plans.py
+++ b/backend/routes/plans.py
@@ -10,7 +10,6 @@ This endpoint provides comprehensive plan information including:
 Data source: `plans` table in database (via SYS-M04 infrastructure)
 """
 
-import asyncio
 import logging
 from typing import List, Dict, Any
 
@@ -21,6 +20,7 @@ from pydantic import BaseModel
 
 from database import get_db
 from public_rate_limit import rate_limit_public
+from supabase_client import sb_execute
 
 logger = logging.getLogger(__name__)
 
@@ -80,19 +80,15 @@ async def get_plans_with_capabilities(db: Any = Depends(get_db)) -> PlansRespons
 
     try:
         # Fetch all active plans from database
-        def _sync_query():
-            return (
+        result = await _run_with_budget(
+            sb_execute(
                 db.table("plans")
                 .select(
                     "id, name, description, price_brl, duration_days, max_searches, is_active"
                 )
                 .eq("is_active", True)
                 .order("price_brl")
-                .execute()
-            )
-
-        result = await _run_with_budget(
-            asyncio.to_thread(_sync_query),
+            ),
             budget=5.0,
             phase="route",
             source="plans.get_plans_with_capabilities",

--- a/backend/routes/survey.py
+++ b/backend/routes/survey.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from auth import require_auth
 from pipeline.budget import _run_with_budget
-from supabase_client import get_supabase
+from supabase_client import get_supabase, sb_execute
 
 logger = logging.getLogger(__name__)
 
@@ -137,16 +137,13 @@ async def submit_export_time_saved_survey(
 
     sb = get_supabase()
 
-    def _sync_insert():
-        return (
-            sb.table("export_time_saved_survey")
-            .insert(payload)
-            .execute()
-        )
-
     try:
         result = await _run_with_budget(
-            asyncio.to_thread(_sync_insert),
+            sb_execute(
+                sb.table("export_time_saved_survey")
+                .insert(payload),
+                category="write",
+            ),
             budget=3.0,
             phase="route",
             source="survey.submit_export_time_saved_survey",

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -155,12 +155,11 @@ async def get_profile(user: dict = Depends(require_auth), db=Depends(get_db)):
     # ISSUE-070: Fetch real Stripe renewal date from profiles
     subscription_end_date_val = None
     try:
-        profile_row = await asyncio.to_thread(
-            lambda: db.table("profiles")
+        profile_row = await sb_execute(
+            db.table("profiles")
                 .select("subscription_end_date")
                 .eq("id", user["id"])
                 .single()
-                .execute()
         )
         if isinstance(profile_row.data, dict) and profile_row.data.get("subscription_end_date"):
             val = profile_row.data["subscription_end_date"]
@@ -309,12 +308,11 @@ async def get_recommended_plan(
 
     cnae_primary: str | None = None
     try:
-        profile_row = await asyncio.to_thread(
-            lambda: db.table("profiles")
+        profile_row = await sb_execute(
+            db.table("profiles")
                 .select("cnae_primary")
                 .eq("id", user_id)
                 .limit(1)
-                .execute()
         )
         if profile_row.data:
             cnae_primary = (profile_row.data[0] or {}).get("cnae_primary")

--- a/backend/services/trial_email_sequence.py
+++ b/backend/services/trial_email_sequence.py
@@ -42,6 +42,10 @@ def _get_founders_seats_remaining() -> int | None:
     falls back to None — the email templates render generic "vagas limitadas" copy
     in that case (no broken email, no over-promising on numbers).
 
+    _check_availability was migrated to sb_execute() (#1182) and is now async.
+    We bridge sync→async via a single-use thread so callers (render path) stay
+    synchronous.
+
     Returns:
         seats_remaining as int when feature flag enabled and RPC succeeds,
         None on any failure (templates use fallback copy).
@@ -55,7 +59,14 @@ def _get_founders_seats_remaining() -> int | None:
         from supabase_client import get_supabase
         from routes.founding import _check_availability
 
-        snapshot = _check_availability(get_supabase())
+        import asyncio
+        import concurrent.futures
+
+        coro = _check_availability(get_supabase())
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(asyncio.run, coro)
+            snapshot = future.result(timeout=15)
+
         if not snapshot.get("available"):
             return None
         seats = int(snapshot.get("seats_remaining") or 0)

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -3,6 +3,7 @@
 Tests AC6-AC11: Align /api/features/me with multi-layer plan fallback strategy.
 """
 
+import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, MagicMock
 from routes.features import fetch_features_from_db
@@ -11,8 +12,9 @@ from routes.features import fetch_features_from_db
 class TestFeaturesFallbackAC6AC7:
     """Test multi-layer fallback in fetch_features_from_db (AC6-AC7)."""
 
+    @pytest.mark.asyncio
     @patch("supabase_client.get_supabase")
-    def test_ac8_active_subscription_returns_correct_plan(self, mock_get_supabase):
+    async def test_ac8_active_subscription_returns_correct_plan(self, mock_get_supabase):
         """AC8: Active subscription → correct plan features."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -33,7 +35,7 @@ class TestFeaturesFallbackAC6AC7:
             {"feature_key": "advanced_filters", "enabled": True, "metadata": None},
         ]
 
-        result = fetch_features_from_db("user-123")
+        result = await fetch_features_from_db("user-123")
 
         assert result.plan_id == "maquina"
         assert result.billing_period == "monthly"
@@ -41,8 +43,9 @@ class TestFeaturesFallbackAC6AC7:
         assert result.features[0].key == "excel_export"
         assert result.features[0].enabled is True
 
+    @pytest.mark.asyncio
     @patch("supabase_client.get_supabase")
-    def test_ac9_expired_subscription_within_grace_returns_plan(self, mock_get_supabase):
+    async def test_ac9_expired_subscription_within_grace_returns_plan(self, mock_get_supabase):
         """AC9: Expired subscription within grace period → correct plan features (not free_trial)."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -67,16 +70,17 @@ class TestFeaturesFallbackAC6AC7:
             {"feature_key": "basic_search", "enabled": True, "metadata": None},
         ]
 
-        result = fetch_features_from_db("user-123")
+        result = await fetch_features_from_db("user-123")
 
         assert result.plan_id == "consultor_agil"
         assert result.billing_period == "monthly"
         assert len(result.features) == 1
         assert result.features[0].key == "basic_search"
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile")
     @patch("supabase_client.get_supabase")
-    def test_ac10_expired_subscription_and_valid_profile_plan(self, mock_get_supabase, mock_get_plan_from_profile):
+    async def test_ac10_expired_subscription_and_valid_profile_plan(self, mock_get_supabase, mock_get_plan_from_profile):
         """AC10: Expired subscription + valid profile plan → profile plan features."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -95,16 +99,17 @@ class TestFeaturesFallbackAC6AC7:
             {"feature_key": "excel_export", "enabled": True, "metadata": None},
         ]
 
-        result = fetch_features_from_db("user-456")
+        result = await fetch_features_from_db("user-456")
 
         assert result.plan_id == "maquina"
         assert result.billing_period == "monthly"  # Default for profile fallback
         assert len(result.features) == 1
         mock_get_plan_from_profile.assert_called_once_with("user-456", mock_sb)
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile")
     @patch("supabase_client.get_supabase")
-    def test_ac11_no_subscription_no_profile_returns_free_trial(self, mock_get_supabase, mock_get_plan_from_profile):
+    async def test_ac11_no_subscription_no_profile_returns_free_trial(self, mock_get_supabase, mock_get_plan_from_profile):
         """AC11: No subscription + no profile plan → free_trial."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -121,15 +126,16 @@ class TestFeaturesFallbackAC6AC7:
         # Mock plan_features result for free_trial (empty or none)
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value.data = []
 
-        result = fetch_features_from_db("user-789")
+        result = await fetch_features_from_db("user-789")
 
         assert result.plan_id == "free_trial"
         assert result.billing_period == "monthly"
         assert len(result.features) == 0
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile")
     @patch("supabase_client.get_supabase")
-    def test_database_error_falls_back_to_profile(self, mock_get_supabase, mock_get_plan_from_profile):
+    async def test_database_error_falls_back_to_profile(self, mock_get_supabase, mock_get_plan_from_profile):
         """Database error during subscription lookup should use profile fallback."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -145,7 +151,7 @@ class TestFeaturesFallbackAC6AC7:
             {"feature_key": "basic_search", "enabled": True, "metadata": None},
         ]
 
-        result = fetch_features_from_db("user-error")
+        result = await fetch_features_from_db("user-error")
 
         assert result.plan_id == "consultor_agil"
         mock_get_plan_from_profile.assert_called_once()
@@ -154,9 +160,10 @@ class TestFeaturesFallbackAC6AC7:
 class TestFeaturesGracePeriodAC7:
     """Test grace period (3 days) is respected in features endpoint (AC7)."""
 
+    @pytest.mark.asyncio
     @patch("quota.SUBSCRIPTION_GRACE_DAYS", 3)
     @patch("supabase_client.get_supabase")
-    def test_grace_period_boundary_exactly_3_days(self, mock_get_supabase):
+    async def test_grace_period_boundary_exactly_3_days(self, mock_get_supabase):
         """Subscription expired exactly 3 days ago should still be used."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -177,15 +184,16 @@ class TestFeaturesGracePeriodAC7:
         # Mock plan_features
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value.data = []
 
-        result = fetch_features_from_db("user-boundary")
+        result = await fetch_features_from_db("user-boundary")
 
         assert result.plan_id == "sala_guerra"
         assert result.billing_period == "yearly"
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile")
     @patch("routes.features.SUBSCRIPTION_GRACE_DAYS", 3)
     @patch("supabase_client.get_supabase")
-    def test_expired_beyond_grace_uses_profile(self, mock_get_supabase, mock_get_plan_from_profile):
+    async def test_expired_beyond_grace_uses_profile(self, mock_get_supabase, mock_get_plan_from_profile):
         """Subscription expired > 3 days ago should fall back to profile."""
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
@@ -202,7 +210,7 @@ class TestFeaturesGracePeriodAC7:
         # Mock plan_features
         mock_sb.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value.data = []
 
-        result = fetch_features_from_db("user-expired-beyond")
+        result = await fetch_features_from_db("user-expired-beyond")
 
         assert result.plan_id == "maquina"
         mock_get_plan_from_profile.assert_called_once()

--- a/backend/tests/test_routes_features.py
+++ b/backend/tests/test_routes_features.py
@@ -6,6 +6,7 @@ STORY-224 Track 4 (AC26): Feature flags route coverage with Redis caching.
 import json
 from unittest.mock import Mock, patch, AsyncMock
 
+import pytest
 from fastapi.testclient import TestClient
 from fastapi import FastAPI
 
@@ -150,8 +151,9 @@ class TestGetMyFeatures:
 
 class TestFetchFeaturesFromDB:
 
+    @pytest.mark.asyncio
     @patch("supabase_client.get_supabase")
-    def test_active_subscription_primary_source(self, mock_get_sb):
+    async def test_active_subscription_primary_source(self, mock_get_sb):
         """Layer 1: Active subscription found — use its plan_id."""
         sb = _mock_sb()
         sub_data = [{"plan_id": "maquina", "billing_period": "annual", "expires_at": None}]
@@ -166,15 +168,16 @@ class TestFetchFeaturesFromDB:
         mock_get_sb.return_value = sb
 
         from routes.features import fetch_features_from_db
-        result = fetch_features_from_db("user-123-uuid")
+        result = await fetch_features_from_db("user-123-uuid")
 
         assert result.plan_id == "maquina"
         assert result.billing_period == "annual"
         assert len(result.features) == 2
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile", return_value=None)
     @patch("supabase_client.get_supabase")
-    def test_grace_period_fallback(self, mock_get_sb, mock_profile):
+    async def test_grace_period_fallback(self, mock_get_sb, mock_profile):
         """Layer 2: No active sub, but recently-expired sub within grace period."""
         sb = _mock_sb()
         # First query: no active subscription
@@ -189,13 +192,14 @@ class TestFetchFeaturesFromDB:
         mock_get_sb.return_value = sb
 
         from routes.features import fetch_features_from_db
-        result = fetch_features_from_db("user-123-uuid")
+        result = await fetch_features_from_db("user-123-uuid")
 
         assert result.plan_id == "consultor_agil"
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile", return_value="maquina")
     @patch("supabase_client.get_supabase")
-    def test_profile_fallback(self, mock_get_sb, mock_profile):
+    async def test_profile_fallback(self, mock_get_sb, mock_profile):
         """Layer 3: No active or grace sub — fall back to profiles.plan_type."""
         sb = _mock_sb()
         features_data = [{"feature_key": "excel_export", "enabled": True, "metadata": None}]
@@ -207,14 +211,15 @@ class TestFetchFeaturesFromDB:
         mock_get_sb.return_value = sb
 
         from routes.features import fetch_features_from_db
-        result = fetch_features_from_db("user-123-uuid")
+        result = await fetch_features_from_db("user-123-uuid")
 
         assert result.plan_id == "maquina"
         assert result.billing_period == "monthly"  # Default for profile fallback
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile", return_value=None)
     @patch("supabase_client.get_supabase")
-    def test_free_trial_last_resort(self, mock_get_sb, mock_profile):
+    async def test_free_trial_last_resort(self, mock_get_sb, mock_profile):
         """Layer 4: Nothing found — defaults to free_trial."""
         sb = _mock_sb()
         features_data = []
@@ -226,15 +231,16 @@ class TestFetchFeaturesFromDB:
         mock_get_sb.return_value = sb
 
         from routes.features import fetch_features_from_db
-        result = fetch_features_from_db("user-123-uuid")
+        result = await fetch_features_from_db("user-123-uuid")
 
         assert result.plan_id == "free_trial"
         assert result.billing_period == "monthly"
         assert result.features == []
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile", return_value="free_trial")
     @patch("supabase_client.get_supabase")
-    def test_profile_free_trial_skipped_to_layer4(self, mock_get_sb, mock_profile):
+    async def test_profile_free_trial_skipped_to_layer4(self, mock_get_sb, mock_profile):
         """Layer 3 returns 'free_trial' — skip it and fall through to Layer 4."""
         sb = _mock_sb()
         sb.execute.side_effect = [
@@ -245,13 +251,14 @@ class TestFetchFeaturesFromDB:
         mock_get_sb.return_value = sb
 
         from routes.features import fetch_features_from_db
-        result = fetch_features_from_db("user-123-uuid")
+        result = await fetch_features_from_db("user-123-uuid")
 
         assert result.plan_id == "free_trial"
 
+    @pytest.mark.asyncio
     @patch("routes.features.get_plan_from_profile", return_value=None)
     @patch("supabase_client.get_supabase")
-    def test_plan_features_query_failure_returns_empty(self, mock_get_sb, mock_profile):
+    async def test_plan_features_query_failure_returns_empty(self, mock_get_sb, mock_profile):
         """If plan_features query fails, return empty features (fail safe)."""
         sb = _mock_sb()
         sub_data = [{"plan_id": "consultor_agil", "billing_period": "monthly", "expires_at": None}]
@@ -262,7 +269,7 @@ class TestFetchFeaturesFromDB:
         mock_get_sb.return_value = sb
 
         from routes.features import fetch_features_from_db
-        result = fetch_features_from_db("user-123-uuid")
+        result = await fetch_features_from_db("user-123-uuid")
 
         assert result.plan_id == "consultor_agil"
         assert result.features == []


### PR DESCRIPTION
## Summary

Complete the sb_execute() migration for authenticated user routes. 13 of 21 files were already migrated in PR #1206. This PR covers the remaining 8.

## Files changed

| File | Endpoints |
|------|-----------|
| `routes/conta.py` | `/conta/*` |
| `routes/features.py` | `/features/*` |
| `routes/founding.py` | `/founding/*` |
| `routes/lead_capture.py` | `/lead-capture/*` |
| `routes/mfa.py` | `/mfa/*` |
| `routes/plans.py` | `/plans` |
| `routes/survey.py` | `/survey` |
| `routes/user.py` | `/user/*` |

## Pattern

Every `.execute()` call wrapped with `await sb_execute()` — non-blocking async execution with circuit breaker protection and HTTP/2 retry. Write operations tagged with `category="write"`.

## Testing Plan

- [ ] All 8 files pass Python syntax check
- [ ] Backend tests pass (`pytest`)
- [ ] No remaining `get_supabase().*.execute()` in migrated routes

## Closes

Closes #1182