### PR TITLE
feat(backend): NETINT-001 — Schema network_events_agg + coleta anonimizada (#1283)

### DIFF
--- a/backend/routes/network_events.py
+++ b/backend/routes/network_events.py
@@ -1,0 +1,218 @@
+"""NETINT-001: Network Events Aggregation endpoints.
+
+Routes for recording and querying anonymized network intelligence events
+(LGPD-first design). All data is strictly aggregated — never individual.
+
+Endpoints:
+  POST /v1/network-events/record  — Record an anonymized event (opt-in gated)
+  GET  /v1/network-events/top     — Top dimensions by event type
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from auth import require_auth
+from database import get_db
+from supabase_client import sb_execute
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/network-events", tags=["network-events"])
+
+
+# ============================================================================
+# Pydantic schemas (response_model)
+# ============================================================================
+
+class RecordEventRequest(BaseModel):
+    evento_tipo: str = Field(
+        ..., description="Tipo do evento: search_query, sector_view, org_view, cnpj_lookup"
+    )
+    dimensao_tipo: str = Field(
+        ..., description="Tipo da dimensao: setor, uf, modalidade, orgao"
+    )
+    dimensao_valor: str = Field(
+        ..., description="Valor da dimensao (ex: saude, SP, pregao)"
+    )
+    metadados: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Metadados adicionais (setores, ufs, modalidades). NUNCA PII.",
+    )
+
+
+class RecordEventResponse(BaseModel):
+    success: bool = True
+    message: str = "Evento registrado com sucesso"
+
+
+class TopItem(BaseModel):
+    dimensao_valor: str
+    contagem: int
+
+
+class TopResponse(BaseModel):
+    evento_tipo: str
+    periodo_inicio: str
+    periodo_fim: str
+    items: list[TopItem]
+
+
+# ============================================================================
+# POST /network-events/record — Record an event (opt-in gated)
+# ============================================================================
+
+ALLOWED_EVENTO_TIPOS = frozenset({
+    "search_query", "sector_view", "org_view", "cnpj_lookup",
+    "discount_view", "migration_view", "competitor_view",
+})
+
+ALLOWED_DIMENSAO_TIPOS = frozenset({
+    "setor", "uf", "modalidade", "orgao", "municipio",
+})
+
+
+@router.post("/record", response_model=RecordEventResponse)
+async def record_network_event(
+    body: RecordEventRequest,
+    user: dict = Depends(require_auth),
+    db=Depends(get_db),
+):
+    """Record an anonymized network event.
+
+    Only collects data if user has explicitly opted in
+    (profiles.allow_network_analytics = true). LGPD Art. 6, I.
+    """
+    user_id = user["id"]
+
+    # ── Opt-in check ───────────────────────────────────────────────────────
+    try:
+        profile_result = await sb_execute(
+            db.table("profiles")
+            .select("allow_network_analytics")
+            .eq("id", user_id)
+            .limit(1)
+            .single()
+        )
+    except Exception as e:
+        logger.warning("Failed to check opt-in for user %s: %s", user_id[:8], e)
+        return RecordEventResponse(
+            success=False,
+            message="Nao foi possivel verificar consentimento. Tente novamente.",
+        )
+
+    allow = profile_result.data.get("allow_network_analytics") if profile_result.data else None
+    if allow is not True:
+        # NULL or false: opt-out — nao coleta
+        logger.debug(
+            "User %s opted out (allow_network_analytics=%s) — event skipped",
+            user_id[:8], allow,
+        )
+        # Return success silently (do not reveal opt-out status to caller)
+        return RecordEventResponse(
+            success=True,
+            message="Evento registrado com sucesso",
+        )
+
+    # ── Input validation ───────────────────────────────────────────────────
+    if body.evento_tipo not in ALLOWED_EVENTO_TIPOS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"evento_tipo invalido: {body.evento_tipo}. "
+                   f"Permitidos: {sorted(ALLOWED_EVENTO_TIPOS)}",
+        )
+
+    if body.dimensao_tipo not in ALLOWED_DIMENSAO_TIPOS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"dimensao_tipo invalido: {body.dimensao_tipo}. "
+                   f"Permitidos: {sorted(ALLOWED_DIMENSAO_TIPOS)}",
+        )
+
+    # ── Call RPC ───────────────────────────────────────────────────────────
+    try:
+        await sb_execute(db.rpc("network_record_event", {
+            "p_evento_tipo": body.evento_tipo,
+            "p_dimensao_tipo": body.dimensao_tipo,
+            "p_dimensao_valor": body.dimensao_valor,
+            "p_metadados": body.metadados,
+        }))
+    except Exception as e:
+        error_msg = str(e)
+        if "rejeitado por seguranca LGPD" in error_msg:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Metadados rejeitados pela sanitizacao LGPD: {error_msg}",
+            )
+        logger.warning("Failed to record network event: %s", error_msg)
+        return RecordEventResponse(
+            success=False,
+            message="Erro ao registrar evento.",
+        )
+
+    logger.debug("Network event recorded: %s/%s/%s",
+                 body.evento_tipo, body.dimensao_tipo, body.dimensao_valor)
+    return RecordEventResponse()
+
+
+# ============================================================================
+# GET /network-events/top — Top dimensions by event type
+# ============================================================================
+
+@router.get("/top", response_model=TopResponse)
+async def get_top_network_events(
+    evento_tipo: str = Query(..., description="Tipo de evento para filtrar"),
+    dimensao_tipo: str = Query("setor", description="Dimensao para agregar"),
+    dias: int = Query(30, ge=1, le=365, description="Janela em dias"),
+    limite: int = Query(20, ge=1, le=100, description="Maximo de resultados"),
+    db=Depends(get_db),
+):
+    """Get top dimension values for a given event type.
+
+    Public endpoint — returns only anonymized aggregated data.
+    """
+    # ── Input validation ───────────────────────────────────────────────────
+    if evento_tipo not in ALLOWED_EVENTO_TIPOS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"evento_tipo invalido: {evento_tipo}. "
+                   f"Permitidos: {sorted(ALLOWED_EVENTO_TIPOS)}",
+        )
+    if dimensao_tipo not in ALLOWED_DIMENSAO_TIPOS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"dimensao_tipo invalido: {dimensao_tipo}. "
+                   f"Permitidos: {sorted(ALLOWED_DIMENSAO_TIPOS)}",
+        )
+
+    data_inicio = date.today() - timedelta(days=dias)
+    data_fim = date.today()
+
+    try:
+        result = await sb_execute(
+            db.table("network_events_agg")
+            .select("dimensao_valor, contagem")
+            .eq("evento_tipo", evento_tipo)
+            .eq("dimensao_tipo", dimensao_tipo)
+            .gte("periodo", data_inicio.isoformat())
+            .lte("periodo", data_fim.isoformat())
+            .order("contagem", desc=True)
+            .limit(limite)
+        )
+    except Exception as e:
+        logger.warning("Failed to query network events: %s", e)
+        raise HTTPException(status_code=500, detail="Erro ao consultar eventos.")
+
+    items = result.data if result.data else []
+    return TopResponse(
+        evento_tipo=evento_tipo,
+        periodo_inicio=data_inicio.isoformat(),
+        periodo_fim=data_fim.isoformat(),
+        items=[TopItem(dimensao_valor=row["dimensao_valor"], contagem=row["contagem"])
+               for row in items],
+    )

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -87,6 +87,7 @@ from routes.pseo_data import router as pseo_data_router
 from routes.seo_coverage_manifest import router as seo_coverage_manifest_router
 from routes.products import router as products_router
 from routes.seasonal_calendar import router as seasonal_calendar_router
+from routes.network_events import router as network_events_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -136,6 +137,7 @@ _v1_routers = [
     seo_coverage_manifest_router,
     products_router,
     seasonal_calendar_router,
+    network_events_router,
 ]
 
 

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -11683,6 +11683,54 @@
         "title": "ReconciliationRunsResponse",
         "type": "object"
       },
+      "RecordEventRequest": {
+        "properties": {
+          "dimensao_tipo": {
+            "description": "Tipo da dimensao: setor, uf, modalidade, orgao",
+            "title": "Dimensao Tipo",
+            "type": "string"
+          },
+          "dimensao_valor": {
+            "description": "Valor da dimensao (ex: saude, SP, pregao)",
+            "title": "Dimensao Valor",
+            "type": "string"
+          },
+          "evento_tipo": {
+            "description": "Tipo do evento: search_query, sector_view, org_view, cnpj_lookup",
+            "title": "Evento Tipo",
+            "type": "string"
+          },
+          "metadados": {
+            "additionalProperties": true,
+            "description": "Metadados adicionais (setores, ufs, modalidades). NUNCA PII.",
+            "title": "Metadados",
+            "type": "object"
+          }
+        },
+        "required": [
+          "evento_tipo",
+          "dimensao_tipo",
+          "dimensao_valor"
+        ],
+        "title": "RecordEventRequest",
+        "type": "object"
+      },
+      "RecordEventResponse": {
+        "properties": {
+          "message": {
+            "default": "Evento registrado com sucesso",
+            "title": "Message",
+            "type": "string"
+          },
+          "success": {
+            "default": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "title": "RecordEventResponse",
+        "type": "object"
+      },
       "RecoveryCodesResponse": {
         "properties": {
           "codes": {
@@ -14814,6 +14862,24 @@
         "title": "TopEntry",
         "type": "object"
       },
+      "TopItem": {
+        "properties": {
+          "contagem": {
+            "title": "Contagem",
+            "type": "integer"
+          },
+          "dimensao_valor": {
+            "title": "Dimensao Valor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dimensao_valor",
+          "contagem"
+        ],
+        "title": "TopItem",
+        "type": "object"
+      },
       "TopOpportunity": {
         "properties": {
           "data_encerramento": {
@@ -14907,6 +14973,37 @@
           "value"
         ],
         "title": "TopOpportunity",
+        "type": "object"
+      },
+      "TopResponse": {
+        "properties": {
+          "evento_tipo": {
+            "title": "Evento Tipo",
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TopItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "periodo_fim": {
+            "title": "Periodo Fim",
+            "type": "string"
+          },
+          "periodo_inicio": {
+            "title": "Periodo Inicio",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evento_tipo",
+          "periodo_inicio",
+          "periodo_fim",
+          "items"
+        ],
+        "title": "TopResponse",
         "type": "object"
       },
       "TopSupplierItem": {
@@ -24155,6 +24252,138 @@
         "summary": "Perfil de municipio com licitacoes abertas (por slug)",
         "tags": [
           "municipios-publicos"
+        ]
+      }
+    },
+    "/v1/network-events/record": {
+      "post": {
+        "description": "Record an anonymized network event.\n\nOnly collects data if user has explicitly opted in\n(profiles.allow_network_analytics = true). LGPD Art. 6, I.",
+        "operationId": "record_network_event_v1_network_events_record_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Record Network Event",
+        "tags": [
+          "network-events"
+        ]
+      }
+    },
+    "/v1/network-events/top": {
+      "get": {
+        "description": "Get top dimension values for a given event type.\n\nPublic endpoint \u2014 returns only anonymized aggregated data.",
+        "operationId": "get_top_network_events_v1_network_events_top_get",
+        "parameters": [
+          {
+            "description": "Tipo de evento para filtrar",
+            "in": "query",
+            "name": "evento_tipo",
+            "required": true,
+            "schema": {
+              "description": "Tipo de evento para filtrar",
+              "title": "Evento Tipo",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Dimensao para agregar",
+            "in": "query",
+            "name": "dimensao_tipo",
+            "required": false,
+            "schema": {
+              "default": "setor",
+              "description": "Dimensao para agregar",
+              "title": "Dimensao Tipo",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Janela em dias",
+            "in": "query",
+            "name": "dias",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "description": "Janela em dias",
+              "maximum": 365,
+              "minimum": 1,
+              "title": "Dias",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximo de resultados",
+            "in": "query",
+            "name": "limite",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Maximo de resultados",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limite",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Top Network Events",
+        "tags": [
+          "network-events"
         ]
       }
     },

--- a/backend/tests/test_network_events_agg.py
+++ b/backend/tests/test_network_events_agg.py
@@ -1,0 +1,507 @@
+"""Tests for NETINT-001 — Schema network_events_agg + coleta anonimizada (Issue #1283).
+
+Validates the migration SQL through static analysis:
+  - Migration file structure (UP + DOWN)
+  - Table schema and constraints
+  - RPC function signature, security attributes, sanitization, and grants
+  - RLS policies
+  - Column addition to profiles
+  - Output structure
+  - Edge cases: sanitization, PII rejection, empty metadados, UPSERT behavior
+
+No live DB connection needed. Follows the pattern from test_network_sector_migration.py.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATIONS_DIR = REPO_ROOT / "supabase" / "migrations"
+
+MIGRATION_TIMESTAMP = "20260531232239"
+UP_FILE = f"{MIGRATION_TIMESTAMP}_network_events_agg.sql"
+DOWN_FILE = f"{MIGRATION_TIMESTAMP}_network_events_agg.down.sql"
+
+
+def load_migration(filename: str) -> str:
+    """Load a migration SQL file from the supabase migrations directory."""
+    path = MIGRATIONS_DIR / filename
+    assert path.exists(), f"Migration not found: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: File Structure
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestMigrationFileStructure:
+    """AC: Migration files exist and have correct structure."""
+
+    def test_up_migration_exists(self):
+        """UP migration file must exist."""
+        assert (MIGRATIONS_DIR / UP_FILE).exists(), (
+            f"UP migration file {UP_FILE} not found"
+        )
+
+    def test_down_migration_exists(self):
+        """DOWN migration file must exist."""
+        assert (MIGRATIONS_DIR / DOWN_FILE).exists(), (
+            f"DOWN migration file {DOWN_FILE} not found"
+        )
+
+    def test_up_contains_begin_commit(self):
+        """UP migration is wrapped in BEGIN / COMMIT."""
+        sql = load_migration(UP_FILE)
+        assert "BEGIN;" in sql
+        assert sql.strip().endswith("COMMIT;")
+
+    def test_down_contains_drop_table_if_exists(self):
+        """DOWN migration drops the table using IF EXISTS."""
+        sql = load_migration(DOWN_FILE)
+        assert "DROP TABLE IF EXISTS" in sql
+        assert "network_events_agg" in sql
+
+    def test_down_contains_drop_rpc(self):
+        """DOWN migration drops the RPC function."""
+        sql = load_migration(DOWN_FILE)
+        assert "DROP FUNCTION IF EXISTS" in sql
+        assert "network_record_event" in sql
+
+    def test_down_contains_drop_column(self):
+        """DOWN migration drops the profiles column."""
+        sql = load_migration(DOWN_FILE)
+        assert "ALTER TABLE public.profiles" in sql
+        assert "DROP COLUMN IF EXISTS" in sql
+        assert "allow_network_analytics" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: Table Schema
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTableSchema:
+    """AC: network_events_agg table has correct schema."""
+
+    REQUIRED_COLUMNS = [
+        "id UUID PRIMARY KEY DEFAULT gen_random_uuid()",
+        "evento_tipo TEXT NOT NULL",
+        "dimensao_tipo TEXT NOT NULL",
+        "dimensao_valor TEXT NOT NULL",
+        "periodo DATE NOT NULL",
+        "contagem INTEGER DEFAULT 1",
+        "metadados JSONB DEFAULT '{}'",
+        "created_at TIMESTAMPTZ DEFAULT now()",
+    ]
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_creates_table(self, sql):
+        """Creates network_events_agg table with IF NOT EXISTS."""
+        assert "CREATE TABLE IF NOT EXISTS public.network_events_agg" in sql
+
+    def test_has_all_required_columns(self, sql):
+        """All required columns are present."""
+        for col in self.REQUIRED_COLUMNS:
+            assert col in sql, f"Required column definition not found: {col}"
+
+    def test_has_comments(self, sql):
+        """Table and columns have descriptive COMMENTs."""
+        assert "COMMENT ON TABLE public.network_events_agg IS" in sql
+        assert "COMMENT ON COLUMN" in sql
+
+    def test_has_idempotent_creation(self, sql):
+        """Uses IF NOT EXISTS for table creation."""
+        assert "IF NOT EXISTS" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: Indexes & Constraints
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestIndexesAndConstraints:
+    """AC: Proper indexes and unique constraint for daily aggregation."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_periodo_index(self, sql):
+        """Creates index on (periodo, evento_tipo, dimensao_tipo)."""
+        assert "CREATE INDEX IF NOT EXISTS idx_network_events_periodo" in sql
+        assert "periodo, evento_tipo, dimensao_tipo" in sql
+
+    def test_tipo_valor_index(self, sql):
+        """Creates index on (evento_tipo, dimensao_valor)."""
+        assert "CREATE INDEX IF NOT EXISTS idx_network_events_tipo_valor" in sql
+        assert "evento_tipo, dimensao_valor" in sql
+
+    def test_unique_daily_constraint(self, sql):
+        """Creates unique constraint for daily aggregation."""
+        assert "idx_network_events_unique_daily" in sql
+        assert "UNIQUE USING INDEX" in sql
+        assert "evento_tipo, dimensao_tipo, dimensao_valor, periodo" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: RLS Policies
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRLSPolicies:
+    """AC: RLS policies allow SELECT for all roles (anonymized data)."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_enable_rls(self, sql):
+        """Enables RLS on network_events_agg."""
+        assert "ALTER TABLE public.network_events_agg ENABLE ROW LEVEL SECURITY" in sql
+
+    def test_select_policy_anon(self, sql):
+        """SELECT policy for anon role."""
+        assert "CREATE POLICY" in sql
+        assert "network_events_agg_select_anon" in sql
+        assert "TO anon" in sql
+        assert "FOR SELECT" in sql
+
+    def test_select_policy_authenticated(self, sql):
+        """SELECT policy for authenticated role."""
+        assert "network_events_agg_select_authenticated" in sql
+        assert "TO authenticated" in sql
+        assert "FOR SELECT" in sql
+
+    def test_select_policy_service_role(self, sql):
+        """SELECT policy for service_role."""
+        assert "network_events_agg_select_service_role" in sql
+        assert "TO service_role" in sql
+        assert "FOR SELECT" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: RPC network_record_event — Signature & Security
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRPCSignature:
+    """AC: RPC function has correct signature and security attributes."""
+
+    FUNCTION_NAME = "public.network_record_event"
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def _function_block(self, sql: str) -> str:
+        """Extract the function definition block."""
+        start = sql.find(f"CREATE OR REPLACE FUNCTION {self.FUNCTION_NAME}")
+        assert start >= 0, "Function definition not found"
+        end = sql.find("$$;", start)
+        assert end >= 0, "Function body end not found"
+        return sql[start:end + 3]
+
+    def test_creates_or_replaces_function(self, sql):
+        """Uses CREATE OR REPLACE FUNCTION."""
+        assert f"CREATE OR REPLACE FUNCTION {self.FUNCTION_NAME}" in sql
+
+    def test_returns_void(self, sql):
+        """Returns void."""
+        assert "RETURNS void" in sql
+
+    def test_language_plpgsql(self, sql):
+        """Uses LANGUAGE plpgsql."""
+        assert "LANGUAGE plpgsql" in sql
+
+    def test_security_definer(self, sql):
+        """Uses SECURITY DEFINER."""
+        assert "SECURITY DEFINER" in sql
+
+    def test_search_path_sanitized(self, sql):
+        """Sets search_path to public, pg_temp."""
+        assert "SET search_path = public, pg_temp" in sql
+
+    def test_has_parameters(self, sql):
+        """Accepts required parameters."""
+        assert "p_evento_tipo TEXT" in sql
+        assert "p_dimensao_tipo TEXT" in sql
+        assert "p_dimensao_valor TEXT" in sql
+        assert "p_metadados JSONB DEFAULT '{}'" in sql
+
+    def test_has_comment(self, sql):
+        """Function has descriptive COMMENT."""
+        assert "COMMENT ON FUNCTION public.network_record_event" in sql
+        assert "NETINT-001" in sql
+        assert "LGPD" in sql
+
+    def test_input_validation(self, sql):
+        """Validates all required parameters are not null/empty."""
+        assert "p_evento_tipo IS NULL OR trim(p_evento_tipo) = ''" in sql
+        assert "p_dimensao_tipo IS NULL OR trim(p_dimensao_tipo) = ''" in sql
+        assert "p_dimensao_valor IS NULL OR trim(p_dimensao_valor) = ''" in sql
+        assert "RAISE EXCEPTION" in sql
+
+    def test_statement_timeout_set(self, sql):
+        """Sets LOCAL statement_timeout for defense."""
+        assert "SET LOCAL statement_timeout" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: PII Sanitization (LGPD)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSanitization:
+    """AC: RPC sanitizes metadados — never stores PII."""
+
+    PROHIBITED_KEYS = [
+        "user_id", "profile_id", "email", "cnpj", "cpf",
+        "ip", "user_agent", "fingerprint", "telefone",
+        "endereco", "nome", "token", "session_id",
+        "userId", "customerId", "profileId",
+    ]
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_defines_prohibited_keys_array(self, sql):
+        """Defines an array of prohibited keys."""
+        assert "v_proibido" in sql
+        for key in ["user_id", "profile_id", "email", "cnpj", "cpf"]:
+            assert f"'{key}'" in sql, f"Prohibited key '{key}' not found in array"
+
+    def test_removes_prohibited_keys(self, sql):
+        """Removes prohibited keys via FOREACH loop."""
+        assert "FOREACH v_key IN ARRAY v_proibido" in sql
+        assert "v_sanitized := v_sanitized - v_key" in sql
+
+    def test_removes_camel_case_variants(self, sql):
+        """Removes camelCase variants of prohibited keys."""
+        assert "replace(v_key, '_', '')" in sql
+        assert "upper(v_key)" in sql
+        assert "initcap(v_key)" in sql
+
+    def test_removes_keys_ending_in_id(self, sql):
+        """Removes any keys ending with 'id', 'Id', or 'ID'."""
+        assert "key ~* '.*(id|Id|ID)$'" in sql
+
+    def test_rejects_cnpj_pattern(self, sql):
+        """Rejects metadados containing CNPJ (14-digit pattern)."""
+        assert "CNPJ" in sql
+        assert "rejeitado por seguranca LGPD" in sql
+
+    def test_rejects_email_pattern(self, sql):
+        """Rejects metadados containing email pattern."""
+        assert "email" in sql
+        assert "rejeitado por seguranca LGPD" in sql
+
+    def test_rejects_uuid_pattern(self, sql):
+        """Rejects metadados containing UUID pattern."""
+        assert "UUID" in sql
+        assert "rejeitado por seguranca LGPD" in sql
+
+    def test_rejects_ip_pattern(self, sql):
+        """Rejects metadados containing IP pattern."""
+        assert "IP" in sql
+        assert "rejeitado por seguranca LGPD" in sql
+
+    def test_handles_null_metadados(self, sql):
+        """Handles NULL metadados gracefully — defaults to empty JSONB."""
+        assert "v_sanitized := '{}'::jsonb" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: UPSERT Behavior
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestUpsertBehavior:
+    """AC: RPC uses UPSERT — increments contagem if same combo exists."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_uses_insert_on_conflict(self, sql):
+        """Uses INSERT ... ON CONFLICT for UPSERT."""
+        assert "ON CONFLICT ON CONSTRAINT network_events_agg_unique_daily" in sql
+
+    def test_increments_contagem(self, sql):
+        """Increments contagem on conflict."""
+        assert "contagem = public.network_events_agg.contagem + 1" in sql
+
+    def test_merges_metadados_on_conflict(self, sql):
+        """Merges metadados arrays on conflict (no duplicates)."""
+        assert "jsonb_agg(DISTINCT elem)" in sql
+        assert "FULL OUTER JOIN" in sql
+
+    def test_creates_current_date(self, sql):
+        """Uses CURRENT_DATE for periodo."""
+        assert "CURRENT_DATE" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: Profiles Column Addition
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestProfilesColumn:
+    """AC: profiles.allow_network_analytics column added."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_adds_column(self, sql):
+        """Adds allow_network_analytics BOOLEAN DEFAULT NULL."""
+        assert "ADD COLUMN IF NOT EXISTS allow_network_analytics BOOLEAN DEFAULT NULL" in sql
+
+    def test_column_is_nullable(self, sql):
+        """Column is nullable — no NOT NULL constraint."""
+        assert "DEFAULT NULL" in sql
+
+    def test_has_comment(self, sql):
+        """Column has descriptive COMMENT."""
+        assert "COMMENT ON COLUMN public.profiles.allow_network_analytics IS" in sql
+        assert "NETINT-001" in sql
+        assert "LGPD" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: Grants
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGrants:
+    """AC: Proper GRANT permissions."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_grant_select_anon(self, sql):
+        """GRANT SELECT to anon on network_events_agg."""
+        assert "GRANT SELECT ON public.network_events_agg TO anon" in sql
+
+    def test_grant_select_authenticated(self, sql):
+        """GRANT SELECT to authenticated on network_events_agg."""
+        assert "GRANT SELECT ON public.network_events_agg TO authenticated" in sql
+
+    def test_grant_select_service_role(self, sql):
+        """GRANT SELECT to service_role on network_events_agg."""
+        assert "GRANT SELECT ON public.network_events_agg TO service_role" in sql
+
+    def test_grant_execute_rpc_authenticated(self, sql):
+        """GRANT EXECUTE on RPC to authenticated."""
+        assert "GRANT EXECUTE ON FUNCTION public.network_record_event" in sql
+        assert "TO authenticated" in sql
+
+    def test_grant_execute_rpc_service_role(self, sql):
+        """GRANT EXECUTE on RPC to service_role."""
+        assert "GRANT EXECUTE ON FUNCTION public.network_record_event" in sql
+        assert "TO service_role" in sql
+
+    def test_no_direct_dml_for_anon(self, sql):
+        """No INSERT/UPDATE/DELETE grants to anon (DML via RPC only)."""
+        # Verify no DML grants to anon exist anywhere in the migration
+        for dml in ["INSERT", "UPDATE", "DELETE"]:
+            pattern = re.compile(rf"GRANT\s+{dml}\s+ON.*TO\s+anon", re.IGNORECASE)
+            assert not pattern.search(sql), (
+                f"Found {dml} grant to anon — DML must be RPC-only"
+            )
+        # Verify SELECT grant to anon exists
+        assert re.search(
+            r"GRANT\s+SELECT\s+ON\s+public\.network_events_agg\s+TO\s+anon",
+            sql, re.IGNORECASE
+        ), "SELECT grant to anon not found"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: No PII in Schema
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNoPII:
+    """AC: Schema has no columns capable of storing individual PII."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_no_user_id_column(self, sql):
+        """Network_events_agg table has no user_id column."""
+        table_def = sql[sql.find("CREATE TABLE"):sql.find(");", sql.find("CREATE TABLE"))]
+        assert "user_id" not in table_def, "Table contains user_id column"
+
+    def test_no_cnpj_column(self, sql):
+        """Network_events_agg table has no cnpj column."""
+        table_def = sql[sql.find("CREATE TABLE"):sql.find(");", sql.find("CREATE TABLE"))]
+        assert "cnpj" not in table_def
+
+    def test_no_email_column(self, sql):
+        """Network_events_agg table has no email column."""
+        table_def = sql[sql.find("CREATE TABLE"):sql.find(");", sql.find("CREATE TABLE"))]
+        assert "email" not in table_def
+
+    def test_aggregated_data_only(self, sql):
+        """Data model is aggregated (contagem INTEGER, no individual rows)."""
+        assert "contagem INTEGER DEFAULT 1" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC: Edge Cases
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEdgeCases:
+    """AC: Edge cases handled correctly."""
+
+    @pytest.fixture(scope="class")
+    def sql(self):
+        return load_migration(UP_FILE)
+
+    def test_empty_metadados_default(self, sql):
+        """Empty metadados defaults to '{}'."""
+        assert "DEFAULT '{}'::jsonb" in sql
+
+    def test_null_metadados_handling(self, sql):
+        """NULL metadados handled — defaults to empty JSONB."""
+        block = sql[sql.find("IF p_metadados IS NULL"):
+                    sql.find("IF p_metadados IS NULL") + 100]
+        assert "v_sanitized := '{}'::jsonb" in block
+
+    def test_trim_on_text_fields(self, sql):
+        """Text fields are trimmed on insert."""
+        assert "trim(p_evento_tipo)" in sql
+        assert "trim(p_dimensao_tipo)" in sql
+        assert "trim(p_dimensao_valor)" in sql
+
+    def test_empty_string_rejected(self, sql):
+        """Empty strings rejected via input validation."""
+        assert "trim(p_evento_tipo) = ''" in sql
+        assert "trim(p_dimensao_tipo) = ''" in sql
+        assert "trim(p_dimensao_valor) = ''" in sql
+
+    def test_allowed_event_types_suggested(self, sql):
+        """COMMENT suggests allowed evento_tipo values."""
+        assert "COMMENT ON COLUMN public.network_events_agg.evento_tipo IS" in sql
+        assert "search_query" in sql
+        assert "sector_view" in sql
+        assert "org_view" in sql
+        assert "cnpj_lookup" in sql
+
+    def test_allowed_dimension_types_suggested(self, sql):
+        """COMMENT suggests allowed dimensao_tipo values."""
+        assert "COMMENT ON COLUMN public.network_events_agg.dimensao_tipo IS" in sql
+        assert "setor" in sql
+        assert "uf" in sql
+        assert "modalidade" in sql
+        assert "orgao" in sql
+        assert "municipio" in sql

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4015,6 +4015,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/network-events/record": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record Network Event
+         * @description Record an anonymized network event.
+         *
+         *     Only collects data if user has explicitly opted in
+         *     (profiles.allow_network_analytics = true). LGPD Art. 6, I.
+         */
+        post: operations["record_network_event_v1_network_events_record_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/network-events/top": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Top Network Events
+         * @description Get top dimension values for a given event type.
+         *
+         *     Public endpoint — returns only anonymized aggregated data.
+         */
+        get: operations["get_top_network_events_v1_network_events_top_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/notifications/new-bids-count": {
         parameters: {
             query?: never;
@@ -10712,6 +10757,44 @@ export interface components {
             /** Items */
             items: components["schemas"]["ReconciliationRun"][];
         };
+        /** RecordEventRequest */
+        RecordEventRequest: {
+            /**
+             * Dimensao Tipo
+             * @description Tipo da dimensao: setor, uf, modalidade, orgao
+             */
+            dimensao_tipo: string;
+            /**
+             * Dimensao Valor
+             * @description Valor da dimensao (ex: saude, SP, pregao)
+             */
+            dimensao_valor: string;
+            /**
+             * Evento Tipo
+             * @description Tipo do evento: search_query, sector_view, org_view, cnpj_lookup
+             */
+            evento_tipo: string;
+            /**
+             * Metadados
+             * @description Metadados adicionais (setores, ufs, modalidades). NUNCA PII.
+             */
+            metadados?: {
+                [key: string]: unknown;
+            };
+        };
+        /** RecordEventResponse */
+        RecordEventResponse: {
+            /**
+             * Message
+             * @default Evento registrado com sucesso
+             */
+            message: string;
+            /**
+             * Success
+             * @default true
+             */
+            success: boolean;
+        };
         /** RecoveryCodesResponse */
         RecoveryCodesResponse: {
             /** Codes */
@@ -12108,6 +12191,13 @@ export interface components {
             /** Name */
             name: string;
         };
+        /** TopItem */
+        TopItem: {
+            /** Contagem */
+            contagem: number;
+            /** Dimensao Valor */
+            dimensao_valor: string;
+        };
         /** TopOpportunity */
         TopOpportunity: {
             /** Data Encerramento */
@@ -12128,6 +12218,17 @@ export interface components {
             title: string;
             /** Value */
             value: number;
+        };
+        /** TopResponse */
+        TopResponse: {
+            /** Evento Tipo */
+            evento_tipo: string;
+            /** Items */
+            items: components["schemas"]["TopItem"][];
+            /** Periodo Fim */
+            periodo_fim: string;
+            /** Periodo Inicio */
+            periodo_inicio: string;
         };
         /** TopSupplierItem */
         TopSupplierItem: {
@@ -17917,6 +18018,77 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MunicipioProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_network_event_v1_network_events_record_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordEventResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_top_network_events_v1_network_events_top_get: {
+        parameters: {
+            query: {
+                /** @description Tipo de evento para filtrar */
+                evento_tipo: string;
+                /** @description Dimensao para agregar */
+                dimensao_tipo?: string;
+                /** @description Janela em dias */
+                dias?: number;
+                /** @description Maximo de resultados */
+                limite?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopResponse"];
                 };
             };
             /** @description Validation Error */

--- a/supabase/migrations/20260531232239_network_events_agg.down.sql
+++ b/supabase/migrations/20260531232239_network_events_agg.down.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- DOWN: NETINT-001 — desfaz network_events_agg + network_record_event
+-- Date: 2026-05-31
+-- Author: @data-engineer
+-- ============================================================================
+-- Context:
+--   Reverte a migracao UP 20260531232239_network_events_agg.sql.
+--   Remove na ordem inversa da UP para evitar dependencias quebradas.
+-- ============================================================================
+
+BEGIN;
+
+-- 1. Drop RPC
+DROP FUNCTION IF EXISTS public.network_record_event(TEXT, TEXT, TEXT, JSONB);
+
+-- 2. Drop table (cascade remove indices, constraints, policies)
+DROP TABLE IF EXISTS public.network_events_agg;
+
+-- 3. Drop column from profiles
+ALTER TABLE public.profiles
+    DROP COLUMN IF EXISTS allow_network_analytics;
+
+COMMIT;

--- a/supabase/migrations/20260531232239_network_events_agg.sql
+++ b/supabase/migrations/20260531232239_network_events_agg.sql
@@ -1,0 +1,278 @@
+-- ============================================================================
+-- NETINT-001: Schema network_events_agg + Mecanismo de coleta anonimizada
+-- Issue: #1283
+-- Wave: NETINT Wave 0 — Fundacao de privacidade e coleta anonimizada
+-- ============================================================================
+-- Context:
+--   Network Intelligence EPIC (#1263). Camada de coleta de eventos agregados
+--   e anonimizados para inteligencia coletiva. LGPD-first: nunca armazena PII
+--   ou dado individual.
+--
+--   Tabela network_events_agg:
+--     - Agregados diarios por (evento_tipo, dimensao_tipo, dimensao_valor)
+--     - UPSERT via network_record_event: se registro do dia ja existe,
+--       incrementa contagem em vez de duplicar
+--     - Sem RLS restritivo — SELECT publico (apenas agregados anonimos)
+--     - Metadados JSONB sanitizados: NUNCA user_id, cnpj, email, ip
+--
+--   Coluna profiles.allow_network_analytics:
+--     - NULL = nao decidiu (tratado como false — opt-out ate consentimento)
+--     - true = contribui com dados anonimos agregados
+--     - false = nunca coleta
+--
+--   SECURITY DEFINER + SET search_path = public (SEC-SECDEF-001/002).
+--   GRANT para authenticated, service_role — INSERT via RPC com sanitizacao.
+--   GRANT SELECT para anon, authenticated, service_role (dados agregados).
+-- ============================================================================
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. Create network_events_agg table
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.network_events_agg (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    evento_tipo TEXT NOT NULL,
+    dimensao_tipo TEXT NOT NULL,
+    dimensao_valor TEXT NOT NULL,
+    periodo DATE NOT NULL,
+    contagem INTEGER DEFAULT 1,
+    metadados JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+COMMENT ON TABLE public.network_events_agg IS
+    'NETINT-001: Eventos agregados anonimos de inteligencia coletiva. NUNCA contem PII.';
+
+COMMENT ON COLUMN public.network_events_agg.evento_tipo IS
+    'Tipo do evento: search_query, sector_view, org_view, cnpj_lookup, discount_view, migration_view, competitor_view';
+
+COMMENT ON COLUMN public.network_events_agg.dimensao_tipo IS
+    'Tipo da dimensao: setor, uf, modalidade, orgao, municipio';
+
+COMMENT ON COLUMN public.network_events_agg.dimensao_valor IS
+    'Valor da dimensao (ex: "saude", "SP", "pregao") — nunca PII';
+
+COMMENT ON COLUMN public.network_events_agg.periodo IS
+    'Data do evento (agregacao diaria)';
+
+COMMENT ON COLUMN public.network_events_agg.contagem IS
+    'Contagem de eventos neste periodo — incremental via UPSERT';
+
+COMMENT ON COLUMN public.network_events_agg.metadados IS
+    'Metadados adicionais: {"setores": [], "ufs": [], "modalidades": []}. NUNCA user_id, cnpj, email, ip.';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. Indexes
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_network_events_periodo
+    ON public.network_events_agg (periodo, evento_tipo, dimensao_tipo);
+
+CREATE INDEX IF NOT EXISTS idx_network_events_tipo_valor
+    ON public.network_events_agg (evento_tipo, dimensao_valor);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. Unique constraint for daily aggregation (antes do RPC que o referencia)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_network_events_unique_daily
+    ON public.network_events_agg (evento_tipo, dimensao_tipo, dimensao_valor, periodo);
+
+ALTER TABLE public.network_events_agg
+    ADD CONSTRAINT network_events_agg_unique_daily
+    UNIQUE USING INDEX idx_network_events_unique_daily;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. RLS — SELECT-only policies (INSERT via SECURITY DEFINER RPC)
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.network_events_agg ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "network_events_agg_select_anon"
+    ON public.network_events_agg
+    FOR SELECT
+    TO anon
+    USING (true);
+
+CREATE POLICY "network_events_agg_select_authenticated"
+    ON public.network_events_agg
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+CREATE POLICY "network_events_agg_select_service_role"
+    ON public.network_events_agg
+    FOR SELECT
+    TO service_role
+    USING (true);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 5. RPC: network_record_event — sanitized UPSERT
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.network_record_event(
+    p_evento_tipo TEXT,
+    p_dimensao_tipo TEXT,
+    p_dimensao_valor TEXT,
+    p_metadados JSONB DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_sanitized JSONB;
+    v_proibido TEXT[];
+    v_key TEXT;
+BEGIN
+    -- ── Input validation ──────────────────────────────────────────────────
+    IF p_evento_tipo IS NULL OR trim(p_evento_tipo) = '' THEN
+        RAISE EXCEPTION 'p_evento_tipo is required';
+    END IF;
+
+    IF p_dimensao_tipo IS NULL OR trim(p_dimensao_tipo) = '' THEN
+        RAISE EXCEPTION 'p_dimensao_tipo is required';
+    END IF;
+
+    IF p_dimensao_valor IS NULL OR trim(p_dimensao_valor) = '' THEN
+        RAISE EXCEPTION 'p_dimensao_valor is required';
+    END IF;
+
+    -- ── Sanitizacao obrigatoria: remove quaisquer chaves proibidas ─────────
+    -- (LGPD: garantir que nenhum PII seja armazenado mesmo que enviado)
+    v_proibido := ARRAY[
+        'user_id', 'profile_id', 'email', 'cnpj', 'cpf',
+        'ip', 'user_agent', 'fingerprint', 'telefone',
+        'endereco', 'nome', 'token', 'session_id'
+    ];
+
+    IF p_metadados IS NULL THEN
+        v_sanitized := '{}'::jsonb;
+    ELSE
+        v_sanitized := p_metadados;
+
+        -- Remove todas as chaves proibidas (case-insensitive)
+        FOREACH v_key IN ARRAY v_proibido
+        LOOP
+            v_sanitized := v_sanitized - v_key;
+            -- Tambem remove variacoes camelCase/snake_case
+            v_sanitized := v_sanitized - replace(v_key, '_', '');
+            v_sanitized := v_sanitized - upper(v_key);
+            v_sanitized := v_sanitized - initcap(v_key);
+        END LOOP;
+
+        -- Remove qualquer chave que termine com "id" (userId, customerId, ...)
+        SELECT v_sanitized - key
+        INTO v_sanitized
+        FROM jsonb_object_keys(v_sanitized) AS key
+        WHERE key ~* '.*(id|Id|ID)$';
+    END IF;
+
+    -- ── Rejeitar se patterns de PII persistirem no JSON serializado ────────
+    -- CNPJ: 14 digitos consecutivos
+    IF v_sanitized::text ~ '"[0-9]{14}"' THEN
+        RAISE EXCEPTION 'metadados contem CNPJ — rejeitado por seguranca LGPD';
+    END IF;
+
+    -- CNPJ formatado: XX.XXX.XXX/XXXX-XX
+    IF v_sanitized::text ~ '[0-9]{2}\.[0-9]{3}\.[0-9]{3}/[0-9]{4}-[0-9]{2}' THEN
+        RAISE EXCEPTION 'metadados contem CNPJ — rejeitado por seguranca LGPD';
+    END IF;
+
+    -- Email pattern
+    IF v_sanitized::text ~ '[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' THEN
+        RAISE EXCEPTION 'metadados contem email — rejeitado por seguranca LGPD';
+    END IF;
+
+    -- UUID pattern (user_id, profile_id)
+    IF v_sanitized::text ~ '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' THEN
+        RAISE EXCEPTION 'metadados contem UUID — rejeitado por seguranca LGPD';
+    END IF;
+
+    -- IPv4 pattern
+    IF v_sanitized::text ~ '\m[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\M' THEN
+        RAISE EXCEPTION 'metadados contem IP — rejeitado por seguranca LGPD';
+    END IF;
+
+    -- ── SET LOCAL statement_timeout para defesa contra runaway ─────────────
+    SET LOCAL statement_timeout = '5s';
+
+    -- ── UPSERT: incrementa contagem se registro do dia ja existe ──────────
+    INSERT INTO public.network_events_agg (
+        evento_tipo,
+        dimensao_tipo,
+        dimensao_valor,
+        periodo,
+        contagem,
+        metadados
+    ) VALUES (
+        trim(p_evento_tipo),
+        trim(p_dimensao_tipo),
+        trim(p_dimensao_valor),
+        CURRENT_DATE,
+        1,
+        v_sanitized
+    )
+    ON CONFLICT ON CONSTRAINT network_events_agg_unique_daily
+    DO UPDATE SET
+        contagem = public.network_events_agg.contagem + 1,
+        metadados = (
+            SELECT jsonb_object_agg(
+                COALESCE(n.key, o.key),
+                CASE
+                    WHEN jsonb_typeof(n.value) = 'array' AND jsonb_typeof(o.value) = 'array'
+                    THEN (
+                        SELECT jsonb_agg(DISTINCT elem)
+                        FROM (
+                            SELECT jsonb_array_elements_text(n.value) AS elem
+                            UNION
+                            SELECT jsonb_array_elements_text(o.value) AS elem
+                        ) sub
+                    )
+                    ELSE COALESCE(n.value, o.value)
+                END
+            )
+            FROM jsonb_each(public.network_events_agg.metadados) o
+            FULL OUTER JOIN jsonb_each(v_sanitized) n ON n.key = o.key
+        ),
+        created_at = now();
+END;
+$$;
+
+COMMENT ON FUNCTION public.network_record_event(TEXT, TEXT, TEXT, JSONB) IS
+    'NETINT-001 — Registra evento anonimo agregado com sanitizacao LGPD. '
+    'UPSERT: incrementa contagem se mesma combinacao ja existe no dia. '
+    'Rejeita metadados contendo PII (CNPJ, email, UUID, IP).';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 6. Add profiles.allow_network_analytics column (aditiva, DEFAULT NULL)
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.profiles
+    ADD COLUMN IF NOT EXISTS allow_network_analytics BOOLEAN DEFAULT NULL;
+
+COMMENT ON COLUMN public.profiles.allow_network_analytics IS
+    'NETINT-001: Consentimento LGPD para coleta anonima. '
+    'NULL = nao decidiu (tratado como false — opt-out ate consentimento explicito). '
+    'true = contribui com dados agregados anonimos. false = nunca coleta.';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 7. Grants
+-- ────────────────────────────────────────────────────────────────────────────
+
+-- SELECT: publico (dados agregados anonimos — sem PII)
+GRANT SELECT ON public.network_events_agg TO anon;
+GRANT SELECT ON public.network_events_agg TO authenticated;
+GRANT SELECT ON public.network_events_agg TO service_role;
+
+-- INSERT/UPDATE/DELETE: apenas via RPC (SECURITY DEFINER)
+-- Nenhuma permissao direta de DML para anon ou authenticated.
+
+-- RPC: authenticated + service_role
+GRANT EXECUTE ON FUNCTION public.network_record_event(TEXT, TEXT, TEXT, JSONB) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.network_record_event(TEXT, TEXT, TEXT, JSONB) TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## Summary

NETINT-001 — Schema de eventos agregados anonimos para inteligencia coletiva (LGPD-first). NUNCA armazena PII.

### O que foi feito

**Migracao SQL** (`supabase/migrations/20260531232239_network_events_agg.sql` + `.down.sql`):
- Nova tabela `network_events_agg` com agregacao diaria por (evento_tipo, dimensao_tipo, dimensao_valor, periodo)
- Indices: `idx_network_events_periodo` (periodo, evento_tipo, dimensao_tipo), `idx_network_events_tipo_valor`
- UNIQUE constraint `network_events_agg_unique_daily` para UPSERT diario
- RLS: SELECT-only policies para anon, authenticated, service_role (dados publicos agregados)
- RPC `network_record_event` (SECURITY DEFINER) com sanitizacao LGPD:
  - Remove chaves proibidas (user_id, profile_id, email, cnpj, cpf, ip, etc.)
  - Remove variantes camelCase (userId, customerId, etc.)
  - Remove qualquer chave terminada em "id"
  - Rejeita metadados contendo CNPJ, email, UUID, IPv4
  - UPSERT: incrementa contagem se mesma combinacao ja existe no dia
  - Merge de arrays JSONB sem duplicatas
- Coluna `profiles.allow_network_analytics` (BOOLEAN DEFAULT NULL)

**Route** (`backend/routes/network_events.py`):
- `POST /v1/network-events/record` — grava evento anonimo (com opt-in check via profiles)
- `GET /v1/network-events/top` — top dimensoes por tipo de evento
- Ambos com `response_model=` (Pydantic schemas)

**Testes** (`backend/tests/test_network_events_agg.py`):
- 58 testes de analise estatica (sem DB connection)
- Cobre: estrutura de arquivos, schema da tabela, indices, RLS, RPC signature, sanitizacao LGPD, UPSERT, grants, profile column, edge cases, zero PII

### Privacidade / LGPD
- [x] Dado coletado e estritamente agregado (count por dimensao) — nunca individual
- [x] Usuario pode desabilitar contribuicao (allow_network_analytics: false)
- [x] Usuarios existentes: coleta desabilitada ate opt-in explicito (NULL = false)
- [x] Nenhum PII ou CNPJ armazenado — sanitizacao server-side
- [x] RPC rejeita metadados com CNPJ/UUID/email/IP

## Changes

See "O que foi feito" section above for full details.

## Testing Plan

```bash
cd backend && python -m pytest tests/test_network_events_agg.py -v
# Result: 58 passed in 6.06s
```

## Closes

Closes #1283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to record and retrieve aggregated anonymized network events
  * Implemented privacy-first network analytics with user opt-in/opt-out controls
  * Added endpoints to view top aggregated event data with customizable time windows and filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->