### PR TITLE
feat(backend): activate 4 premium feature flags (B2G_OPS, SUBCONTRACT_INTEL, COMPETITIVE_INTEL, PREDICTIVE_INTEL)

### DIFF
--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -197,22 +197,22 @@ EMBEDDING_THRESHOLD: float = float(os.getenv("EMBEDDING_THRESHOLD", "0.6"))
 # / Supply-Chain Intelligence vertical. Default OFF — the entire vertical
 # (RPCs, /v1/subcontract/* endpoints, frontend) stays inert until explicitly
 # enabled. Strictly additive: no existing feature changes while this is false.
-SUBCONTRACT_INTEL_ENABLED: bool = str_to_bool(os.getenv("SUBCONTRACT_INTEL_ENABLED", "false"))
+SUBCONTRACT_INTEL_ENABLED: bool = str_to_bool(os.getenv("SUBCONTRACT_INTEL_ENABLED", "true"))
 
 # PREDINT-000 (EPIC-PREDINT #1260): global kill-switch for the Predictive
 # Intelligence vertical. Default OFF — the entire feature set (RPCs, endpoints,
 # frontend) stays inert until explicitly enabled. Strictly additive: no existing
 # feature changes while this is false.
-PREDICTIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("PREDICTIVE_INTEL_ENABLED", "false"))
+PREDICTIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("PREDICTIVE_INTEL_ENABLED", "true"))
 # COMPINT-000 (EPIC-COMPINT #1261): global kill-switch for the Competitive
 # Intelligence vertical (analise-concorrencia/, /v1/competitive-intel/*
 # endpoints, frontend). Default OFF — the entire vertical stays inert until
 # explicitly enabled. Strictly additive: no existing feature changes while
 # this is false.
-COMPETITIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("COMPETITIVE_INTEL_ENABLED", "false"))
+COMPETITIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("COMPETITIVE_INTEL_ENABLED", "true"))
 # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations vertical gate
 # Default OFF — the entire B2GOPS vertical stays inert until explicitly enabled.
-B2G_OPS_ENABLED: bool = str_to_bool(os.getenv("B2G_OPS_ENABLED", "false"))
+B2G_OPS_ENABLED: bool = str_to_bool(os.getenv("B2G_OPS_ENABLED", "true"))
 
 
 # ============================================
@@ -277,13 +277,13 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "MESSAGES_ENABLED": ("MESSAGES_ENABLED", "true"),
     "PARTNERS_ENABLED": ("PARTNERS_ENABLED", "false"),
     # SUBINTEL-030 (EPIC-SUBINTEL #1224): subcontracting intelligence vertical
-    "SUBCONTRACT_INTEL_ENABLED": ("SUBCONTRACT_INTEL_ENABLED", "false"),
+    "SUBCONTRACT_INTEL_ENABLED": ("SUBCONTRACT_INTEL_ENABLED", "true"),
     # PREDINT-000 (EPIC-PREDINT #1260): predictive intelligence vertical
-    "PREDICTIVE_INTEL_ENABLED": ("PREDICTIVE_INTEL_ENABLED", "false"),
+    "PREDICTIVE_INTEL_ENABLED": ("PREDICTIVE_INTEL_ENABLED", "true"),
     # COMPINT-000 (EPIC-COMPINT #1261): competitive intelligence vertical
-    "COMPETITIVE_INTEL_ENABLED": ("COMPETITIVE_INTEL_ENABLED", "false"),
+    "COMPETITIVE_INTEL_ENABLED": ("COMPETITIVE_INTEL_ENABLED", "true"),
     # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations workspace_basic gate
-    "B2G_OPS_ENABLED": ("B2G_OPS_ENABLED", "false"),
+    "B2G_OPS_ENABLED": ("B2G_OPS_ENABLED", "true"),
     # --- Infra ---
     "METRICS_ENABLED": ("METRICS_ENABLED", "true"),
     "RATE_LIMITING_ENABLED": ("RATE_LIMITING_ENABLED", "true"),

--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -194,24 +194,25 @@ EMBEDDING_ENABLED: bool = str_to_bool(os.getenv("EMBEDDING_ENABLED", "false"))
 EMBEDDING_THRESHOLD: float = float(os.getenv("EMBEDDING_THRESHOLD", "0.6"))
 
 # SUBINTEL-030 (EPIC-SUBINTEL #1224): global kill-switch for the Subcontracting
-# / Supply-Chain Intelligence vertical. Default OFF — the entire vertical
-# (RPCs, /v1/subcontract/* endpoints, frontend) stays inert until explicitly
-# enabled. Strictly additive: no existing feature changes while this is false.
+# / Supply-Chain Intelligence vertical. Default ON (true) — the vertical is
+# active by default. Set env var to "false" to disable. Strictly additive: no
+# existing feature changes while this is false.
 SUBCONTRACT_INTEL_ENABLED: bool = str_to_bool(os.getenv("SUBCONTRACT_INTEL_ENABLED", "true"))
 
 # PREDINT-000 (EPIC-PREDINT #1260): global kill-switch for the Predictive
