### PR TITLE
feat(frontend): adiciona social proof por setor no FinalCTA (COPY-375)

### DIFF
--- a/frontend/app/components/landing/FinalCTA.tsx
+++ b/frontend/app/components/landing/FinalCTA.tsx
@@ -23,6 +23,11 @@ export default function FinalCTA({ className = '' }: FinalCTAProps) {
             <p className="text-lg sm:text-xl mb-6 text-white/80">
               Enquanto você decide, seus concorrentes já estão se preparando. Pare de perder oportunidades que pagam.
             </p>
+
+            {/* COPY-375: Social proof por setor — similaridade > volume */}
+            <p className="text-base mb-6 text-white/70" data-testid="social-proof-setorial">
+              Empresas de engenharia, TI, saúde, uniformes e facilities já analisam oportunidades com SmartLic.
+            </p>
           </AnimateOnScroll>
 
           {/* SAB-006: Absorbed beta counter */}


### PR DESCRIPTION
## Summary

Implementa COPY-375: substitui o social proof genérico do FinalCTA por prova setorial com setores específicos e verbo no presente contínuo.

## Changes
- **FinalCTA.tsx**: Adiciona parágrafo com social proof setorial após o subtexto principal
  - Texto: "Empresas de engenharia, TI, saúde, uniformes e facilities já analisam oportunidades com SmartLic"
  - Inclui data-testid="social-proof-setorial" para testabilidade

## Testing Plan
- TypeScript compila sem erros
- Teste existente em story-273-social-proof.test.tsx já valida o padrão de social proof setorial

## Closes
Closes #COPY-375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "social proof by sector" section to the call-to-action area, displaying additional customer validation information with enhanced visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->