### PR TITLE
feat(frontend): add WhatsApp CTA component with founder contact (#1324)

### DIFF
--- a/frontend/__tests__/api/sse-proxy-crit026.test.ts
+++ b/frontend/__tests__/api/sse-proxy-crit026.test.ts
@@ -43,10 +43,13 @@ describe("CRIT-026: SSE Proxy Retry + Observability", () => {
   }
 
   // --------------------------------------------------------------------------
-  // AC5: Undici diagnostic logging
+  // AC5: Diagnostic logging on each SSE request
   // --------------------------------------------------------------------------
+  // Nota (2026-06-01): undici dynamic import removido (webpack nao resolve
+  // modulo built-in do Node 20). Log mudou de `undici_dispatcher=custom|default`
+  // para `dispatcher=built-in`.
 
-  it("AC5: logs undici dispatcher status on each request", async () => {
+  it("AC5: logs dispatcher info on each request", async () => {
     const consoleSpy = jest
       .spyOn(console, "log")
       .mockImplementation(() => {});
@@ -67,15 +70,15 @@ describe("CRIT-026: SSE Proxy Retry + Observability", () => {
     });
 
     const GET = await getHandler();
-    await GET(makeRequest("test-undici-log"));
+    await GET(makeRequest("test-dispatcher-log"));
 
-    const undiciLogs = consoleSpy.mock.calls.filter(
+    const dispatcherLogs = consoleSpy.mock.calls.filter(
       (call) =>
         typeof call[0] === "string" &&
         call[0].includes("[SSE-PROXY]") &&
-        call[0].includes("undici_dispatcher")
+        call[0].includes("dispatcher=built-in")
     );
-    expect(undiciLogs.length).toBeGreaterThanOrEqual(1);
+    expect(dispatcherLogs.length).toBeGreaterThanOrEqual(1);
 
     consoleSpy.mockRestore();
   });

--- a/frontend/app/api/buscar-progress/route.ts
+++ b/frontend/app/api/buscar-progress/route.ts
@@ -42,8 +42,13 @@ function getInactivityTimeoutMs(): number {
 }
 
 /**
- * CRIT-026 AC6+AC7: Perform the actual SSE fetch to backend with undici
- * dispatcher and fallback timeout. Extracted for retry support.
+ * CRIT-026 AC6+AC7: Perform SSE fetch to backend. Extracted for retry support.
+ *
+ * Nota: dispatcher undici (bodyTimeout: 0) removido na build de 2026-06-01.
+ * Node 20+ built-in fetch já usa undici internamente; HARDEN-011 provê
+ * inactivity timeout (120s) via Promise.race no reader loop — o dispatcher
+ * customizado tornou-se redundante e o `import("undici")` quebrava o build
+ * (webpack não resolve módulo built-in não declarado).
  */
 async function fetchSSEStream(
   backendUrl: string,
@@ -51,36 +56,18 @@ async function fetchSSEStream(
   headers: Record<string, string>,
   signal: AbortSignal
 ): Promise<Response> {
-  const fetchOptions: Record<string, unknown> = {
+  const fetchOptions: RequestInit = {
     headers,
     signal,
   };
 
-  // CRIT-012 AC4 + CRIT-026 AC5: Build fetch options with undici bodyTimeout: 0
-  let undiciActive = false;
-  try {
-    // @ts-expect-error — undici is available at runtime in Node.js but lacks type declarations
-    const undiciModule = await import("undici");
-    const UndiciAgent = undiciModule.Agent;
-    if (UndiciAgent) {
-      fetchOptions.dispatcher = new UndiciAgent({
-        bodyTimeout: 0,
-        headersTimeout: 30_000,
-      });
-      undiciActive = true;
-    }
-  } catch {
-    // undici not available — proceed without custom dispatcher
-  }
-
-  // CRIT-026 AC5: Diagnostic logging for undici import result
   console.log(
-    `[SSE-PROXY] search_id=${searchId} undici_dispatcher=${undiciActive ? "custom" : "default"}`
+    `[SSE-PROXY] search_id=${searchId} dispatcher=built-in`
   );
 
   return fetch(
     `${backendUrl}/v1/buscar-progress/${encodeURIComponent(searchId)}`,
-    fetchOptions as RequestInit
+    fetchOptions
   );
 }
 

--- a/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
+++ b/frontend/app/blog/licitacoes/[setor]/[uf]/page.tsx
@@ -26,6 +26,7 @@ import {
 import { getCitiesByUf } from '@/lib/cities';
 import { getFreshnessLabel } from '@/lib/seo';
 import { isNoindexed } from '@/lib/seo/noindex';
+import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 
 /**
  * MKT-003 AC1: Sector × UF programmatic page.
@@ -713,6 +714,17 @@ export default async function LicitacoesSectorUfPage({
               </section>
             );
           })()}
+
+          {/* CONV-013: WhatsApp CTA — falar com founder */}
+          <div className="mt-10">
+            <WhatsAppCTA
+              source="blog_licitacoes_page"
+              entity={sector.name}
+              entityId={`${setor}-${uf}`}
+              setor={setor}
+              uf={ufUpper}
+            />
+          </div>
         </div>
       </main>
 

--- a/frontend/app/cnpj/[cnpj]/page.tsx
+++ b/frontend/app/cnpj/[cnpj]/page.tsx
@@ -7,6 +7,7 @@ import InlineTrialCTA from '../../components/InlineTrialCTA';
 import IntelReportCTA from './IntelReportCTA';
 import { LeadCapture } from '@/components/LeadCapture';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
+import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
 import { buildOrgSchema } from './_jsonld';
@@ -272,6 +273,17 @@ export default async function CnpjPerfilPage({
           Mapear meu setor
         </Link>
       </section>
+
+      {/* CONV-013: WhatsApp CTA — falar com founder */}
+      <div className="mt-8">
+        <WhatsAppCTA
+          source="cnpj_page"
+          entity={empresa.razao_social}
+          entityId={cnpj}
+          setor={perfil.setor_detectado}
+          uf={empresa.uf}
+        />
+      </div>
 
       {/* #788: Founders plan CTA for high-intent organic visitors */}
       <FoundersRibbon

--- a/frontend/app/components/whatsapp/WhatsAppCTA.tsx
+++ b/frontend/app/components/whatsapp/WhatsAppCTA.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+/**
+ * CONV-013: WhatsApp CTA component for pSEO pages.
+ *
+ * Renders a WhatsApp button that opens a direct conversation with the founder
+ * (+55 48 98834-4559) with a pre-filled contextual message.
+ *
+ * Two variants:
+ *  - 'floating' : Fixed button at bottom-right corner (mobile-first)
+ *  - 'inline'   : Banner-style CTA below the first data block (desktop)
+ *
+ * Tracking (Mixpanel):
+ *  - whatsapp_cta_viewed  — fires when the CTA enters the viewport
+ *  - whatsapp_cta_clicked — fires on click
+ *
+ * Usage:
+ *   <WhatsAppCTA
+ *     source="fornecedor_page"
+ *     entity="Empresa XYZ Ltda"
+ *     entityId="12345678000199"
+ *     setor="pavimentacao-asfaltica"
+ *     uf="SC"
+ *   />
+ */
+
+import { useEffect, useRef, useCallback } from "react";
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { buildWhatsAppUrl, getWhatsAppCtaLabel, WhatsAppSourceTemplate, WhatsAppContext } from "@/lib/whatsapp-messages";
+import { trackWhatsAppCTAViewed, trackWhatsAppCTAClicked } from "@/lib/analytics/whatsapp";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type CTAVariant = "floating" | "inline";
+
+export interface WhatsAppCTAProps {
+  /** Source template identifier (e.g. 'fornecedor_page', 'orgao_page') */
+  source: WhatsAppSourceTemplate;
+  /** Entity display name (e.g. company name, orgao name) */
+  entity?: string;
+  /** Entity identifier (CNPJ, slug, etc.) */
+  entityId?: string;
+  /** Sector slug */
+  setor?: string;
+  /** Two-letter UF code */
+  uf?: string;
+  /** Visual variant — 'floating' (mobile bottom-right) or 'inline' (desktop contextual) */
+  variant?: CTAVariant;
+  /** Additional classes for the wrapper (inline only) */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Device detection — mobile below this breakpoint. Tailwind `md:` = 768px */
+const MOBILE_BREAKPOINT_PX = 768;
+
+// ---------------------------------------------------------------------------
+// Inline variant
+// ---------------------------------------------------------------------------
+
+function InlineWhatsAppCTA({
+  source,
+  entity,
+  entityId,
+  setor,
+  uf,
+  className = "",
+}: WhatsAppCTAProps) {
+  const sectionRef = useRef<HTMLElement>(null);
+  const viewTracked = useRef(false);
+
+  const whatsappContext: WhatsAppContext = { entity, setor, uf };
+  const whatsappUrl = buildWhatsAppUrl(source, whatsappContext);
+
+  // Track view on mount (once)
+  useEffect(() => {
+    if (viewTracked.current) return;
+    viewTracked.current = true;
+    trackWhatsAppCTAViewed({
+      source_template: source,
+      entity_id: entityId,
+      setor,
+      uf,
+    });
+  }, [source, entityId, setor, uf]);
+
+  const handleClick = useCallback(() => {
+    trackWhatsAppCTAClicked({
+      source_template: source,
+      entity_id: entityId,
+      setor,
+      uf,
+    });
+  }, [source, entityId, setor, uf]);
+
+  return (
+    <section
+      ref={sectionRef}
+      aria-label="Falar com especialista no WhatsApp"
+      data-testid={`whatsapp-cta-inline`}
+      className={`rounded-xl border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/30 p-5 sm:p-6 ${className}`}
+    >
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+        <div className="flex items-start gap-3 flex-1">
+          <div className="shrink-0 w-10 h-10 rounded-full bg-green-500 flex items-center justify-center mt-0.5">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="white"
+              className="w-5 h-5"
+              aria-hidden="true"
+            >
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.095 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+            </svg>
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-gray-900 dark:text-white">
+              {getWhatsAppCtaLabel()}
+            </p>
+            <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+              Tire dúvidas diretamente com o founder. Resposta em até 1h em horário comercial.
+            </p>
+          </div>
+        </div>
+        <a
+          href={whatsappUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleClick}
+          data-testid="whatsapp-cta-inline-link"
+          className="
+            inline-flex items-center justify-center gap-2
+            min-h-[44px] px-5 py-2.5
+            bg-green-600 hover:bg-green-700
+            text-white text-sm font-semibold
+            rounded-lg transition-colors
+            focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2
+            whitespace-nowrap shrink-0
+          "
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="w-4 h-4"
+            aria-hidden="true"
+          >
+            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.095 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+          </svg>
+          Falar agora
+        </a>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Floating variant (mobile bottom-right)
+// ---------------------------------------------------------------------------
+
+function FloatingWhatsAppCTA({
+  source,
+  entity,
+  entityId,
+  setor,
+  uf,
+}: WhatsAppCTAProps) {
+  const buttonRef = useRef<HTMLAnchorElement>(null);
+  const viewTracked = useRef(false);
+
+  const whatsappContext: WhatsAppContext = { entity, setor, uf };
+  const whatsappUrl = buildWhatsAppUrl(source, whatsappContext);
+
+  // Track view on mount (once)
+  useEffect(() => {
+    if (viewTracked.current) return;
+    viewTracked.current = true;
+    trackWhatsAppCTAViewed({
+      source_template: source,
+      entity_id: entityId,
+      setor,
+      uf,
+    });
+  }, [source, entityId, setor, uf]);
+
+  const handleClick = useCallback(() => {
+    trackWhatsAppCTAClicked({
+      source_template: source,
+      entity_id: entityId,
+      setor,
+      uf,
+    });
+  }, [source, entityId, setor, uf]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.8 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ delay: 0.5, duration: 0.3 }}
+      className="fixed bottom-6 right-4 z-50 md:hidden"
+    >
+      <a
+        ref={buttonRef}
+        href={whatsappUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleClick}
+        data-testid="whatsapp-cta-floating"
+        aria-label="Falar com especialista no WhatsApp"
+        className="
+          flex items-center gap-2
+          min-h-[48px] px-4 py-2.5
+          bg-green-600 hover:bg-green-700
+          text-white text-sm font-semibold
+          rounded-full shadow-lg
+          transition-all duration-200
+          hover:shadow-xl hover:scale-105
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2
+        "
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-5 h-5 shrink-0"
+          aria-hidden="true"
+        >
+          <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.095 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+        </svg>
+        <span className="whitespace-nowrap">{getWhatsAppCtaLabel()}</span>
+      </a>
+    </motion.div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+/**
+ * WhatsApp CTA component with two variants:
+ * - `floating`: Fixed button at bottom-right (mobile only, hidden on md+)
+ * - `inline`: Contextual banner (shown on desktop, or always depending on usage)
+ *
+ * Default behavior (no variant specified):
+ * - Floating on mobile (< 768px)
+ * - Inline on desktop (>= 768px)
+ *
+ * When explicitly set:
+ * - `variant="floating"`: renders ONLY the floating button (hidden on md+)
+ * - `variant="inline"`: renders ONLY the inline banner
+ *
+ * For pages that want both: render with default (no variant) or render both explicitly.
+ */
+export default function WhatsAppCTA(props: WhatsAppCTAProps) {
+  const { variant } = props;
+
+  // If variant explicitly set, render just that one
+  if (variant === "floating") {
+    return <FloatingWhatsAppCTA {...props} />;
+  }
+  if (variant === "inline") {
+    return <InlineWhatsAppCTA {...props} />;
+  }
+
+  // Default: both — floating on mobile, inline on desktop
+  return (
+    <>
+      <FloatingWhatsAppCTA {...props} />
+      <div className="hidden md:block">
+        <InlineWhatsAppCTA {...props} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -9,6 +9,7 @@ import Footer from '@/app/components/Footer';
 import FornecedorPseoCTA from './FornecedorPseoCTA';
 import { isNoindexed } from '@/lib/seo/noindex';
 import AlertEntityCta from '@/components/seo/AlertEntityCta';
+import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 
 // Sprint 3 Parte 13: paginas de perfil de fornecedor por CNPJ
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -483,6 +484,15 @@ export default async function FornecedorCnpjPage({ params }: Props) {
 
           {/* Lead Capture — client component fires pseo_supplier_viewed + pseo_checkout_click */}
           <FornecedorPseoCTA cnpj={cnpj} razaoSocial={profile.razao_social} />
+
+          {/* CONV-013: WhatsApp CTA — falar com founder */}
+          <WhatsAppCTA
+            source="fornecedor_page"
+            entity={profile.razao_social}
+            entityId={cnpj}
+            setor={undefined}
+            uf={profile.uf_sede}
+          />
 
           <p className="text-xs text-gray-400 mt-8">{profile.aviso_legal}</p>
         </div>

--- a/frontend/app/itens/[catmat]/page.tsx
+++ b/frontend/app/itens/[catmat]/page.tsx
@@ -60,19 +60,31 @@ async function fetchProfile(catmat: string): Promise<ItemProfile | null> {
 
 // Memory feedback_isr_fetch_cache_alignment_next16: usar `next.revalidate` em vez de
 // `cache: 'no-store'` — alinha com semântica ISR (revalidate=86400 abaixo).
+// BUILD-FIX-2026-06-01: generateStaticParams com try-catch. Se backend falhar
+// durante build (timeout/rede), retorna [] — páginas serão geradas on-demand
+// via ISR no primeiro request. Sem isso, 200 páginas × 31 workers = cascade
+// timeout que mata o build.
+export const dynamicParams = true;
 export async function generateStaticParams() {
-  const data = await fetchWithBudget<{ catmats?: string[] }>(
-    `${BACKEND_URL}/v1/sitemap/itens`,
-    {
-      timeout: 15000,
-      retries: 0,
-      revalidate: 3600,
-      label: 'sitemap-itens-static',
-      fallback: { catmats: [] },
-    },
-  );
-  const catmats: string[] = (data?.catmats || []).slice(0, _MAX_STATIC_CATMATS);
-  return catmats.map((catmat) => ({ catmat }));
+  try {
+    const data = await fetchWithBudget<{ catmats?: string[] }>(
+      `${BACKEND_URL}/v1/sitemap/itens`,
+      {
+        timeout: 30000,
+        retries: 2,
+        revalidate: 3600,
+        label: 'sitemap-itens-static',
+        fallback: { catmats: [] },
+      },
+    );
+    const catmats: string[] = (data?.catmats || []).slice(0, _MAX_STATIC_CATMATS);
+    return catmats.map((catmat) => ({ catmat }));
+  } catch {
+    // Backend unreachable during build — skip pre-rendering.
+    // ISR will generate pages on-demand at runtime.
+    console.warn('[generateStaticParams] /itens/[catmat] — backend unreachable, skipping pre-render');
+    return [];
+  }
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -26,6 +26,7 @@ import { SeoOpportunityBanner } from "@/app/components/seo/SeoOpportunityBanner"
 import { LeadCapture } from "@/components/LeadCapture";
 import SeoBannerCta from "@/app/components/landing/SeoBannerCta";
 import AlertEntityCta from "@/components/seo/AlertEntityCta";
+import WhatsAppCTA from "@/app/components/whatsapp/WhatsAppCTA";
 
 /**
  * STORY-324 AC5: SSG with ISR 6h for sector landing pages.
@@ -513,6 +514,16 @@ export default async function SectorPage({
           variant="contextual"
           copy="Receba inteligência B2G sem mensalidade. Acesso vitalício R$997."
           src="pseo_licitacoes"
+        />
+      </section>
+
+      {/* CONV-013: WhatsApp CTA — falar com founder */}
+      <section className="max-w-5xl mx-auto px-4 pb-4">
+        <WhatsAppCTA
+          source="licitacoes_page"
+          entity={sector.name}
+          entityId={setor}
+          setor={setor}
         />
       </section>
 

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
 import { AdvisoryDisclaimer } from '@/components/legal/AdvisoryDisclaimer';
+import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 
 const BACKEND_URL = getBackendUrl();
 
@@ -244,6 +245,16 @@ export default async function OrgaoPerfilPage({
           Solicitar análise de edital
         </Link>
       </section>
+
+      {/* CONV-013: WhatsApp CTA — falar com founder */}
+      <div className="mt-8">
+        <WhatsAppCTA
+          source="orgao_page"
+          entity={stats.nome}
+          entityId={slug}
+          uf={stats.uf}
+        />
+      </div>
 
       {/* #788: Founders plan CTA for high-intent organic visitors */}
       <FoundersRibbon

--- a/frontend/lib/analytics/whatsapp.ts
+++ b/frontend/lib/analytics/whatsapp.ts
@@ -1,0 +1,90 @@
+/**
+ * CONV-013: Typed Mixpanel analytics wrappers for WhatsApp CTA events.
+ *
+ * Two events:
+ *  - whatsapp_cta_viewed  — fired when the CTA enters the viewport
+ *  - whatsapp_cta_clicked — fired when the user clicks the CTA
+ *
+ * Each carries the source template, entity_id, setor, uf, and device type
+ * for downstream conversion funnel analysis.
+ *
+ * All functions are SSR-safe: they return early when window is unavailable.
+ * All functions never throw — errors are swallowed silently.
+ */
+
+import mixpanel from 'mixpanel-browser';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WhatsAppCTAEventProperties {
+  /** Source template identifier (e.g. 'fornecedor_page', 'orgao_page') */
+  source_template: string;
+  /** Entity identifier (CNPJ, slug, sector, etc.) */
+  entity_id?: string;
+  /** Sector slug (e.g. 'pavimentacao-asfaltica') */
+  setor?: string;
+  /** Two-letter UF code (e.g. 'SC') */
+  uf?: string;
+  /** Device type: 'mobile' or 'desktop' */
+  device?: string;
+  /** Allow extra properties */
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isTrackingEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (!process.env.NEXT_PUBLIC_MIXPANEL_TOKEN) return false;
+  return true;
+}
+
+function safeTrack(eventName: string, properties: Record<string, unknown>): void {
+  if (!isTrackingEnabled()) return;
+  try {
+    mixpanel.track(eventName, {
+      ...properties,
+      timestamp: new Date().toISOString(),
+      environment: process.env.NODE_ENV || 'development',
+    });
+  } catch {
+    // Mixpanel not initialized — swallow silently
+  }
+}
+
+function detectDevice(): string {
+  if (typeof window === 'undefined') return 'unknown';
+  return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) ? 'mobile' : 'desktop';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Track when the WhatsApp CTA becomes visible in the viewport.
+ *
+ * @param props - Event properties (source_template, entity_id, setor, uf)
+ */
+export function trackWhatsAppCTAViewed(props: WhatsAppCTAEventProperties): void {
+  safeTrack('whatsapp_cta_viewed', {
+    ...props,
+    device: detectDevice(),
+  });
+}
+
+/**
+ * Track when the user clicks the WhatsApp CTA.
+ *
+ * @param props - Event properties (source_template, entity_id, setor, uf)
+ */
+export function trackWhatsAppCTAClicked(props: WhatsAppCTAEventProperties): void {
+  safeTrack('whatsapp_cta_clicked', {
+    ...props,
+    device: detectDevice(),
+  });
+}

--- a/frontend/lib/whatsapp-messages.ts
+++ b/frontend/lib/whatsapp-messages.ts
@@ -1,0 +1,124 @@
+/**
+ * CONV-013: Centralized WhatsApp message builder per source template.
+ *
+ * Builds a context-aware pre-filled message for the founder's WhatsApp link.
+ * The phone number is always +55 48 98834-4559 (founder direct line).
+ *
+ * Usage:
+ *   import { buildWhatsAppUrl } from '@/lib/whatsapp-messages';
+ *   const url = buildWhatsAppUrl('fornecedor_page', {
+ *     entity: 'Empresa XYZ Ltda',
+ *     setor: 'pavimentacao-asfaltica',
+ *     uf: 'SC',
+ *   });
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FOUNDER_PHONE = '5548988344559';
+const WHATSAPP_BASE = `https://wa.me/${FOUNDER_PHONE}`;
+const FALLBACK_MESSAGE = 'Olá! Vim do SmartLic e quero saber mais sobre como vocês podem ajudar minha empresa a ganhar licitações públicas.';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WhatsAppSourceTemplate =
+  | 'fornecedor_page'
+  | 'orgao_page'
+  | 'licitacoes_page'
+  | 'cnpj_page'
+  | 'blog_licitacoes_page';
+
+export interface WhatsAppContext {
+  /** Entity name or label (e.g. company name, orgao name, sector name) */
+  entity?: string;
+  /** Sector slug (e.g. 'pavimentacao-asfaltica') */
+  setor?: string;
+  /** Two-letter UF code (e.g. 'SC') */
+  uf?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Message builders per source template
+// ---------------------------------------------------------------------------
+
+function buildFornecedorMessage(entity?: string, setor?: string, uf?: string): string {
+  const entityLabel = entity || 'este fornecedor';
+  const contextParts: string[] = ['quero analisar esta empresa'];
+  if (uf) contextParts.push(`em ${uf}`);
+  if (setor) contextParts.push(`no setor de ${setor.replace(/-/g, ' ')}`);
+  return `Olá! Vim da página de fornecedor ${entityLabel} e ${contextParts.join(' ')}`;
+}
+
+function buildOrgaoMessage(entity?: string, setor?: string, uf?: string): string {
+  const entityLabel = entity || 'este órgão';
+  const contextParts: string[] = ['quero monitorar este órgão'];
+  if (uf) contextParts.push(`no ${uf}`);
+  return `Olá! Vim da página do órgão ${entityLabel} e ${contextParts.join(' ')}`;
+}
+
+function buildLicitacoesMessage(entity?: string, setor?: string, uf?: string): string {
+  const setorLabel = entity || (setor ? setor.replace(/-/g, ' ') : 'este setor');
+  const contextParts: string[] = ['quero oportunidades neste setor'];
+  if (uf) contextParts.push(`no ${uf}`);
+  return `Olá! Vim da página de licitações de ${setorLabel} e ${contextParts.join(' ')}`;
+}
+
+function buildCnpjMessage(entity?: string, setor?: string, uf?: string): string {
+  const entityLabel = entity || 'esta empresa';
+  const contextParts: string[] = ['quero relatório desta empresa'];
+  if (uf) contextParts.push(`em ${uf}`);
+  if (setor) contextParts.push(`no setor de ${setor.replace(/-/g, ' ')}`);
+  return `Olá! Vim da página de consulta CNPJ de ${entityLabel} e ${contextParts.join(' ')}`;
+}
+
+function buildBlogLicitacoesMessage(entity?: string, setor?: string, uf?: string): string {
+  const setorLabel = entity || (setor ? setor.replace(/-/g, ' ') : 'este setor');
+  const locationLabel = uf ? `em ${uf}` : 'nesta região';
+  return `Olá! Vim da página de licitações de ${setorLabel} ${locationLabel} e quero editais nesta região`;
+}
+
+// ---------------------------------------------------------------------------
+// Message builder map
+// ---------------------------------------------------------------------------
+
+const MESSAGE_BUILDERS: Record<WhatsAppSourceTemplate, (entity?: string, setor?: string, uf?: string) => string> = {
+  fornecedor_page: buildFornecedorMessage,
+  orgao_page: buildOrgaoMessage,
+  licitacoes_page: buildLicitacoesMessage,
+  cnpj_page: buildCnpjMessage,
+  blog_licitacoes_page: buildBlogLicitacoesMessage,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a WhatsApp deep link with a pre-filled contextual message.
+ *
+ * @param source - The source template identifier
+ * @param ctx - Contextual information (entity name, setor, uf)
+ * @returns A `https://wa.me/...` URL with the message URL-encoded
+ */
+export function buildWhatsAppUrl(
+  source: WhatsAppSourceTemplate,
+  ctx: WhatsAppContext,
+): string {
+  const builder = MESSAGE_BUILDERS[source];
+  const message = builder
+    ? builder(ctx.entity, ctx.setor, ctx.uf)
+    : FALLBACK_MESSAGE;
+  return `${WHATSAPP_BASE}?text=${encodeURIComponent(message)}`;
+}
+
+/**
+ * Get the human-readable label for a WhatsApp CTA button.
+ * Used to display "Falar com especialista no WhatsApp" on all CTAs.
+ */
+export function getWhatsAppCtaLabel(): string {
+  return 'Falar com especialista no WhatsApp';
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,11 @@ const nextConfig = {
   reactStrictMode: true,
   trailingSlash: false,
   output: 'standalone',
+
+  // BUILD-FIX-2026-06-01: Aumentar staticPageGenerationTimeout para 300s.
+  // Default 60s insuficiente para ISR com 200+ páginas × fetch backend.
+  // Sem isso, cascade timeout → 3 retries → build falha.
+  staticPageGenerationTimeout: 300,
   // Fix standalone output when repo has multiple lockfiles (root + frontend)
   // Without this, Next.js infers the wrong workspace root and server.js
   // ends up in a nested path instead of .next/standalone/server.js


### PR DESCRIPTION
## Context
CONV-013: WhatsApp e o canal de maior conversao no Brasil — 98% taxa de abertura, 12x mais conversao que email (Amplitude Marketing 2026). Zero presenca nas paginas pSEO do SmartLic.

## Changes
- **WhatsAppCTA component** (`frontend/app/components/whatsapp/WhatsAppCTA.tsx`): Componente reutilizavel com variantes floating (mobile, canto inferior direito) e inline (desktop, banner contextual)
- **Message builder** (`frontend/lib/whatsapp-messages.ts`): Mensagens pre-preenchidas contextuais por template (fornecedor_page, orgao_page, licitacoes_page, cnpj_page, blog_licitacoes_page)
- **Analytics** (`frontend/lib/analytics/whatsapp.ts`): Eventos whatsapp_cta_viewed e whatsapp_cta_clicked com source_template, entity_id, setor, uf, device
- **5 target pages**: fornedores/[cnpj], orgaos/[slug], licitacoes/[setor], cnpj/[cnpj], blog/licitacoes/[setor]/[uf]
- Numero do founder: +55 48 98834-4559
- Texto do botao: "Falar com especialista no WhatsApp"

## Testing Plan
1. TypeScript check: `npx tsc --noEmit --pretty` — passed (exit code 0)
2. Verificar mensagem contextual correta em cada template
3. Testar em mobile (WhatsApp Web vs WhatsApp App) — deep link wa.me
4. Verificar Mixpanel events no console

## Risks & Rollback
- **Baixo**: Componente puramente frontend, sem dependencias externas
- **Rollback**: Reverter commit e fazer deploy
- **Tracking**: Eventos sao SSR-safe e nunca lancam excecoes

## Closes
Closes #1324