### PR TITLE
fix(ci): add PYSEC-2026-161 ignore to dep-scan and dependency-audit workflows

### DIFF
--- a/.github/workflows/dep-scan.yml
+++ b/.github/workflows/dep-scan.yml
@@ -51,13 +51,16 @@ jobs:
         run: pip install pip-audit
 
       - name: Run pip-audit (blocks on HIGH/CRITICAL)
+        # PYSEC-2026-161: starlette<1.0.1 Host header — pre-existing, not fixable
+        # without FastAPI major upgrade (starlette is a FastAPI dep). Tracked separately.
         run: |
           cd backend
           echo "Running pip-audit on requirements.txt..."
           pip-audit --strict -r requirements.txt \
+            --ignore-vuln PYSEC-2026-161 \
             --desc on \
             --format columns
-          echo "✅ pip-audit: no HIGH or CRITICAL vulnerabilities"
+          echo "✅ pip-audit: no HIGH or CRITICAL vulnerabilities (PYSEC-2026-161 ignored — tracked separately)"
 
   # ─────────────────────────────────────────────────
   # Frontend: npm audit — 0 HIGH/CRITICAL = gate

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -50,6 +50,8 @@ jobs:
         # --strict: fail on any vulnerability (not just HIGH/CRITICAL); pairs with
         # documented --ignore-vuln entries in docs/security/dependency-scanning.md.
         # --vulnerability-service osv: free OSV.dev advisories with broad coverage.
+        # PYSEC-2026-161: starlette<1.0.1 Host header — pre-existing, not fixable
+        # without FastAPI major upgrade (starlette is a FastAPI dep). Tracked separately.
         run: |
           set -euo pipefail
           mkdir -p audit-reports
@@ -57,10 +59,11 @@ jobs:
             -r backend/requirements.txt \
             --strict \
             --vulnerability-service osv \
+            --ignore-vuln PYSEC-2026-161 \
             --desc on \
             --format json \
             --output audit-reports/pip-audit.json
-          echo "pip-audit (OSV): clean"
+          echo "pip-audit (OSV): clean (PYSEC-2026-161 ignored — tracked separately)"
 
       - name: Upload pip-audit report
         if: always()


### PR DESCRIPTION
## Summary/Context

PYSEC-2026-161 (starlette<1.0.1 Host header vulnerability) is pre-existing and not fixable without a FastAPI major upgrade (starlette is pinned by FastAPI). `backend-tests.yml` already has `--ignore-vuln PYSEC-2026-161` but `dep-scan.yml` and `dependency-audit.yml` also run `pip-audit` and were blocking ALL Dependabot PRs.

## Changes

- `.github/workflows/dep-scan.yml`: add `--ignore-vuln PYSEC-2026-161` to pip-audit step
- `.github/workflows/dependency-audit.yml`: add `--ignore-vuln PYSEC-2026-161` to pip-audit (OSV) step

## Testing Plan

- CI: all pip-audit steps pass
- Dependabot PRs (when recreated from main) will pass dep-scan gate
- No functional change — only CI configuration

## Closes

- Unblocks all Dependabot PRs (previously failing dep-scan gate)
- Prerequisite for PR #1258 (pyjwt security update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)