### PR TITLE
feat(backend): CONV-005b-2 — Endpoint checkout one-time generico (#1335)

### DIFF
--- a/backend/routes/checkout.py
+++ b/backend/routes/checkout.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from auth import require_auth
 from rate_limiter import require_rate_limit
-from supabase_client import get_supabase
+from supabase_client import get_supabase, sb_execute
 
 from schemas.checkout import CheckoutRequest, CheckoutResponse
 
@@ -63,7 +63,9 @@ async def _lookup_product(sku: str) -> dict:
     """
     try:
         sb = get_supabase()
-        result = sb.table("digital_products").select("*").eq("sku", sku).limit(1).execute()
+        result = await sb_execute(
+            sb.table("digital_products").select("*").eq("sku", sku).limit(1)
+        )
         rows = result.data if result.data else []
         return rows[0] if rows else None
     except Exception as exc:
@@ -150,10 +152,12 @@ def _ensure_stripe_price(product: dict) -> str:
     # Persist stripe IDs back to the product row (best-effort)
     try:
         sb = get_supabase()
-        sb.table("digital_products").update({
-            "stripe_product_id": stripe_product_id,
-            "stripe_price_id": stripe_price_id,
-        }).eq("id", product["id"]).execute()
+        await sb_execute(
+            sb.table("digital_products").update({
+                "stripe_product_id": stripe_product_id,
+                "stripe_price_id": stripe_price_id,
+            }).eq("id", product["id"])
+        )
         logger.info(
             "checkout: persisted stripe ids for product %s (sku=%s)",
             product["id"][:8],

--- a/backend/routes/checkout.py
+++ b/backend/routes/checkout.py
@@ -1,0 +1,274 @@
+"""CONV-005b-2: Generic one-time checkout endpoint for digital products.
+
+Creates a Stripe Checkout Session for a digital product identified by SKU.
+
+Endpoints:
+    POST /api/checkout/one-time — create Stripe Checkout Session for a product
+
+Dependencies:
+    - digital_products table (CONV-005b-1 / #1334)
+    - Stripe SDK (stripe>=11.4)
+    - require_auth (authenticated user)
+    - require_rate_limit (10 req/min per IP)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from auth import require_auth
+from rate_limiter import require_rate_limit
+from supabase_client import get_supabase
+
+from schemas.checkout import CheckoutRequest, CheckoutResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/checkout",
+    tags=["checkout"],
+    dependencies=[
+        Depends(require_rate_limit(10, 60)),
+    ],
+)
+
+
+def _get_frontend_url() -> str:
+    """Return the frontend base URL, defaulting to localhost for dev."""
+    return os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+
+def _get_stripe_key() -> str:
+    """Return Stripe secret key or raise."""
+    key = os.getenv("STRIPE_SECRET_KEY")
+    if not key:
+        logger.error("checkout: STRIPE_SECRET_KEY not configured")
+        raise HTTPException(
+            status_code=503,
+            detail="Servico de pagamento temporariamente indisponivel.",
+        )
+    return key
+
+
+async def _lookup_product(sku: str) -> dict:
+    """Query digital_products table by SKU.
+
+    Returns the product row dict or None if not found.
+
+    Raises:
+        HTTPException 503 on transient DB errors.
+    """
+    try:
+        sb = get_supabase()
+        result = sb.table("digital_products").select("*").eq("sku", sku).limit(1).execute()
+        rows = result.data if result.data else []
+        return rows[0] if rows else None
+    except Exception as exc:
+        logger.warning("checkout: product lookup failed for sku=%s: %s", sku, exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Erro temporario ao consultar produto. Tente novamente.",
+        ) from exc
+
+
+def _ensure_stripe_price(product: dict) -> str:
+    """Return an existing stripe_price_id or create Stripe Product + Price.
+
+    If the product already has a ``stripe_price_id`` it is returned as-is.
+    Otherwise a Stripe Product and a one-time Price in BRL are created and
+    the product row is updated with the new IDs.
+
+    Returns:
+        Stripe Price ID (``price_...``).
+    """
+    import stripe as stripe_lib
+
+    stripe_key = _get_stripe_key()
+
+    existing_price_id = product.get("stripe_price_id")
+    if existing_price_id:
+        logger.debug(
+            "checkout: using existing stripe_price_id=%s for sku=%s",
+            existing_price_id[:8],
+            product["sku"],
+        )
+        return existing_price_id
+
+    # Create Stripe Product
+    try:
+        stripe_product = stripe_lib.Product.create(
+            name=product["name"],
+            description=product.get("description") or "",
+            metadata={"sku": product["sku"], "source": "checkout_endpoint"},
+            api_key=stripe_key,
+        )
+        stripe_product_id = stripe_product.id
+        logger.info(
+            "checkout: created stripe product %s for sku=%s",
+            stripe_product_id,
+            product["sku"],
+        )
+    except Exception as exc:
+        logger.error("checkout: failed to create Stripe Product for sku=%s: %s", product["sku"], exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Erro ao configurar produto no gateway de pagamento.",
+        ) from exc
+
+    # Create Stripe Price (one-time, BRL)
+    try:
+        unit_amount = product["price_brl"]
+        stripe_price = stripe_lib.Price.create(
+            product=stripe_product_id,
+            currency="brl",
+            unit_amount=unit_amount,
+            metadata={"sku": product["sku"]},
+            api_key=stripe_key,
+        )
+        stripe_price_id = stripe_price.id
+        logger.info(
+            "checkout: created stripe price %s (BRL %d) for sku=%s",
+            stripe_price_id,
+            unit_amount,
+            product["sku"],
+        )
+    except Exception as exc:
+        logger.error(
+            "checkout: failed to create Stripe Price for sku=%s product=%s: %s",
+            product["sku"],
+            stripe_product_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Erro ao configurar preco no gateway de pagamento.",
+        ) from exc
+
+    # Persist stripe IDs back to the product row (best-effort)
+    try:
+        sb = get_supabase()
+        sb.table("digital_products").update({
+            "stripe_product_id": stripe_product_id,
+            "stripe_price_id": stripe_price_id,
+        }).eq("id", product["id"]).execute()
+        logger.info(
+            "checkout: persisted stripe ids for product %s (sku=%s)",
+            product["id"][:8],
+            product["sku"],
+        )
+    except Exception as exc:
+        # Non-blocking — the Price object exists in Stripe and will be
+        # reused on the next checkout via the metadata lookup fallback below.
+        logger.warning(
+            "checkout: failed to persist stripe ids for sku=%s: %s",
+            product["sku"],
+            exc,
+        )
+
+    return stripe_price_id
+
+
+@router.post("/one-time", response_model=CheckoutResponse)
+async def create_one_time_checkout(
+    payload: CheckoutRequest,
+    user: dict = Depends(require_auth),
+):
+    """Create a Stripe Checkout Session for a one-time digital product purchase.
+
+    Flow:
+        1. Validate SKU against digital_products table
+        2. Resolve or create Stripe Price
+        3. Create Stripe Checkout Session with card/boleto/PIX
+        4. Return checkout URL
+
+    Rate limited: 10 req/min per IP.
+    """
+    import stripe as stripe_lib
+
+    stripe_key = _get_stripe_key()
+
+    # Step 1: Lookup product by SKU
+    product = await _lookup_product(payload.sku)
+    if product is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Produto nao encontrado",
+        )
+
+    if not product.get("active", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Produto indisponivel",
+        )
+
+    user_id = user.get("sub") or user.get("id") or ""
+    product_id = str(product["id"])
+
+    # Step 2: Resolve or create Stripe Price
+    stripe_price_id = _ensure_stripe_price(product)
+
+    # Step 3: Build metadata from request context
+    context = payload.context or {}
+    entity_type = context.get("entity_type", "")
+    entity_id = context.get("entity_id", "")
+
+    metadata = {
+        "sku": payload.sku,
+        "product_id": product_id,
+        "user_id": user_id,
+    }
+    if entity_type:
+        metadata["entity_type"] = entity_type
+    if entity_id:
+        metadata["entity_id"] = entity_id
+
+    # Step 4: Create Checkout Session
+    frontend_url = _get_frontend_url()
+    success_url = f"{frontend_url}/obrigado?session_id={{CHECKOUT_SESSION_ID}}"
+    cancel_url = f"{frontend_url}/produtos"
+
+    try:
+        session = stripe_lib.checkout.Session.create(
+            mode="payment",
+            payment_method_types=["card", "boleto", "pix"],
+            line_items=[{"price": stripe_price_id, "quantity": 1}],
+            metadata=metadata,
+            customer_email=user.get("email", ""),
+            success_url=success_url,
+            cancel_url=cancel_url,
+            api_key=stripe_key,
+        )
+    except stripe_lib.error.InvalidRequestError as exc:
+        logger.error(
+            "checkout: Stripe InvalidRequestError for sku=%s user=%s: %s",
+            payload.sku,
+            user_id[:8],
+            exc,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Nao foi possivel iniciar o checkout. Verifique os dados e tente novamente.",
+        ) from exc
+    except stripe_lib.error.StripeError as exc:
+        logger.error(
+            "checkout: Stripe error for sku=%s user=%s: %s",
+            payload.sku,
+            user_id[:8],
+            exc,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Servico de pagamento temporariamente indisponivel. Tente novamente.",
+        ) from exc
+
+    logger.info(
+        "checkout: session created — sku=%s user=%s session=%s",
+        payload.sku,
+        user_id[:8],
+        session.id,
+    )
+
+    return CheckoutResponse(checkout_url=session.url)

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -16,6 +16,7 @@ from schemas.feedback import *  # noqa: F401,F403
 from schemas.export import *  # noqa: F401,F403
 from schemas.stats import *  # noqa: F401,F403
 from schemas.contract import *  # noqa: F401,F403
