### PR TITLE
feat: urgency signals on pSEO entity pages (#1330)

### DIFF
--- a/backend/routes/_recency_helpers.py
+++ b/backend/routes/_recency_helpers.py
@@ -1,0 +1,167 @@
+"""CONV-016: Shared recency/urgency data helpers for pSEO entity pages.
+
+Provides the ``AtividadeRecenteData`` Pydantic model and helper functions
+to compute recency indicators (counts, trends, seasonality) from the
+DataLake tables (pncp_raw_bids, pncp_supplier_contracts).
+"""
+
+import logging
+from collections import Counter, defaultdict
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared model
+# ---------------------------------------------------------------------------
+
+class AtividadeRecenteData(BaseModel):
+    """Recency/urgency data for entity pages (CONV-016).
+
+    Each pSEO entity response should include this block so the frontend
+    can render time-based urgency signals that create motivation to act.
+    """
+    contagem_30d: int = 0              # count of events in last 30 days
+    contagem_90d: int = 0              # count in last 90 days
+    valor_total_30d: float = 0.0       # total value in last 30 days
+    tendencia_12m: str = "stable"      # "up", "stable", "down"
+    tendencia_percentual: float = 0.0  # percent change
+    ultimo_evento_data: Optional[str] = None  # ISO date of most recent event
+    sazonalidade_mes_pico: Optional[int] = None  # peak month (1-12)
+
+
+# ---------------------------------------------------------------------------
+# Trend calculation
+# ---------------------------------------------------------------------------
+
+def _compute_trend(
+    monthly_counts: dict[str, int],
+) -> tuple[str, float]:
+    """Compute 12-month trend from monthly count data.
+
+    Splits the data into two 6-month halves and compares averages.
+    Returns (direction, percent_change) where direction is
+    "up", "down", or "stable".
+    """
+    if len(monthly_counts) < 3:
+        return "stable", 0.0
+
+    sorted_months = sorted(monthly_counts.keys())
+    mid = len(sorted_months) // 2
+    first_half = [monthly_counts[m] for m in sorted_months[:mid]]
+    second_half = [monthly_counts[m] for m in sorted_months[mid:]]
+
+    avg_first = sum(first_half) / len(first_half) if first_half else 0
+    avg_second = sum(second_half) / len(second_half) if second_half else 0
+
+    if avg_first == 0 and avg_second == 0:
+        return "stable", 0.0
+
+    if avg_first == 0:
+        pct = 100.0 if avg_second > 0 else 0.0
+    else:
+        pct = ((avg_second - avg_first) / avg_first) * 100
+
+    if pct > 15:
+        return "up", round(pct, 1)
+    elif pct < -15:
+        return "down", round(pct, 1)
+    else:
+        return "stable", round(pct, 1)
+
+
+def _compute_seasonality(monthly_counts: dict[str, int]) -> Optional[int]:
+    """Find the peak month (1-12) from monthly count data.
+
+    Returns None if data is insufficient.
+    """
+    month_total: Counter = Counter()
+    for month_key, count in monthly_counts.items():
+        try:
+            month_num = int(month_key.split("-")[1])
+            month_total[month_num] += count
+        except (IndexError, ValueError):
+            continue
+
+    if not month_total:
+        return None
+
+    peak = month_total.most_common(1)[0]
+    return peak[0] if peak[1] > 0 else None
+
+
+# ---------------------------------------------------------------------------
+# Build recency data from a list of records with date + value fields
+# ---------------------------------------------------------------------------
+
+def build_recency_from_records(
+    records: list[dict],
+    date_field: str = "data_assinatura",
+    value_field: str = "valor_global",
+) -> dict:
+    """Compute ``AtividadeRecenteData`` fields from a flat record list.
+
+    Args:
+        records: List of dicts, each containing at least a date string.
+        date_field: Key for the date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS).
+        value_field: Key for the numeric value.
+
+    Returns:
+        A dict matching ``AtividadeRecenteData`` field names.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff_30d = now - timedelta(days=30)
+    cutoff_90d = now - timedelta(days=90)
+
+    contagem_30d = 0
+    contagem_90d = 0
+    valor_total_30d = 0.0
+    ultimo_evento: Optional[str] = None
+    monthly_counts: dict[str, int] = defaultdict(int)
+
+    for rec in records:
+        raw_date = rec.get(date_field) or ""
+        date_str = raw_date[:10]  # YYYY-MM-DD
+        if not date_str:
+            continue
+
+        try:
+            dt = datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            continue
+
+        # Last event date
+        if ultimo_evento is None or date_str > ultimo_evento:
+            ultimo_evento = date_str
+
+        # Window counts
+        if dt >= cutoff_90d:
+            contagem_90d += 1
+        if dt >= cutoff_30d:
+            contagem_30d += 1
+            try:
+                v = float(rec.get(value_field) or 0)
+                valor_total_30d += v
+            except (ValueError, TypeError):
+                pass
+
+        # Monthly bucket for trend
+        month_key = date_str[:7]
+        monthly_counts[month_key] += 1
+
+    tendencia, pct = _compute_trend(dict(monthly_counts))
+    sazonalidade = _compute_seasonality(dict(monthly_counts))
+
+    return {
+        "contagem_30d": contagem_30d,
+        "contagem_90d": contagem_90d,
+        "valor_total_30d": round(valor_total_30d, 2),
+        "tendencia_12m": tendencia,
+        "tendencia_percentual": pct,
+        "ultimo_evento_data": ultimo_evento,
+        "sazonalidade_mes_pico": sazonalidade,
+    }

--- a/backend/routes/contratos_publicos.py
+++ b/backend/routes/contratos_publicos.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from pipeline.budget import _run_with_budget
+from routes._recency_helpers import AtividadeRecenteData, build_recency_from_records
 from sectors import SECTORS
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,8 @@ class ContratosStatsResponse(BaseModel):
     sample_contracts: list[SampleContract]
     last_updated: str
     aviso_legal: str
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +121,8 @@ class OrgaoContratosStatsResponse(BaseModel):
     sample_contracts: list[SampleContract]
     last_updated: str
     aviso_legal: str
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +145,8 @@ class FornecedoresStatsResponse(BaseModel):
     top_orgaos_compradores: list[OrgaoRank]
     last_updated: str
     aviso_legal: str
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +265,15 @@ def _build_orgao_unavailable(cnpj: str) -> dict:
         "sample_contracts": [],
         "last_updated": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "aviso_legal": "Dados temporariamente indisponíveis. Tente novamente em alguns minutos.",
+        "atividade_recente": {
+            "contagem_30d": 0,
+            "contagem_90d": 0,
+            "valor_total_30d": 0.0,
+            "tendencia_12m": "stable",
+            "tendencia_percentual": 0.0,
+            "ultimo_evento_data": None,
+            "sazonalidade_mes_pico": None,
+        },
     }
 
 
@@ -392,6 +408,13 @@ async def orgao_contratos_stats(cnpj: str):
             "data_assinatura": (row.get("data_assinatura") or "")[:10],
         })
 
+    # CONV-016: compute recency/urgency data from contracts
+    atividade_recente = build_recency_from_records(
+        rows,
+        date_field="data_assinatura",
+        value_field="valor_global",
+    )
+
     response_data = {
         "orgao_nome": orgao_nome,
         "orgao_cnpj": cnpj_clean,
@@ -409,6 +432,8 @@ async def orgao_contratos_stats(cnpj: str):
             "Dados de fontes publicas: Portal Nacional de Contratacoes Publicas (PNCP). "
             "Atualizacao diaria."
         ),
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }
 
     _set_cached(_orgao_contratos_cache, cache_key, response_data)
@@ -513,6 +538,13 @@ async def contratos_stats(setor: str, uf: str):
             "data_assinatura": (row.get("data_assinatura") or "")[:10],
         })
 
+    # CONV-016: compute recency/urgency data from matched contracts
+    atividade_recente = build_recency_from_records(
+        matched,
+        date_field="data_assinatura",
+        value_field="valor_global",
+    )
+
     response_data = {
         "sector_id": sector_id_clean,
         "sector_name": sector.name,
@@ -535,6 +567,8 @@ async def contratos_stats(setor: str, uf: str):
             "Dados de fontes publicas: Portal Nacional de Contratacoes Publicas (PNCP). "
             "Atualizacao diaria."
         ),
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }
 
     _set_cached(
@@ -597,6 +631,13 @@ async def fornecedores_stats(setor: str, uf: str):
     top_orgaos = sorted(orgao_agg.values(), key=lambda x: x["valor"], reverse=True)[:10]
 
     now = datetime.now(timezone.utc)
+    # CONV-016: compute recency/urgency data from matched contracts
+    atividade_recente = build_recency_from_records(
+        matched,
+        date_field="data_assinatura",
+        value_field="valor_global",
+    )
+
     response_data = {
         "sector_id": sector_id_clean,
         "sector_name": sector.name,
@@ -615,6 +656,8 @@ async def fornecedores_stats(setor: str, uf: str):
             "Dados de fontes publicas: Portal Nacional de Contratacoes Publicas (PNCP). "
             "Atualizacao diaria."
         ),
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }
 
     _set_cached(
@@ -672,6 +715,8 @@ class FornecedorProfileResponse(BaseModel):
     faq_items: list[FaqItem]
     last_updated: str
     aviso_legal: str
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 # ---------------------------------------------------------------------------
@@ -744,6 +789,15 @@ def _build_fornecedor_unavailable(cnpj: str) -> dict:
         "faq_items": [],
         "last_updated": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "aviso_legal": "Dados temporariamente indisponíveis. Tente novamente em alguns minutos.",
+        "atividade_recente": {
+            "contagem_30d": 0,
+            "contagem_90d": 0,
+            "valor_total_30d": 0.0,
+            "tendencia_12m": "stable",
+            "tendencia_percentual": 0.0,
+            "ultimo_evento_data": None,
+            "sazonalidade_mes_pico": None,
+        },
     }
 
 
@@ -872,6 +926,14 @@ async def _build_fornecedor_profile(cnpj_clean: str) -> dict:
     ]
 
     now = datetime.now(timezone.utc)
+
+    # CONV-016: compute recency/urgency data from contracts
+    atividade_recente = build_recency_from_records(
+        rows,
+        date_field="data_assinatura",
+        value_field="valor_global",
+    )
+
     response_data = {
         "cnpj": cnpj_clean,
         "razao_social": razao_social,
@@ -895,6 +957,8 @@ async def _build_fornecedor_profile(cnpj_clean: str) -> dict:
             "Dados de fontes publicas: Portal Nacional de Contratacoes Publicas (PNCP). "
             "Atualizacao diaria. CNPJ e dados cadastrais via BrasilAPI."
         ),
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }
 
     return response_data

--- a/backend/routes/empresa_publica.py
+++ b/backend/routes/empresa_publica.py
@@ -17,6 +17,7 @@ import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from routes._recency_helpers import AtividadeRecenteData, build_recency_from_records
 from sectors import SECTORS
 from utils.cnae_mapping import map_cnae_to_setor, get_setor_name
 
@@ -144,6 +145,8 @@ class PerfilB2GResponse(BaseModel):
     # STORY-417 AC3: True when one or more data sources were unavailable
     # and the response contains only partial information.
     partial: bool = False
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +211,15 @@ def _build_unavailable_response(cnpj: str) -> dict:
         "aviso_legal": "Dados temporariamente indisponíveis. Tente novamente em alguns minutos.",
         "brasilapi_status": "unavailable",
         "partial": True,
+        "atividade_recente": {
+            "contagem_30d": 0,
+            "contagem_90d": 0,
+            "valor_total_30d": 0.0,
+            "tendencia_12m": "stable",
+            "tendencia_percentual": 0.0,
+            "ultimo_evento_data": None,
+            "sazonalidade_mes_pico": None,
+        },
     }
 
 
@@ -639,6 +651,13 @@ async def _build_perfil(cnpj: str) -> dict:
 
     editais_amostra = [_to_edital_amostra(b) for b in editais_raw[:5]]
 
+    # CONV-016: compute recency/urgency data from contracts
+    atividade_recente = build_recency_from_records(
+        contratos_all,
+        date_field="data_assinatura",
+        value_field="valor_global",
+    )
+
     return {
         "empresa": {
             "razao_social": razao_social,
@@ -665,4 +684,6 @@ async def _build_perfil(cnpj: str) -> dict:
         # STORY-417 AC3: partial=True signals one or more upstream sources
         # were unavailable; frontend should render a degraded card.
         "partial": brasilapi_status != "ok",
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }

--- a/backend/routes/municipios_publicos.py
+++ b/backend/routes/municipios_publicos.py
@@ -20,6 +20,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Response
 
 from routes._sitemap_cache_headers import SITEMAP_CACHE_HEADERS
+from routes._recency_helpers import AtividadeRecenteData, build_recency_from_records
 from pydantic import BaseModel
 
 from metrics import record_sitemap_count
@@ -341,6 +342,8 @@ class MunicipioProfileResponse(BaseModel):
     faq_items: list[FaqItem]
     last_updated: str
     aviso_legal: str
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 class SitemapMunicipiosResponse(BaseModel):
@@ -524,6 +527,18 @@ async def municipio_profile(slug: str):
 
     faq_items = _build_faq(nome, uf, total_licitacoes, populacao)
 
+    # CONV-016: compute recency/urgency data from open bids (rows may be undefined in degraded paths)
+    _rows_for_recency: list[dict] = []
+    try:
+        _rows_for_recency = rows  # type: ignore[name-defined] # noqa
+    except NameError:
+        pass
+    atividade_recente = build_recency_from_records(
+        _rows_for_recency,
+        date_field="data_publicacao",
+        value_field="valor_total_estimado",
+    )
+
     response_data = {
         "slug": slug_clean,
         "nome": nome,
@@ -541,6 +556,8 @@ async def municipio_profile(slug: str):
             "e Instituto Brasileiro de Geografia e Estatistica (IBGE). "
             "Atualizacao diaria. Populacao: estimativa IBGE."
         ),
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }
 
     if bids_query_degraded:

--- a/backend/routes/orgao_publico.py
+++ b/backend/routes/orgao_publico.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from pipeline.budget import _run_with_budget
+from routes._recency_helpers import AtividadeRecenteData, build_recency_from_records
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["orgao-publico"])
@@ -83,6 +84,8 @@ class OrgaoStatsResponse(BaseModel):
     total_contratos_24m: int = 0
     valor_total_contratos_24m: float = 0.0
     aviso_legal: str
+    # CONV-016: temporal urgency signals for pSEO pages
+    atividade_recente: AtividadeRecenteData = AtividadeRecenteData()
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +250,15 @@ def _build_orgao_unavailable(cnpj: str) -> dict:
         "aviso_legal": (
             "Dados temporariamente indisponíveis. Tente novamente em alguns minutos."
         ),
+        "atividade_recente": {
+            "contagem_30d": 0,
+            "contagem_90d": 0,
+            "valor_total_30d": 0.0,
+            "tendencia_12m": "stable",
+            "tendencia_percentual": 0.0,
+            "ultimo_evento_data": None,
+            "sazonalidade_mes_pico": None,
+        },
     }
 
 
@@ -413,6 +425,13 @@ async def _build_orgao_stats(cnpj: str) -> tuple[dict, bool]:
     # Contracts data from pncp_supplier_contracts (graceful: empty if backfill not done)
     contracts_data = await _fetch_contracts_data(cnpj)
 
+    # CONV-016: compute recency/urgency data from open bids
+    atividade_recente = build_recency_from_records(
+        rows,
+        date_field="data_publicacao",
+        value_field="valor_total_estimado",
+    )
+
     return {
         "nome": nome,
         "cnpj": cnpj,
@@ -435,6 +454,8 @@ async def _build_orgao_stats(cnpj: str) -> tuple[dict, bool]:
             "Dados de fontes públicas: Portal Nacional de Contratações Públicas (PNCP). "
             "Atualização diária."
         ),
+        # CONV-016: recency/urgency indicators for frontend badges
+        "atividade_recente": atividade_recente,
     }, False
 
 

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -1159,6 +1159,60 @@
         "title": "AppConfigRow",
         "type": "object"
       },
+      "AtividadeRecenteData": {
+        "description": "Recency/urgency data for entity pages (CONV-016).\n\nEach pSEO entity response should include this block so the frontend\ncan render time-based urgency signals that create motivation to act.",
+        "properties": {
+          "contagem_30d": {
+            "default": 0,
+            "title": "Contagem 30D",
+            "type": "integer"
+          },
+          "contagem_90d": {
+            "default": 0,
+            "title": "Contagem 90D",
+            "type": "integer"
+          },
+          "sazonalidade_mes_pico": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sazonalidade Mes Pico"
+          },
+          "tendencia_12m": {
+            "default": "stable",
+            "title": "Tendencia 12M",
+            "type": "string"
+          },
+          "tendencia_percentual": {
+            "default": 0.0,
+            "title": "Tendencia Percentual",
+            "type": "number"
+          },
+          "ultimo_evento_data": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ultimo Evento Data"
+          },
+          "valor_total_30d": {
+            "default": 0.0,
+            "title": "Valor Total 30D",
+            "type": "number"
+          }
+        },
+        "title": "AtividadeRecenteData",
+        "type": "object"
+      },
       "AuthStatusResponse": {
         "properties": {
           "confirmed": {
@@ -3819,6 +3873,16 @@
       },
       "ContratosStatsResponse": {
         "properties": {
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "avg_value": {
             "title": "Avg Value",
             "type": "number"
@@ -6242,6 +6306,16 @@
             "title": "Anos Atividade",
             "type": "array"
           },
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "aviso_legal": {
             "title": "Aviso Legal",
             "type": "string"
@@ -6394,6 +6468,16 @@
       },
       "FornecedoresStatsResponse": {
         "properties": {
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "aviso_legal": {
             "title": "Aviso Legal",
             "type": "string"
@@ -8945,6 +9029,16 @@
       },
       "MunicipioProfileResponse": {
         "properties": {
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "aviso_legal": {
             "title": "Aviso Legal",
             "type": "string"
@@ -9420,6 +9514,16 @@
       },
       "OrgaoContratosStatsResponse": {
         "properties": {
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "avg_value": {
             "title": "Avg Value",
             "type": "number"
@@ -9515,6 +9619,16 @@
       },
       "OrgaoStatsResponse": {
         "properties": {
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "aviso_legal": {
             "title": "Aviso Legal",
             "type": "string"
@@ -10255,6 +10369,16 @@
       },
       "PerfilB2GResponse": {
         "properties": {
+          "atividade_recente": {
+            "$ref": "#/components/schemas/AtividadeRecenteData",
+            "default": {
+              "contagem_30d": 0,
+              "contagem_90d": 0,
+              "tendencia_12m": "stable",
+              "tendencia_percentual": 0.0,
+              "valor_total_30d": 0.0
+            }
+          },
           "aviso_legal": {
             "title": "Aviso Legal",
             "type": "string"

--- a/backend/tests/test_urgency_signals.py
+++ b/backend/tests/test_urgency_signals.py
@@ -1,0 +1,198 @@
+"""CONV-016: Tests for recency/urgency signals on pSEO entity pages.
+
+Covers:
+  1. AtividadeRecenteData schema validation
+  2. Trend calculation logic (_compute_trend)
+  3. Seasonality detection (_compute_seasonality)
+  4. build_recency_from_records helper
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from routes._recency_helpers import (
+    AtividadeRecenteData,
+    build_recency_from_records,
+)
+
+
+class TestAtividadeRecenteData:
+    """Schema validation for the AtividadeRecenteData model."""
+
+    def test_defaults(self):
+        """Default values should be zero/empty for all fields."""
+        data = AtividadeRecenteData()
+        assert data.contagem_30d == 0
+        assert data.contagem_90d == 0
+        assert data.valor_total_30d == 0.0
+        assert data.tendencia_12m == "stable"
+        assert data.tendencia_percentual == 0.0
+        assert data.ultimo_evento_data is None
+        assert data.sazonalidade_mes_pico is None
+
+    def test_custom_values(self):
+        """Custom values should be accepted."""
+        data = AtividadeRecenteData(
+            contagem_30d=5,
+            contagem_90d=15,
+            valor_total_30d=100000.00,
+            tendencia_12m="up",
+            tendencia_percentual=25.5,
+            ultimo_evento_data="2026-05-28",
+            sazonalidade_mes_pico=3,
+        )
+        assert data.contagem_30d == 5
+        assert data.contagem_90d == 15
+        assert data.valor_total_30d == pytest.approx(100000.00)
+        assert data.tendencia_12m == "up"
+        assert data.tendencia_percentual == pytest.approx(25.5)
+        assert data.ultimo_evento_data == "2026-05-28"
+        assert data.sazonalidade_mes_pico == 3
+
+
+class TestBuildRecencyFromRecords:
+    """Tests for the build_recency_from_records helper."""
+
+    def _make_record(self, date_str: str, value: float = 1000.0) -> dict:
+        return {"data_assinatura": date_str, "valor_global": value}
+
+    def test_empty_records(self):
+        """Empty records should return all-default recency data."""
+        result = build_recency_from_records([])
+        assert result["contagem_30d"] == 0
+        assert result["contagem_90d"] == 0
+        assert result["valor_total_30d"] == 0.0
+        assert result["tendencia_12m"] == "stable"
+        assert result["ultimo_evento_data"] is None
+
+    def test_single_recent_record(self):
+        """A single record from today should return correct counts."""
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        records = [self._make_record(today, 5000.0)]
+        result = build_recency_from_records(records)
+
+        assert result["contagem_30d"] == 1
+        assert result["contagem_90d"] == 1
+        assert result["valor_total_30d"] == pytest.approx(5000.0)
+        assert result["ultimo_evento_data"] == today
+
+    def test_record_older_than_90d(self):
+        """A record older than 90 days should count only in trend."""
+        past = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%d")
+        records = [self._make_record(past, 1000.0)]
+        result = build_recency_from_records(records)
+
+        assert result["contagem_30d"] == 0
+        assert result["contagem_90d"] == 0
+        assert result["valor_total_30d"] == 0.0
+        # ultimo_evento_data should still be set
+        assert result["ultimo_evento_data"] == past
+
+    def test_mixed_records(self):
+        """Mix of recent and old records should separate window counts."""
+        today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        old = (datetime.now(timezone.utc) - timedelta(days=60)).strftime("%Y-%m-%d")
+        very_old = (datetime.now(timezone.utc) - timedelta(days=200)).strftime("%Y-%m-%d")
+
+        records = [
+            self._make_record(today_str, 1000.0),
+            self._make_record(today_str, 2000.0),
+            self._make_record(old, 3000.0),
+            self._make_record(very_old, 4000.0),
+        ]
+        result = build_recency_from_records(records)
+
+        # 2 today + 1 within 90d = 3 in 90d window; 2 in 30d
+        assert result["contagem_30d"] == 2
+        assert result["contagem_90d"] == 3
+        assert result["valor_total_30d"] == pytest.approx(3000.0)
+        assert result["ultimo_evento_data"] == today_str
+
+    def _make_monthly_records(self, counts_by_month_offset: list[tuple[int, int]]) -> list[dict]:
+        """Helper to generate records with specific counts per month offset (0=current)."""
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        records = []
+        for offset_months, count in counts_by_month_offset:
+            m = now.month - offset_months
+            y = now.year
+            while m <= 0:
+                m += 12
+                y -= 1
+            for _ in range(count):
+                records.append(self._make_record(f"{y:04d}-{m:02d}-15", 1000.0))
+        return records
+
+    def test_trend_up(self):
+        """Records concentrated in recent months should show 'up' trend."""
+        records = self._make_monthly_records([
+            (0, 5), (1, 5), (2, 5), (3, 5), (4, 5), (5, 5),  # recent: 5 each
+            (6, 1), (7, 1), (8, 1), (9, 1), (10, 1), (11, 1),  # older: 1 each
+        ])
+        result = build_recency_from_records(records)
+        assert result["tendencia_12m"] == "up"
+        assert result["tendencia_percentual"] > 15
+
+    def test_trend_down(self):
+        """Records concentrated in older months should show 'down' trend."""
+        records = self._make_monthly_records([
+            (0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1),  # recent: 1 each
+            (6, 5), (7, 5), (8, 5), (9, 5), (10, 5), (11, 5),  # older: 5 each
+        ])
+        result = build_recency_from_records(records)
+        assert result["tendencia_12m"] == "down"
+        assert result["tendencia_percentual"] < -15
+
+    def test_trend_stable(self):
+        """Similar counts across months should show 'stable' trend."""
+        records = self._make_monthly_records([
+            (i, 2) for i in range(12)  # 2 per month for 12 months
+        ])
+        result = build_recency_from_records(records)
+        assert result["tendencia_12m"] == "stable"
+
+    def test_seasonality_detected(self):
+        """Peak month should be correctly identified."""
+        from datetime import datetime, timezone
+        year = datetime.now(timezone.utc).year
+        records = []
+        # Peak in month 3 (March): lots of records
+        for _ in range(20):
+            records.append(self._make_record(f"{year}-03-15", 1000.0))
+        # Other months: few records
+        for m in [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12]:
+            records.append(self._make_record(f"{year}-{m:02d}-15", 1000.0))
+
+        result = build_recency_from_records(records)
+        assert result["sazonalidade_mes_pico"] == 3
+
+    def test_custom_date_and_value_fields(self):
+        """Custom field names should work for date and value."""
+        from datetime import datetime, timezone, timedelta
+        today = datetime.now(timezone.utc)
+        recent1 = (today - timedelta(days=5)).strftime("%Y-%m-%d")
+        recent2 = (today - timedelta(days=10)).strftime("%Y-%m-%d")
+        records = [
+            {"minha_data": recent1, "meu_valor": 999.99},
+            {"minha_data": recent2, "meu_valor": 500.50},
+        ]
+        result = build_recency_from_records(
+            records,
+            date_field="minha_data",
+            value_field="meu_valor",
+        )
+        assert result["contagem_30d"] == 2  # both within 30 days of now
+        assert result["valor_total_30d"] > 0
+
+    def test_insufficient_data_for_trend(self):
+        """Fewer than 3 months of data should default to stable."""
+        from datetime import datetime, timezone, timedelta
+        now = datetime.now(timezone.utc)
+        m1 = (now - timedelta(days=5)).strftime("%Y-%m-%d")
+        m2 = (now - timedelta(days=35)).strftime("%Y-%m-%d")
+        records = [
+            self._make_record(m1, 1000.0),
+            self._make_record(m2, 1000.0),
+        ]
+        result = build_recency_from_records(records)
+        assert result["tendencia_12m"] == "stable"
+        assert result["tendencia_percentual"] == 0.0

--- a/frontend/__tests__/components/pseo/UrgencyBadge.test.tsx
+++ b/frontend/__tests__/components/pseo/UrgencyBadge.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * UrgencyBadge Component Tests (CONV-016)
+ *
+ * Tests:
+ *  - Color coding for different time ranges
+ *  - Text matches expected patterns
+ *  - Edge cases (null date, future date)
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { UrgencyBadge, daysSince, urgencyLabel } from '@/components/pseo/UrgencyBadge';
+
+describe('UrgencyBadge', () => {
+  describe('daysSince helper', () => {
+    it('should return -1 for null input', () => {
+      expect(daysSince(null)).toBe(-1);
+    });
+
+    it('should return -1 for undefined input', () => {
+      expect(daysSince(undefined)).toBe(-1);
+    });
+
+    it('should return -1 for empty string', () => {
+      expect(daysSince('')).toBe(-1);
+    });
+
+    it('should return 0 for today', () => {
+      const today = new Date().toISOString().split('T')[0];
+      expect(daysSince(today)).toBe(0);
+    });
+
+    it('should return a positive number for a past date', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 10);
+      const dateStr = pastDate.toISOString().split('T')[0];
+      const result = daysSince(dateStr);
+      expect(result).toBeGreaterThanOrEqual(9);
+      expect(result).toBeLessThanOrEqual(11);
+    });
+  });
+
+  describe('urgencyLabel helper', () => {
+    it('should return "Ativo esta semana" for dates within 7 days', () => {
+      const label = urgencyLabel(new Date().toISOString().split('T')[0]);
+      expect(label).toBe('Ativo esta semana');
+    });
+
+    it('should return "Sem atividade recente" for null', () => {
+      expect(urgencyLabel(null)).toBe('Sem atividade recente');
+    });
+
+    it('should return "Ativo este mês" for a date 20 days ago', () => {
+      const past = new Date();
+      past.setDate(past.getDate() - 20);
+      expect(urgencyLabel(past.toISOString().split('T')[0])).toBe('Ativo este mês');
+    });
+
+    it('should return "Ativo recentemente" for a date 60 days ago', () => {
+      const past = new Date();
+      past.setDate(past.getDate() - 60);
+      expect(urgencyLabel(past.toISOString().split('T')[0])).toBe('Ativo recentemente');
+    });
+
+    it('should return "Sem atividade recente" for a date 180 days ago', () => {
+      const past = new Date();
+      past.setDate(past.getDate() - 180);
+      expect(urgencyLabel(past.toISOString().split('T')[0])).toBe('Sem atividade recente');
+    });
+  });
+
+  describe('rendering', () => {
+    it('should render with "Ativo esta semana" for daysSinceLastEvent <= 7', () => {
+      render(<UrgencyBadge daysSinceLastEvent={3} />);
+      expect(screen.getByText('Ativo esta semana')).toBeInTheDocument();
+    });
+
+    it('should render with "Ativo este mês" for daysSinceLastEvent between 7 and 30', () => {
+      render(<UrgencyBadge daysSinceLastEvent={15} />);
+      expect(screen.getByText('Ativo este mês')).toBeInTheDocument();
+    });
+
+    it('should render with "Ativo recentemente" for daysSinceLastEvent between 30 and 90', () => {
+      render(<UrgencyBadge daysSinceLastEvent={60} />);
+      expect(screen.getByText('Ativo recentemente')).toBeInTheDocument();
+    });
+
+    it('should render with "Sem atividade recente" for daysSinceLastEvent > 90', () => {
+      render(<UrgencyBadge daysSinceLastEvent={120} />);
+      expect(screen.getByText('Sem atividade recente')).toBeInTheDocument();
+    });
+
+    it('should render with "Sem atividade recente" for negative daysSinceLastEvent', () => {
+      render(<UrgencyBadge daysSinceLastEvent={-1} />);
+      expect(screen.getByText('Sem atividade recente')).toBeInTheDocument();
+    });
+
+    it('should use custom label when provided', () => {
+      render(<UrgencyBadge daysSinceLastEvent={3} label="5 contratos este mês" />);
+      expect(screen.getByText('5 contratos este mês')).toBeInTheDocument();
+    });
+
+    it('should apply custom className', () => {
+      const { container } = render(
+        <UrgencyBadge daysSinceLastEvent={3} className="my-custom-class" />
+      );
+      const badge = container.firstChild as HTMLElement;
+      expect(badge.className).toContain('my-custom-class');
+    });
+
+    it('should render a colored dot indicator', () => {
+      const { container } = render(<UrgencyBadge daysSinceLastEvent={3} />);
+      const dot = container.querySelector('span.inline-block');
+      expect(dot).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -6136,6 +6136,44 @@ export interface components {
             /** Value */
             value: unknown;
         };
+        /**
+         * AtividadeRecenteData
+         * @description Recency/urgency data for entity pages (CONV-016).
+         *
+         *     Each pSEO entity response should include this block so the frontend
+         *     can render time-based urgency signals that create motivation to act.
+         */
+        AtividadeRecenteData: {
+            /**
+             * Contagem 30D
+             * @default 0
+             */
+            contagem_30d: number;
+            /**
+             * Contagem 90D
+             * @default 0
+             */
+            contagem_90d: number;
+            /** Sazonalidade Mes Pico */
+            sazonalidade_mes_pico?: number | null;
+            /**
+             * Tendencia 12M
+             * @default stable
+             */
+            tendencia_12m: string;
+            /**
+             * Tendencia Percentual
+             * @default 0
+             */
+            tendencia_percentual: number;
+            /** Ultimo Evento Data */
+            ultimo_evento_data?: string | null;
+            /**
+             * Valor Total 30D
+             * @default 0
+             */
+            valor_total_30d: number;
+        };
         /** AuthStatusResponse */
         AuthStatusResponse: {
             /** Confirmed */
@@ -7348,6 +7386,16 @@ export interface components {
         };
         /** ContratosStatsResponse */
         ContratosStatsResponse: {
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Avg Value */
             avg_value: number;
             /** Aviso Legal */
@@ -8486,6 +8534,16 @@ export interface components {
         FornecedorProfileResponse: {
             /** Anos Atividade */
             anos_atividade: number[];
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Aviso Legal */
             aviso_legal: string;
             /** Cnae Descricao */
@@ -8541,6 +8599,16 @@ export interface components {
         };
         /** FornecedoresStatsResponse */
         FornecedoresStatsResponse: {
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Aviso Legal */
             aviso_legal: string;
             /** Last Updated */
@@ -9710,6 +9778,16 @@ export interface components {
         };
         /** MunicipioProfileResponse */
         MunicipioProfileResponse: {
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Aviso Legal */
             aviso_legal: string;
             /** Faq Items */
@@ -9863,6 +9941,16 @@ export interface components {
         };
         /** OrgaoContratosStatsResponse */
         OrgaoContratosStatsResponse: {
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Avg Value */
             avg_value: number;
             /** Aviso Legal */
@@ -9897,6 +9985,16 @@ export interface components {
         };
         /** OrgaoStatsResponse */
         OrgaoStatsResponse: {
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Aviso Legal */
             aviso_legal: string;
             /** Cnpj */
@@ -10133,6 +10231,16 @@ export interface components {
         };
         /** PerfilB2GResponse */
         PerfilB2GResponse: {
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Aviso Legal */
             aviso_legal: string;
             /**

--- a/frontend/app/contratos/[setor]/[uf]/page.tsx
+++ b/frontend/app/contratos/[setor]/[uf]/page.tsx
@@ -27,6 +27,7 @@ import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 import { OpportunitySignalsPanel } from '@/app/components/OpportunitySignalsPanel';
 import { resolveJourney } from '@/lib/seo/relatedResolver';
 import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
+import { ContratosUrgency } from '@/components/pseo/ContratosUrgency';
 
 export const revalidate = 14400; // 4h ISR (reduzido de 24h para melhorar freshness dos dados)
 
@@ -35,6 +36,16 @@ export function generateStaticParams() {
 }
 
 type Props = { params: Promise<{ setor: string; uf: string }> };
+
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
 
 interface ContratosStats {
   sector_id: string;
@@ -49,6 +60,7 @@ interface ContratosStats {
   sample_contracts: { objeto: string; orgao: string; fornecedor: string; valor: number | null; data_assinatura: string }[];
   last_updated: string;
   aviso_legal: string;
+  atividade_recente: AtividadeRecente;
 }
 
 async function fetchContratosStats(setor: string, uf: string): Promise<ContratosStats | null> {
@@ -351,6 +363,13 @@ export default async function ContratosSetorUfPage({ params }: Props) {
                       <p className="text-2xl font-bold text-gray-900">{formatBRL(data.avg_value)}</p>
                     </div>
                   </div>
+
+                  {/* CONV-016: urgency signal — recent contract activity */}
+                  <ContratosUrgency
+                    atividade_recente={data.atividade_recente}
+                    sectorName={data.sector_name}
+                    ufLabel={ufName}
+                  />
 
                   {/* CONV-002 (#1311): OpportunitySignalsPanel — sinais do mercado de contratos */}
                   {contratosSignals.length > 0 && (

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -17,6 +17,7 @@ import AhaMomentPanel from '@/app/components/AhaMomentPanel';
 import type { InsightCard } from '@/app/components/AhaMomentPanel';
 import { resolveJourney } from '@/lib/seo/relatedResolver';
 import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
+import { FornecedorUrgency } from '@/components/pseo/FornecedorUrgency';
 
 // Sprint 3 Parte 13: paginas de perfil de fornecedor por CNPJ
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -48,6 +49,16 @@ interface FaqItem {
   answer: string;
 }
 
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
+
 interface FornecedorProfile {
   cnpj: string;
   razao_social: string;
@@ -65,6 +76,7 @@ interface FornecedorProfile {
   faq_items: FaqItem[];
   last_updated: string;
   aviso_legal: string;
+  atividade_recente: AtividadeRecente;
 }
 
 async function fetchProfile(cnpj: string): Promise<FornecedorProfile | null> {
@@ -436,6 +448,12 @@ export default async function FornecedorCnpjPage({ params }: Props) {
               </div>
             </div>
           </div>
+
+          {/* CONV-016: urgency signal — recent contract activity */}
+          <FornecedorUrgency
+            atividade_recente={profile.atividade_recente}
+            razao_social={profile.razao_social}
+          />
 
           {/* CONV-002 (#1311): OpportunitySignalsPanel — sinais de oportunidade acima da dobra */}
           {fornecedorSignals.length > 0 && (

--- a/frontend/app/municipios/[slug]/page.tsx
+++ b/frontend/app/municipios/[slug]/page.tsx
@@ -13,6 +13,7 @@ import AlertEntityCta from '@/components/seo/AlertEntityCta';
 import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 import { resolveJourney } from '@/lib/seo/relatedResolver';
 import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
+import { MunicipioUrgency } from '@/components/pseo/MunicipioUrgency';
 
 // Sprint 4 Parte 13: páginas de municípios com licitações abertas
 // ISR 24h — dados do PNCP atualizados diariamente
@@ -35,6 +36,16 @@ interface FaqItem {
   answer: string;
 }
 
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
+
 interface MunicipioProfile {
   slug: string;
   nome: string;
@@ -48,6 +59,7 @@ interface MunicipioProfile {
   faq_items: FaqItem[];
   last_updated: string;
   aviso_legal: string;
+  atividade_recente: AtividadeRecente;
 }
 
 async function fetchProfile(slug: string): Promise<MunicipioProfile | null> {
@@ -324,6 +336,13 @@ export default async function MunicipioSlugPage({ params }: Props) {
               )}
             </div>
           </div>
+
+          {/* CONV-016: urgency signal — recent bid activity */}
+          <MunicipioUrgency
+            atividade_recente={profile.atividade_recente}
+            nome={profile.nome}
+            uf={profile.uf}
+          />
 
           {/* Licitações Recentes */}
           {profile.licitacoes_recentes.length > 0 && (

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -19,6 +19,7 @@ import {
   buildOperationalTitle,
   buildOperationalDescription,
 } from '@/lib/seo';
+import { OrgaoUrgency } from '@/components/pseo/OrgaoUrgency';
 
 const BACKEND_URL = getBackendUrl();
 
@@ -33,6 +34,16 @@ interface LicitacaoRecente {
 interface ModalidadeCount {
   nome: string;
   count: number;
+}
+
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
 }
 
 interface OrgaoStats {
@@ -53,6 +64,7 @@ interface OrgaoStats {
   total_contratos_24m?: number;
   valor_total_contratos_24m?: number;
   aviso_legal: string;
+  atividade_recente: AtividadeRecente;
 }
 
 export const revalidate = 3600; // 24h ISR
@@ -299,6 +311,12 @@ export default async function OrgaoPerfilPage({
       />
 
       <OrgaoPerfilClient stats={stats} />
+
+      {/* CONV-016: urgency signal — recent bid activity */}
+      <OrgaoUrgency
+        atividade_recente={stats.atividade_recente}
+        nome={stats.nome}
+      />
 
       {/* CONV-002 (#1311): OpportunitySignalsPanel — categorias + ticket médio + sazonalidade */}
       {orgaoSignals.length > 0 && (

--- a/frontend/components/pseo/ContratosUrgency.tsx
+++ b/frontend/components/pseo/ContratosUrgency.tsx
@@ -1,0 +1,81 @@
+/// CONV-016: Contratos urgency signal block.
+/// Displays contract/sector recency data with UrgencyBadge and contextual messages.
+
+import React from 'react';
+import { UrgencyBadge, daysSince } from './UrgencyBadge';
+
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
+
+interface ContratosUrgencyProps {
+  atividade_recente: AtividadeRecente;
+  sectorName: string;
+  ufLabel: string;
+}
+
+export function ContratosUrgency({ atividade_recente, sectorName, ufLabel }: ContratosUrgencyProps) {
+  const { contagem_30d, contagem_90d, valor_total_30d, tendencia_12m, tendencia_percentual, ultimo_evento_data } = atividade_recente;
+  const daysSinceLast = daysSince(ultimo_evento_data);
+
+  if (contagem_90d === 0) {
+    return null;
+  }
+
+  const valorFmt = valor_total_30d >= 1_000_000
+    ? `R$ ${(valor_total_30d / 1_000_000).toFixed(1)} mi`
+    : valor_total_30d >= 1_000
+    ? `R$ ${(valor_total_30d / 1_000).toFixed(0)} mil`
+    : `R$ ${valor_total_30d.toFixed(2)}`;
+
+  const tendenciaIcon = tendencia_12m === 'up' ? '↑' : tendencia_12m === 'down' ? '↓' : '→';
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 mb-6">
+      <div className="flex items-center gap-2 mb-3">
+        <UrgencyBadge daysSinceLastEvent={daysSinceLast} label={contagem_30d > 0 ? `${contagem_30d} contratos este mês` : undefined} />
+        <span className="text-sm font-medium text-gray-700">{sectorName} — {ufLabel}</span>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+        <div>
+          <p className="text-xs text-gray-500">Contratos (30 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_30d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Contratos (90 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_90d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Valor contratado (30d)</p>
+          <p className="font-semibold text-green-700">{valorFmt}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Tendência</p>
+          <p className={`font-semibold ${
+            tendencia_12m === 'up' ? 'text-green-600' :
+            tendencia_12m === 'down' ? 'text-red-600' :
+            'text-gray-600'
+          }`}>
+            {tendenciaIcon} {tendencia_12m === 'up' ? `+${tendencia_percentual}%` :
+             tendencia_12m === 'down' ? `${tendencia_percentual}%` :
+             'estável'}
+          </p>
+        </div>
+      </div>
+
+      {ultimo_evento_data && (
+        <p className="text-xs text-gray-400 mt-2">
+          Último contrato: {new Date(ultimo_evento_data).toLocaleDateString('pt-BR')}
+          {daysSinceLast >= 0 && ` (há ${daysSinceLast} ${daysSinceLast === 1 ? 'dia' : 'dias'})`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/pseo/ContratosUrgency.tsx
+++ b/frontend/components/pseo/ContratosUrgency.tsx
@@ -15,12 +15,14 @@ interface AtividadeRecente {
 }
 
 interface ContratosUrgencyProps {
-  atividade_recente: AtividadeRecente;
+  atividade_recente?: AtividadeRecente | null;
   sectorName: string;
   ufLabel: string;
 }
 
 export function ContratosUrgency({ atividade_recente, sectorName, ufLabel }: ContratosUrgencyProps) {
+  if (!atividade_recente) return null;
+
   const { contagem_30d, contagem_90d, valor_total_30d, tendencia_12m, tendencia_percentual, ultimo_evento_data } = atividade_recente;
   const daysSinceLast = daysSince(ultimo_evento_data);
 

--- a/frontend/components/pseo/FornecedorUrgency.tsx
+++ b/frontend/components/pseo/FornecedorUrgency.tsx
@@ -1,0 +1,83 @@
+/// CONV-016: Fornecedor urgency signal block.
+/// Displays contract recency data with UrgencyBadge and contextual messages.
+
+import React from 'react';
+import { UrgencyBadge, daysSince } from './UrgencyBadge';
+
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
+
+interface FornecedorUrgencyProps {
+  atividade_recente: AtividadeRecente;
+  razao_social: string;
+}
+
+export function FornecedorUrgency({ atividade_recente, razao_social }: FornecedorUrgencyProps) {
+  const { contagem_30d, contagem_90d, valor_total_30d, tendencia_12m, tendencia_percentual, ultimo_evento_data } = atividade_recente;
+  const daysSinceLast = daysSince(ultimo_evento_data);
+
+  if (contagem_90d === 0) {
+    return null; // No data to show
+  }
+
+  const valorFmt = valor_total_30d >= 1_000_000
+    ? `R$ ${(valor_total_30d / 1_000_000).toFixed(1)} mi`
+    : valor_total_30d >= 1_000
+    ? `R$ ${(valor_total_30d / 1_000).toFixed(0)} mil`
+    : `R$ ${valor_total_30d.toFixed(2)}`;
+
+  const tendenciaLabel =
+    tendencia_12m === 'up' ? `+${tendencia_percentual}%` :
+    tendencia_12m === 'down' ? `${tendencia_percentual}%` :
+    'estável';
+
+  const tendenciaIcon = tendencia_12m === 'up' ? '↑' : tendencia_12m === 'down' ? '↓' : '→';
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 mb-6">
+      <div className="flex items-center gap-2 mb-3">
+        <UrgencyBadge daysSinceLastEvent={daysSinceLast} />
+        <span className="text-sm font-medium text-gray-700">{razao_social}</span>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+        <div>
+          <p className="text-xs text-gray-500">Contratos (30 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_30d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Contratos (90 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_90d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Valor (30 dias)</p>
+          <p className="font-semibold text-green-700">{valorFmt}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Tendência 12m</p>
+          <p className={`font-semibold ${
+            tendencia_12m === 'up' ? 'text-green-600' :
+            tendencia_12m === 'down' ? 'text-red-600' :
+            'text-gray-600'
+          }`}>
+            {tendenciaIcon} {tendenciaLabel}
+          </p>
+        </div>
+      </div>
+
+      {ultimo_evento_data && (
+        <p className="text-xs text-gray-400 mt-2">
+          Último contrato: {new Date(ultimo_evento_data).toLocaleDateString('pt-BR')}
+          {daysSinceLast >= 0 && ` (há ${daysSinceLast} ${daysSinceLast === 1 ? 'dia' : 'dias'})`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/pseo/FornecedorUrgency.tsx
+++ b/frontend/components/pseo/FornecedorUrgency.tsx
@@ -15,11 +15,13 @@ interface AtividadeRecente {
 }
 
 interface FornecedorUrgencyProps {
-  atividade_recente: AtividadeRecente;
+  atividade_recente?: AtividadeRecente | null;
   razao_social: string;
 }
 
 export function FornecedorUrgency({ atividade_recente, razao_social }: FornecedorUrgencyProps) {
+  if (!atividade_recente) return null;
+
   const { contagem_30d, contagem_90d, valor_total_30d, tendencia_12m, tendencia_percentual, ultimo_evento_data } = atividade_recente;
   const daysSinceLast = daysSince(ultimo_evento_data);
 

--- a/frontend/components/pseo/MunicipioUrgency.tsx
+++ b/frontend/components/pseo/MunicipioUrgency.tsx
@@ -1,0 +1,67 @@
+/// CONV-016: Municipio urgency signal block.
+/// Displays bid recency data with UrgencyBadge and contextual messages for municipality pages.
+
+import React from 'react';
+import { UrgencyBadge, daysSince } from './UrgencyBadge';
+
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
+
+interface MunicipioUrgencyProps {
+  atividade_recente: AtividadeRecente;
+  nome: string;
+  uf: string;
+}
+
+export function MunicipioUrgency({ atividade_recente, nome, uf }: MunicipioUrgencyProps) {
+  const { contagem_30d, contagem_90d, valor_total_30d, ultimo_evento_data } = atividade_recente;
+  const daysSinceLast = daysSince(ultimo_evento_data);
+
+  if (contagem_90d === 0) {
+    return null;
+  }
+
+  const valorFmt = valor_total_30d >= 1_000_000
+    ? `R$ ${(valor_total_30d / 1_000_000).toFixed(1)} mi`
+    : valor_total_30d >= 1_000
+    ? `R$ ${(valor_total_30d / 1_000).toFixed(0)} mil`
+    : `R$ ${valor_total_30d.toFixed(2)}`;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 mb-6">
+      <div className="flex items-center gap-2 mb-3">
+        <UrgencyBadge daysSinceLastEvent={daysSinceLast} label={contagem_30d > 0 ? `${contagem_30d} licitações este mês` : undefined} />
+        <span className="text-sm font-medium text-gray-700">{nome} — {uf}</span>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+        <div>
+          <p className="text-xs text-gray-500">Licitações (30 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_30d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Licitações (90 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_90d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Valor estimado (30d)</p>
+          <p className="font-semibold text-green-700">{valorFmt}</p>
+        </div>
+      </div>
+
+      {ultimo_evento_data && (
+        <p className="text-xs text-gray-400 mt-2">
+          Última licitação: {new Date(ultimo_evento_data).toLocaleDateString('pt-BR')}
+          {daysSinceLast >= 0 && ` (há ${daysSinceLast} ${daysSinceLast === 1 ? 'dia' : 'dias'})`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/pseo/MunicipioUrgency.tsx
+++ b/frontend/components/pseo/MunicipioUrgency.tsx
@@ -15,12 +15,14 @@ interface AtividadeRecente {
 }
 
 interface MunicipioUrgencyProps {
-  atividade_recente: AtividadeRecente;
+  atividade_recente?: AtividadeRecente | null;
   nome: string;
   uf: string;
 }
 
 export function MunicipioUrgency({ atividade_recente, nome, uf }: MunicipioUrgencyProps) {
+  if (!atividade_recente) return null;
+
   const { contagem_30d, contagem_90d, valor_total_30d, ultimo_evento_data } = atividade_recente;
   const daysSinceLast = daysSince(ultimo_evento_data);
 

--- a/frontend/components/pseo/OrgaoUrgency.tsx
+++ b/frontend/components/pseo/OrgaoUrgency.tsx
@@ -1,0 +1,68 @@
+/// CONV-016: Orgão urgency signal block.
+/// Displays bid recency data with UrgencyBadge and contextual messages.
+
+import React from 'react';
+import { UrgencyBadge, daysSince } from './UrgencyBadge';
+
+interface AtividadeRecente {
+  contagem_30d: number;
+  contagem_90d: number;
+  valor_total_30d: number;
+  tendencia_12m: string;
+  tendencia_percentual: number;
+  ultimo_evento_data: string | null;
+  sazonalidade_mes_pico: number | null;
+}
+
+interface OrgaoUrgencyProps {
+  atividade_recente: AtividadeRecente;
+  nome: string;
+}
+
+const MESES: Record<number, string> = {
+  1: 'Janeiro', 2: 'Fevereiro', 3: 'Março', 4: 'Abril',
+  5: 'Maio', 6: 'Junho', 7: 'Julho', 8: 'Agosto',
+  9: 'Setembro', 10: 'Outubro', 11: 'Novembro', 12: 'Dezembro',
+};
+
+export function OrgaoUrgency({ atividade_recente, nome }: OrgaoUrgencyProps) {
+  const { contagem_30d, contagem_90d, ultimo_evento_data, sazonalidade_mes_pico } = atividade_recente;
+  const daysSinceLast = daysSince(ultimo_evento_data);
+
+  if (contagem_90d === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 mb-6">
+      <div className="flex items-center gap-2 mb-3">
+        <UrgencyBadge daysSinceLastEvent={daysSinceLast} />
+        <span className="text-sm font-medium text-gray-700">{nome}</span>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+        <div>
+          <p className="text-xs text-gray-500">Licitações (30 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_30d}</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500">Licitações (90 dias)</p>
+          <p className="font-semibold text-gray-900">{contagem_90d}</p>
+        </div>
+        {sazonalidade_mes_pico && (
+          <div>
+            <p className="text-xs text-gray-500">Mês de pico</p>
+            <p className="font-semibold text-gray-900">{MESES[sazonalidade_mes_pico] || sazonalidade_mes_pico}</p>
+          </div>
+        )}
+      </div>
+
+      {ultimo_evento_data && (
+        <p className="text-xs text-gray-400 mt-2">
+          Última licitação: {new Date(ultimo_evento_data).toLocaleDateString('pt-BR')}
+          {daysSinceLast >= 0 && ` (há ${daysSinceLast} ${daysSinceLast === 1 ? 'dia' : 'dias'})`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/pseo/OrgaoUrgency.tsx
+++ b/frontend/components/pseo/OrgaoUrgency.tsx
@@ -15,7 +15,7 @@ interface AtividadeRecente {
 }
 
 interface OrgaoUrgencyProps {
-  atividade_recente: AtividadeRecente;
+  atividade_recente?: AtividadeRecente | null;
   nome: string;
 }
 
@@ -26,6 +26,8 @@ const MESES: Record<number, string> = {
 };
 
 export function OrgaoUrgency({ atividade_recente, nome }: OrgaoUrgencyProps) {
+  if (!atividade_recente) return null;
+
   const { contagem_30d, contagem_90d, ultimo_evento_data, sazonalidade_mes_pico } = atividade_recente;
   const daysSinceLast = daysSince(ultimo_evento_data);
 

--- a/frontend/components/pseo/UrgencyBadge.tsx
+++ b/frontend/components/pseo/UrgencyBadge.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React from 'react';
+
+// ---------------------------------------------------------------------------
+// CONV-016: Visual badge with time-based color coding for pSEO urgency signals
+// ---------------------------------------------------------------------------
+
+type UrgencyLevel = 'green' | 'yellow' | 'neutral' | 'gray';
+
+interface UrgencyBadgeProps {
+  /** Days since the last event */
+  daysSinceLastEvent: number;
+  /** Optional custom text override */
+  label?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const COLOR_MAP: Record<UrgencyLevel, string> = {
+  green: 'bg-green-100 text-green-800 border-green-200',
+  yellow: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  neutral: 'bg-blue-50 text-blue-700 border-blue-100',
+  gray: 'bg-gray-100 text-gray-500 border-gray-200',
+};
+
+const LEVEL_LABELS: Record<UrgencyLevel, { text: string; title: string }> = {
+  green: { text: 'Ativo esta semana', title: 'Atividade registrada nos últimos 7 dias' },
+  yellow: { text: 'Ativo este mês', title: 'Atividade registrada nos últimos 30 dias' },
+  neutral: { text: 'Ativo recentemente', title: 'Atividade registrada nos últimos 90 dias' },
+  gray: { text: 'Sem atividade recente', title: 'Nenhuma atividade registrada nos últimos 90 dias' },
+};
+
+function getUrgencyLevel(days: number): UrgencyLevel {
+  if (days < 0) return 'gray';
+  if (days <= 7) return 'green';
+  if (days <= 30) return 'yellow';
+  if (days <= 90) return 'neutral';
+  return 'gray';
+}
+
+function getDaysSince(dateStr: string | null | undefined): number {
+  if (!dateStr) return -1;
+  try {
+    const eventDate = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - eventDate.getTime();
+    return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  } catch {
+    return -1;
+  }
+}
+
+/**
+ * UrgencyBadge — small badge showing recency of activity for an entity.
+ * Color-coded: green (< 7d), yellow (7-30d), neutral (31-90d), gray (> 90d).
+ */
+export function UrgencyBadge({
+  daysSinceLastEvent,
+  label,
+  className = '',
+}: UrgencyBadgeProps) {
+  const level = getUrgencyLevel(daysSinceLastEvent);
+  const defaults = LEVEL_LABELS[level];
+  const displayText = label ?? defaults.text;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium ${COLOR_MAP[level]} ${className}`}
+      title={defaults.title}
+    >
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${
+          level === 'green'
+            ? 'bg-green-500'
+            : level === 'yellow'
+            ? 'bg-yellow-500'
+            : level === 'neutral'
+            ? 'bg-blue-500'
+            : 'bg-gray-400'
+        }`}
+      />
+      {displayText}
+    </span>
+  );
+}
+
+/**
+ * Convenience function to compute days-since from a date string
+ * and return the badge. Used inline in server components.
+ */
+export function daysSince(dateStr: string | null | undefined): number {
+  return getDaysSince(dateStr);
+}
+
+/**
+ * Helper to get the appropriate label text for a date string.
+ */
+export function urgencyLabel(dateStr: string | null | undefined): string {
+  const days = getDaysSince(dateStr);
+  const level = getUrgencyLevel(days);
+  return LEVEL_LABELS[level].text;
+}


### PR DESCRIPTION
## Summary
Implements CONV-016: Temporal urgency signals on programmatic SEO pages to create motivation to act now.

## Changes
### Backend
- `AtividadeRecenteData` schema on entity response models
- Recency queries from DataLake (30d/90d counts, trends, seasonality)
- Applied to fornecedor, órgão, contratos, and município endpoints

### Frontend
- `UrgencyBadge` component (green/yellow/neutral time-based coloring)
- Entity-specific urgency signal blocks
- Integrated into 4 pSEO page templates

## Testing Plan
- Recency field inclusion in API responses
- Trend calculation correctness
- UrgencyBadge color coding
- Renders correctly on all entity page types

## Closes

Closes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)