### PR TITLE
feat(frontend): rewrite SERP metadata for 4 blog pages (#1320)

### DIFF
--- a/frontend/lib/blog.ts
+++ b/frontend/lib/blog.ts
@@ -1078,10 +1078,10 @@ export const BLOG_ARTICLES: BlogArticleMeta[] = [
   // GUIA-T1
   {
     slug: 'como-participar-primeira-licitacao-2026',
-    title: 'Primeira Licitação [2026]: Guia Passo a Passo | SmartLic',
+    title: 'Primeira licitação em 2026: encontre editais compatíveis com sua empresa',
     h1: 'Editais abertos e oportunidades de licitação por setor em 2026',
     description:
-      'Guia completo para participar da sua primeira licitação em 2026: cadastro no SICAF, como escolher o edital certo e comprovar habilitação. Em 5 minutos.',
+      'Descubra oportunidades reais no PNCP filtrando por setor, UF e valor. Checklist gratuito + alertas de editais novos no seu segmento.',
     category: 'Guias',
     tags: ['primeira licitação', 'guia iniciante', 'passo a passo', 'cadastro'],
     publishDate: '2026-04-04',
@@ -1140,10 +1140,10 @@ export const BLOG_ARTICLES: BlogArticleMeta[] = [
   // GUIA-T3
   {
     slug: 'pncp-guia-completo-empresas',
-    title: 'PNCP para Empresas [2026]: Editais e Contratos | SmartLic',
+    title: 'PNCP para empresas: encontre órgãos que já compram o que você vende',
     h1: 'Encontre editais, contratos e fornecedores públicos no PNCP',
     description:
-      'Aprenda a usar o PNCP para encontrar editais e contratos públicos em 2026: filtre por setor, UF e modalidade. Monitoramento automático, atualizado diariamente.',
+      'Busque editais, contratos e fornecedores no PNCP filtrando por setor, UF e valor. Descubra quais órgãos compram seu produto e quanto pagam.',
     category: 'Guias',
     tags: ['PNCP', 'portal de contratações', 'busca de editais', 'monitoramento'],
     publishDate: '2026-04-04',
@@ -1874,10 +1874,10 @@ export const BLOG_ARTICLES: BlogArticleMeta[] = [
   // SEO-12.3.3 Art-01: como consultar contratos públicos PNCP
   {
     slug: 'como-consultar-contratos-publicos-pncp',
-    title: 'Consultar Contratos Públicos no PNCP [2026] | SmartLic',
+    title: 'Contratos públicos no PNCP: veja quem compra, quanto paga e com que frequência',
     h1: 'Busque contratos públicos no PNCP por fornecedor, órgão ou objeto',
     description:
-      'Veja como consultar contratos públicos no PNCP em 3 passos: busque por CNPJ, órgão ou objeto. Mais de 2 milhões de contratos com exportação gratuita em 2026.',
+      'Consulte contratos por órgão, fornecedor, setor e valor. Descubra padrões de compra, ticket médio e sazonalidade dos órgãos públicos.',
     category: 'Guias',
     tags: ['contratos públicos', 'PNCP', 'consultar contratos', 'fornecedores', 'inteligência de mercado'],
     lastModified: '2026-05-08',
@@ -2072,10 +2072,10 @@ export const BLOG_ARTICLES: BlogArticleMeta[] = [
   // SEO-12.3.3 Art-07: Subcontratação em licitações — contratos cluster
   {
     slug: 'subcontratacao-licitacoes-regras-lei-14133',
-    title: 'Subcontratação em Licitações [2026]: Lei 14.133 | SmartLic',
+    title: 'Subcontratação em licitações: descubra quem vence contratos e pode comprar de você',
     h1: 'Subcontratação em contratos públicos: limites, vedações e como aproveitar oportunidades',
     description:
-      'Entenda as regras de subcontratação em licitações pela Lei 14.133: limites legais, vedações e responsabilidade solidária. Como formalizar corretamente em 2026.',
+      'Mapeie empresas que vencem contratos públicos e precisam de fornecedores. Veja pontes de subcontratação por setor, UF e valor.',
     category: 'Guias',
     tags: [
       'subcontratação',


### PR DESCRIPTION
## Summary

CONV-006a Quick Win SERP: Rewrites `<title>` and `<meta name="description">` for the 4 worst-performing blog pages based on GSC data (lowest CTR-to-position ratio).

## Pages Updated

| Pagina | Novo Titulo | Caracteres |
|--------|------------|-----------|
| `pncp-guia-completo-empresas` | PNCP para empresas: encontre orgaos que ja compram o que voce vende | 67 |
| `como-participar-primeira-licitacao-2026` | Primeira licitacao em 2026: encontre editais compativeis com sua empresa | 72 |
| `subcontratacao-licitacoes-regras-lei-14133` | Subcontratacao em licitacoes: descubra quem vence contratos e pode comprar de voce | 82 |
| `como-consultar-contratos-publicos-pncp` | Contratos publicos no PNCP: veja quem compra, quanto paga e com que frequencia | 78 |

## Acceptance Criteria

- [x] 4 pages with rewritten title + description deployed
- [x] Title changes from educational to operational promise
- [x] Description includes economic consequence trigger
- [ ] CTR monitored via GSC 7 days post-deploy

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] SEO / Conversion

## Testing Plan

- [x] Lint: pre-existing errors only (no new errors from this change)
- [x] Tests: 591 blog-related tests pass (1 pre-existing playwright e2e env failure)
- [x] TypeScript: no new type errors

## Impact

Only `frontend/lib/blog.ts` changed — 8 insertions, 8 deletions. Pure metadata update, no logic changes.

## Rollback Plan

```bash
# Revert the merge commit — zero code logic, pure string literals.
git revert HEAD --no-edit -m 1
# Or: revert to prior blog.ts version
git checkout HEAD~1 -- frontend/lib/blog.ts && git commit -m "revert(frontend): rollback SERP metadata to educational titles"
```

No DB migration, no API change, no dependency bump. Revert is instant and safe.

## Closes

Closes #1320

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>