### PR TITLE
feat(frontend): wire PSEOTemplate + PreviewCTA into 5 top-traffic entity pages (#1327)

### DIFF
--- a/frontend/app/components/programmatic/PreviewCTA.tsx
+++ b/frontend/app/components/programmatic/PreviewCTA.tsx
@@ -38,6 +38,9 @@ export interface PreviewCTAProps {
   setorLabel: string; // Human label, e.g. "Pavimentacao asfaltica"
   ufLabel: string; // Human label, e.g. "Santa Catarina"
   totalOpen?: number; // Total open editais for the banner label
+  /** Pre-fetched items — when provided, skips API fetch and renders data immediately.
+   *  Used by entity pages (fornecedores, orgaos, municipios) that have their own data. */
+  items?: EditalItem[];
 }
 
 /* ------------------------------------------------------------------ */
@@ -191,6 +194,7 @@ export default function PreviewCTA({
   setorLabel,
   ufLabel,
   totalOpen,
+  items: preFetchedItems,
 }: PreviewCTAProps) {
   const [isOpen, setIsOpen] = useState(hasPreviewParam);
   const [data, setData] = useState<RecentEditaisResponse | null>(null);
@@ -229,13 +233,23 @@ export default function PreviewCTA({
       });
     }
 
+    // If pre-fetched items provided, use them directly — skip API fetch
+    if (preFetchedItems) {
+      setData({ items: preFetchedItems, total: preFetchedItems.length });
+      return;
+    }
+
     fetchData();
-  }, [setor, uf, fetchData]);
+  }, [setor, uf, fetchData, preFetchedItems]);
 
   // Auto-open if ?preview=true was in the URL on mount
   useEffect(() => {
     if (hasPreviewParam() && !data && !loading && !error) {
-      fetchData();
+      if (preFetchedItems) {
+        setData({ items: preFetchedItems, total: preFetchedItems.length });
+      } else {
+        fetchData();
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -14,11 +14,11 @@ import { buildCanonical, getFreshnessLabel } from '@/lib/seo';
 import { ssgLimitedFetch } from '@/lib/concurrency';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
-import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 import SeoBannerCta from '@/app/components/landing/SeoBannerCta';
 import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import { PseoPageTracker } from '@/app/components/seo/PseoPageTracker';
 import { PseoLink } from '@/app/components/seo/PseoLink';
+import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 
 export const revalidate = 14400; // 4h ISR (reduzido de 24h para melhorar freshness dos dados)
 
@@ -208,7 +208,23 @@ export default async function ContratosSetorUfPage({ params }: Props) {
         uf={ufUpper}
       />
       <LandingNavbar />
-      <StickyTrialCTA refParam="sticky-contratos" />
+      {/* CONV-002b: Sticky bottom mobile CTA — contextual */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-brand-navy text-white px-4 py-3 shadow-lg"
+        data-testid="pseo-sticky-cta"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm font-medium">
+            {totalContracts} contratos · {sector.name} {ufName}
+          </span>
+          <Link
+            href={`/signup?ref=contratos-${setor}-${uf}-sticky`}
+            className="px-4 py-2 bg-brand-blue rounded-lg text-sm font-semibold whitespace-nowrap"
+          >
+            Receber alertas →
+          </Link>
+        </div>
+      </div>
       <main className="min-h-screen bg-gray-50 pt-20 pb-16">
         {jsonLd.map((ld, i) => (
           <script
@@ -405,6 +421,19 @@ export default async function ContratosSetorUfPage({ params }: Props) {
                       </div>
                     </section>
                   )}
+
+                  {/* CONV-002b: PreviewCTA — 3 contratos reais + 3 blurred (degustação) */}
+                  {data.sample_contracts.length > 0 && (
+                    <section className="mb-8">
+                      <PreviewCTA
+                        setor={setor}
+                        uf={ufUpper.toLowerCase()}
+                        setorLabel={sector.name}
+                        ufLabel={ufName}
+                        totalOpen={totalContracts}
+                      />
+                    </section>
+                  )}
                 </>
               )}
 
@@ -481,24 +510,29 @@ export default async function ContratosSetorUfPage({ params }: Props) {
             </div>
           </section>
 
-          {/* Lead Capture */}
-          <section className="mt-12 bg-blue-50 rounded-lg p-6 text-center">
-            <h2 className="text-xl font-bold text-gray-900 mb-2">
-              Monitore contratos de {sector.name} {getUfPrep(ufUpper)} {ufName}
-            </h2>
-            <p className="text-gray-600 mb-4">
-              Receba alertas quando novos contratos forem publicados nas fontes oficiais.
+          {/* CONV-002b: Lead Capture — contextual CTA + "Só quero ver os dados" */}
+          <section className="mt-12 rounded-2xl border border-brand-blue/30 bg-brand-blue/5 dark:bg-brand-blue/10 p-6 sm:p-8">
+            <p className="text-lg text-gray-900 dark:text-white mb-4">
+              Quer receber os próximos contratos de {sector.name} em {ufName}?
             </p>
-            <PseoLink
-              href="/signup?ref=contratos-bot"
-              className="inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
-              eventName="pseo_lead_captured"
-              sourceTemplate="contrato_page"
-              setor={setor}
-              uf={ufUpper}
-            >
-              Testar 14 dias grátis →
-            </PseoLink>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <PseoLink
+                href={`/signup?ref=contratos-${setor}-${uf}`}
+                className="inline-block px-6 py-3 bg-brand-blue text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors text-center"
+                eventName="pseo_alert_signup"
+                sourceTemplate="contrato_page"
+                setor={setor}
+                uf={ufUpper}
+              >
+                Receber alertas grátis 14 dias →
+              </PseoLink>
+              <Link
+                href={`/observatorio/${setor}`}
+                className="inline-block px-6 py-3 bg-white dark:bg-gray-900 text-brand-navy dark:text-white font-medium rounded-lg border border-gray-300 dark:border-gray-700 hover:border-brand-blue transition-colors text-center"
+              >
+                Só quero ver os dados
+              </Link>
+            </div>
           </section>
 
           {/* CONV-014: Alert CTA — criar alerta de setor em UF */}

--- a/frontend/app/fornecedores/[cnpj]/FornecedorPseoCTA.tsx
+++ b/frontend/app/fornecedores/[cnpj]/FornecedorPseoCTA.tsx
@@ -13,6 +13,9 @@ interface Props {
  * Client component for the fornecedor lead-capture CTA section.
  * Fires pseo_supplier_viewed on mount and pseo_checkout_click on CTA click.
  * Extracted from the server component to keep the page SSR-rendered.
+ *
+ * CONV-002b: Updated to PSEOTemplate-style contextual CTA with
+ * trial + "Só quero ver os dados" secondary link.
  */
 export default function FornecedorPseoCTA({ cnpj, razaoSocial }: Props) {
   useEffect(() => {
@@ -26,27 +29,35 @@ export default function FornecedorPseoCTA({ cnpj, razaoSocial }: Props) {
 
   const destination = `/signup?ref=cnpj&cnpj=${cnpj}&utm_source=pseo&utm_medium=organic&utm_content=fornecedor_page`;
 
+  const handleCheckoutClick = () => {
+    trackPseoEvent('pseo_checkout_click', {
+      source_template: 'fornecedor_page',
+      destination,
+    });
+  };
+
   return (
-    <section className="mt-4 bg-blue-50 rounded-lg p-6 text-center">
-      <h2 className="text-xl font-bold text-gray-900 mb-2">
-        Monitore editais do setor de {razaoSocial}
-      </h2>
-      <p className="text-gray-600 mb-4">
-        O SmartLic rastreia licitações abertas nas fontes oficiais e avisa quando surgem
-        oportunidades relevantes para sua empresa.
-      </p>
-      <Link
-        href={destination}
-        onClick={() =>
-          trackPseoEvent('pseo_checkout_click', {
-            source_template: 'fornecedor_page',
-            destination,
-          })
-        }
-        className="inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
-      >
-        Testar 14 dias grátis →
-      </Link>
+    <section className="max-w-5xl mx-auto px-4 py-8">
+      <div className="rounded-2xl border border-brand-blue/30 bg-brand-blue/5 dark:bg-brand-blue/10 p-6 sm:p-8">
+        <p className="text-lg text-gray-900 dark:text-white mb-4">
+          Quer receber alertas de editais e contratos públicos de <strong>{razaoSocial}</strong>?
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Link
+            href={destination}
+            onClick={handleCheckoutClick}
+            className="inline-block px-6 py-3 bg-brand-blue text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors text-center"
+          >
+            Receber alertas grátis 14 dias →
+          </Link>
+          <Link
+            href="/observatorio"
+            className="inline-block px-6 py-3 bg-white dark:bg-gray-900 text-brand-navy dark:text-white font-medium rounded-lg border border-gray-300 dark:border-gray-700 hover:border-brand-blue transition-colors text-center"
+          >
+            Só quero ver os dados
+          </Link>
+        </div>
+      </div>
     </section>
   );
 }

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -11,6 +11,7 @@ import { isNoindexed } from '@/lib/seo/noindex';
 import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
 import { PseoPageTracker } from '@/app/components/seo/PseoPageTracker';
+import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 
 // Sprint 3 Parte 13: paginas de perfil de fornecedor por CNPJ
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -252,6 +253,16 @@ export default async function FornecedorCnpjPage({ params }: Props) {
       : []),
   ];
 
+  // CONV-002b: preview items for PreviewCTA — 3 contratos recentes + 3 blurred
+  const previewItems = profile.contratos_recentes.slice(0, 6).map((c) => ({
+    orgao: c.orgao,
+    objeto: c.objeto,
+    valor_estimado: c.valor,
+    data_limite: null as string | null,
+    data_publicacao: c.data_assinatura,
+    link_interno: `/fornecedores/${cnpj}`,
+  }));
+
   return (
     <>
       {/* CONV-009b (#1325): scroll depth + engagement tracking (view event handled by FornecedorPseoCTA) */}
@@ -296,18 +307,26 @@ export default async function FornecedorCnpjPage({ params }: Props) {
             {' · Fonte: Portal Nacional de Contratacoes Publicas'}
           </p>
 
-          {/* PSEO-MOBILE-001 #886: Primary CTA above the fold — visible on mobile 375px without scroll */}
+          {/* CONV-002b: Primary CTA above the fold — contextual + "Só quero ver os dados" */}
           <div className="mb-6 rounded-lg bg-blue-600 px-4 py-4 text-center sm:text-left sm:flex sm:items-center sm:justify-between sm:gap-4">
             <p className="text-sm text-blue-100 mb-3 sm:mb-0">
               Monitore editais do setor de <span className="font-semibold text-white">{profile.razao_social}</span> e receba alertas automáticos.
             </p>
-            <Link
-              href={`/signup?ref=fornecedor&cnpj=${cnpj}`}
-              data-testid="pseo-cta-primary"
-              className="inline-block whitespace-nowrap rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-blue-700 hover:bg-blue-50 transition-colors min-h-[44px] leading-[44px] sm:leading-normal sm:py-2.5"
-            >
-              Testar 14 dias grátis →
-            </Link>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Link
+                href={`/signup?ref=fornecedor&cnpj=${cnpj}`}
+                data-testid="pseo-cta-primary"
+                className="inline-block whitespace-nowrap rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-blue-700 hover:bg-blue-50 transition-colors min-h-[44px] leading-[44px] sm:leading-normal sm:py-2.5"
+              >
+                Receber alertas grátis →
+              </Link>
+              <Link
+                href="/observatorio"
+                className="inline-block whitespace-nowrap rounded-lg border border-white/30 px-5 py-2.5 text-sm font-medium text-white hover:bg-white/10 transition-colors"
+              >
+                Só quero ver os dados
+              </Link>
+            </div>
           </div>
 
           {/* KPI Cards */}
@@ -396,6 +415,19 @@ export default async function FornecedorCnpjPage({ params }: Props) {
               </table>
             </div>
           </section>
+
+          {/* CONV-002b: PreviewCTA — 3 contratos reais + 3 blurred, "degustação" */}
+          {profile.contratos_recentes.length >= 3 && (
+            <div className="mb-8">
+              <PreviewCTA
+                setor="contratos-fornecedor"
+                setorLabel={profile.razao_social}
+                ufLabel="Brasil"
+                totalOpen={profile.total_contratos}
+                items={previewItems}
+              />
+            </div>
+          )}
 
           {/* Top Compradores */}
           {profile.top_compradores.length > 0 && (
@@ -504,6 +536,24 @@ export default async function FornecedorCnpjPage({ params }: Props) {
         </div>
       </main>
       <Footer />
+
+      {/* CONV-002b: Sticky bottom mobile CTA — contextual */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-brand-navy text-white px-4 py-3 shadow-lg"
+        data-testid="pseo-sticky-cta"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm font-medium">
+            {profile.total_contratos} contratos · {profile.razao_social}
+          </span>
+          <Link
+            href={`/signup?ref=fornecedor-${cnpj}-sticky`}
+            className="px-4 py-2 bg-brand-blue rounded-lg text-sm font-semibold whitespace-nowrap"
+          >
+            Receber alertas →
+          </Link>
+        </div>
+      </div>
     </>
   );
 }

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -15,7 +15,6 @@ import { getSectorFaqs } from "@/data/sector-faqs";
 import { getFreshnessLabel } from "@/lib/seo";
 import { MicroDemo } from "@/components/seo/MicroDemo";
 import { MicroDemoSchema } from "@/components/seo/MicroDemoSchema";
-import StickyTrialCTA from "@/app/components/StickyTrialCTA";
 import { buildDatasetJsonLd } from "./_jsonld";
 import { FoundersRibbon } from "@/components/banners/FoundersRibbon";
 import { AdvisoryDisclaimer } from "@/components/legal/AdvisoryDisclaimer";
@@ -29,6 +28,7 @@ import AlertEntityCta from "@/components/seo/AlertEntityCta";
 import WhatsAppCTA from "@/app/components/whatsapp/WhatsAppCTA";
 import { PseoPageTracker } from "@/app/components/seo/PseoPageTracker";
 import { PseoLink } from "@/app/components/seo/PseoLink";
+import PreviewCTA from "@/app/components/programmatic/PreviewCTA";
 
 /**
  * STORY-324 AC5: SSG with ISR 6h for sector landing pages.
@@ -125,7 +125,23 @@ export default async function SectorPage({
         setor={setor}
         viewEventName="pseo_edital_viewed"
       />
-      <StickyTrialCTA refParam="sticky-licitacoes" />
+      {/* CONV-002b: Sticky bottom mobile CTA — contextual */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-brand-navy text-white px-4 py-3 shadow-lg"
+        data-testid="pseo-sticky-cta"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm font-medium">
+            {stats?.total_open ?? 0} editais abertos · {sector.name}
+          </span>
+          <Link
+            href={`/signup?ref=licitacoes-${sector.slug}-sticky`}
+            className="px-4 py-2 bg-brand-blue rounded-lg text-sm font-semibold whitespace-nowrap"
+          >
+            Receber alertas →
+          </Link>
+        </div>
+      </div>
       <main id="main-content" className="min-h-screen bg-white dark:bg-gray-950">
       {/* AC6: Hero */}
       <section className="bg-gradient-to-br from-brand-blue to-blue-700 text-white py-16 px-4">
@@ -234,6 +250,16 @@ export default async function SectorPage({
         ufLabel="Brasil"
         totalOpen={stats?.total_open}
       />
+
+      {/* CONV-002b: PreviewCTA — 3 editais grátis + 3 blurred (degustação) */}
+      <div className="max-w-5xl mx-auto py-8 px-4">
+        <PreviewCTA
+          setor={setor}
+          setorLabel={sector.name}
+          ufLabel="Brasil"
+          totalOpen={stats?.total_open}
+        />
+      </div>
 
       {/* AC6: CTA (inline — catches users who don't scroll) */}
       <section className="bg-brand-blue/5 dark:bg-brand-blue/10 py-12 px-4">

--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -7,10 +7,10 @@ import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import { getUfPrep } from '@/lib/programmatic';
 import LandingNavbar from '@/app/components/landing/LandingNavbar';
 import Footer from '@/app/components/Footer';
-import StickyTrialCTA from '@/app/components/StickyTrialCTA';
 import { AdvisoryDisclaimer } from '@/components/legal/AdvisoryDisclaimer';
 import { LeadCapture } from '@/components/LeadCapture';
 import AlertEntityCta from '@/components/seo/AlertEntityCta';
+import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 
 // Sprint 4 Parte 13: páginas de municípios com licitações abertas
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -166,6 +166,16 @@ export default async function MunicipioSlugPage({ params }: Props) {
     (f: { question: string; answer: string }) => f.answer.replace(/<[^>]*>/g, '').length >= 300
   );
 
+  // CONV-002b: preview items for PreviewCTA — 3 licitações reais + 3 blurred
+  const previewItems = profile.licitacoes_recentes.slice(0, 6).map((l) => ({
+    orgao: l.orgao,
+    objeto: l.objeto,
+    valor_estimado: l.valor,
+    data_limite: null as string | null,
+    data_publicacao: l.data_publicacao,
+    link_interno: `/municipios/${slug}`,
+  }));
+
   const jsonLd = [
     {
       // SEO-Sprint2 P6.4: AdministrativeArea (was City) with containedInPlace hierarchy
@@ -221,7 +231,23 @@ export default async function MunicipioSlugPage({ params }: Props) {
   return (
     <>
       <LandingNavbar />
-      <StickyTrialCTA refParam="sticky-municipio" />
+      {/* CONV-002b: Sticky bottom mobile CTA — contextual */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-brand-navy text-white px-4 py-3 shadow-lg"
+        data-testid="pseo-sticky-cta"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm font-medium">
+            {profile.total_licitacoes_abertas} editais · {profile.nome}-{profile.uf}
+          </span>
+          <Link
+            href={`/signup?ref=municipios-${slug}-sticky`}
+            className="px-4 py-2 bg-brand-blue rounded-lg text-sm font-semibold whitespace-nowrap"
+          >
+            Receber alertas →
+          </Link>
+        </div>
+      </div>
       <main className="min-h-screen bg-gray-50 pt-20 pb-16">
         {jsonLd.map((ld, i) => (
           <script
@@ -331,6 +357,19 @@ export default async function MunicipioSlugPage({ params }: Props) {
             </section>
           )}
 
+          {/* CONV-002b: PreviewCTA — 3 editais reais + 3 blurred (degustação) */}
+          {profile.licitacoes_recentes.length >= 3 && (
+            <div className="mb-8">
+              <PreviewCTA
+                setor="municipio-editais"
+                setorLabel={`${profile.nome}-${profile.uf}`}
+                ufLabel={profile.uf}
+                totalOpen={profile.total_licitacoes_abertas}
+                items={previewItems}
+              />
+            </div>
+          )}
+
           {/* FAQ */}
           {profile.faq_items.length > 0 && (
             <section className="mb-8">
@@ -365,21 +404,25 @@ export default async function MunicipioSlugPage({ params }: Props) {
             </div>
           </section>
 
-          {/* CTA */}
-          <section className="mt-4 bg-blue-50 rounded-lg p-6 text-center">
-            <h2 className="text-xl font-bold text-gray-900 mb-2">
-              Monitore editais em {profile.nome}-{profile.uf}
-            </h2>
-            <p className="text-gray-600 mb-4">
-              O SmartLic rastreia licitações abertas nas fontes oficiais e avisa quando surgem
-              oportunidades relevantes para sua empresa no município e região.
+          {/* CONV-002b: Contextual CTA — trial + "Só quero ver os dados" */}
+          <section className="mt-4 rounded-2xl border border-brand-blue/30 bg-brand-blue/5 dark:bg-brand-blue/10 p-6 sm:p-8">
+            <p className="text-lg text-gray-900 dark:text-white mb-4">
+              Quer receber alertas de editais em {profile.nome}-{profile.uf}?
             </p>
-            <Link
-              href={`/signup?ref=municipios-${slug}&source=municipio-page`}
-              className="inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              Teste grátis por 14 dias
-            </Link>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Link
+                href={`/signup?ref=municipios-${slug}&source=municipio-page`}
+                className="inline-block px-6 py-3 bg-brand-blue text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors text-center"
+              >
+                Receber alertas grátis 14 dias →
+              </Link>
+              <Link
+                href="/observatorio"
+                className="inline-block px-6 py-3 bg-white dark:bg-gray-900 text-brand-navy dark:text-white font-medium rounded-lg border border-gray-300 dark:border-gray-700 hover:border-brand-blue transition-colors text-center"
+              >
+                Só quero ver os dados
+              </Link>
+            </div>
           </section>
 
           {/* Lead magnet — email capture before hard trial gate */}

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import ContentPageLayout from '../../components/ContentPageLayout';
 import OrgaoPerfilClient from './OrgaoPerfilClient';
 import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
-import InlineTrialCTA from '../../components/InlineTrialCTA';
 import { LeadCapture } from '@/components/LeadCapture';
 import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
@@ -11,6 +10,7 @@ import { fetchWithBudget } from '@/lib/safe-fetch';
 import { getBackendUrl } from '@/lib/backend-url';
 import { AdvisoryDisclaimer } from '@/components/legal/AdvisoryDisclaimer';
 import WhatsAppCTA from '@/app/components/whatsapp/WhatsAppCTA';
+import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 
 const BACKEND_URL = getBackendUrl();
 
@@ -172,6 +172,16 @@ export default async function OrgaoPerfilPage({
     },
   };
 
+  // CONV-002b: preview items for PreviewCTA — 3 últimas licitações + 3 blurred
+  const previewItems = stats.ultimas_licitacoes.slice(0, 6).map((l) => ({
+    orgao: stats.nome,
+    objeto: l.objeto_compra,
+    valor_estimado: l.valor_total_estimado,
+    data_limite: null as string | null,
+    data_publicacao: l.data_publicacao,
+    link_interno: `/orgaos/${slug}`,
+  }));
+
   // SEO-P1-007 (#993): Visual breadcrumb derived from same trail as JSON-LD.
   // ContentPageLayout's BreadcrumbNav emits the BreadcrumbList JSON-LD when
   // breadcrumbItems is provided (suppressSchema=false), so we no longer need
@@ -183,6 +193,24 @@ export default async function OrgaoPerfilPage({
   ];
 
   return (
+    <>
+    {/* CONV-002b: Sticky bottom mobile CTA — contextual */}
+    <div
+      className="fixed bottom-0 left-0 right-0 z-40 sm:hidden bg-brand-navy text-white px-4 py-3 shadow-lg"
+      data-testid="pseo-sticky-cta"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium">
+          {stats.licitacoes_30d} editais · {stats.nome}
+        </span>
+        <Link
+          href={`/signup?ref=orgao-${slug}-sticky`}
+          className="px-4 py-2 bg-brand-blue rounded-lg text-sm font-semibold whitespace-nowrap"
+        >
+          Receber alertas →
+        </Link>
+      </div>
+    </div>
     <ContentPageLayout
       breadcrumbLabel={stats.nome}
       breadcrumbItems={breadcrumbItems}
@@ -204,12 +232,41 @@ export default async function OrgaoPerfilPage({
 
       <OrgaoPerfilClient stats={stats} />
 
-      {/* #652: Inline trial CTA after licitações list */}
-      <InlineTrialCTA
-        page="orgao"
-        source="orgao-page"
-        extraParam={{ name: 'slug', value: slug }}
-      />
+      {/* CONV-002b: PreviewCTA — 3 últimas licitações + 3 blurred (degustação) */}
+      {stats.ultimas_licitacoes.length >= 3 && (
+        <div className="mt-8">
+          <PreviewCTA
+            setor="orgao-licitacoes"
+            setorLabel={stats.nome}
+            ufLabel={stats.uf}
+            totalOpen={stats.licitacoes_30d}
+            items={previewItems}
+          />
+        </div>
+      )}
+
+      {/* CONV-002b: Contextual CTA — trial + "Só quero ver os dados" */}
+      <section className="max-w-5xl mx-auto px-4 py-8">
+        <div className="rounded-2xl border border-brand-blue/30 bg-brand-blue/5 dark:bg-brand-blue/10 p-6 sm:p-8">
+          <p className="text-lg text-gray-900 dark:text-white mb-4">
+            Quer receber os próximos editais de <strong>{stats.nome}</strong>?
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Link
+              href={`/signup?ref=orgao-${slug}`}
+              className="inline-block px-6 py-3 bg-brand-blue text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors text-center"
+            >
+              Receber alertas grátis 14 dias →
+            </Link>
+            <Link
+              href="/observatorio"
+              className="inline-block px-6 py-3 bg-white dark:bg-gray-900 text-brand-navy dark:text-white font-medium rounded-lg border border-gray-300 dark:border-gray-700 hover:border-brand-blue transition-colors text-center"
+            >
+              Só quero ver os dados
+            </Link>
+          </div>
+        </div>
+      </section>
 
       <div className="mt-10">
         <LeadCapture
@@ -266,5 +323,6 @@ export default async function OrgaoPerfilPage({
       {/* REPO-020 (#772): Advisory disclaimer for algorithmic data aggregations */}
       <AdvisoryDisclaimer variant="full" />
     </ContentPageLayout>
+    </>
   );
 }


### PR DESCRIPTION
## Context
PSEOTemplate e PreviewCTA sao componentes PRONTOS (issues #1004, #1009) que nenhuma rota real usava. As paginas pSEO continuavam com CTAs hardcoded "Testar 14 dias gratis".

## Changes
Substitui CTAs hardcoded pelo PSEOTemplate + PreviewCTA em 5 paginas-alvo:

### 1. /fornecedores/[cnpj]
- PreviewCTA com 3 contratos recentes reais + 3 blurred (pre-fetched items)
- Primary CTA acima da dobra com "Receber alertas gratis" + "So quero ver os dados"
- FornecedorPseoCTA atualizado para template contextual (preserva tracking pseo_supplier_viewed + pseo_checkout_click)
- Mobile sticky CTA contextual

### 2. /licitacoes/[setor]
- PreviewCTA via API fetch (setor disponivel)
- Mobile sticky CTA contextual substituindo StickyTrialCTA generico

### 3. /contratos/[setor]/[uf]
- PreviewCTA via API fetch (setor + UF disponiveis)
- Bottom CTA substituido por versao contextual com "So quero ver os dados" → /observatorio/{setor}
- Mobile sticky CTA contextual

### 4. /orgaos/[slug]
- PreviewCTA com ultimas_licitacoes mapeadas para EditalItem (pre-fetched)
- Contextual CTA substituindo InlineTrialCTA
- Mobile sticky CTA contextual

### 5. /municipios/[slug]
- PreviewCTA com licitacoes_recentes mapeadas para EditalItem (pre-fetched)
- Bottom CTA substituido por versao contextual com "So quero ver os dados"
- Mobile sticky CTA contextual substituindo StickyTrialCTA generico

### Componente compartilhado
- PreviewCTA.tsx: modified to accept optional `items` prop — when provided, skips API fetch and shows data immediately.

## Pattern applied por pagina
| Elemento | Antes | Depois |
|----------|-------|--------|
| Hero CTA | "Testar 14 dias gratis" | Contextual + "So quero ver os dados" |
| Mid-page | — | PreviewCTA (3 free + 3 blurred) |
| Footer CTA | "Testar 14 dias gratis" | Contextual trial + observatorio link |
| Mobile sticky | StickyTrialCTA generico | Contextual (total + entidade) |

## Testing Plan
1. Visual verification on each entity page: fornecedores, licitacoes, contratos, orgaos, municipios
2. Confirm PreviewCTA renders with pre-fetched items vs API fetch
3. Verify mobile sticky CTA on sm breakpoint
4. Confirm all CTAs have correct signup refs for attribution

## Files changed
- frontend/app/components/programmatic/PreviewCTA.tsx
- frontend/app/fornecedores/[cnpj]/page.tsx + FornecedorPseoCTA.tsx
- frontend/app/licitacoes/[setor]/page.tsx
- frontend/app/contratos/[setor]/[uf]/page.tsx
- frontend/app/orgaos/[slug]/page.tsx
- frontend/app/municipios/[slug]/page.tsx

## Closes
Closes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview sections displaying recent items (contracts, tenders, suppliers) across multiple pages.
  * Introduced sticky mobile call-to-action buttons with contextual sector, location, and supplier information.
  * Added secondary "view data only" option alongside free 14-day signup alerts.

* **Improvements**
  * Updated call-to-action messaging and layout for better user engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->