### PR TITLE
feat(backend): PREDINT-005 — RPC predict_expansion_organs (#1268)

### DIFF
--- a/backend/tests/test_predict_expansion_organs.py
+++ b/backend/tests/test_predict_expansion_organs.py
@@ -1,0 +1,593 @@
+"""PREDINT-005: Tests for RPC predict_expansion_organs (#1268).
+
+Identifica orgaos publicos com tendencia de expansao nos contratos
+nos ultimos 3 anos, usando CAGR.
+
+Strategy:
+- Content validation: check migration SQL for required statements
+- Unit tests: mock supabase.rpc() to validate JSON output shape
+- Edge cases: empty data, UF filter, p_min_crescimento filter
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Migration file paths
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATION_DIR = REPO_ROOT / "supabase" / "migrations"
+UP_MIGRATION = MIGRATION_DIR / "20260531175504_predict_expansion_organs.sql"
+DOWN_MIGRATION = MIGRATION_DIR / "20260531175504_predict_expansion_organs.down.sql"
+
+
+# ============================================================================
+# Migration SQL Content Validation
+# ============================================================================
+
+
+class TestMigrationContent:
+    """Validate the migration SQL files contain all required operations."""
+
+    @pytest.fixture(autouse=True)
+    def load_migrations(self):
+        assert UP_MIGRATION.exists(), f"Migration file not found: {UP_MIGRATION}"
+        assert DOWN_MIGRATION.exists(), f"Down migration not found: {DOWN_MIGRATION}"
+        self.up_sql = UP_MIGRATION.read_text(encoding="utf-8")
+        self.down_sql = DOWN_MIGRATION.read_text(encoding="utf-8")
+
+    # -- Function definition --
+    def test_creates_function(self):
+        """Migration creates predict_expansion_organs RPC."""
+        assert "CREATE OR REPLACE FUNCTION public.predict_expansion_organs(" in self.up_sql
+        assert "RETURNS json" in self.up_sql
+
+    def test_function_signature(self):
+        """Function has correct parameters with defaults."""
+        assert "p_setor TEXT DEFAULT NULL" in self.up_sql
+        assert "p_uf VARCHAR(2) DEFAULT NULL" in self.up_sql
+        assert "p_min_crescimento FLOAT DEFAULT 0.15" in self.up_sql
+
+    def test_language_plpgsql(self):
+        """Function uses LANGUAGE plpgsql (needs local statement_timeout)."""
+        assert "LANGUAGE plpgsql" in self.up_sql
+
+    def test_stable_volatility(self):
+        """Function is STABLE (read-only query)."""
+        assert "STABLE" in self.up_sql
+
+    def test_security_definer(self):
+        """Function uses SECURITY DEFINER."""
+        assert "SECURITY DEFINER" in self.up_sql
+
+    def test_search_path(self):
+        """Function sets search_path = public, pg_temp."""
+        assert "SET search_path = public, pg_temp" in self.up_sql
+
+    def test_statement_timeout(self):
+        """Function sets LOCAL statement_timeout = '15s'."""
+        assert "statement_timeout = '15s'" in self.up_sql
+
+    # -- Data source --
+    def test_reads_from_pncp_supplier_contracts(self):
+        """Function reads from pncp_supplier_contracts."""
+        assert "pncp_supplier_contracts" in self.up_sql
+
+    def test_filters_is_active(self):
+        """Function filters psc.is_active = TRUE."""
+        assert "is_active = TRUE" in self.up_sql
+
+    def test_filters_valor_global_not_null(self):
+        """Function excludes NULL or zero valor_global."""
+        assert "valor_global IS NOT NULL" in self.up_sql
+        assert "valor_global > 0" in self.up_sql
+
+    def test_filters_orgao_nome_not_null(self):
+        """Function excludes NULL orgao_nome."""
+        assert "orgao_nome IS NOT NULL" in self.up_sql
+
+    def test_filters_uf_not_null(self):
+        """Function excludes NULL uf."""
+        assert "uf IS NOT NULL" in self.up_sql
+
+    def test_uf_filter_optional(self):
+        """UF filter is optional (uses OR pattern)."""
+        assert "p_uf IS NULL OR UPPER(psc.uf) = UPPER(p_uf)" in self.up_sql
+
+    def test_setor_filter_optional(self):
+        """Setor filter is optional."""
+        assert "p_setor IS NULL OR psc.setor_classificado = p_setor" in self.up_sql
+
+    def test_3_year_window(self):
+        """Function filters by 3 complete calendar years."""
+        assert "v_ano_1" in self.up_sql
+        assert "v_ano_2" in self.up_sql
+        assert "v_ano_3" in self.up_sql
+
+    def test_cagr_formula(self):
+        """Function uses CAGR formula with exponent 1/3."""
+        assert "^ (1.0 / 3.0)" in self.up_sql
+
+    def test_positive_trend_filter(self):
+        """Function excludes organs with negative trend."""
+        assert "vol_ano_1 > vol_ano_3" in self.up_sql
+
+    def test_min_crescimento_filter(self):
+        """Function applies p_min_crescimento filter."""
+        assert "p_min_crescimento" in self.up_sql
+
+    def test_3_year_data_requirement(self):
+        """Function requires all 3 years to have data (excludes <3 anos)."""
+        assert "vol_ano_1 IS NOT NULL" in self.up_sql
+        assert "vol_ano_2 IS NOT NULL" in self.up_sql
+        assert "vol_ano_3 IS NOT NULL" in self.up_sql
+
+    # -- Output structure --
+    def test_output_orgaos_expandindo(self):
+        """Output JSON includes 'orgaos_expandindo' array."""
+        assert "'orgaos_expandindo'" in self.up_sql
+
+    def test_output_stats(self):
+        """Output JSON includes 'stats' object."""
+        assert "'stats'" in self.up_sql
+
+    def test_output_orgao_nome(self):
+        """Each organ entry includes orgao_nome."""
+        assert "'orgao_nome'" in self.up_sql
+
+    def test_output_orgao_uf(self):
+        """Each organ entry includes orgao_uf."""
+        assert "'orgao_uf'" in self.up_sql
+
+    def test_output_categoria(self):
+        """Each organ entry includes categoria."""
+        assert "'categoria'" in self.up_sql
+
+    def test_output_crescimento_anual_medio(self):
+        """Each organ entry includes crescimento_anual_medio."""
+        assert "'crescimento_anual_medio'" in self.up_sql
+
+    def test_output_volume_ultimo_ano(self):
+        """Each organ entry includes volume_ultimo_ano."""
+        assert "'volume_ultimo_ano'" in self.up_sql
+
+    def test_output_tendencia_3anos(self):
+        """Each organ entry includes tendencia_3anos array."""
+        assert "'tendencia_3anos'" in self.up_sql
+
+    def test_output_categorias_emergentes(self):
+        """Each organ entry includes categorias_emergentes array."""
+        assert "'categorias_emergentes'" in self.up_sql
+
+    def test_output_sinal(self):
+        """Each organ entry includes sinal."""
+        assert "'sinal'" in self.up_sql
+
+    def test_stats_orgaos_analisados(self):
+        """Stats includes orgaos_analisados."""
+        assert "'orgaos_analisados'" in self.up_sql
+
+    def test_stats_expandindo(self):
+        """Stats includes expandindo."""
+        assert "'expandindo'" in self.up_sql
+
+    def test_stats_crescimento_medio_nacional(self):
+        """Stats includes crescimento_medio_nacional."""
+        assert "'crescimento_medio_nacional'" in self.up_sql
+
+    # -- Sinal classification --
+    def test_sinal_expansao_forte(self):
+        """Sinal 'expansao_forte' for crescimento > 0.30."""
+        assert "expansao_forte" in self.up_sql
+        assert "0.30" in self.up_sql
+
+    def test_sinal_expansao_moderada(self):
+        """Sinal 'expansao_moderada' for crescimento between 0.15 and 0.30."""
+        assert "expansao_moderada" in self.up_sql
+
+    # -- Coalesce empty arrays --
+    def test_empty_orgaos_expandindo(self):
+        """Empty results use '[]'::json, not NULL."""
+        assert "COALESCE" in self.up_sql
+        assert "'[]'::json" in self.up_sql
+
+    # -- Grants --
+    def test_grants_to_all_roles(self):
+        """GRANT EXECUTE to anon, authenticated, and service_role."""
+        grants = re.findall(
+            r"GRANT EXECUTE ON FUNCTION public\.predict_expansion_organs\(TEXT, VARCHAR, FLOAT\)",
+            self.up_sql,
+        )
+        assert len(grants) == 3, (
+            f"Expected 3 GRANT statements, found {len(grants)}. "
+            "Need separate GRANTs for anon, authenticated, service_role."
+        )
+        assert "TO anon" in self.up_sql
+        assert "TO authenticated" in self.up_sql
+        assert "TO service_role" in self.up_sql
+
+    # -- Down migration --
+    def test_down_drops_function(self):
+        """Down migration drops the function with correct signature."""
+        assert "DROP FUNCTION IF EXISTS public.predict_expansion_organs" in self.down_sql
+        assert "TEXT, VARCHAR, FLOAT" in self.down_sql
+
+
+# ============================================================================
+# Unit Tests — Mocked Supabase RPC
+# ============================================================================
+
+
+def _make_supabase_mock(return_data):
+    """Create a MagicMock for supabase that returns the given data from rpc().execute()."""
+    from unittest.mock import MagicMock
+
+    rpc_response = MagicMock()
+    rpc_response.data = return_data
+    mock_sb = MagicMock()
+    mock_sb.rpc.return_value.execute.return_value = rpc_response
+    return mock_sb
+
+
+class TestRpcContract:
+    """Verify the RPC output shape via mock."""
+
+    def test_accepts_no_filters(self):
+        """RPC can be called without any parameters (all defaults)."""
+        mock_sb = _make_supabase_mock({
+            "orgaos_expandindo": [],
+            "stats": {
+                "orgaos_analisados": 0,
+                "expandindo": 0,
+                "crescimento_medio_nacional": 0.0,
+            },
+        })
+
+        result = mock_sb.rpc("predict_expansion_organs", {}).execute().data
+
+        assert "orgaos_expandindo" in result
+        assert "stats" in result
+        assert result["stats"]["orgaos_analisados"] == 0
+        assert result["stats"]["expandindo"] == 0
+
+    def test_accepts_setor_filter(self):
+        """RPC can filter by sector."""
+        mock_sb = _make_supabase_mock({
+            "orgaos_expandindo": [],
+            "stats": {
+                "orgaos_analisados": 10,
+                "expandindo": 0,
+                "crescimento_medio_nacional": 0.0,
+            },
+        })
+
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {"p_setor": "tecnologia"},
+        ).execute().data
+
+        assert result["stats"]["orgaos_analisados"] == 10
+
+    def test_accepts_uf_filter(self):
+        """RPC can filter by UF."""
+        mock_sb = _make_supabase_mock({
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "SECRETARIA DE EDUCACAO SP",
+                    "orgao_uf": "SP",
+                    "categoria": "educacao",
+                    "crescimento_anual_medio": 0.25,
+                    "volume_ultimo_ano": 50000000.00,
+                    "tendencia_3anos": [30000000.0, 40000000.0, 50000000.0],
+                    "categorias_emergentes": ["infraestrutura"],
+                    "sinal": "expansao_moderada",
+                },
+            ],
+            "stats": {
+                "orgaos_analisados": 50,
+                "expandindo": 1,
+                "crescimento_medio_nacional": 0.25,
+            },
+        })
+
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {"p_uf": "SP"},
+        ).execute().data
+
+        assert len(result["orgaos_expandindo"]) == 1
+        assert result["orgaos_expandindo"][0]["orgao_uf"] == "SP"
+
+    def test_output_shape_has_all_fields(self):
+        """Each organ entry has all required fields per spec."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "MINISTERIO DA EDUCACAO",
+                    "orgao_uf": "DF",
+                    "categoria": "tecnologia",
+                    "crescimento_anual_medio": 0.35,
+                    "volume_ultimo_ano": 250000000.00,
+                    "tendencia_3anos": [120000000.0, 185000000.0, 250000000.0],
+                    "categorias_emergentes": ["software", "cloud"],
+                    "sinal": "expansao_forte",
+                },
+            ],
+            "stats": {
+                "orgaos_analisados": 200,
+                "expandindo": 28,
+                "crescimento_medio_nacional": 0.08,
+            },
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        organ = result["orgaos_expandindo"][0]
+        # All organ fields present
+        assert "orgao_nome" in organ
+        assert "orgao_uf" in organ
+        assert "categoria" in organ
+        assert "crescimento_anual_medio" in organ
+        assert "volume_ultimo_ano" in organ
+        assert "tendencia_3anos" in organ
+        assert "categorias_emergentes" in organ
+        assert "sinal" in organ
+
+        # Stats fields present
+        stats = result["stats"]
+        assert "orgaos_analisados" in stats
+        assert "expandindo" in stats
+        assert "crescimento_medio_nacional" in stats
+
+        # Verify exact spec values
+        assert organ["orgao_nome"] == "MINISTERIO DA EDUCACAO"
+        assert organ["orgao_uf"] == "DF"
+        assert organ["categoria"] == "tecnologia"
+        assert organ["crescimento_anual_medio"] == 0.35
+        assert organ["sinal"] == "expansao_forte"
+        assert len(organ["tendencia_3anos"]) == 3
+        assert organ["tendencia_3anos"][0] < organ["tendencia_3anos"][2]  # ascending
+
+    def test_sinal_classification(self):
+        """Sinal correctly classifies as expansao_forte or expansao_moderada."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "ORGAO FORTE",
+                    "orgao_uf": "SP",
+                    "categoria": "saude",
+                    "crescimento_anual_medio": 0.45,
+                    "volume_ultimo_ano": 1000000.00,
+                    "tendencia_3anos": [500000.0, 700000.0, 1000000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_forte",
+                },
+                {
+                    "orgao_nome": "ORGAO MODERADO",
+                    "orgao_uf": "RJ",
+                    "categoria": "educacao",
+                    "crescimento_anual_medio": 0.20,
+                    "volume_ultimo_ano": 800000.00,
+                    "tendencia_3anos": [600000.0, 700000.0, 800000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_moderada",
+                },
+            ],
+            "stats": {},
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        organs = {o["orgao_nome"]: o for o in result["orgaos_expandindo"]}
+        assert organs["ORGAO FORTE"]["sinal"] == "expansao_forte"
+        assert organs["ORGAO MODERADO"]["sinal"] == "expansao_moderada"
+
+    def test_crescimento_anual_medio_positive(self):
+        """crescimento_anual_medio values are positive (negative trend excluded)."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "ORGAO EM EXPANSAO",
+                    "orgao_uf": "MG",
+                    "categoria": "obras",
+                    "crescimento_anual_medio": 0.18,
+                    "volume_ultimo_ano": 2000000.00,
+                    "tendencia_3anos": [1500000.0, 1700000.0, 2000000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_moderada",
+                },
+            ],
+            "stats": {},
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        for organ in result["orgaos_expandindo"]:
+            assert organ["crescimento_anual_medio"] > 0
+
+    def test_tendencia_3anos_ascending(self):
+        """tendencia_3anos should be ascending (oldest to newest)."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "ORGAO TESTE",
+                    "orgao_uf": "DF",
+                    "categoria": "tecnologia",
+                    "crescimento_anual_medio": 0.30,
+                    "volume_ultimo_ano": 3000000.00,
+                    "tendencia_3anos": [1000000.0, 2000000.0, 3000000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_moderada",
+                },
+            ],
+            "stats": {},
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        tendencia = result["orgaos_expandindo"][0]["tendencia_3anos"]
+        assert len(tendencia) == 3
+        # Verify ascending order: oldest first
+        assert tendencia[0] < tendencia[1] < tendencia[2]
+
+    def test_categorias_emergentes_max_3(self):
+        """categorias_emergentes should be at most 3 items."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "ORGAO MULTI CAT",
+                    "orgao_uf": "SP",
+                    "categoria": "servicos",
+                    "crescimento_anual_medio": 0.40,
+                    "volume_ultimo_ano": 5000000.00,
+                    "tendencia_3anos": [2000000.0, 3500000.0, 5000000.0],
+                    "categorias_emergentes": ["cat_a", "cat_b", "cat_c"],
+                    "sinal": "expansao_forte",
+                },
+            ],
+            "stats": {},
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        cats = result["orgaos_expandindo"][0]["categorias_emergentes"]
+        assert len(cats) <= 3
+
+    def test_min_crescimento_filter_respected(self):
+        """Organs below p_min_crescimento are excluded."""
+        # Simulate response where all organs have growth >= 0.15 (default)
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "ORGAO CRESCENTE",
+                    "orgao_uf": "SP",
+                    "categoria": "saude",
+                    "crescimento_anual_medio": 0.22,
+                    "volume_ultimo_ano": 1000000.00,
+                    "tendencia_3anos": [700000.0, 850000.0, 1000000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_moderada",
+                },
+            ],
+            "stats": {},
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {"p_min_crescimento": 0.15},
+        ).execute().data
+
+        # All returned organs should have growth >= 0.15
+        for organ in result["orgaos_expandindo"]:
+            assert organ["crescimento_anual_medio"] >= 0.15
+
+    def test_empty_result_no_data(self):
+        """When no data matches, returns empty orgaos_expandindo."""
+        mock_sb = _make_supabase_mock({
+            "orgaos_expandindo": [],
+            "stats": {
+                "orgaos_analisados": 0,
+                "expandindo": 0,
+                "crescimento_medio_nacional": 0.0,
+            },
+        })
+
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {"p_uf": "XX"},
+        ).execute().data
+
+        assert result["orgaos_expandindo"] == []
+        assert result["stats"]["expandindo"] == 0
+
+    def test_multiple_organs_in_result(self):
+        """Result can contain entries for multiple organs."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": "ORGAO A",
+                    "orgao_uf": "SP",
+                    "categoria": "saude",
+                    "crescimento_anual_medio": 0.35,
+                    "volume_ultimo_ano": 1000000.00,
+                    "tendencia_3anos": [500000.0, 700000.0, 1000000.0],
+                    "categorias_emergentes": ["software"],
+                    "sinal": "expansao_forte",
+                },
+                {
+                    "orgao_nome": "ORGAO B",
+                    "orgao_uf": "RJ",
+                    "categoria": "educacao",
+                    "crescimento_anual_medio": 0.18,
+                    "volume_ultimo_ano": 2000000.00,
+                    "tendencia_3anos": [1500000.0, 1800000.0, 2000000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_moderada",
+                },
+            ],
+            "stats": {
+                "orgaos_analisados": 100,
+                "expandindo": 2,
+                "crescimento_medio_nacional": 0.12,
+            },
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        assert len(result["orgaos_expandindo"]) == 2
+        names = [o["orgao_nome"] for o in result["orgaos_expandindo"]]
+        assert "ORGAO A" in names
+        assert "ORGAO B" in names
+
+
+class TestStatsConsistency:
+    """Verify stats are internally consistent."""
+
+    def test_expandindo_never_exceeds_analisados(self):
+        """expandindo count cannot exceed orgaos_analisados."""
+        mock_result = {
+            "orgaos_expandindo": [
+                {
+                    "orgao_nome": f"ORGAO {i}",
+                    "orgao_uf": "SP",
+                    "categoria": "servicos",
+                    "crescimento_anual_medio": 0.20 + i * 0.05,
+                    "volume_ultimo_ano": 1000000.00,
+                    "tendencia_3anos": [700000.0, 850000.0, 1000000.0],
+                    "categorias_emergentes": [],
+                    "sinal": "expansao_moderada",
+                }
+                for i in range(3)
+            ],
+            "stats": {
+                "orgaos_analisados": 50,
+                "expandindo": 3,
+                "crescimento_medio_nacional": 0.10,
+            },
+        }
+        mock_sb = _make_supabase_mock(mock_result)
+        result = mock_sb.rpc(
+            "predict_expansion_organs",
+            {},
+        ).execute().data
+
+        assert result["stats"]["expandindo"] <= result["stats"]["orgaos_analisados"]
+        assert result["stats"]["expandindo"] == len(result["orgaos_expandindo"])

--- a/supabase/migrations/20260531175504_predict_expansion_organs.down.sql
+++ b/supabase/migrations/20260531175504_predict_expansion_organs.down.sql
@@ -1,0 +1,5 @@
+-- ============================================================================
+-- PREDINT-005 (DOWN): Remove RPC predict_expansion_organs
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.predict_expansion_organs(TEXT, VARCHAR, FLOAT);

--- a/supabase/migrations/20260531175504_predict_expansion_organs.sql
+++ b/supabase/migrations/20260531175504_predict_expansion_organs.sql
@@ -1,0 +1,268 @@
+-- ============================================================================
+-- PREDINT-005: RPC predict_expansion_organs — orgaos em expansao por CAGR
+-- Date: 2026-05-31
+-- Issue: #1268
+-- ============================================================================
+-- Context:
+--   Wave 0 RPC for Predictive Intelligence EPIC (#1260). Identifica orgaos
+--   publicos com tendencia de crescimento no volume de contratos nos ultimos
+--   3 anos. Usa CAGR (Compound Annual Growth Rate) para medir expansao.
+--
+--   CAGR formula: (volume_ano_1 / volume_ano_3) ^ (1/3) - 1
+--
+--   Fonte: pncp_supplier_contracts (dados publicos PNCP).
+--
+--   Privacy: 100% dados publicos PNCP. Zero dados de usuario.
+--
+--   Performance:
+--     - statement_timeout = 15s
+--     - Indices existentes: idx_psc_data_assinatura, idx_psc_active
+--     - Retorno esperado < 300ms p95
+--
+--   Assinatura:
+--     predict_expansion_organs(p_setor TEXT DEFAULT NULL,
+--                              p_uf VARCHAR(2) DEFAULT NULL,
+--                              p_min_crescimento FLOAT DEFAULT 0.15)
+--     RETURNS json
+--
+--   SECURITY DEFINER + SET search_path = public, pg_temp conforme padrao.
+--   GRANT para anon, authenticated, service_role (dados publicos).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.predict_expansion_organs(
+    p_setor TEXT DEFAULT NULL,
+    p_uf VARCHAR(2) DEFAULT NULL,
+    p_min_crescimento FLOAT DEFAULT 0.15
+)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_ano_1 INTEGER;  -- last complete calendar year
+    v_ano_2 INTEGER;  -- year before last
+    v_ano_3 INTEGER;  -- 3 years ago
+    v_result json;
+BEGIN
+    -- ------------------------------------------------------------------
+    -- Defesa contra queries runaway
+    -- ------------------------------------------------------------------
+    SET LOCAL statement_timeout = '15s';
+
+    -- ------------------------------------------------------------------
+    -- Determinar os 3 anos calendario completos mais recentes
+    -- Ex: se hoje = 2026-05-31, anos = 2025, 2024, 2023
+    -- ------------------------------------------------------------------
+    v_ano_1 := EXTRACT(YEAR FROM CURRENT_DATE)::INTEGER - 1;
+    v_ano_2 := v_ano_1 - 1;
+    v_ano_3 := v_ano_1 - 2;
+
+    -- ------------------------------------------------------------------
+    -- CTEs de agregacao
+    -- ------------------------------------------------------------------
+    WITH
+    -- Base: contratos ativos com valor nos ultimos 3 anos
+    base AS (
+        SELECT
+            psc.orgao_nome,
+            psc.uf,
+            psc.valor_global,
+            EXTRACT(YEAR FROM psc.data_assinatura)::INTEGER AS ano,
+            COALESCE(psc.setor_classificado, 'sem_classificacao') AS categoria
+        FROM pncp_supplier_contracts psc
+        WHERE psc.is_active = TRUE
+          AND psc.valor_global IS NOT NULL
+          AND psc.valor_global > 0
+          AND psc.orgao_nome IS NOT NULL
+          AND psc.uf IS NOT NULL
+          AND psc.data_assinatura IS NOT NULL
+          AND (p_uf IS NULL OR UPPER(psc.uf) = UPPER(p_uf))
+          AND (p_setor IS NULL OR psc.setor_classificado = p_setor)
+          AND EXTRACT(YEAR FROM psc.data_assinatura)::INTEGER IN (v_ano_1, v_ano_2, v_ano_3)
+    ),
+    -- Volume anual por orgao + UF
+    orgao_volumes AS (
+        SELECT
+            orgao_nome,
+            uf,
+            ano,
+            SUM(valor_global) AS volume_anual
+        FROM base
+        GROUP BY orgao_nome, uf, ano
+    ),
+    -- Pivot: volumes nos 3 anos por orgao
+    orgao_pivot AS (
+        SELECT
+            orgao_nome,
+            uf,
+            MAX(CASE WHEN ano = v_ano_3 THEN volume_anual END) AS vol_ano_3,
+            MAX(CASE WHEN ano = v_ano_2 THEN volume_anual END) AS vol_ano_2,
+            MAX(CASE WHEN ano = v_ano_1 THEN volume_anual END) AS vol_ano_1
+        FROM orgao_volumes
+        GROUP BY orgao_nome, uf
+    ),
+    -- CAGR: orgaos com dados completos nos 3 anos e tendencia positiva
+    orgao_com_cagr AS (
+        SELECT
+            orgao_nome,
+            uf,
+            vol_ano_3,
+            vol_ano_2,
+            vol_ano_1,
+            (vol_ano_1 / vol_ano_3) ^ (1.0 / 3.0) - 1 AS crescimento_anual_medio,
+            ARRAY[
+                ROUND((vol_ano_3)::numeric, 2)::float8,
+                ROUND((vol_ano_2)::numeric, 2)::float8,
+                ROUND((vol_ano_1)::numeric, 2)::float8
+            ] AS tendencia_3anos
+        FROM orgao_pivot
+        WHERE vol_ano_1 IS NOT NULL
+          AND vol_ano_2 IS NOT NULL
+          AND vol_ano_3 IS NOT NULL
+          AND vol_ano_3 > 0
+          AND vol_ano_1 > vol_ano_3  -- tendencia positiva (exclui queda)
+    ),
+    -- Categoria dominante do orgao (maior volume acumulado nos 3 anos)
+    orgao_categoria AS (
+        SELECT DISTINCT ON (orgao_nome, uf)
+            sq.orgao_nome,
+            sq.uf,
+            sq.categoria
+        FROM (
+            SELECT
+                orgao_nome,
+                uf,
+                categoria,
+                SUM(valor_global) AS total_volume
+            FROM base
+            GROUP BY orgao_nome, uf, categoria
+        ) sq
+        ORDER BY sq.orgao_nome, sq.uf, sq.total_volume DESC
+    ),
+    -- Volume anual por categoria dentro de cada orgao
+    cat_volumes AS (
+        SELECT
+            orgao_nome,
+            uf,
+            categoria,
+            ano,
+            SUM(valor_global) AS volume
+        FROM base
+        GROUP BY orgao_nome, uf, categoria, ano
+    ),
+    -- CAGR por categoria dentro de cada orgao
+    cat_growth AS (
+        SELECT
+            cv.orgao_nome,
+            cv.uf,
+            cv.categoria,
+            (MAX(CASE WHEN cv.ano = v_ano_1 THEN cv.volume END) /
+             NULLIF(MAX(CASE WHEN cv.ano = v_ano_3 THEN cv.volume END), 0)
+            ) ^ (1.0 / 3.0) - 1 AS crescimento
+        FROM cat_volumes cv
+        GROUP BY cv.orgao_nome, cv.uf, cv.categoria
+        HAVING MAX(CASE WHEN cv.ano = v_ano_1 THEN cv.volume END) IS NOT NULL
+           AND MAX(CASE WHEN cv.ano = v_ano_3 THEN cv.volume END) IS NOT NULL
+           AND MAX(CASE WHEN cv.ano = v_ano_3 THEN cv.volume END) > 0
+           AND MAX(CASE WHEN cv.ano = v_ano_1 THEN cv.volume END) >
+               MAX(CASE WHEN cv.ano = v_ano_3 THEN cv.volume END)
+    ),
+    -- Categorias emergentes (ate 3) por orgao: crescem acima da baseline
+    emergentes AS (
+        SELECT
+            oc.orgao_nome,
+            oc.uf,
+            COALESCE(
+                (SELECT json_agg(sub.categoria ORDER BY sub.excesso DESC)
+                 FROM (
+                     SELECT cg.categoria,
+                            (cg.crescimento - oc.crescimento_anual_medio) AS excesso
+                     FROM cat_growth cg
+                     WHERE cg.orgao_nome = oc.orgao_nome
+                       AND cg.uf = oc.uf
+                       AND cg.crescimento > oc.crescimento_anual_medio
+                       AND cg.categoria != 'sem_classificacao'
+                     ORDER BY excesso DESC
+                     LIMIT 3
+                 ) sub
+                ),
+                '[]'::json
+            ) AS cats
+        FROM orgao_com_cagr oc
+    ),
+    -- Orgaos que passaram pelo filtro p_min_crescimento
+    orgaos_expandindo AS (
+        SELECT
+            oc.orgao_nome,
+            oc.uf,
+            ocat.categoria,
+            ROUND(oc.crescimento_anual_medio::numeric, 4)::float8 AS crescimento_anual_medio,
+            ROUND(oc.vol_ano_1::numeric, 2)::float8 AS volume_ultimo_ano,
+            oc.tendencia_3anos,
+            e.cats AS categorias_emergentes,
+            CASE
+                WHEN oc.crescimento_anual_medio > 0.30 THEN 'expansao_forte'
+                ELSE 'expansao_moderada'
+            END AS sinal
+        FROM orgao_com_cagr oc
+        LEFT JOIN orgao_categoria ocat
+            ON ocat.orgao_nome = oc.orgao_nome AND ocat.uf = oc.uf
+        LEFT JOIN emergentes e
+            ON e.orgao_nome = oc.orgao_nome AND e.uf = oc.uf
+        WHERE oc.crescimento_anual_medio >= p_min_crescimento
+    ),
+    -- Stats
+    total_orgaos AS (
+        SELECT COUNT(DISTINCT orgao_nome || '|' || uf)::INTEGER AS total
+        FROM base
+    ),
+    expandindo_count AS (
+        SELECT COUNT(*)::INTEGER AS total FROM orgaos_expandindo
+    ),
+    media_nacional AS (
+        SELECT COALESCE(
+            ROUND(AVG(crescimento_anual_medio)::numeric, 4)::float8, 0.0
+        ) AS media
+        FROM orgao_com_cagr
+    )
+    -- ------------------------------------------------------------------
+    -- Montagem do payload JSON final
+    -- ------------------------------------------------------------------
+    SELECT json_build_object(
+        'orgaos_expandindo', COALESCE(
+            (SELECT json_agg(
+                json_build_object(
+                    'orgao_nome', oe.orgao_nome,
+                    'orgao_uf', oe.uf,
+                    'categoria', oe.categoria,
+                    'crescimento_anual_medio', oe.crescimento_anual_medio,
+                    'volume_ultimo_ano', oe.volume_ultimo_ano,
+                    'tendencia_3anos', oe.tendencia_3anos,
+                    'categorias_emergentes', oe.categorias_emergentes,
+                    'sinal', oe.sinal
+                ) ORDER BY oe.crescimento_anual_medio DESC
+            ) FROM orgaos_expandindo oe),
+            '[]'::json
+        ),
+        'stats', json_build_object(
+            'orgaos_analisados', COALESCE((SELECT total FROM total_orgaos), 0),
+            'expandindo', COALESCE((SELECT total FROM expandindo_count), 0),
+            'crescimento_medio_nacional', COALESCE((SELECT media FROM media_nacional), 0.0)
+        )
+    ) INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.predict_expansion_organs(TEXT, VARCHAR, FLOAT) IS
+    'PREDINT-005 — Orgaos em expansao por CAGR. '
+    'CAGR = (vol_ano_1 / vol_ano_3) ^ (1/3) - 1 sobre 3 anos completos. '
+    'Dados publicos PNCP. SECURITY DEFINER.';
+
+-- Grants: dados publicos PNCP — todos os roles podem consultar
+GRANT EXECUTE ON FUNCTION public.predict_expansion_organs(TEXT, VARCHAR, FLOAT) TO anon;
+GRANT EXECUTE ON FUNCTION public.predict_expansion_organs(TEXT, VARCHAR, FLOAT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.predict_expansion_organs(TEXT, VARCHAR, FLOAT) TO service_role;


### PR DESCRIPTION
## Summary

**Issue:** Closes #1268

### O que faz

Nova RPC `predict_expansion_organs` que identifica orgaos publicos com tendencia de expansao orcamentaria. Usa CAGR (Compound Annual Growth Rate) sobre os ultimos 3 anos completos para medir crescimento, e classifica o sinal como expansao_forte (>30%), expansao_moderada (15-30%).

### Especificacao

**Input:**
- `p_setor` TEXT (optional)
- `p_uf` VARCHAR(2) (optional)
- `p_min_crescimento` FLOAT DEFAULT 0.15

**Output JSON:**
```json
{
  "orgaos_expandindo": [
    {
      "orgao_nome": "...",
      "orgao_uf": "SP",
      "categoria": "tecnologia",
      "crescimento_anual_medio": 0.35,
      "volume_ultimo_ano": 250000000.00,
      "tendencia_3anos": [120000000, 185000000, 250000000],
      "categorias_emergentes": ["software", "cloud"],
      "sinal": "expansao_forte"
    }
  ],
  "stats": { "orgaos_analisados": 200, "expandindo": 28, "crescimento_medio_nacional": 0.08 }
}
```

### Arquivos alterados

- `supabase/migrations/20260531175504_predict_expansion_organs.sql` — RPC + grants
- `supabase/migrations/20260531175504_predict_expansion_organs.down.sql` — DROP FUNCTION
- `backend/tests/test_predict_expansion_organs.py` — 49 tests (migration content validation + mock unit tests)

### Acceptance Criteria

- [x] RPC retorna JSON com `orgaos_expandindo` + `stats`
- [x] CAGR formula: (vol_ano_1 / vol_ano_3) ^ (1/3) - 1
- [x] Orgaos com <3 anos de dados → excluidos (vol_ano_[1-3] IS NOT NULL)
- [x] Tendencia negativa (vol_ano_1 <= vol_ano_3) → excluida
- [x] sinal: expansao_forte (>30%), expansao_moderada (15-30%)
- [x] Filtros opcionais: setor, UF, crescimento minimo (default 0.15)
- [x] categorias_emergentes (ate 3) com CAGR acima da baseline do orgao
- [x] statement_timeout = 15s, SECURITY DEFINER, STABLE
- [x] GRANT para anon, authenticated, service_role
- [x] .down.sql remove RPC sem erro
- [x] 49 tests passing
- [x] Apenas SELECT em pncp_supplier_contracts

## Testing Plan

```bash
cd backend && python -m pytest tests/test_predict_expansion_organs.py -v
# 49 passed in 5.24s
```

## Closes

Closes #1268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New government body contract expansion analysis feature identifies which entities show growth over 3-year periods using CAGR-based metrics, with automatic classification of expansion strength (strong vs. moderate).

* **Tests**
  * Comprehensive test suite validates database migration content, API response structure and required fields, result ordering, statistical consistency, and filtering by sector and region parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
