### PR TITLE
fix(frontend): remove termos banidos 'plano' e 'assinatura' da FAQ e ajuda (COPY-371 AC9)

### DIFF
--- a/frontend/app/ajuda/faqData.ts
+++ b/frontend/app/ajuda/faqData.ts
@@ -49,7 +49,7 @@ export const FAQ_DATA: FAQCategoryData[] = [
       {
         question: 'Como faço download dos resultados em Excel?',
         answer:
-          'Após a análise ser concluída, clique no botão "Download Excel" que aparece junto aos resultados. O arquivo será gerado e baixado automaticamente com todas as oportunidades encontradas. Este recurso está disponível em planos pagos.',
+          'Após a análise ser concluída, clique no botão "Download Excel" que aparece junto aos resultados. O arquivo será gerado e baixado automaticamente com todas as oportunidades encontradas. Este recurso está disponível no SmartLic Pro.',
       },
       {
         question: 'Como funciona a avaliação por IA?',
@@ -59,16 +59,16 @@ export const FAQ_DATA: FAQCategoryData[] = [
     ],
   },
   {
-    id: 'planos',
-    title: 'Planos',
+    id: 'opcoes',
+    title: 'Opções de Acesso',
     items: [
       {
         question: 'Qual a diferença entre o período de avaliação e o SmartLic Pro?',
         answer:
-          'Durante os 14 dias de avaliação gratuita, você usa o produto completo sem restrições: Excel, Pipeline, IA completa e histórico. Após o período de avaliação, assine o SmartLic Pro para continuar com acesso completo.',
+          'Durante os 14 dias de avaliação gratuita, você usa o produto completo sem restrições: Excel, Pipeline, IA completa e histórico. Após o período de avaliação, escolha o SmartLic Pro para continuar com acesso completo.',
       },
       {
-        question: 'Posso testar antes de assinar?',
+        question: 'Posso testar antes de ativar?',
         answer:
           'Sim! Ao criar sua conta, você experimenta o produto completo por 14 dias gratuitamente, sem limites. Não é necessário informar dados de pagamento.',
       },
@@ -104,7 +104,7 @@ export const FAQ_DATA: FAQCategoryData[] = [
           'Sim. Todos os pagamentos são processados pelo Stripe, plataforma certificada PCI-DSS nível 1. Nós nunca armazenamos os dados do seu cartão em nossos servidores.',
       },
       {
-        question: 'Como cancelo minha assinatura?',
+        question: 'Como cancelo meu acesso?',
         answer:
           'Você pode cancelar a qualquer momento acessando Minha Conta. O acesso permanece ativo até o final do período já pago. Após essa data, o acesso ao sistema é encerrado.',
       },
@@ -179,7 +179,7 @@ export const FAQ_DATA: FAQCategoryData[] = [
       {
         question: 'Como excluo minha conta?',
         answer:
-          'Acesse Minha Conta, na seção "Dados e Privacidade", clique em "Excluir Minha Conta". Esta ação é irreversível e apaga permanentemente todos os seus dados, incluindo histórico de análises e assinaturas.',
+          'Acesse Minha Conta, na seção "Dados e Privacidade", clique em "Excluir Minha Conta". Esta ação é irreversível e apaga permanentemente todos os seus dados, incluindo histórico de análises e acessos.',
       },
       {
         question: 'Posso exportar meus dados?',

--- a/frontend/app/ajuda/page.tsx
+++ b/frontend/app/ajuda/page.tsx
@@ -24,7 +24,7 @@ export default function AjudaPage() {
       <SchemaMarkup
         pageType="faq"
         title="Central de Ajuda — SmartLic"
-        description="Respostas para as dúvidas mais comuns sobre o SmartLic: busca de licitações, planos, pagamentos, fontes de dados e conta."
+        description="Respostas para as dúvidas mais comuns sobre o SmartLic: análises de licitações, opções de acesso, pagamentos, fontes de dados e conta."
         url={url}
         faqs={faqs}
         breadcrumbs={[


### PR DESCRIPTION
## Summary

Implementa COPY-371 AC9: elimina termos banidos ("plano", "assinatura", "assine") do texto visível ao usuário na Central de Ajuda.

## Changes
- **page.tsx**: "planos" → "opções de acesso" na meta description
- **faqData.ts**: 6 substituições terminológicas:
  - "planos pagos" → "SmartLic Pro"
  - "Planos" → "Opções de Acesso" (categoria)
  - "assine o SmartLic Pro" → "escolha o SmartLic Pro"
  - "antes de assinar" → "antes de ativar"
  - "minha assinatura" → "meu acesso"
  - "assinaturas" → "acessos"

## Testing Plan
- TypeScript compila sem erros
- Nenhum teste existente referencia as strings antigas da FAQ

## Closes
Closes #COPY-371