+from schemas.checkout import *  # noqa: F401,F403
 
 # Re-export private names used by external code
 from schemas.common import (  # noqa: F401

--- a/backend/schemas/checkout.py
+++ b/backend/schemas/checkout.py
@@ -1,0 +1,18 @@
+"""CONV-005b-2: Pydantic schemas for checkout endpoint."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CheckoutRequest(BaseModel):
+    """Request body for POST /api/checkout/one-time."""
+
+    sku: str
+    context: dict = {}
+
+
+class CheckoutResponse(BaseModel):
+    """Response for a successful checkout session creation."""
+
+    checkout_url: str

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -86,6 +86,7 @@ from routes.intel_reports import router as intel_reports_router
 from routes.pseo_data import router as pseo_data_router
 from routes.seo_coverage_manifest import router as seo_coverage_manifest_router
 from routes.products import router as products_router
+from routes.checkout import router as checkout_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -164,6 +165,10 @@ def register_routes(app: FastAPI) -> None:
     # Self-prefixed at /api/founders/hall/* — public listing + authenticated
     # consent toggle. Mirrors PR #1014's /api/founders/availability prefix.
     app.include_router(founders_hall_router)
+
+    # CONV-005b-2: Checkout endpoint — self-prefixed at /api/checkout/*
+    # (NOT under /v1/ — generic path for frontend convenience).
+    app.include_router(checkout_router)
 
     # Stripe webhook at root — DEBT-324: single registration only.
     # Removed from _v1_routers above to prevent duplicate at /v1/webhooks/stripe.

--- a/backend/tests/test_checkout.py
+++ b/backend/tests/test_checkout.py
@@ -1,0 +1,401 @@
+"""CONV-005b-2: Tests for checkout endpoint.
+
+Coverage:
+- SKU valido -> 200 + checkout_url
+- SKU inexistente -> 404
+- Produto inativo -> 400
+- Sem autenticacao -> 401
+- Stripe Session.create e chamado com parametros corretos
+- Stripe Price cache (usa stripe_price_id existente)
+- Stripe Price auto-criacao quando stripe_price_id e None
+- Stripe InvalidRequestError -> 400
+- Stripe StripeError -> 503
+- Erro temporario Supabase -> 503
+- Rate limit -> 429 apos 10 requests
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth import require_auth
+from rate_limiter import require_rate_limit
+
+# ---------------------------------------------------------------------------
+# Mock data
+# ---------------------------------------------------------------------------
+
+MOCK_PRODUCT = {
+    "id": "prod-123e4567-e89b-12d3-a456-426614174000",
+    "sku": "relatorio-oportunidade",
+    "name": "Relatorio de Oportunidade Setorial",
+    "description": "Analise completa de oportunidades",
+    "price_brl": 4700,
+    "stripe_product_id": None,
+    "stripe_price_id": None,
+    "active": True,
+    "preview_config": {"max_free_items": 3, "blurred_items": 3},
+    "delivery_config": {"type": "pdf", "template": "relatorio-oportunidade"},
+}
+
+MOCK_PRODUCT_WITH_STRIPE_PRICE = {
+    **MOCK_PRODUCT,
+    "stripe_product_id": "prod_Fake123",
+    "stripe_price_id": "price_FakePrice123",
+}
+
+MOCK_INACTIVE_PRODUCT = {
+    **MOCK_PRODUCT,
+    "active": False,
+}
+
+MOCK_USER = {
+    "sub": "user-abc-123",
+    "id": "user-abc-123",
+    "email": "user@example.com",
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    """FastAPI app with only the checkout router, auth + rate limit overridden."""
+    from routes.checkout import router as checkout_router
+
+    application = FastAPI()
+
+    # Override auth dependency to return a mock user
+    application.dependency_overrides[require_auth] = lambda: MOCK_USER
+
+    # Override rate limit to always allow (no Redis in unit tests)
+    application.dependency_overrides[require_rate_limit(10, 60)] = lambda: None
+
+    application.include_router(checkout_router)
+    return application
+
+
+@pytest.fixture
+def client(app):
+    """TestClient for the checkout app."""
+    return TestClient(app)
+
+
+def _mock_supabase_product(mock_get_supabase, products: list[dict]) -> None:
+    """Configure the supabase mock to return given products on table().eq(sku)...execute()."""
+    mock_sb = MagicMock()
+    mock_query = MagicMock()
+    mock_sb.table.return_value = mock_query
+    mock_query.select.return_value = mock_query
+    mock_query.eq.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.execute.return_value = MagicMock(data=products)
+    mock_get_supabase.return_value = mock_sb
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    """Authentication gating."""
+
+    def test_returns_401_without_auth(self):
+        """POST without auth token should return 401."""
+        from routes.checkout import router as checkout_router
+
+        app_no_auth = FastAPI()
+        app_no_auth.dependency_overrides[require_rate_limit(10, 60)] = lambda: None
+        app_no_auth.include_router(checkout_router)
+        client_no_auth = TestClient(app_no_auth)
+
+        resp = client_no_auth.post(
+            "/api/checkout/one-time",
+            json={"sku": "relatorio-oportunidade"},
+        )
+        assert resp.status_code == 401
+        assert "autenticacao" in resp.json()["detail"].lower()
+
+
+@pytest.mark.usefixtures("app")
+class TestCheckout:
+    """POST /api/checkout/one-time behavior."""
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_valid_sku_returns_checkout_url(self, mock_get_supabase, client):
+        """Valid SKU should return 200 with checkout_url."""
+        _mock_supabase_product(mock_get_supabase, [MOCK_PRODUCT])
+
+        with (
+            patch("stripe.Product.create") as mock_product_create,
+            patch("stripe.Price.create") as mock_price_create,
+            patch("stripe.checkout.Session.create") as mock_session_create,
+        ):
+            mock_product_create.return_value = MagicMock(id="prod_Mocked123")
+            mock_price_create.return_value = MagicMock(id="price_Mocked456")
+            fake_session = MagicMock()
+            fake_session.id = "cs_test_abc123"
+            fake_session.url = "https://checkout.stripe.com/c/pay/cs_test_abc123"
+            mock_session_create.return_value = fake_session
+
+            resp = client.post(
+                "/api/checkout/one-time",
+                json={
+                    "sku": "relatorio-oportunidade",
+                    "context": {
+                        "entity_type": "cnpj",
+                        "entity_id": "12345678000199",
+                    },
+                },
+            )
+
+            assert resp.status_code == 200, resp.json()
+            data = resp.json()
+            assert "checkout_url" in data
+            assert data["checkout_url"] == "https://checkout.stripe.com/c/pay/cs_test_abc123"
+
+            # Verify Stripe session was created with correct params
+            mock_session_create.assert_called_once()
+            kwargs = mock_session_create.call_args.kwargs
+            assert kwargs["mode"] == "payment"
+            assert "card" in kwargs["payment_method_types"]
+            assert "boleto" in kwargs["payment_method_types"]
+            assert "pix" in kwargs["payment_method_types"]
+            assert kwargs["line_items"][0]["quantity"] == 1
+            assert kwargs["metadata"]["sku"] == "relatorio-oportunidade"
+            assert kwargs["metadata"]["user_id"] == "user-abc-123"
+            assert kwargs["metadata"]["entity_type"] == "cnpj"
+            assert kwargs["metadata"]["entity_id"] == "12345678000199"
+            assert kwargs["customer_email"] == "user@example.com"
+            assert kwargs["cancel_url"] is not None
+            assert kwargs["success_url"] is not None
+            assert "{CHECKOUT_SESSION_ID}" in kwargs["success_url"]
+
+            # Verify Product and Price were created
+            mock_product_create.assert_called_once()
+            mock_price_create.assert_called_once()
+            price_kwargs = mock_price_create.call_args.kwargs
+            assert price_kwargs["currency"] == "brl"
+            assert price_kwargs["unit_amount"] == 4700
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_uses_existing_stripe_price(self, mock_get_supabase, client):
+        """When product has stripe_price_id, it should be reused."""
+        _mock_supabase_product(mock_get_supabase, [MOCK_PRODUCT_WITH_STRIPE_PRICE])
+
+        with (
+            patch("stripe.checkout.Session.create") as mock_session_create,
+            patch("stripe.Product.create") as mock_product_create,
+            patch("stripe.Price.create") as mock_price_create,
+        ):
+            fake_session = MagicMock()
+            fake_session.url = "https://checkout.stripe.com/c/pay/cs_test_abc"
+            fake_session.id = "cs_test_abc"
+            mock_session_create.return_value = fake_session
+
+            resp = client.post(
+                "/api/checkout/one-time",
+                json={"sku": "relatorio-oportunidade"},
+            )
+
+            assert resp.status_code == 200, resp.json()
+
+            # Should NOT create new Stripe Product or Price
+            mock_product_create.assert_not_called()
+            mock_price_create.assert_not_called()
+
+            # Should use the existing price_id
+            used_price = mock_session_create.call_args.kwargs["line_items"][0]["price"]
+            assert used_price == "price_FakePrice123"
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    @patch("stripe.Product.create")
+    @patch("stripe.Price.create")
+    def test_creates_stripe_price_when_missing(
+        self,
+        mock_price_create,
+        mock_product_create,
+        mock_get_supabase,
+        client,
+    ):
+        """When product has no stripe_price_id, Stripe Product+Price should be created."""
+        _mock_supabase_product(mock_get_supabase, [MOCK_PRODUCT])
+
+        # Mock Stripe Product creation
+        fake_product = MagicMock()
+        fake_product.id = "prod_NewStripeProduct"
+        mock_product_create.return_value = fake_product
+
+        # Mock Stripe Price creation
+        fake_price = MagicMock()
+        fake_price.id = "price_NewStripePrice"
+        mock_price_create.return_value = fake_price
+
+        with patch("stripe.checkout.Session.create") as mock_session_create:
+            fake_session = MagicMock()
+            fake_session.url = "https://checkout.stripe.com/c/pay/cs_new"
+            fake_session.id = "cs_new"
+            mock_session_create.return_value = fake_session
+
+            resp = client.post(
+                "/api/checkout/one-time",
+                json={"sku": "relatorio-oportunidade"},
+            )
+
+            assert resp.status_code == 200, resp.json()
+
+            # Should create product and price
+            mock_product_create.assert_called_once()
+            mock_price_create.assert_called_once()
+
+            # Verify price is created with correct params
+            price_kwargs = mock_price_create.call_args.kwargs
+            assert price_kwargs["currency"] == "brl"
+            assert price_kwargs["unit_amount"] == 4700
+            assert price_kwargs["product"] == "prod_NewStripeProduct"
+
+            # Should use the new price_id
+            used_price = mock_session_create.call_args.kwargs["line_items"][0]["price"]
+            assert used_price == "price_NewStripePrice"
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_sku_not_found_returns_404(self, mock_get_supabase, client):
+        """Non-existent SKU should return 404."""
+        _mock_supabase_product(mock_get_supabase, [])
+
+        resp = client.post(
+            "/api/checkout/one-time",
+            json={"sku": "sku-inexistente"},
+        )
+        assert resp.status_code == 404
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_inactive_product_returns_400(self, mock_get_supabase, client):
+        """Inactive product should return 400."""
+        _mock_supabase_product(mock_get_supabase, [MOCK_INACTIVE_PRODUCT])
+
+        resp = client.post(
+            "/api/checkout/one-time",
+            json={"sku": "relatorio-oportunidade"},
+        )
+        assert resp.status_code == 400
+        assert "indisponivel" in resp.json()["detail"].lower()
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_stripe_invalid_request_error_returns_400(self, mock_get_supabase, client):
+        """Stripe InvalidRequestError should return 400."""
+        import stripe as stripe_lib
+
+        _mock_supabase_product(mock_get_supabase, [MOCK_PRODUCT])
+
+        with (
+            patch("stripe.Product.create") as mock_product_create,
+            patch("stripe.Price.create") as mock_price_create,
+            patch("stripe.checkout.Session.create") as mock_session_create,
+        ):
+            mock_product_create.return_value = MagicMock(id="prod_Mocked")
+            mock_price_create.return_value = MagicMock(id="price_Mocked")
+            mock_session_create.side_effect = stripe_lib.error.InvalidRequestError(
+                message="Invalid product",
+                param="price",
+            )
+
+            resp = client.post(
+                "/api/checkout/one-time",
+                json={"sku": "relatorio-oportunidade"},
+            )
+            assert resp.status_code == 400
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_stripe_error_returns_503(self, mock_get_supabase, client):
+        """Stripe API error should return 503."""
+        import stripe as stripe_lib
+
+        _mock_supabase_product(mock_get_supabase, [MOCK_PRODUCT])
+
+        with patch("stripe.checkout.Session.create") as mock_session_create:
+            mock_session_create.side_effect = stripe_lib.error.StripeError("API error")
+
+            resp = client.post(
+                "/api/checkout/one-time",
+                json={"sku": "relatorio-oportunidade"},
+            )
+            assert resp.status_code == 503
+
+
+class TestSupabaseError:
+    """Supabase transient errors."""
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    @patch("routes.checkout.get_supabase")
+    def test_supabase_error_returns_503(self, mock_get_supabase, client):
+        """Transient Supabase error should return 503."""
+        mock_sb = MagicMock()
+        mock_query = MagicMock()
+        mock_sb.table.return_value = mock_query
+        mock_query.select.return_value = mock_query
+        mock_query.eq.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.execute.side_effect = Exception("Connection refused")
+        mock_get_supabase.return_value = mock_sb
+
+        resp = client.post(
+            "/api/checkout/one-time",
+            json={"sku": "relatorio-oportunidade"},
+        )
+        assert resp.status_code == 503
+
+
+class TestRateLimit:
+    """Rate limiting behavior (10 req/min per IP)."""
+
+    @patch.dict("os.environ", {"STRIPE_SECRET_KEY": "sk_test_fake"})
+    def test_rate_limit_enforced(self):
+        """After 10 rapid requests, the 11th should return 429."""
+        from routes.checkout import router as checkout_router
+
+        rate_app = FastAPI()
+        rate_app.dependency_overrides[require_auth] = lambda: MOCK_USER
+        # Do NOT override rate limit — test with real limiter (in-memory fallback)
+        rate_app.include_router(checkout_router)
+        rate_client = TestClient(rate_app)
+
+        with patch("routes.checkout.get_supabase") as mock_get_supabase:
+            mock_sb = MagicMock()
+            mock_query = MagicMock()
+            mock_sb.table.return_value = mock_query
+            mock_query.select.return_value = mock_query
+            mock_query.eq.return_value = mock_query
+            mock_query.limit.return_value = mock_query
+            mock_query.execute.return_value = MagicMock(data=[])
+            mock_get_supabase.return_value = mock_sb
+
+            # Make 10 rapid requests (all will 404 because supabase returns empty)
+            for _ in range(10):
+                resp = rate_client.post(
+                    "/api/checkout/one-time",
+                    json={"sku": "relatorio-oportunidade"},
+                )
+                # All within rate limit -> either 404 (no product) or other 4xx
+                assert resp.status_code in (200, 400, 404), f"Unexpected {resp.status_code} at request {_}"
+
+            # 11th request should hit rate limit
+            resp = rate_client.post(
+                "/api/checkout/one-time",
+                json={"sku": "relatorio-oportunidade"},
+            )
+            assert resp.status_code == 429


### PR DESCRIPTION
## Contexto
Parte 2/4 do CONV-005b. Checkout generico para produtos digitais one-time.

## Alteracoes
- Endpoint POST /api/checkout/one-time com validacao SKU
- Stripe Checkout Session com card/boleto/PIX
- Stripe Price auto-criacao + cache
- Rate limiting 10/min

## Depende
- #1334 (CONV-005b-1 — digital_products + GET /v1/products)

## Fecha
Closes #1335