### PR TITLE
fix: register lead magnet ARQ jobs + fix exit-intent source mismatch

### DIFF
--- a/backend/jobs/queue/config.py
+++ b/backend/jobs/queue/config.py
@@ -172,6 +172,14 @@ class WorkerSettings:
     except ImportError:
         _founders_functions = []
 
+    # Lead magnet PDF delivery jobs
+    try:
+        from jobs.cron.send_lead_magnet import send_lead_magnet_job as _send_lead_magnet_job
+        from jobs.cron.send_lead_magnet import send_lead_magnet_batch_job as _send_lead_magnet_batch_job
+        _lead_magnet_functions = [_send_lead_magnet_job, _send_lead_magnet_batch_job]
+    except ImportError:
+        _lead_magnet_functions = []
+
     functions = [
         llm_summary_job, excel_generation_job, search_job,
         bid_analysis_job, daily_digest_job, email_alerts_job,
@@ -182,6 +190,7 @@ class WorkerSettings:
         *_ingestion_functions,
         *_monitoring_functions,
         *_founders_functions,
+        *_lead_magnet_functions,
     ]
     cron_jobs = _worker_cron_jobs
     on_startup = _worker_on_startup

--- a/backend/jobs/queue/config.py
+++ b/backend/jobs/queue/config.py
@@ -178,6 +178,9 @@ class WorkerSettings:
         from jobs.cron.send_lead_magnet import send_lead_magnet_batch_job as _send_lead_magnet_batch_job
         _lead_magnet_functions = [_send_lead_magnet_job, _send_lead_magnet_batch_job]
     except ImportError:
+        logger.exception(
+            "Lead magnet jobs not registered; queued lead-magnet jobs will silently fail"
+        )
         _lead_magnet_functions = []
 
     functions = [

--- a/frontend/app/api/lead-capture/route.ts
+++ b/frontend/app/api/lead-capture/route.ts
@@ -53,13 +53,20 @@ export async function POST(request: NextRequest) {
     });
 
     if (!res.ok) {
-      console.warn(`Lead capture backend returned ${res.status} — storing locally only`);
+      const errorBody = await res.text();
+      console.warn(`Lead capture backend returned ${res.status}: ${errorBody}`);
+      return NextResponse.json(
+        { success: false, error: `Erro ao processar (${res.status})` },
+        { status: 502 },
+      );
     }
 
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Lead capture error:', error);
-    // Still return success — we don't want to block the UX
-    return NextResponse.json({ success: true });
+    return NextResponse.json(
+      { success: false, error: 'Serviço indisponível. Tente novamente.' },
+      { status: 502 },
+    );
   }
 }

--- a/frontend/app/api/lead-capture/route.ts
+++ b/frontend/app/api/lead-capture/route.ts
@@ -53,8 +53,11 @@ export async function POST(request: NextRequest) {
     });
 
     if (!res.ok) {
-      const errorBody = await res.text();
-      console.warn(`Lead capture backend returned ${res.status}: ${errorBody}`);
+      const requestId = res.headers.get('x-request-id');
+      console.warn('Lead capture backend returned non-OK response', {
+        status: res.status,
+        requestId,
+      });
       return NextResponse.json(
         { success: false, error: `Erro ao processar (${res.status})` },
         { status: 502 },

--- a/frontend/app/components/landing/ExitIntentPopup.tsx
+++ b/frontend/app/components/landing/ExitIntentPopup.tsx
@@ -85,7 +85,7 @@ export default function ExitIntentPopup() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             email,
-            source: 'exit-intent',
+            source: 'exit_intent',
           }),
         });
         if (res.ok) {


### PR DESCRIPTION
## Summary

Two independent bugs broke PDF delivery for ALL lead capture forms. Zero leads ever received the PDF.

**RC1:** send_lead_magnet_job not in WorkerSettings.functions -> ARQ worker never executed jobs.
**RC2:** ExitIntentPopup sent source=exit-intent (hyphen) but backend expects exit_intent (underscore). 422 silently swallowed by route.ts.

## Changes

| File | Change |
|------|--------|
| backend/jobs/queue/config.py | Register send_lead_magnet_job + send_lead_magnet_batch_job in WorkerSettings.functions |
| frontend/.../ExitIntentPopup.tsx | Fix exit-intent -> exit_intent |
| frontend/app/api/lead-capture/route.ts | Propagate backend errors (502) + strip PII from logs |

## Testing Plan

- [ ] Submit email via landing page exit-intent popup
- [ ] Verify ARQ worker picks up send_lead_magnet_job
- [ ] Verify batch job processes pending leads
- [ ] Manual QA: verify email received with PDF attachment

## Closes

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)