-# Intelligence vertical. Default OFF — the entire feature set (RPCs, endpoints,
-# frontend) stays inert until explicitly enabled. Strictly additive: no existing
-# feature changes while this is false.
+# Intelligence vertical. Default ON (true) — the vertical is active by default.
+# Set env var to "false" to disable. Strictly additive: no existing feature
+# changes while this is false.
 PREDICTIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("PREDICTIVE_INTEL_ENABLED", "true"))
 # COMPINT-000 (EPIC-COMPINT #1261): global kill-switch for the Competitive
 # Intelligence vertical (analise-concorrencia/, /v1/competitive-intel/*
-# endpoints, frontend). Default OFF — the entire vertical stays inert until
-# explicitly enabled. Strictly additive: no existing feature changes while
-# this is false.
+# endpoints, frontend). Default ON (true) — the vertical is active by default.
+# Set env var to "false" to disable. Strictly additive: no existing feature
+# changes while this is false.
 COMPETITIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("COMPETITIVE_INTEL_ENABLED", "true"))
 # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations vertical gate
-# Default OFF — the entire B2GOPS vertical stays inert until explicitly enabled.
+# Default ON (true) — the vertical is active by default.
+# Set env var to "false" to disable.
 B2G_OPS_ENABLED: bool = str_to_bool(os.getenv("B2G_OPS_ENABLED", "true"))
 
 

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -205,10 +205,10 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "ORGANIZATIONS_ENABLED": "Organizations feature (unreleased)",
     "MESSAGES_ENABLED": "Messaging system",
     "PARTNERS_ENABLED": "Partners feature (unreleased)",
-    "SUBCONTRACT_INTEL_ENABLED": "Subcontracting / supply-chain intelligence vertical (EPIC-SUBINTEL #1224, unreleased)",
-    "PREDICTIVE_INTEL_ENABLED": "Predictive intelligence vertical (EPIC-PREDINT #1260, unreleased)",
-    "COMPETITIVE_INTEL_ENABLED": "Competitive intelligence vertical (EPIC-COMPINT #1261, unreleased)",
-    "B2G_OPS_ENABLED": "B2G Operations workspace_basic vertical (EPIC-B2GOPS #1262, unreleased)",
+    "SUBCONTRACT_INTEL_ENABLED": "Subcontracting / supply-chain intelligence vertical (EPIC-SUBINTEL #1224)",
+    "PREDICTIVE_INTEL_ENABLED": "Predictive intelligence vertical (EPIC-PREDINT #1260)",
+    "COMPETITIVE_INTEL_ENABLED": "Competitive intelligence vertical (EPIC-COMPINT #1261)",
+    "B2G_OPS_ENABLED": "B2G Operations workspace_basic vertical (EPIC-B2GOPS #1262)",
     # Infra
     "METRICS_ENABLED": "Prometheus metrics collection",
     "RATE_LIMITING_ENABLED": "Redis token-bucket rate limiting",
@@ -290,13 +290,13 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     # BIZ-FOUND-002: Founders lifetime offer kill switch
     "FOUNDERS_OFFER_ENABLED": {"owner": "billing", "category": "founding", "lifecycle": "temporary", "created": "2026-05"},
     # SUBINTEL-030 (EPIC-SUBINTEL #1224): subcontracting intelligence vertical
-    "SUBCONTRACT_INTEL_ENABLED": {"owner": "product", "category": "subcontract", "lifecycle": "experimental", "created": "2026-05"},
+    "SUBCONTRACT_INTEL_ENABLED": {"owner": "product", "category": "subcontract", "lifecycle": "permanent", "created": "2026-05"},
     # PREDINT-000 (EPIC-PREDINT #1260): predictive intelligence vertical
-    "PREDICTIVE_INTEL_ENABLED": {"owner": "product", "category": "predictive", "lifecycle": "experimental", "created": "2026-05"},
+    "PREDICTIVE_INTEL_ENABLED": {"owner": "product", "category": "predictive", "lifecycle": "permanent", "created": "2026-05"},
     # COMPINT-000 (EPIC-COMPINT #1261): competitive intelligence vertical
-    "COMPETITIVE_INTEL_ENABLED": {"owner": "product", "category": "competitive", "lifecycle": "experimental", "created": "2026-05"},
+    "COMPETITIVE_INTEL_ENABLED": {"owner": "product", "category": "competitive", "lifecycle": "permanent", "created": "2026-05"},
     # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations workspace_basic gate
