### PR TITLE
fix: accent-insensitive municipio fallback — unaccent()

### DIFF
--- a/backend/routes/municipios_publicos.py
+++ b/backend/routes/municipios_publicos.py
@@ -462,7 +462,7 @@ async def municipio_profile(slug: str):
                 "data_publicacao,modalidade_nome"
             )
             .eq("uf", uf)
-            .ilike("municipio", nome)
+            .filter("unaccent(municipio)", "ilike", nome)
             .eq("is_active", True)
             .order("data_publicacao", desc=True)
             .limit(500)


### PR DESCRIPTION
## Summary

`.ilike("municipio", nome)` no fallback query não é accent-insensitive — "Sao Paulo" não matcha "São Paulo" no datalake. Municípios com acento (São Paulo, Brasília, Belém, São Luís, etc.) mostravam 0 editais abertos.

**Fix:** trocar `.ilike("municipio", nome)` por `.filter("unaccent(municipio)", "ilike", nome)`. Extensão `unaccent` v1.1 já instalada no Supabase.

**Diff:** 1 linha em `backend/routes/municipios_publicos.py`.

## Changes

| File | Delta | Description |
|------|-------|-------------|
| `backend/routes/municipios_publicos.py` | +1/-1 | `.filter("unaccent(municipio)", "ilike", nome)` |

## Testing Plan

- [x] 56 municipio-related tests pass, 0 regressions
- [ ] Validar `/municipios/sao-paulo-sp` mostra editais > 0 após deploy

## Closes

Follow-up ao PR #1256 — corrige edge case de acento no fallback por nome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved municipality name matching in public procurement bids search to be accent-insensitive, enabling users to find results regardless of accent mark usage in their search queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tjsasakifln/SmartLic/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->