### PR TITLE
fix(backend): migrate remaining routes to sb_execute() async (#1182)

### DIFF
--- a/backend/routes/sitemap_cnpjs.py
+++ b/backend/routes/sitemap_cnpjs.py
@@ -119,7 +119,7 @@ async def sitemap_cnpjs(response: Response):
     _fresh_fetch = True
     try:
         data = await _run_with_budget(
-            asyncio.to_thread(_fetch_top_cnpjs),
+            _fetch_top_cnpjs(),
             budget=_BUDGET_S,
             phase="route",
             source="sitemap_cnpjs.sitemap_cnpjs",
@@ -207,16 +207,16 @@ def _merge_with_seed(buyer_cnpjs: list[str]) -> list[str]:
     return result[:_MAX_CNPJS]
 
 
-def _fetch_top_cnpjs() -> dict:
+async def _fetch_top_cnpjs() -> dict:
     """Query mv_sitemap_cnpjs for distinct orgao_cnpj com ≥1 licitação ativa.
 
     SEO-SITEMAP-MV-001: MV pré-agregada substitui RPC + fallback paginado.
     Query < 50ms contra < 1ms no MV indexado.
 
-    Sync — supabase-py is sync, so caller wraps this in asyncio.to_thread.
+    Async com sb_execute() para retry HTTP/2 (SEN-BE-004).
     """
     try:
-        from supabase_client import get_supabase
+        from supabase_client import get_supabase, sb_execute
 
         sb = get_supabase()
 
@@ -224,12 +224,11 @@ def _fetch_top_cnpjs() -> dict:
         page_size = 1000
         offset = 0
         while True:
-            resp = (
+            resp = await sb_execute(
                 sb.table("mv_sitemap_cnpjs")
                 .select("cnpj")
                 .order("cnpj")
                 .range(offset, offset + page_size - 1)
-                .execute()
             )
             if not resp.data:
                 break


### PR DESCRIPTION
## Summary

Converte as últimas chamadas `.execute()` síncronas em `backend/routes/` para `sb_execute()` assíncrono com circuit breaker + retry HTTP/2.

- **10 arquivos de rota** migrados: conta.py, features.py, founding.py, lead_capture.py, mfa.py, plans.py, sitemap_cnpjs.py, survey.py, user.py + trial_email_sequence.py
- **_fetch_top_cnpjs()** em sitemap_cnpjs.py era a última função sync com `.execute()` bare — convertida para async
- **0** chamadas `.execute()` restantes em routes (apenas comentários)
- **56/80** route files agora usam `sb_execute()`
- Testes atualizados: test_features.py, test_routes_features.py

## Testing Plan

- [x] `pytest tests/test_sitemap_cnpjs.py` — 15/15 passando
- [ ] CI: backend-tests suite completa
- [ ] CI: migration-check gate
- [ ] Smoke: deploy Railway → health endpoint 200

## Closes

Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)