-    "B2G_OPS_ENABLED": {"owner": "product", "category": "b2gops", "lifecycle": "experimental", "created": "2026-05"},
+    "B2G_OPS_ENABLED": {"owner": "product", "category": "b2gops", "lifecycle": "permanent", "created": "2026-05"},
 }
 
 

--- a/backend/tests/test_workspace_timeline.py
+++ b/backend/tests/test_workspace_timeline.py
@@ -971,11 +971,11 @@ class TestFeatureFlag:
         """B2G_OPS_ENABLED must be defined in config.features module-level."""
         from config.features import B2G_OPS_ENABLED  # noqa: F401
 
-    def test_b2g_ops_flag_default_false(self):
-        """B2G_OPS_ENABLED must default to False (not active in production yet)."""
+    def test_b2g_ops_flag_default_true(self):
+        """B2G_OPS_ENABLED must default to True (active in production)."""
         from config.features import B2G_OPS_ENABLED as flag
 
-        assert flag is False, "B2G_OPS_ENABLED must default to False"
+        assert flag is True, "B2G_OPS_ENABLED must default to True"
 
     def test_b2g_ops_flag_in_registry(self):
         """B2G_OPS_ENABLED must be in the runtime feature flag registry."""
@@ -986,12 +986,12 @@ class TestFeatureFlag:
         )
 
     def test_b2g_ops_flag_registry_value(self):
-        """Registry entry must have default false."""
+        """Registry entry must have default true."""
         from config.features import _FEATURE_FLAG_REGISTRY
 
         env_var, registry_default = _FEATURE_FLAG_REGISTRY["B2G_OPS_ENABLED"]
-        assert registry_default == "false", (
-            f"Registry default must be 'false', got '{registry_default}'"
+        assert registry_default == "true", (
+            f"Registry default must be 'true', got '{registry_default}'"
         )
 
     def test_b2g_ops_flag_env_override_true(self, monkeypatch):

--- a/backend/tests/test_workspace_watchlists.py
+++ b/backend/tests/test_workspace_watchlists.py
@@ -611,12 +611,12 @@ class TestFeatureFlag:
         # We test the module variable directly
         from config.features import B2G_OPS_ENABLED  # noqa: F401
 
-    def test_b2g_ops_flag_default_false(self):
-        """B2G_OPS_ENABLED must default to False (not active in production yet)."""
+    def test_b2g_ops_flag_default_true(self):
+        """B2G_OPS_ENABLED must default to True (active in production)."""
         from config.features import B2G_OPS_ENABLED as flag
 
-        # When no env is set, default must be False
-        assert flag is False, "B2G_OPS_ENABLED must default to False"
+        # When no env is set, default must be True
+        assert flag is True, "B2G_OPS_ENABLED must default to True"
 
     def test_b2g_ops_flag_in_registry(self):
         """B2G_OPS_ENABLED must be in the runtime feature flag registry."""
@@ -627,12 +627,12 @@ class TestFeatureFlag:
         )
 
     def test_b2g_ops_flag_registry_value(self):
-        """Registry entry must have default false."""
+        """Registry entry must have default true."""
         from config.features import _FEATURE_FLAG_REGISTRY
 
         env_var, registry_default = _FEATURE_FLAG_REGISTRY["B2G_OPS_ENABLED"]
-        assert registry_default == "false", (
-            f"Registry default must be 'false', got '{registry_default}'"
+        assert registry_default == "true", (
+            f"Registry default must be 'true', got '{registry_default}'"
         )
 
     def test_b2g_ops_flag_env_override_true(self, monkeypatch):


### PR DESCRIPTION
## Context
Issue #1373 — Ativar 4 feature flags premium. Código já existe atrás das flags; esta PR apenas altera os defaults de false→true.

## Changes
- `backend/config/features.py`: B2G_OPS_ENABLED, SUBCONTRACT_INTEL_ENABLED, COMPETITIVE_INTEL_ENABLED, PREDICTIVE_INTEL_ENABLED defaults changed from false→true
- `backend/routes/feature_flags.py`: Updated descriptions (removed 'unreleased') and lifecycle metadata (experimental→permanent) for all 4 flags
- `backend/tests/test_workspace_timeline.py`, `backend/tests/test_workspace_watchlists.py`: Updated test assertions to match new default (true)

## Testing Plan
- [x] Backend tests passing
- [ ] Manual validation on staging: verify each flag returns true on GET /feature-flags
- [ ] Stripe products created for each add-on (separate operational task)

## Rollback
Set env var to `false` in Railway dashboard — no deploy needed. Each flag can be toggled independently.

## Closes
Closes #1373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Four intelligence features—Subcontract Intelligence, Predictive Intelligence, Competitive Intelligence, and B2G Operations—are now enabled by default for all users.
- These capabilities have been promoted from experimental to permanent status, ensuring improved stability and long-term support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->