### PR TITLE
feat(frontend): CONV-017 — replace flat related links with intent-progressive JourneyLinks (#1332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Frontend / SEO
+- **JourneyLinks — jornadas de intenção progressiva [CONV-017] (#1332)** — Substitui 'Páginas Relacionadas' (lista plana) por jornadas estruturadas de intenção progressiva em 4 entity pages (`fornecedores`, `orgaos`, `contratos`, `municipios`). `JourneyLinks` (server component com Schema.org ItemList JSON-LD) + `JourneyLinkTracker` (client component para Mixpanel). `relatedResolver.ts` com tipos `JourneyStep`/`JourneyContext` e resolvers por contexto de entidade. Rollback: `git revert <merge-commit>`.
+
 ### Added — Backend / Subcontracting Intelligence
 - **Capability `allow_subcontract_intel` + feature flag `SUBCONTRACT_INTEL_ENABLED` [SUBINTEL-030] (#1234)** — Mecanismo de gating **estritamente aditivo** para a futura vertical de Inteligência de Cadeia de Fornecimento (EPIC-SUBINTEL #1224). Novo campo `allow_subcontract_intel: bool` em `PlanCapabilities` (TypedDict) + `_UNKNOWN_PLAN_DEFAULTS` + 3 construtores do loader DB (jsonb opcional via `.get(...,False)` — não-regressão para linhas existentes), com valor `False` em todos os 9 planos atuais. Dependency `requires_subcontract_intel` + factory `get_subcontract_intel_dependency` em `quota/plan_auth.py` (flag off → 404 rota inerte; capability false → 403 upsell; master bypass; fail-closed em circuit-breaker open) para os futuros endpoints `/v1/subcontract/*`. Feature flag `SUBCONTRACT_INTEL_ENABLED` (default `false`) registrada em `config/features.py` + registry + lifecycle/description em `routes/feature_flags.py`. Comportamento de produção inalterado até ativação explícita. 23 testes novos + atualização de não-regressão. Rollback: reverter o merge ou manter a flag off (estado default).
 

--- a/frontend/app/components/ContentPageLayout.tsx
+++ b/frontend/app/components/ContentPageLayout.tsx
@@ -3,6 +3,8 @@ import Footer from './Footer';
 import Link from 'next/link';
 import BreadcrumbNav from '@/components/seo/BreadcrumbNav';
 import type { BreadcrumbItem } from '@/lib/seo';
+import type { JourneyStep } from '@/lib/seo/relatedResolver';
+import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
 
 interface RelatedPage {
   href: string;
@@ -15,6 +17,14 @@ interface ContentPageLayoutProps {
   relatedPages: RelatedPage[];
   /** Optional full breadcrumb trail. If provided, overrides the 2-level default. */
   breadcrumbItems?: BreadcrumbItem[];
+  /**
+   * CONV-017 (#1332): Intent-progressive journey links.
+   * When provided, replaces the legacy `relatedPages` sidebar section with
+   * JourneyLinks structured as numbered steps. Up to 5 steps.
+   */
+  journeyLinks?: JourneyStep[];
+  /** Template identifier for analytics when journeyLinks is used. */
+  journeySourceTemplate?: string;
 }
 
 export default function ContentPageLayout({
@@ -22,6 +32,8 @@ export default function ContentPageLayout({
   breadcrumbLabel,
   relatedPages,
   breadcrumbItems,
+  journeyLinks,
+  journeySourceTemplate = 'entity',
 }: ContentPageLayoutProps) {
   const items: BreadcrumbItem[] =
     breadcrumbItems ?? [
@@ -68,25 +80,52 @@ export default function ContentPageLayout({
                   </Link>
                 </div>
 
-                {/* Related Pages */}
-                {relatedPages.length > 0 && (
+                {/* Journey Links (CONV-017) — replaces legacy relatedPages when provided */}
+                {journeyLinks && journeyLinks.length > 0 ? (
                   <div className="bg-surface-1 rounded-xl p-4 sm:p-6 border border-[var(--border)]">
                     <h3 className="font-semibold text-ink text-sm sm:text-base mb-3 sm:mb-4">
-                      Conteúdo relacionado
+                      Navegação recomendada
                     </h3>
-                    <ul className="space-y-2.5 sm:space-y-3">
-                      {relatedPages.map((page) => (
-                        <li key={page.href}>
+                    <ul className="space-y-3">
+                      {journeyLinks.map((step) => (
+                        <li key={step.position}>
                           <Link
-                            href={page.href}
-                            className="text-xs sm:text-sm text-brand-blue hover:underline transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 rounded px-1"
+                            href={step.href}
+                            className="group flex items-start gap-2 text-xs sm:text-sm text-brand-blue hover:underline transition-colors rounded px-1"
                           >
-                            {page.title}
+                            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-blue-100 text-[10px] font-bold text-blue-700 group-hover:bg-blue-200 transition-colors" aria-hidden="true">
+                              {step.position}
+                            </span>
+                            <span className="flex-1 min-w-0">
+                              <span className="block font-medium">{step.icon} {step.title}</span>
+                              <span className="block text-gray-500 text-xs mt-0.5 line-clamp-2">{step.description}</span>
+                            </span>
                           </Link>
                         </li>
                       ))}
                     </ul>
                   </div>
+                ) : (
+                  /* Legacy Related Pages (fallback) */
+                  relatedPages.length > 0 && (
+                    <div className="bg-surface-1 rounded-xl p-4 sm:p-6 border border-[var(--border)]">
+                      <h3 className="font-semibold text-ink text-sm sm:text-base mb-3 sm:mb-4">
+                        Conteúdo relacionado
+                      </h3>
+                      <ul className="space-y-2.5 sm:space-y-3">
+                        {relatedPages.map((page) => (
+                          <li key={page.href}>
+                            <Link
+                              href={page.href}
+                              className="text-xs sm:text-sm text-brand-blue hover:underline transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 rounded px-1"
+                            >
+                              {page.title}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )
                 )}
 
                 {/* Features Link */}
@@ -104,6 +143,16 @@ export default function ContentPageLayout({
               </div>
             </aside>
           </div>
+
+          {/* Full-width JourneyLinks below the grid when not in sidebar */}
+          {journeyLinks && journeyLinks.length > 0 && (
+            <div className="mt-8 max-w-2xl">
+              <JourneyLinks
+                journey={journeyLinks}
+                sourceTemplate={journeySourceTemplate}
+              />
+            </div>
+          )}
         </div>
       </main>
 

--- a/frontend/app/components/navigation/JourneyLinkTracker.tsx
+++ b/frontend/app/components/navigation/JourneyLinkTracker.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * CONV-017 (#1332): Client component for tracking journey_link_clicked events.
+ *
+ * Renders a Link with an onClick handler that fires a Mixpanel event with
+ * source_template, destination_type, and position metadata.
+ *
+ * SSR-safe (renders anchor statically, tracking only fires on client).
+ */
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { trackJourneyLinkClicked } from '@/lib/analytics-events';
+
+interface JourneyLinkTrackerProps {
+  href: string;
+  sourceTemplate: string;
+  destinationType: string;
+  position: number;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Tracked link wrapper for journey steps. Fires `journey_link_clicked` on
+ * click with structured metadata for Mixpanel analysis.
+ */
+export function JourneyLinkTracker({
+  href,
+  sourceTemplate,
+  destinationType,
+  position,
+  className,
+  children,
+}: JourneyLinkTrackerProps) {
+  const handleClick = () => {
+    trackJourneyLinkClicked({
+      source_template: sourceTemplate,
+      destination_type: destinationType,
+      position,
+    });
+  };
+
+  return (
+    <Link href={href} className={className} onClick={handleClick}>
+      {children}
+    </Link>
+  );
+}

--- a/frontend/app/components/navigation/JourneyLinks.tsx
+++ b/frontend/app/components/navigation/JourneyLinks.tsx
@@ -1,0 +1,117 @@
+/**
+ * CONV-017 (#1332): JourneyLinks — intent-progressive journey component.
+ *
+ * Renders a structured, ordered set of up to 5 links that guide the user
+ * through a progression of commercial intent (most transactional first,
+ * most exploratory last). Replaces the flat "Páginas Relacionadas" section
+ * on entity pages.
+ *
+ * Features:
+ * - Numbered steps with emoji icons and descriptive text
+ * - Schema.org ItemList JSON-LD for rich search results
+ * - Mixpanel tracking via JourneyLinkTracker client wrapper
+ * - Ordered by intent (never shuffled)
+ */
+
+import type { JourneyStep } from '@/lib/seo/relatedResolver';
+import { JourneyLinkTracker } from './JourneyLinkTracker';
+
+interface JourneyLinksProps {
+  /** Ordered journey steps (max 5). */
+  journey: JourneyStep[];
+  /** Template identifier for analytics (e.g. 'fornecedor', 'orgao'). */
+  sourceTemplate: string;
+  /** Optional heading override. Default: "Próximos passos" */
+  heading?: string;
+}
+
+export function JourneyLinks({
+  journey,
+  sourceTemplate,
+  heading = 'Próximos passos',
+}: JourneyLinksProps) {
+  if (journey.length === 0) return null;
+
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: heading,
+    description: 'Jornada de navegação progressiva para explorar dados públicos.',
+    numberOfItems: journey.length,
+    itemListElement: journey.map((step) => ({
+      '@type': 'ListItem',
+      position: step.position,
+      name: step.title,
+      description: step.description,
+      url: `https://smartlic.tech${step.href}`,
+    })),
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }}
+      />
+
+      <section className="border-t border-gray-200 pt-8 mb-8">
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">{heading}</h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Explore dados relacionados em ordem recomendada.
+        </p>
+
+        <div className="space-y-3">
+          {journey.map((step) => (
+            <JourneyLinkTracker
+              key={step.position}
+              href={step.href}
+              sourceTemplate={sourceTemplate}
+              destinationType={step.destinationType}
+              position={step.position}
+              className="block group"
+            >
+              <div className="flex items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 transition-colors hover:border-blue-300 hover:bg-blue-50/50">
+                {/* Position badge */}
+                <span
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700 group-hover:bg-blue-200 transition-colors"
+                  aria-hidden="true"
+                >
+                  {step.position}
+                </span>
+
+                {/* Content */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-base" aria-hidden="true">{step.icon}</span>
+                    <span className="text-sm font-medium text-gray-900 group-hover:text-blue-700 transition-colors">
+                      {step.title}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-gray-500 line-clamp-2">
+                    {step.description}
+                  </p>
+                </div>
+
+                {/* Arrow */}
+                <svg
+                  className="mt-1 h-4 w-4 shrink-0 text-gray-400 group-hover:text-blue-600 transition-colors"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </div>
+            </JourneyLinkTracker>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -19,6 +19,8 @@ import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import { PseoPageTracker } from '@/app/components/seo/PseoPageTracker';
 import { PseoLink } from '@/app/components/seo/PseoLink';
 import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
+import { resolveJourney } from '@/lib/seo/relatedResolver';
+import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
 
 export const revalidate = 14400; // 4h ISR (reduzido de 24h para melhorar freshness dos dados)
 
@@ -130,6 +132,17 @@ export default async function ContratosSetorUfPage({ params }: Props) {
   const year = new Date().getFullYear();
   const totalContracts = data?.total_contracts ?? 0;
   const totalEditais = blogStats?.total_editais ?? 0;
+
+  // CONV-017 (#1332): Build intent-progressive journey for this contrato page.
+  const journey = resolveJourney({
+    type: 'contrato',
+    value: setor,
+    currentUrl: `/contratos/${setor}/${uf}`,
+    sectorSlug: setor,
+    sectorName: sector.name,
+    uf: ufUpper,
+    ufName,
+  });
 
   const breadcrumbs = [
     { name: 'SmartLic', url: '/' },
@@ -491,24 +504,8 @@ export default async function ContratosSetorUfPage({ params }: Props) {
             </div>
           </section>
 
-          {/* Internal Linking */}
-          <section className="border-t border-gray-200 pt-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-3">Páginas Relacionadas</h2>
-            <div className="flex flex-wrap gap-3 text-sm">
-              <Link href={`/fornecedores/${setor}/${uf}`} className="text-blue-600 hover:underline">
-                Fornecedores de {sector.name} {getUfPrep(ufUpper)} {ufName}
-              </Link>
-              <Link href={`/alertas-publicos/${setor}/${uf}`} className="text-blue-600 hover:underline">
-                Alertas de {sector.name} {getUfPrep(ufUpper)} {ufName}
-              </Link>
-              <Link href={`/blog/licitacoes/${setor}/${uf}`} className="text-blue-600 hover:underline">
-                Licitações de {sector.name} {getUfPrep(ufUpper)} {ufName}
-              </Link>
-              <Link href="/contratos" className="text-blue-600 hover:underline">
-                Todos os Setores
-              </Link>
-            </div>
-          </section>
+          {/* CONV-017 (#1332): JourneyLinks replaces flat "Páginas Relacionadas" */}
+          <JourneyLinks journey={journey} sourceTemplate="contrato" />
 
           {/* CONV-002b: Lead Capture — contextual CTA + "Só quero ver os dados" */}
           <section className="mt-12 rounded-2xl border border-brand-blue/30 bg-brand-blue/5 dark:bg-brand-blue/10 p-6 sm:p-8">

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -12,6 +12,8 @@ import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 import { PseoPageTracker } from '@/app/components/seo/PseoPageTracker';
 import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
+import { resolveJourney } from '@/lib/seo/relatedResolver';
+import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
 
 // Sprint 3 Parte 13: paginas de perfil de fornecedor por CNPJ
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -171,6 +173,17 @@ export default async function FornecedorCnpjPage({ params }: Props) {
   const valorFmtLd = profile.valor_total >= 1_000_000
     ? `R$ ${(profile.valor_total / 1_000_000).toFixed(1)} mi`
     : `R$ ${(profile.valor_total / 1_000).toFixed(0)} mil`;
+
+  // CONV-017 (#1332): Build intent-progressive journey from profile data.
+  const journey = resolveJourney({
+    type: 'fornecedor',
+    value: cnpj,
+    currentUrl: `/fornecedores/${cnpj}`,
+    name: profile.razao_social,
+    uf: profile.uf_sede,
+    orgaoCnpjs: profile.top_compradores.map((o) => o.cnpj),
+    orgaoNames: profile.top_compradores.map((o) => o.nome),
+  });
 
   const jsonLd = [
     {
@@ -482,36 +495,8 @@ export default async function FornecedorCnpjPage({ params }: Props) {
             </div>
           </section>
 
-          {/* Páginas Relacionadas — PSEO-TMPL-001 (#882): interlinking bidirecional completo */}
-          <section className="border-t border-gray-200 pt-8 mb-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-3">Páginas Relacionadas</h2>
-            <div className="flex flex-wrap gap-3 text-sm">
-              <Link href={`/cnpj/${cnpj}`} className="text-blue-600 hover:underline">
-                Consulta CNPJ — {cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5')}
-              </Link>
-              <Link href="/fornecedores" className="text-blue-600 hover:underline">
-                Todos os Fornecedores
-              </Link>
-              {profile.top_compradores.slice(0, 2).map((o) => (
-                <Link
-                  key={o.cnpj}
-                  href={`/contratos/orgao/${o.cnpj}`}
-                  className="text-blue-600 hover:underline"
-                >
-                  Contratos de {o.nome.split(' ').slice(0, 3).join(' ')}
-                </Link>
-              ))}
-              {profile.ufs_atuantes.slice(0, 2).map((uf) => (
-                <Link
-                  key={uf}
-                  href={`/contratos/${uf.toLowerCase()}`}
-                  className="text-blue-600 hover:underline"
-                >
-                  Contratos em {uf}
-                </Link>
-              ))}
-            </div>
-          </section>
+          {/* CONV-017 (#1332): JourneyLinks replaces flat "Páginas Relacionadas" */}
+          <JourneyLinks journey={journey} sourceTemplate="fornecedor" />
 
           {/* CONV-014: Alert CTA — monitorar contratos desta empresa */}
           <AlertEntityCta

--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -11,6 +11,8 @@ import { AdvisoryDisclaimer } from '@/components/legal/AdvisoryDisclaimer';
 import { LeadCapture } from '@/components/LeadCapture';
 import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
+import { resolveJourney } from '@/lib/seo/relatedResolver';
+import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
 
 // Sprint 4 Parte 13: páginas de municípios com licitações abertas
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -175,6 +177,15 @@ export default async function MunicipioSlugPage({ params }: Props) {
     data_publicacao: l.data_publicacao,
     link_interno: `/municipios/${slug}`,
   }));
+
+  // CONV-017 (#1332): Build intent-progressive journey for this municipio.
+  const journey = resolveJourney({
+    type: 'municipio',
+    value: slug,
+    currentUrl: `/municipios/${slug}`,
+    name: profile.nome,
+    uf: profile.uf,
+  });
 
   const jsonLd = [
     {
@@ -385,24 +396,8 @@ export default async function MunicipioSlugPage({ params }: Props) {
             </section>
           )}
 
-          {/* Links relacionados */}
-          <section className="border-t border-gray-200 pt-8 mb-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-3">Páginas Relacionadas</h2>
-            <div className="flex flex-wrap gap-3 text-sm">
-              <Link href="/municipios" className="text-blue-600 hover:underline">
-                Todos os Municípios
-              </Link>
-              <Link
-                href={`/fornecedores`}
-                className="text-blue-600 hover:underline"
-              >
-                Fornecedores em {profile.uf}
-              </Link>
-              <Link href="/licitacoes" className="text-blue-600 hover:underline">
-                Licitações por Setor
-              </Link>
-            </div>
-          </section>
+          {/* CONV-017 (#1332): JourneyLinks replaces flat "Páginas Relacionadas" */}
+          <JourneyLinks journey={journey} sourceTemplate="municipio" />
 
           {/* CONV-002b: Contextual CTA — trial + "Só quero ver os dados" */}
           <section className="mt-4 rounded-2xl border border-brand-blue/30 bg-brand-blue/5 dark:bg-brand-blue/10 p-6 sm:p-8">

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { getBackendUrl } from '@/lib/backend-url';
 import { AdvisoryDisclaimer } from '@/components/legal/AdvisoryDisclaimer';
 import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
+import { resolveJourney } from '@/lib/seo/relatedResolver';
 
 const BACKEND_URL = getBackendUrl();
 
@@ -192,6 +193,19 @@ export default async function OrgaoPerfilPage({
     { label: stats.nome },
   ];
 
+  // CONV-017 (#1332): Build intent-progressive journey for this órgão.
+  const journey = resolveJourney({
+    type: 'orgao',
+    value: stats.cnpj,
+    currentUrl: `/orgaos/${slug}`,
+    name: stats.nome,
+    uf: stats.uf,
+    sectorSlug: stats.top_setores?.[0],
+    sectorName: stats.top_setores?.[0]
+      ? undefined
+      : undefined,
+  });
+
   return (
     <>
     {/* CONV-002b: Sticky bottom mobile CTA — contextual */}
@@ -214,12 +228,9 @@ export default async function OrgaoPerfilPage({
     <ContentPageLayout
       breadcrumbLabel={stats.nome}
       breadcrumbItems={breadcrumbItems}
-      relatedPages={[
-        { href: '/orgaos', title: 'Órgãos Compradores' },
-        { href: '/cnpj', title: 'Consulta CNPJ' },
-        { href: '/calculadora', title: 'Calculadora de Oportunidades' },
-        { href: '/licitacoes', title: 'Licitações por Setor' },
-      ]}
+      relatedPages={[]}
+      journeyLinks={journey}
+      journeySourceTemplate="orgao"
     >
       <script
         type="application/ld+json"

--- a/frontend/lib/analytics-events.ts
+++ b/frontend/lib/analytics-events.ts
@@ -40,6 +40,13 @@ export type LeadCapturedEvent = {
   form_name?: string;
 };
 
+/** CONV-017 (#1332): Event payload for journey_link_clicked tracking. */
+export type JourneyLinkClickedEvent = {
+  source_template: string;
+  destination_type: string;
+  position: number;
+};
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -99,4 +106,12 @@ export function trackFormSubmitted(event: FormSubmittedEvent): void {
  */
 export function trackLeadCaptured(event: LeadCapturedEvent): void {
   safeTrack('lead_captured', event as unknown as Record<string, unknown>);
+}
+
+/**
+ * CONV-017 (#1332): Track a journey link click on entity pages.
+ * Event name: 'journey_link_clicked'
+ */
+export function trackJourneyLinkClicked(event: JourneyLinkClickedEvent): void {
+  safeTrack('journey_link_clicked', event as unknown as Record<string, unknown>);
 }

--- a/frontend/lib/seo/relatedResolver.ts
+++ b/frontend/lib/seo/relatedResolver.ts
@@ -9,11 +9,16 @@
  * Diversity: results are seeded by a hash of `currentUrl` so different pages
  * surface different subsets of the candidate pool — avoids the "every page
  * links to the same 6 URLs" anti-pattern flagged by site crawlers.
+ *
+ * CONV-017 (#1332): Interlinking journeys for entity pages. Adds
+ * journey-specific context types (fornecedor, orgao, contrato, municipio) and
+ * a resolveJourney() function that returns ordered, intent-progressive steps
+ * instead of shuffled related links.
  */
 import { BLOG_ARTICLES } from '@/lib/blog';
 import { GLOSSARY_TERMS } from '@/lib/glossary-terms';
 import { QUESTIONS } from '@/lib/questions';
-import { SECTORS } from '@/lib/sectors';
+import { SECTORS, getRelatedSectors } from '@/lib/sectors';
 
 export type RelatedContextType =
   | 'sector'
@@ -46,6 +51,62 @@ export interface RelatedLink {
   href: string;
   /** Tag for the badge in the UI. */
   kind: 'artigo' | 'pergunta' | 'glossario' | 'setor' | 'panorama' | 'ferramenta';
+}
+
+/* -------------------------------------------------------------------------- */
+/* CONV-017 (#1332): Journey types for entity-page interlinking               */
+/* -------------------------------------------------------------------------- */
+
+/** Entity page types that support intent-progressive journeys. */
+export type JourneyEntityType =
+  | 'fornecedor'
+  | 'orgao'
+  | 'contrato'
+  | 'municipio';
+
+/**
+ * A single step in an intent-progressive journey.
+ * Ordered by commercial intent (most transactional → most exploratory).
+ */
+export interface JourneyStep {
+  /** 1-based position in the journey (1–5). */
+  position: number;
+  /** Short heading for the link. */
+  title: string;
+  /** Descriptive text explaining why the user would take this step. */
+  description: string;
+  /** Internal URL. */
+  href: string;
+  /** Semantic type of the destination for analytics tracking. */
+  destinationType: string;
+  /** Emoji icon representing the step. */
+  icon: string;
+}
+
+/**
+ * Context for resolving an intent-progressive journey on entity pages.
+ */
+export interface JourneyContext {
+  /** Entity type. */
+  type: JourneyEntityType;
+  /** Primary identifier (CNPJ, slug, or sector). */
+  value: string;
+  /** Current page path (excluded from self-linking). */
+  currentUrl: string;
+  /** Human-readable name of the entity. */
+  name?: string;
+  /** UF code (e.g. "SP", "RJ") for geography-biased links. */
+  uf?: string;
+  /** Human-readable UF name. */
+  ufName?: string;
+  /** Sector slug when known (e.g. "engenharia"). */
+  sectorSlug?: string;
+  /** Sector name when known. */
+  sectorName?: string;
+  /** Top buyer CNPJs for fornecedor/orgao pages (first = primary). */
+  orgaoCnpjs?: string[];
+  /** Top buyer names matching orgaoCnpjs. */
+  orgaoNames?: string[];
 }
 
 /* -------------------------------------------------------------------------- */
@@ -321,6 +382,272 @@ function resolveCnpj(ctx: RelatedContext): RelatedLink[] {
 }
 
 /* -------------------------------------------------------------------------- */
+/* CONV-017 (#1332): Journey resolvers per entity type                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Jornada do Fornecedor — intenção progressiva.
+ *
+ * 1. Órgãos compradores  → transacional
+ * 2. Setores de atuação   → exploratório-setorial
+ * 3. Concorrentes         → inteligência competitiva
+ * 4. Subcontratação       → parceria
+ * 5. Relatório completo   → aprofundamento
+ */
+function resolveFornecedorJourney(ctx: JourneyContext): JourneyStep[] {
+  const cnpj = ctx.value;
+  const name = ctx.name ?? 'este fornecedor';
+
+  // Step 1: link to top comprador orgão if available, else generic orgãos page.
+  const orgaoHref = ctx.orgaoCnpjs?.[0]
+    ? `/orgaos/${ctx.orgaoCnpjs[0]}`
+    : '/orgaos';
+  const orgaoTitle = ctx.orgaoCnpjs?.[0]
+    ? `Órgãos compradores de ${name}`
+    : 'Órgãos compradores do governo';
+
+  // Step 2: link to setor if available, else generic licitacoes page.
+  const setorHref = ctx.sectorSlug
+    ? `/licitacoes/${ctx.sectorSlug}`
+    : '/licitacoes';
+
+  return [
+    {
+      position: 1,
+      title: orgaoTitle,
+      description: 'Conheça os órgãos que mais contratam esta empresa.',
+      href: orgaoHref,
+      destinationType: 'orgao',
+      icon: '🏛️',
+    },
+    {
+      position: 2,
+      title: `Setores de atuação`,
+      description: 'Descubra os setores onde esta empresa atua em licitações.',
+      href: setorHref,
+      destinationType: 'licitacoes',
+      icon: '📋',
+    },
+    {
+      position: 3,
+      title: 'Concorrentes',
+      description: 'Veja quem compete com esta empresa nos mesmos mercados.',
+      href: `/intel-concorrente?cnpj=${cnpj}`,
+      destinationType: 'concorrente',
+      icon: '🔍',
+    },
+    {
+      position: 4,
+      title: 'Subcontratação',
+      description: 'Identifique oportunidades de subcontratação com esta empresa.',
+      href: '/subcontratacao/mapear',
+      destinationType: 'subcontratacao',
+      icon: '🤝',
+    },
+    {
+      position: 5,
+      title: 'Relatório completo',
+      description: `Análise aprofundada de oportunidades B2G para ${name}.`,
+      href: `/intel-reports/new?cnpj=${cnpj}`,
+      destinationType: 'relatorio',
+      icon: '📊',
+    },
+  ];
+}
+
+/**
+ * Jornada do Órgão — intenção progressiva.
+ *
+ * 1. Categorias principais → transacional
+ * 2. Fornecedores          → descoberta
+ * 3. Contratos             → histórico
+ * 4. Órgãos similares      → comparação
+ * 5. Criar alerta          → conversão
+ */
+function resolveOrgaoJourney(ctx: JourneyContext): JourneyStep[] {
+  const cnpj = ctx.value;
+  const name = ctx.name ?? 'este órgão';
+
+  // Step 1: link to setor if available, else generic licitacoes.
+  const categoriasHref = ctx.sectorSlug
+    ? `/licitacoes/${ctx.sectorSlug}`
+    : '/licitacoes';
+
+  // Step 4: link to orgaos filtered by UF.
+  const similaresHref = ctx.uf
+    ? `/orgaos?uf=${ctx.uf.toLowerCase()}`
+    : '/orgaos';
+
+  return [
+    {
+      position: 1,
+      title: 'Categorias principais',
+      description: `Veja as licitações por categoria que ${name} publica.`,
+      href: categoriasHref,
+      destinationType: 'licitacoes',
+      icon: '📋',
+    },
+    {
+      position: 2,
+      title: `Fornecedores recorrentes`,
+      description: 'Quem mais vence licitações e fornece para este órgão.',
+      href: `/fornecedores/${cnpj}`,
+      destinationType: 'fornecedor',
+      icon: '🏢',
+    },
+    {
+      position: 3,
+      title: `Contratos do órgão`,
+      description: 'Histórico completo de contratos firmados por este órgão.',
+      href: `/contratos/orgao/${cnpj}`,
+      destinationType: 'contrato',
+      icon: '📄',
+    },
+    {
+      position: 4,
+      title: 'Órgãos similares',
+      description: 'Compare com outros órgãos compradores na mesma região.',
+      href: similaresHref,
+      destinationType: 'orgao',
+      icon: '🏛️',
+    },
+    {
+      position: 5,
+      title: 'Criar alerta',
+      description: 'Receba notificações de novos editais publicados por este órgão.',
+      href: `/signup?ref=orgao-${cnpj}`,
+      destinationType: 'alerta',
+      icon: '🔔',
+    },
+  ];
+}
+
+/**
+ * Jornada do Contrato (setor × UF) — intenção progressiva.
+ *
+ * 1. Editais abertos agora → transacional
+ * 2. Fornecedores ativos   → descoberta
+ * 3. Órgãos compradores    → top buyers
+ * 4. Setores relacionados  → adjacência
+ * 5. Relatório             → aprofundamento
+ */
+function resolveContratoJourney(ctx: JourneyContext): JourneyStep[] {
+  const { sectorSlug, uf, sectorName, ufName, value } = ctx;
+  const sl = sectorSlug ?? value;
+  const u = (uf ?? '').toLowerCase();
+
+  // Step 4: related sectors for branching.
+  const relatedSectors = getRelatedSectors(sl);
+  const relatedSector = relatedSectors[0];
+
+  return [
+    {
+      position: 1,
+      title: `Editais abertos agora`,
+      description: `Veja os editais abertos de ${sectorName ?? 'licitações'}${ufName ? ` em ${ufName}` : ''}.`,
+      href: `/licitacoes/${sl}/${u}`,
+      destinationType: 'licitacoes',
+      icon: '📢',
+    },
+    {
+      position: 2,
+      title: `Fornecedores ativos`,
+      description: `Fornecedores que atuam em ${sectorName ?? 'licitações'}${ufName ? ` ${ufName}` : ''}.`,
+      href: `/fornecedores/${sl}/${u}`,
+      destinationType: 'fornecedor',
+      icon: '🏢',
+    },
+    {
+      position: 3,
+      title: 'Órgãos que mais compram',
+      description: 'Os maiores compradores deste setor na região.',
+      href: `/orgaos?uf=${u}`,
+      destinationType: 'orgao',
+      icon: '🏛️',
+    },
+    {
+      position: 4,
+      title: relatedSector
+        ? `Setores relacionados: ${relatedSector.name}`
+        : 'Setores relacionados',
+      description: relatedSector
+        ? `Explore contratos de ${relatedSector.name}${ufName ? ` em ${ufName}` : ''}.`
+        : 'Veja contratos em outros setores.',
+      href: relatedSector
+        ? `/contratos/${relatedSector.slug}/${u}`
+        : '/contratos',
+      destinationType: 'contrato',
+      icon: '📎',
+    },
+    {
+      position: 5,
+      title: 'Relatório de oportunidade',
+      description: `Análise completa de oportunidades em ${sectorName ?? 'licitações'}${ufName ? ` ${ufName}` : ''}.`,
+      href: `/intel-reports/new?sector=${sl}&uf=${u}`,
+      destinationType: 'relatorio',
+      icon: '📊',
+    },
+  ];
+}
+
+/**
+ * Jornada do Município — intenção progressiva.
+ *
+ * 1. Editais abertos   → transacional
+ * 2. Fornecedores      → descoberta
+ * 3. Órgãos municipais → exploração
+ * 4. Comparar          → benchmarking
+ * 5. Alerta            → conversão
+ */
+function resolveMunicipioJourney(ctx: JourneyContext): JourneyStep[] {
+  const { value: slug, name, uf } = ctx;
+  const nome = name ?? slug;
+
+  return [
+    {
+      position: 1,
+      title: `Editais abertos em ${nome}`,
+      description: `Veja as licitações públicas abertas em ${nome} agora.`,
+      href: `/licitacoes?municipio=${slug}`,
+      destinationType: 'licitacoes',
+      icon: '📢',
+    },
+    {
+      position: 2,
+      title: `Fornecedores em ${nome}`,
+      description: `Empresas que fornecem para órgãos em ${nome}.`,
+      href: uf ? `/fornecedores?uf=${uf.toLowerCase()}&municipio=${slug}` : '/fornecedores',
+      destinationType: 'fornecedor',
+      icon: '🏢',
+    },
+    {
+      position: 3,
+      title: `Órgãos municipais`,
+      description: `Órgãos públicos sediados em ${nome}.`,
+      href: uf ? `/orgaos?uf=${uf.toLowerCase()}&municipio=${slug}` : '/orgaos',
+      destinationType: 'orgao',
+      icon: '🏛️',
+    },
+    {
+      position: 4,
+      title: 'Comparar municípios',
+      description: 'Compare indicadores de licitações entre municípios.',
+      href: `/comparador?municipio=${slug}`,
+      destinationType: 'comparador',
+      icon: '📊',
+    },
+    {
+      position: 5,
+      title: 'Criar alerta',
+      description: `Receba alertas semanais de editais em ${nome}.`,
+      href: `/signup?ref=municipio-${slug}`,
+      destinationType: 'alerta',
+      icon: '🔔',
+    },
+  ];
+}
+
+/* -------------------------------------------------------------------------- */
 /* Public API                                                                  */
 /* -------------------------------------------------------------------------- */
 
@@ -373,4 +700,41 @@ export function resolveRelated(
   // Deterministic shuffle for diversity, then cap.
   const shuffled = deterministicShuffle(filtered, ctx.currentUrl);
   return shuffled.slice(0, limit);
+}
+
+/**
+ * CONV-017 (#1332): Resolve an intent-progressive journey for entity pages.
+ *
+ * Unlike resolveRelated(), this returns an ordered, non-shuffled sequence of
+ * up to 5 steps that guides the user from transactional to exploratory pages.
+ * Each step carries structured metadata for tracking and Schema.org markup.
+ *
+ * Guarantees:
+ * - Always returns exactly 5 steps (may overshoot).
+ * - Ordered by commercial intent (most actionable first).
+ * - Never includes `ctx.currentUrl`.
+ */
+export function resolveJourney(ctx: JourneyContext): JourneyStep[] {
+  let steps: JourneyStep[];
+  switch (ctx.type) {
+    case 'fornecedor':
+      steps = resolveFornecedorJourney(ctx);
+      break;
+    case 'orgao':
+      steps = resolveOrgaoJourney(ctx);
+      break;
+    case 'contrato':
+      steps = resolveContratoJourney(ctx);
+      break;
+    case 'municipio':
+      steps = resolveMunicipioJourney(ctx);
+      break;
+    default:
+      steps = [];
+  }
+
+  // Filter out current page, limit to 5.
+  return steps
+    .filter((s) => s.href !== ctx.currentUrl)
+    .slice(0, 5);
 }


### PR DESCRIPTION
## Context
Entity pages do SmartLic tinham seção "Páginas Relacionadas" — lista plana de links sem progressão de intenção comercial. O relatedResolver.ts já existia com suporte a contextos de blog, mas não era usado nas entity pages.

## Changes
- **relatedResolver.ts**: Extendido com tipos JourneyStep, JourneyContext e funções resolver para fornecedor, orgao, contrato, municipio. Novos resolvers retornam jornadas ordenadas por intenção comercial (mais transacional → mais exploratório).
- **JourneyLinks.tsx**: Novo componente servidor que renderiza links como jornada com heading contextual, badges numerados, ícones de progressão e Schema.org ItemList JSON-LD. Máximo 5 links.
- **JourneyLinkTracker.tsx**: Componente cliente para tracking Mixpanel — dispara `journey_link_clicked` com `(source_template, destination_type, position)`.
- **ContentPageLayout.tsx**: Adicionada prop `journeyLinks` que substitui a sidebar legada "Conteúdo relacionado" quando fornecida.
- **4 entity templates migrados**: fornecedor, orgao, contrato, municipio — todos substituem "Páginas Relacionadas" por `<JourneyLinks />`.
- **analytics-events.ts**: Adicionado tipo `JourneyLinkClickedEvent` + função `trackJourneyLinkClicked`.

### Jornadas por template

| Template | Passos |
|----------|--------|
| Fornecedor | Órgãos compradores → Setores → Concorrentes → Subcontratação → Relatório |
| Órgão | Categorias → Fornecedores → Contratos → Órgãos similares → Alerta |
| Contrato | Editais abertos → Fornecedores ativos → Órgãos compradores → Setores relacionados → Relatório |
| Município | Editais abertos → Fornecedores → Órgãos municipais → Comparar → Alerta |

## Testing Plan
1. `npx tsc --noEmit --pretty` — passou (exit code 0)
2. Verificar visualmente cada entity page: fornecedores/XXXX, orgaos/XXXX, contratos/[setor]/[uf], municipios/XXXX
3. Confirmar que Schema.org ItemList JSON-LD é renderizado no <head>
4. Confirmar que tracking `journey_link_clicked` é disparado no clique

## Risks & Rollback
- **Low risk**: não altera APIs, schemas de dados ou rotas existentes. Apenas substitui a seção "Páginas Relacionadas" por JourneyLinks em 4 páginas.
- **Rollback**: reverter o commit restaura o comportamento anterior.

## Closes
Closes #1332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intent-progressive “journey” links that appear as a numbered, step-by-step recommended navigation ("Navegação recomendada") and as a full-width "Próximos passos" section below content.
  * Sidebar falls back to the legacy "Conteúdo relacionado" list when no journey is available.
  * Journey links include Schema.org structured data and emit analytics events when clicked to measure engagement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
