### PR TITLE
feat(backend): add compute_user_lifecycle SQL function and admin segments endpoint (#1428)

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -34,6 +34,7 @@ from schemas import (
     AdminUsersListResponse, AdminCreateUserResponse, AdminDeleteUserResponse,
     AdminUpdateUserResponse, AdminResetPasswordResponse, AdminAssignPlanResponse,
     AdminUpdateCreditsResponse, MemorySnapshot, TraceMallocEntry,
+    UserSegmentsResponse,
 )
 from log_sanitizer import sanitize_dict, log_admin_action
 from filter.stats import filter_stats_tracker
@@ -1238,3 +1239,187 @@ def _assign_plan(sb, user_id: str, plan_id: str):
         "expires_at": expires_at,
         "is_active": True,
     }).execute()
+
+
+# ============================================================================
+# LIFECYCLE-003 (#1428): User Segments Dashboard
+# ============================================================================
+
+
+_CACHE_PREFIX = "smartlic:segments:"
+_CACHE_TTL = 300  # 5 minutes
+
+
+async def _get_segments_cache() -> Optional[dict]:
+    """Get segments data from Redis cache."""
+    try:
+        from cache_module import redis_cache
+        import json
+        raw = await redis_cache.get(f"{_CACHE_PREFIX}dashboard")
+        if raw:
+            return json.loads(raw)
+    except Exception:
+        pass
+    return None
+
+
+async def _set_segments_cache(data: dict) -> None:
+    """Set segments data in Redis cache."""
+    try:
+        from cache_module import redis_cache
+        import json
+        await redis_cache.setex(
+            f"{_CACHE_PREFIX}dashboard", _CACHE_TTL,
+            json.dumps(data, default=str),
+        )
+    except Exception as e:
+        logger.warning(f"Failed to cache segments data: {e}")
+
+
+@router.get("/users/segments", response_model=UserSegmentsResponse)
+async def get_user_segments(
+    admin: dict = Depends(require_admin),
+) -> UserSegmentsResponse:
+    """LIFECYCLE-003: Return user lifecycle segment counts, transitions,
+    and power user details.
+
+    Classifies every user into one of 10 lifecycle states:
+    anonymous, lead, trial_active, trial_limited, trial_expired,
+    paid_active, paid_past_due, canceled, churned, power_user.
+
+    Results are cached in Redis for 5 minutes.
+    """
+    from datetime import datetime, timedelta, timezone
+    from supabase_client import get_supabase, sb_execute
+
+    # Check cache first
+    cached = await _get_segments_cache()
+    if cached is not None:
+        return UserSegmentsResponse(**cached)
+
+    sb = get_supabase()
+    now = datetime.now(timezone.utc)
+
+    try:
+        # 1. Compute all user lifecycles via batch function
+        result = await sb_execute(
+            sb.rpc("compute_all_user_lifecycles"),
+            category="read",
+        )
+        all_lifecycles = result.data or []
+
+        # 2. Aggregate counts by state
+        count_by_state: dict[str, int] = {}
+        power_user_ids: list[str] = []
+        for row in all_lifecycles:
+            state = row.get("lifecycle", "anonymous")
+            count_by_state[state] = count_by_state.get(state, 0) + 1
+            if state == "power_user":
+                power_user_ids.append(row["user_id"])
+
+        total_users = len(all_lifecycles)
+
+        # 3. Get transitions in the last week
+        transitions_result = await sb_execute(
+            sb.table("user_lifecycle_events")
+            .select("user_id, previous_lifecycle, new_lifecycle, changed_at")
+            .gte("changed_at", (now - timedelta(days=7)).isoformat())
+            .order("changed_at", desc=True)
+            .limit(100),
+            category="read",
+        )
+
+        transitions = [
+            {
+                "user_id": t["user_id"],
+                "previous_lifecycle": t.get("previous_lifecycle"),
+                "new_lifecycle": t["new_lifecycle"],
+                "changed_at": t["changed_at"],
+            }
+            for t in (transitions_result.data or [])
+        ]
+
+        # 4. Get power user details
+        power_users: list[dict] = []
+        if power_user_ids:
+            for puid in power_user_ids:
+                try:
+                    profile = await sb_execute(
+                        sb.table("profiles")
+                        .select("id, email, full_name, company")
+                        .eq("id", puid)
+                        .single(),
+                        category="read",
+                    )
+                    p = profile.data or {}
+
+                    la = await sb_execute(
+                        sb.table("login_activity")
+                        .select("id", count="exact")
+                        .eq("user_id", puid)
+                        .gte("login_date",
+                              (now - timedelta(days=14)).date().isoformat()),
+                        category="read",
+                    )
+                    pi = await sb_execute(
+                        sb.table("pipeline_items")
+                        .select("id", count="exact")
+                        .eq("user_id", puid),
+                        category="read",
+                    )
+                    al = await sb_execute(
+                        sb.table("alerts")
+                        .select("id", count="exact")
+                        .eq("user_id", puid)
+                        .eq("active", True),
+                        category="read",
+                    )
+
+                    lc = await sb_execute(
+                        sb.table("user_lifecycle")
+                        .select("lifecycle")
+                        .eq("user_id", puid)
+                        .single(),
+                        category="read",
+                    )
+
+                    power_users.append({
+                        "user_id": puid,
+                        "email": p.get("email", ""),
+                        "full_name": p.get("full_name", ""),
+                        "company": p.get("company", ""),
+                        "logins_14d": la.count or 0,
+                        "pipeline_count": pi.count or 0,
+                        "alert_count": al.count or 0,
+                        "lifecycle": (
+                            lc.data.get("lifecycle", "power_user")
+                            if lc.data else "power_user"
+                        ),
+                    })
+                except Exception as e:
+                    logger.warning(
+                        "Failed to get power user details for %s: %s",
+                        puid[:8], e,
+                    )
+                    continue
+
+        # 5. Build response
+        response_data = {
+            "count_by_state": count_by_state,
+            "total_users": total_users,
+            "transitions_last_week": transitions,
+            "power_users": power_users,
+            "queried_at": now.isoformat(),
+        }
+
+        # Cache the result (fire-and-forget)
+        await _set_segments_cache(response_data)
+
+        return UserSegmentsResponse(**response_data)
+
+    except Exception as e:
+        logger.error(f"Failed to compute user segments: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Erro ao calcular segmentos de usuarios",
+        )

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -204,3 +204,35 @@ class AdminLlmCostResponse(BaseModel):
     projected_end_of_month_usd: float = 0.0
     month: str
     exceeded: bool = False
+
+
+# --- LIFECYCLE-003 (#1428): User Segments ------------------------------------
+
+
+class UserLifecycleTransition(BaseModel):
+    """A single lifecycle transition event."""
+    user_id: str
+    previous_lifecycle: Optional[str] = None
+    new_lifecycle: str
+    changed_at: str
+
+
+class PowerUserDetail(BaseModel):
+    """Power user detail row for the segments dashboard."""
+    user_id: str
+    email: Optional[str] = None
+    full_name: Optional[str] = None
+    company: Optional[str] = None
+    logins_14d: int = 0
+    pipeline_count: int = 0
+    alert_count: int = 0
+    lifecycle: str
+
+
+class UserSegmentsResponse(BaseModel):
+    """Response for GET /admin/users/segments (LIFECYCLE-003)."""
+    count_by_state: dict
+    total_users: int
+    transitions_last_week: list
+    power_users: list
+    queried_at: str

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -16282,6 +16282,43 @@
         "title": "UserProfileResponse",
         "type": "object"
       },
+      "UserSegmentsResponse": {
+        "description": "Response for GET /admin/users/segments (LIFECYCLE-003).",
+        "properties": {
+          "count_by_state": {
+            "additionalProperties": true,
+            "title": "Count By State",
+            "type": "object"
+          },
+          "power_users": {
+            "items": {},
+            "title": "Power Users",
+            "type": "array"
+          },
+          "queried_at": {
+            "title": "Queried At",
+            "type": "string"
+          },
+          "total_users": {
+            "title": "Total Users",
+            "type": "integer"
+          },
+          "transitions_last_week": {
+            "items": {},
+            "title": "Transitions Last Week",
+            "type": "array"
+          }
+        },
+        "required": [
+          "count_by_state",
+          "total_users",
+          "transitions_last_week",
+          "power_users",
+          "queried_at"
+        ],
+        "title": "UserSegmentsResponse",
+        "type": "object"
+      },
       "ValidateSignupEmailResponse": {
         "additionalProperties": true,
         "description": "POST /validate-signup-email response.",
@@ -19522,6 +19559,33 @@
           }
         ],
         "summary": "Create User",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/v1/admin/users/segments": {
+      "get": {
+        "description": "LIFECYCLE-003: Return user lifecycle segment counts, transitions,\nand power user details.\n\nClassifies every user into one of 10 lifecycle states:\nanonymous, lead, trial_active, trial_limited, trial_expired,\npaid_active, paid_past_due, canceled, churned, power_user.\n\nResults are cached in Redis for 5 minutes.",
+        "operationId": "get_user_segments_v1_admin_users_segments_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSegmentsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get User Segments",
         "tags": [
           "admin"
         ]

--- a/backend/tests/test_lifecycle_003_segments.py
+++ b/backend/tests/test_lifecycle_003_segments.py
@@ -1,0 +1,376 @@
+"""Tests for LIFECYCLE-003 (#1428): User lifecycle segments endpoint.
+
+Tests GET /admin/users/segments endpoint classification,
+transition tracking, and power user detection.
+Uses mocked Supabase client to avoid external API calls.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from fastapi.testclient import TestClient
+
+# Valid UUID v4 test fixtures
+VALID_UUID_1 = "550e8400-e29b-41d4-a716-446655440001"
+VALID_UUID_2 = "550e8400-e29b-41d4-a716-446655440002"
+VALID_UUID_3 = "550e8400-e29b-41d4-a716-446655440003"
+ADMIN_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+class TestUserLifecycleClassification:
+    """Test suite for lifecycle classification logic."""
+
+    @pytest.fixture
+    def mock_admin_user(self):
+        """Create mock admin user with valid UUID."""
+        return {
+            "id": ADMIN_UUID,
+            "email": "admin@example.com",
+            "role": "authenticated",
+        }
+
+    @pytest.fixture
+    def admin_app_with_overrides(self, mock_admin_user):
+        """Create FastAPI app with admin router and auth override."""
+        from fastapi import FastAPI
+        from admin import router, require_admin
+
+        app = FastAPI()
+        app.include_router(router)
+
+        async def mock_require_admin():
+            return mock_admin_user
+
+        app.dependency_overrides[require_admin] = mock_require_admin
+        return app
+
+    @pytest.fixture
+    def client(self, admin_app_with_overrides):
+        """Create test client with admin auth mocked."""
+        return TestClient(admin_app_with_overrides)
+
+    def test_segments_requires_admin(self):
+        """Should return 401 without authentication."""
+        from fastapi import FastAPI
+        from admin import router
+
+        app = FastAPI()
+        app.include_router(router)
+
+        client = TestClient(app)
+        response = client.get("/admin/users/segments")
+
+        assert response.status_code == 401
+
+    def test_segments_returns_state_counts(self, client):
+        """Should return count_by_state with correct aggregation."""
+        lifecycles = [
+            {"user_id": VALID_UUID_1, "lifecycle": "trial_active"},
+            {"user_id": VALID_UUID_2, "lifecycle": "trial_active"},
+            {"user_id": VALID_UUID_3, "lifecycle": "paid_active"},
+        ]
+
+        mock_sb = Mock()
+
+        # RPC mock
+        rpc_result = Mock()
+        rpc_result.data = lifecycles
+        mock_rpc = Mock()
+        mock_rpc.execute.return_value = rpc_result
+        mock_sb.rpc.return_value = mock_rpc
+
+        # Events mock
+        events_table = Mock()
+        events_result = Mock()
+        events_result.data = []
+        events_table.select.return_value.gte.return_value.order.return_value.limit.return_value.execute.return_value = events_result
+        mock_sb.table.return_value = events_table
+
+        def table_side_effect(name):
+            if name == "user_lifecycle_events":
+                return events_table
+            return Mock()
+
+        mock_sb.table.side_effect = table_side_effect
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("admin._get_segments_cache", return_value=None):
+            response = client.get("/admin/users/segments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_users"] == 3
+        assert data["count_by_state"]["trial_active"] == 2
+        assert data["count_by_state"]["paid_active"] == 1
+        assert data["transitions_last_week"] == []
+        assert data["power_users"] == []
+
+    def test_segments_returns_cache_hit(self, client):
+        """Should return cached data when available."""
+        cached = {
+            "count_by_state": {"trial_active": 5, "paid_active": 3},
+            "total_users": 8,
+            "transitions_last_week": [],
+            "power_users": [],
+            "queried_at": "2026-06-04T00:00:00+00:00",
+        }
+
+        with patch("admin._get_segments_cache", return_value=cached):
+            response = client.get("/admin/users/segments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_users"] == 8
+        assert data["count_by_state"]["trial_active"] == 5
+
+    def test_segments_includes_power_users(self, client):
+        """Should return power user details when power users exist."""
+        lifecycles = [
+            {"user_id": VALID_UUID_1, "lifecycle": "power_user"},
+        ]
+
+        sb = Mock()
+
+        # RPC mock
+        rpc_result = Mock()
+        rpc_result.data = lifecycles
+        mock_rpc = Mock()
+        mock_rpc.execute.return_value = rpc_result
+        sb.rpc.return_value = mock_rpc
+
+        # Events mock
+        events_table = Mock()
+        events_result = Mock()
+        events_result.data = []
+        events_table.select.return_value.gte.return_value.order.return_value.limit.return_value.execute.return_value = events_result
+
+        # Profile mock for power user
+        profile_result = Mock()
+        profile_result.data = {
+            "id": VALID_UUID_1,
+            "email": "power@user.com",
+            "full_name": "Power User",
+            "company": "Power Corp",
+        }
+        profile_table = Mock()
+        profile_table.select.return_value.eq.return_value.single.return_value.execute.return_value = profile_result
+
+        # Count mocks for login_activity, pipeline_items, alerts
+        count_result_14d = Mock()
+        count_result_14d.count = 8
+        count_mock_14d = Mock()
+        count_mock_14d.select.return_value = count_mock_14d
+        count_mock_14d.eq.return_value = count_mock_14d
+        count_mock_14d.gte.return_value = count_mock_14d
+        count_mock_14d.execute.return_value = count_result_14d
+
+        count_result_pi = Mock()
+        count_result_pi.count = 5
+        count_mock_pi = Mock()
+        count_mock_pi.select.return_value = count_mock_pi
+        count_mock_pi.eq.return_value = count_mock_pi
+        count_mock_pi.execute.return_value = count_result_pi
+
+        count_result_al = Mock()
+        count_result_al.count = 2
+        count_mock_al = Mock()
+        count_mock_al.select.return_value = count_mock_al
+        count_mock_al.eq.return_value = count_mock_al
+        count_mock_al.execute.return_value = count_result_al
+
+        # Lifecycle cache mock
+        lc_result = Mock()
+        lc_result.data = {"lifecycle": "power_user"}
+        lc_table = Mock()
+        lc_table.select.return_value.eq.return_value.single.return_value.execute.return_value = lc_result
+
+        # Side effects for table()
+        def table_side_effect(name):
+            if name == "user_lifecycle_events":
+                return events_table
+            elif name == "profiles":
+                return profile_table
+            elif name == "login_activity":
+                return count_mock_14d
+            elif name == "pipeline_items":
+                return count_mock_pi
+            elif name == "alerts":
+                return count_mock_al
+            elif name == "user_lifecycle":
+                return lc_table
+            return Mock()
+
+        sb.table.side_effect = table_side_effect
+
+        with patch("supabase_client.get_supabase", return_value=sb), \
+             patch("admin._get_segments_cache", return_value=None), \
+             patch("admin._set_segments_cache"):
+            response = client.get("/admin/users/segments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["power_users"]) == 1
+        pu = data["power_users"][0]
+        assert pu["user_id"] == VALID_UUID_1
+        assert pu["email"] == "power@user.com"
+        assert pu["full_name"] == "Power User"
+        assert pu["logins_14d"] == 8
+        assert pu["pipeline_count"] == 5
+        assert pu["alert_count"] == 2
+
+    def test_segments_includes_transitions(self, client):
+        """Should return transitions from the last week."""
+        lifecycles = [
+            {"user_id": VALID_UUID_1, "lifecycle": "paid_active"},
+        ]
+        transitions = [
+            {
+                "user_id": VALID_UUID_1,
+                "previous_lifecycle": "trial_active",
+                "new_lifecycle": "paid_active",
+                "changed_at": "2026-06-02T10:00:00+00:00",
+            }
+        ]
+
+        sb = Mock()
+
+        # RPC mock
+        rpc_result = Mock()
+        rpc_result.data = lifecycles
+        mock_rpc = Mock()
+        mock_rpc.execute.return_value = rpc_result
+        sb.rpc.return_value = mock_rpc
+
+        # Events mock
+        events_table = Mock()
+        events_result = Mock()
+        events_result.data = transitions
+        events_table.select.return_value.gte.return_value.order.return_value.limit.return_value.execute.return_value = events_result
+
+        def table_side_effect(name):
+            if name == "user_lifecycle_events":
+                return events_table
+            return Mock()
+
+        sb.table.side_effect = table_side_effect
+
+        with patch("supabase_client.get_supabase", return_value=sb), \
+             patch("admin._get_segments_cache", return_value=None), \
+             patch("admin._set_segments_cache"):
+            response = client.get("/admin/users/segments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["transitions_last_week"]) == 1
+        t = data["transitions_last_week"][0]
+        assert t["user_id"] == VALID_UUID_1
+        assert t["previous_lifecycle"] == "trial_active"
+        assert t["new_lifecycle"] == "paid_active"
+
+    def test_segments_handles_db_error_gracefully(self, client):
+        """Should return 500 when Supabase call fails."""
+        sb = Mock()
+        sb.rpc.side_effect = Exception("DB connection error")
+
+        with patch("supabase_client.get_supabase", return_value=sb), \
+             patch("admin._get_segments_cache", return_value=None):
+            response = client.get("/admin/users/segments")
+
+        assert response.status_code == 500
+        assert "segmentos" in response.json()["detail"].lower()
+
+    def test_segments_empty_database(self, client):
+        """Should handle empty database with no users."""
+        sb = Mock()
+
+        # RPC mock returns empty
+        rpc_result = Mock()
+        rpc_result.data = []
+        mock_rpc = Mock()
+        mock_rpc.execute.return_value = rpc_result
+        sb.rpc.return_value = mock_rpc
+
+        events_table = Mock()
+        events_result = Mock()
+        events_result.data = []
+        events_table.select.return_value.gte.return_value.order.return_value.limit.return_value.execute.return_value = events_result
+
+        def table_side_effect(name):
+            if name == "user_lifecycle_events":
+                return events_table
+            return Mock()
+
+        sb.table.side_effect = table_side_effect
+
+        with patch("supabase_client.get_supabase", return_value=sb), \
+             patch("admin._get_segments_cache", return_value=None), \
+             patch("admin._set_segments_cache"):
+            response = client.get("/admin/users/segments")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_users"] == 0
+        assert data["count_by_state"] == {}
+        assert data["transitions_last_week"] == []
+        assert data["power_users"] == []
+
+
+class TestSegmentsCache:
+    """Test suite for segments caching."""
+
+    @pytest.mark.asyncio
+    async def test_cache_get_returns_none_when_empty(self):
+        """Should return None when no cached data."""
+        from admin import _get_segments_cache
+
+        with patch("cache_module.redis_cache.get", return_value=None):
+            result = await _get_segments_cache()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cache_get_returns_parsed_json(self):
+        """Should parse and return cached JSON data."""
+        import json
+        from admin import _get_segments_cache
+
+        cached_data = {"total_users": 5, "count_by_state": {"trial_active": 3}}
+        with patch("cache_module.redis_cache.get", return_value=json.dumps(cached_data)):
+            result = await _get_segments_cache()
+
+        assert result == cached_data
+
+    @pytest.mark.asyncio
+    async def test_cache_set_stores_data(self):
+        """Should store serialized data in Redis."""
+        import json
+        from admin import _set_segments_cache
+
+        mock_setex = Mock(return_value=True)
+        with patch("cache_module.redis_cache.setex", mock_setex):
+            data = {"total_users": 10, "count_by_state": {}}
+            await _set_segments_cache(data)
+
+        mock_setex.assert_called_once()
+        args, kwargs = mock_setex.call_args
+        assert args[0].startswith("smartlic:segments:")
+        assert args[1] == 300  # 5 min TTL
+        parsed = json.loads(args[2])
+        assert parsed["total_users"] == 10
+
+    @pytest.mark.asyncio
+    async def test_cache_get_handles_redis_failure(self):
+        """Should handle Redis failure gracefully."""
+        from admin import _get_segments_cache
+
+        with patch("cache_module.redis_cache.get", side_effect=Exception("Redis down")):
+            result = await _get_segments_cache()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cache_set_handles_redis_failure(self):
+        """Should handle Redis failure gracefully on set."""
+        from admin import _set_segments_cache
+
+        with patch("cache_module.redis_cache.setex", side_effect=Exception("Redis down")):
+            await _set_segments_cache({"total_users": 5})

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4,162 +4,6 @@
  */
 
 export interface paths {
-    "/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Root
-         * @description API root — navigation and version info.
-         */
-        get: operations["root__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/checkout/one-time": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create One Time Checkout
-         * @description Create a Stripe Checkout Session for a one-time digital product purchase.
-         *
-         *     Flow:
-         *         1. Validate SKU against digital_products table
-         *         2. Resolve or create Stripe Price
-         *         3. Create Stripe Checkout Session with card/boleto/PIX
-         *         4. Return checkout URL
-         *
-         *     Rate limited: 10 req/min per IP.
-         */
-        post: operations["create_one_time_checkout_api_checkout_one_time_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/founders/availability": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founders Availability
-         * @description Public seat counter + countdown feed (issue #1002).
-         */
-        get: operations["founders_availability_api_founders_availability_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/founders/hall": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Hall Listing
-         * @description Public Hall of Founders listing (issue #1008).
-         *
-         *     Anonymous endpoint consumed by ``/fundadores/hall`` (ISR revalidate=300s).
-         *     Returns up to 100 founders that opted in via
-         *     ``founder_public_listing_consent=TRUE``.
-         */
-        get: operations["get_hall_listing_api_founders_hall_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/founders/hall/consent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Toggle Consent
-         * @description Authenticated opt-in / opt-out toggle (issue #1008).
-         *
-         *     Updates ``profiles.founder_public_listing_consent`` for the caller and,
-         *     on opt-in, also persists optional display name and logo URL. Logs an
-         *     LGPD audit event regardless of direction.
-         */
-        post: operations["toggle_consent_api_founders_hall_consent_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug/pncp-test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Debug Pncp Test
-         * @description Diagnostic: test if PNCP API is reachable from this server. Admin only.
-         */
-        get: operations["debug_pncp_test_debug_pncp_test_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health
-         * @description Comprehensive health check with dependency status, circuit breakers, bulkheads.
-         */
-        get: operations["health_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/health/live": {
         parameters: {
             query?: never;
@@ -202,6 +46,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health
+         * @description Comprehensive health check with dependency status, circuit breakers, bulkheads.
+         */
+        get: operations["health_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sources/health": {
         parameters: {
             query?: never;
@@ -215,6 +79,124 @@ export interface paths {
          */
         get: operations["sources_health_sources_health_get"];
         put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Users
+         * @description List all users with profiles and subscription info.
+         */
+        get: operations["list_users_v1_admin_users_get"];
+        put?: never;
+        /**
+         * Create User
+         * @description Create a new user with optional plan assignment.
+         */
+        post: operations["create_user_v1_admin_users_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update User
+         * @description Update user profile or plan.
+         */
+        put: operations["update_user_v1_admin_users__user_id__put"];
+        post?: never;
+        /**
+         * Delete User
+         * @description Delete a user and all their data.
+         */
+        delete: operations["delete_user_v1_admin_users__user_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{user_id}/reset-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset User Password
+         * @description Reset a user's password (admin only).
+         */
+        post: operations["reset_user_password_v1_admin_users__user_id__reset_password_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{user_id}/assign-plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assign Plan
+         * @description Manually assign a plan to a user (bypasses payment).
+         */
+        post: operations["assign_plan_v1_admin_users__user_id__assign_plan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{user_id}/credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update User Credits
+         * @description Manually adjust a user's credits (admin only).
+         *
+         *     Sets the credits_remaining value directly on the user's active subscription.
+         *     If no active subscription exists, creates one based on user's current plan.
+         *
+         *     Args:
+         *         user_id: UUID of the user
+         *         req.credits: New credit value (must be >= 0)
+         *
+         *     Returns:
+         *         Updated user info with new credit value
+         */
+        put: operations["update_user_credits_v1_admin_users__user_id__credits_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -249,49 +231,6 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/at-risk-trials": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get At Risk Trials
-         * @description Paginated list of trial users with risk categorization.
-         */
-        get: operations["get_at_risk_trials_v1_admin_at_risk_trials_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cache": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete All Cache Endpoint
-         * @description B-05 AC6: Invalidate ALL cache entries (nuclear option).
-         *
-         *     Requires X-Confirm: delete-all header for safety.
-         *     Without header, returns 400 Bad Request.
-         */
-        delete: operations["delete_all_cache_endpoint_v1_admin_cache_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -352,106 +291,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/calibration/recalibrate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Recalibrate
-         * @description Compute new ``hours_saved_per_search`` from survey distribution.
-         *
-         *     Eligibility rules (mirrors AC6 + risk R3):
-         *         * After IQR outlier removal there must be >= MIN_SAMPLE_SIZE rows.
-         *         * The new median must be in (0, 50].
-         *
-         *     When ``apply=true`` and eligible, persists the new value via
-         *     ``app_config`` and drops the cache.
-         */
-        post: operations["recalibrate_v1_admin_calibration_recalibrate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cb/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset Circuit Breakers
-         * @description STORY-416 AC5: Reset all segregated Supabase CBs to CLOSED.
-         *
-         *     Intended for on-call use after an upstream incident has been mitigated
-         *     and the CBs are still in OPEN/HALF_OPEN due to the cooldown. Returns
-         *     the previous state per category so the action is auditable in logs.
-         *     Admin only — never expose this without authentication.
-         */
-        post: operations["reset_circuit_breakers_v1_admin_cb_reset_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/clear-contracts-checkpoints": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Clear Contracts Checkpoints
-         * @description Clear all Redis checkpoints for contracts crawler.
-         *
-         *     Use before re-triggering a full crawl when stale checkpoints
-         *     cause windows to be incorrectly skipped.
-         */
-        post: operations["clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cnae-mapping": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Cnae Mappings
-         * @description List CNAE mappings, optionally filtered by ``setor``.
-         */
-        get: operations["list_cnae_mappings_v1_admin_cnae_mapping_get"];
-        put?: never;
-        /**
-         * Create Cnae Mapping
-         * @description Create a new CNAE -> setor mapping.
-         */
-        post: operations["create_cnae_mapping_v1_admin_cnae_mapping_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cnae-mapping/{cnae_code}": {
+    "/v1/admin/cache": {
         parameters: {
             query?: never;
             header?: never;
@@ -462,465 +302,13 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Delete Cnae Mapping
-         * @description Soft delete: marks ``notes='deleted'`` so audit trail is preserved.
+         * Delete All Cache Endpoint
+         * @description B-05 AC6: Invalidate ALL cache entries (nuclear option).
          *
-         *     The DB lookup in ``utils.cnae_mapping._db_lookup`` skips rows with
-         *     ``notes = 'deleted'`` and the LRU cache is invalidated so the next
-         *     request falls back to the hardcoded dict (if present there).
+         *     Requires X-Confirm: delete-all header for safety.
+         *     Without header, returns 400 Bad Request.
          */
-        delete: operations["delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Cnae Mapping
-         * @description Patch an existing mapping. Fields not present in the body are untouched.
-         */
-        patch: operations["update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch"];
-        trace?: never;
-    };
-    "/v1/admin/config/{key}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Patch App Config
-         * @description Update one row in ``app_config``. Whitelist enforced.
-         *
-         *     On success the in-process TTL cache for *key* is invalidated so
-         *     the new value becomes visible in this worker on the next read
-         *     (other workers see it after their TTL expires).
-         */
-        patch: operations["patch_app_config_v1_admin_config__key__patch"];
-        trace?: never;
-    };
-    "/v1/admin/cron-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Cron Status
-         * @description Return the pg_cron health snapshot.
-         *
-         *     Calls ``public.get_cron_health()`` (SECURITY DEFINER) via the backend's
-         *     service-role Supabase client. Response shape::
-         *
-         *         {
-         *             "queried_at": "2026-04-14T12:00:00+00:00",
-         *             "jobs": [
-         *                 {
-         *                     "jobname": "purge-old-bids",
-         *                     "schedule": "0 7 * * *",
-         *                     "active": true,
-         *                     "last_status": "succeeded",
-         *                     "last_run_at": "2026-04-14T07:00:04+00:00",
-         *                     "runs_24h": 1,
-         *                     "failures_24h": 0,
-         *                     "latency_avg_ms": 120,
-         *                     "last_return_message": null
-         *                 },
-         *                 ...
-         *             ],
-         *             "count": 6
-         *         }
-         *
-         *     On transient failure (Supabase CB open, RPC error) returns ``status=error``
-         *     with ``jobs=[]`` so that dashboards degrade gracefully instead of 500-ing.
-         */
-        get: operations["get_cron_status_v1_admin_cron_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/feature-flags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Feature Flags
-         * @description List all registered feature flags with current values and sources.
-         *
-         *     Returns each flag's effective value, where it comes from (redis override,
-         *     env var, or default), its description, and registry metadata.
-         *
-         *     Admin only.
-         */
-        get: operations["list_feature_flags_v1_admin_feature_flags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/feature-flags/reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reload Flags Endpoint
-         * @description Reload all feature flags from environment variables (admin only).
-         *
-         *     This clears:
-         *     1. All Redis overrides (smartlic:ff:* keys)
-         *     2. All in-memory overrides
-         *     3. The feature flag TTL cache
-         *
-         *     After reload, flags return to their env var or registry default values.
-         *     Useful after updating env vars via Railway dashboard without restarting.
-         */
-        post: operations["reload_flags_endpoint_v1_admin_feature_flags_reload_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/feature-flags/{flag_name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Feature Flag
-         * @description Update a feature flag value at runtime (admin only).
-         *
-         *     The new value is persisted to Redis (if available) and stored in-memory.
-         *     Takes effect immediately -- no container restart required.
-         *
-         *     The change persists across process restarts as long as Redis is available.
-         *     Use POST /admin/feature-flags/reload to clear all overrides.
-         */
-        patch: operations["update_feature_flag_v1_admin_feature_flags__flag_name__patch"];
-        trace?: never;
-    };
-    "/v1/admin/feedback/patterns": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Feedback Patterns
-         * @description AC6: Admin endpoint for feedback pattern analysis.
-         *
-         *     Requires admin role (via require_admin dependency).
-         */
-        get: operations["feedback_patterns_v1_admin_feedback_patterns_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/leads": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Founding Leads
-         * @description List founding leads ordered by creation desc.
-         *
-         *     Optional ``status`` filter restricts to one of the checkout_status enum
-         *     values (pending|completed|abandoned|failed|cap_violated).
-         */
-        get: operations["list_founding_leads_v1_admin_founding_leads_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/pause": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Pause Founding
-         * @description Soft-pause founding checkouts. Idempotent.
-         */
-        post: operations["pause_founding_v1_admin_founding_pause_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/policy": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Founding Policy
-         * @description Snapshot of the canonical policy + live seat usage.
-         */
-        get: operations["get_founding_policy_v1_admin_founding_policy_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/resume": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Resume Founding
-         * @description Resume founding checkouts (clear paused_at + paused_by + paused_reason).
-         */
-        post: operations["resume_founding_v1_admin_founding_resume_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/llm-cost": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Admin Llm Cost
-         * @description Return LLM cost snapshot para o mês corrente (admin-only).
-         *
-         *     Response shape::
-         *
-         *         {
-         *             "month_to_date_usd": 42.1234,
-         *             "budget_usd": 100.0,
-         *             "pct_used": 42.12,
-         *             "projected_end_of_month_usd": 78.55,
-         *             "month": "llm_cost_month_2026_04",
-         *             "exceeded": false
-         *         }
-         *
-         *     Em caso de Redis indisponível, retorna zeros (graceful degradation).
-         */
-        get: operations["admin_llm_cost_v1_admin_llm_cost_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/memory-snapshot": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Memory Snapshot
-         * @description Return current process memory snapshot for leak investigation.
-         *
-         *     Master/admin only. Snapshots are NOT persisted (PII risk + size).
-         *     Caller is responsible for capturing 10× over 24h to build baseline.
-         */
-        get: operations["memory_snapshot_v1_admin_memory_snapshot_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/partners": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Partners Endpoint
-         * @description AC10: List all partners. Admin only.
-         */
-        get: operations["list_partners_endpoint_v1_admin_partners_get"];
-        put?: never;
-        /**
-         * Create Partner Endpoint
-         * @description AC11: Create a new partner. Admin only.
-         */
-        post: operations["create_partner_endpoint_v1_admin_partners_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/partners/{partner_id}/referrals": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Partner Referrals Endpoint
-         * @description AC12: Get referrals for a specific partner. Admin only.
-         */
-        get: operations["get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/partners/{partner_id}/revenue": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Partner Revenue Endpoint
-         * @description AC13: Get revenue share for a partner in a given month. Admin only.
-         */
-        get: operations["get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/billing-sync": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Billing Sync Rows
-         * @description Return every plan_billing_periods row enriched with drift_status.
-         */
-        get: operations["list_billing_sync_rows_v1_admin_plans_billing_sync_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/reconcile-now": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Reconcile Now */
-        post: operations["reconcile_now_v1_admin_plans_reconcile_now_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/reconciliation-runs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Reconciliation Runs */
-        get: operations["list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/{plan_billing_period_id}/sync-to-stripe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Sync To Stripe
-         * @description AC8/AC9: Push DB price -> Stripe by creating a new Price + archiving old.
-         */
-        post: operations["sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post"];
-        delete?: never;
+        delete: operations["delete_all_cache_endpoint_v1_admin_cache_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -970,187 +358,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/revalidate-seo": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Admin Revalidate Seo
-         * @description Manually trigger ISR revalidation for the given frontend paths.
-         *
-         *     Calls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).
-         *     Fire-and-forget — the HTTP call is made but result is not awaited for
-         *     user-facing errors.  Any failure is logged as a warning.
-         *
-         *     Requires admin role.  Raises HTTP 400 if ``paths`` is empty.
-         */
-        post: operations["admin_revalidate_seo_v1_admin_revalidate_seo_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/schema-contract-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Schema Contract Status
-         * @description STORY-414 AC4: Expose the last schema-contract validation result.
-         *
-         *     Returns the cached result from the startup check plus a ``stale``
-         *     flag that tells callers whether a fresh run is advisable (the cache
-         *     lives for ``schemas.contract.STATUS_CACHE_TTL`` seconds — 5 min by
-         *     default). Forcing a re-validation is out of scope here because it
-         *     would defeat the point of the cache on a polled dashboard.
-         */
-        get: operations["get_schema_contract_status_v1_admin_schema_contract_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/search-trace/{search_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Search Trace
-         * @description Reconstruct complete search journey from search_id.
-         *
-         *     Aggregates:
-         *     - Progress tracker state (if still active)
-         *     - Cache entries matching this search
-         *     - Job queue results (if ARQ available)
-         */
-        get: operations["get_search_trace_v1_admin_search_trace__search_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/seo-metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Seo Metrics
-         * @description Return SEO metrics for the last N days (legacy S14 daily rollup). Admin-only.
-         */
-        get: operations["get_seo_metrics_v1_admin_seo_metrics_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/seo/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Gsc Summary
-         * @description Return aggregated GSC analytics from gsc_metrics cache. Admin-only.
-         *
-         *     STORY-SEO-005 AC4. Populated weekly by backend/jobs/cron/gsc_sync.py.
-         */
-        get: operations["get_gsc_summary_v1_admin_seo_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/sitemap-cache/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Force-refresh sitemap combos cache (admin only)
-         * @description Clears the 24h in-memory sitemap cache and recomputes indexable combos immediately.
-         */
-        post: operations["refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/slo": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Slo Dashboard
-         * @description AC7-AC9: SLO compliance data for admin dashboard.
-         *
-         *     Returns all SLO statuses, alert evaluations, and metadata.
-         */
-        get: operations["get_slo_dashboard_v1_admin_slo_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/slo/alerts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Slo Alerts
-         * @description Return current alert evaluation results.
-         */
-        get: operations["get_slo_alerts_v1_admin_slo_alerts_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/admin/support-sla": {
         parameters: {
             query?: never;
@@ -1168,86 +375,6 @@ export interface paths {
          *         breached_count: Number of conversations exceeding 20 business hours
          */
         get: operations["get_support_sla_v1_admin_support_sla_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/survey/export-time-saved": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Export Surveys Aggregate
-         * @description Aggregated histogram + summary stats for the calibration dashboard.
-         */
-        get: operations["list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trial-emails/preview": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Preview Trial Emails
-         * @description AC15: Preview all 6 trial email templates.
-         */
-        get: operations["preview_trial_emails_v1_admin_trial_emails_preview_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trial-emails/test-send": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Test Send Trial Email
-         * @description AC14: Send a test trial email to the admin's own email.
-         */
-        post: operations["test_send_trial_email_v1_admin_trial_emails_test_send_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trial-exit-surveys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Exit Surveys Admin
-         * @description STORY-369 AC6: Admin endpoint — exit survey counts grouped by reason.
-         */
-        get: operations["get_exit_surveys_admin_v1_admin_trial_exit_surveys_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1279,54 +406,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/trigger-bids-backfill": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Trigger Bids Backfill
-         * @description Enqueue ingestion_backfill_job to ARQ Worker.
-         *
-         *     One-time historical crawl: fetches up to 365 days of PNCP bids
-         *     to capture all currently open opportunities.
-         *     Expected runtime: 4-8h. Safe to call multiple times (ARQ dedup).
-         */
-        post: operations["trigger_bids_backfill_v1_admin_trigger_bids_backfill_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trigger-contracts-backfill": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Trigger Contracts Backfill
-         * @description Enqueue contracts_full_crawl_job to ARQ Worker.
-         *
-         *     Runs on Railway Worker (better network for PNCP).
-         *     Safe to call multiple times — ARQ deduplicates by job name.
-         */
-        post: operations["trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users": {
+    "/v1/admin/at-risk-trials": {
         parameters: {
             query?: never;
             header?: never;
@@ -1334,128 +414,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Users
-         * @description List all users with profiles and subscription info.
+         * Get At Risk Trials
+         * @description Paginated list of trial users with risk categorization.
          */
-        get: operations["list_users_v1_admin_users_get"];
-        put?: never;
-        /**
-         * Create User
-         * @description Create a new user with optional plan assignment.
-         */
-        post: operations["create_user_v1_admin_users_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Update User
-         * @description Update user profile or plan.
-         */
-        put: operations["update_user_v1_admin_users__user_id__put"];
-        post?: never;
-        /**
-         * Delete User
-         * @description Delete a user and all their data.
-         */
-        delete: operations["delete_user_v1_admin_users__user_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}/assign-plan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Assign Plan
-         * @description Manually assign a plan to a user (bypasses payment).
-         */
-        post: operations["assign_plan_v1_admin_users__user_id__assign_plan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}/credits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Update User Credits
-         * @description Manually adjust a user's credits (admin only).
-         *
-         *     Sets the credits_remaining value directly on the user's active subscription.
-         *     If no active subscription exists, creates one based on user's current plan.
-         *
-         *     Args:
-         *         user_id: UUID of the user
-         *         req.credits: New credit value (must be >= 0)
-         *
-         *     Returns:
-         *         Updated user info with new credit value
-         */
-        put: operations["update_user_credits_v1_admin_users__user_id__credits_put"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}/reset-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset User Password
-         * @description Reset a user's password (admin only).
-         */
-        post: operations["reset_user_password_v1_admin_users__user_id__reset_password_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/alertas/{setor_id}/uf/{uf}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Alertas
-         * @description Return latest 20 bids for sector × UF from datalake (public, no auth).
-         */
-        get: operations["get_alertas_v1_alertas__setor_id__uf__uf__get"];
+        get: operations["get_at_risk_trials_v1_admin_at_risk_trials_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1464,7 +426,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts": {
+    "/v1/admin/memory-snapshot": {
         parameters: {
             query?: never;
             header?: never;
@@ -1472,28 +434,256 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Alerts
-         * @description List all alerts for the authenticated user, ordered by created_at desc.
+         * Memory Snapshot
+         * @description Return current process memory snapshot for leak investigation.
          *
-         *     AC2: Includes sent_count (number of items sent for each alert).
+         *     Master/admin only. Snapshots are NOT persisted (PII risk + size).
+         *     Caller is responsible for capturing 10× over 24h to build baseline.
          */
-        get: operations["list_alerts_v1_alerts_get"];
+        get: operations["memory_snapshot_v1_admin_memory_snapshot_get"];
         put?: never;
-        /**
-         * Create Alert
-         * @description Create a new email alert for the authenticated user.
-         *
-         *     AC1: Persists alert definition with filter criteria.
-         *     Enforces a per-user limit to prevent abuse.
-         */
-        post: operations["create_alert_v1_alerts_post"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts/{alert_id}": {
+    "/v1/admin/users/segments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get User Segments
+         * @description LIFECYCLE-003: Return user lifecycle segment counts, transitions,
+         *     and power user details.
+         *
+         *     Classifies every user into one of 10 lifecycle states:
+         *     anonymous, lead, trial_active, trial_limited, trial_expired,
+         *     paid_active, paid_past_due, canceled, churned, power_user.
+         *
+         *     Results are cached in Redis for 5 minutes.
+         */
+        get: operations["get_user_segments_v1_admin_users_segments_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/subscriptions/update-billing-period": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Update Billing Period
+         * @description Update subscription billing period (monthly / semiannual / annual).
+         *
+         *     GTM-002: Simplified flow — Stripe handles proration automatically.
+         *     No deferral logic, no manual credit calculations.
+         */
+        post: operations["update_billing_period_v1_api_subscriptions_update_billing_period_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/subscriptions/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Subscription
+         * @description Cancel subscription at period end.
+         *
+         *     GTM-FIX-006: User-initiated cancellation flow.
+         *     UX-308: Accepts optional cancellation reason for retention analytics.
+         *     Sets cancel_at_period_end=True in Stripe, updates status to 'canceling'.
+         */
+        post: operations["cancel_subscription_v1_api_subscriptions_cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/subscriptions/cancel-feedback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Cancel Feedback
+         * @description Submit post-cancellation feedback (UX-308 AC6).
+         *
+         *     Logs feedback as a user action for analytics. Fire-and-forget — never blocks UX.
+         */
+        post: operations["submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/subscriptions/upgrade-to-lifetime/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Upgrade To Lifetime Preview
+         * @description Preview pro-rata math for the upgrade-to-lifetime modal (#1011).
+         *
+         *     Returns ``eligible=False`` with a structured ``reason`` whenever the user
+         *     is not allowed to upgrade (already founder, no active sub, cap reached,
+         *     feature flag off). Front-end uses this to render the right copy without
+         *     parsing free text.
+         */
+        get: operations["upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/subscriptions/upgrade-to-lifetime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upgrade To Lifetime
+         * @description Upgrade Pro mensal -> Lifetime founder (#1011 / UPGRADE-PATH-013).
+         *
+         *     Flow:
+         *       1. Re-check founder cap via existing ``check_founding_availability()`` RPC
+         *          (race-guarded, atomic). Reject 410 if cap reached.
+         *       2. Reject 409 if ``profiles.is_founder`` is already TRUE (idempotent).
+         *       3. Cancel the active Stripe subscription with ``prorate=True``. Stripe
+         *          issues a credit balance to the customer automatically — no custom
+         *          prorata math.
+         *       4. Create a Stripe Checkout Session in ``mode='payment'`` for the
+         *          R$997 one-time founder price (``FOUNDING_ONE_TIME_PRICE_ID``).
+         *          Customer balance is consumed automatically by Stripe.
+         *       5. Return checkout URL. The existing webhook handler
+         *          (``webhooks/handlers/founding.py::_activate_lifetime_founder_entitlement``)
+         *          flips ``is_founder=TRUE`` once payment completes — DO NOT duplicate.
+         *       6. Audit log via ``audit_logger`` for billing.subscription_change.
+         */
+        post: operations["upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/features/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get My Features
+         * @description Get current user's enabled features.
+         *
+         *     CACHING STRATEGY (STORY-217: unified pool):
+         *     - Redis cache with 5-minute TTL via shared pool
+         *     - Cache key: ``features:{user_id}``
+         *     - Cache miss: Fetch from Supabase (JOIN user_subscriptions + plan_features)
+         *     - Graceful degradation via InMemoryCache fallback
+         */
+        get: operations["get_my_features_v1_api_features_me_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/messages/conversations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Conversations */
+        get: operations["list_conversations_v1_api_messages_conversations_get"];
+        put?: never;
+        /** Create Conversation */
+        post: operations["create_conversation_v1_api_messages_conversations_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/messages/conversations/{conversation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Conversation */
+        get: operations["get_conversation_v1_api_messages_conversations__conversation_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/messages/conversations/{conversation_id}/reply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reply To Conversation */
+        post: operations["reply_to_conversation_v1_api_messages_conversations__conversation_id__reply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/messages/conversations/{conversation_id}/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -1503,41 +693,22 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /**
-         * Delete Alert
-         * @description Delete an alert and its sent-item history.
-         *
-         *     AC4: Cascading delete removes associated alert_sent_items.
-         *     Validates that the alert belongs to the authenticated user.
-         */
-        delete: operations["delete_alert_v1_alerts__alert_id__delete"];
+        delete?: never;
         options?: never;
         head?: never;
-        /**
-         * Update Alert
-         * @description Update an existing alert (partial update).
-         *
-         *     AC3: Only name, filters, and active status can be updated.
-         *     Validates that the alert belongs to the authenticated user.
-         */
-        patch: operations["update_alert_v1_alerts__alert_id__patch"];
+        /** Update Conversation Status */
+        patch: operations["update_conversation_status_v1_api_messages_conversations__conversation_id__status_patch"];
         trace?: never;
     };
-    "/v1/alerts/{alert_id}/history": {
+    "/v1/api/messages/unread-count": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Alert History
-         * @description Paginated history of items sent for this alert.
-         *
-         *     AC13: Returns alert_sent_items ordered by sent_at desc.
-         *     Only accessible if the alert belongs to the authenticated user.
-         */
-        get: operations["alert_history_v1_alerts__alert_id__history_get"];
+        /** Get Unread Count */
+        get: operations["get_unread_count_v1_api_messages_unread_count_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1546,7 +717,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts/{alert_id}/preview": {
+    "/v1/analytics/summary": {
         parameters: {
             query?: never;
             header?: never;
@@ -1554,13 +725,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Preview Alert
-         * @description Preview what opportunities an alert would match (dry-run).
-         *
-         *     STORY-315 AC12: Executes matching without sending email.
-         *     Returns opportunities that would be sent, useful for validating filters.
+         * Get Analytics Summary
+         * @description Get overall user analytics summary.
          */
-        get: operations["preview_alert_v1_alerts__alert_id__preview_get"];
+        get: operations["get_analytics_summary_v1_analytics_summary_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1569,7 +737,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts/{alert_id}/unsubscribe": {
+    "/v1/analytics/searches-over-time": {
         parameters: {
             query?: never;
             header?: never;
@@ -1577,14 +745,53 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Unsubscribe Alert
-         * @description One-click unsubscribe from an email alert (RFC 8058).
-         *
-         *     AC9: No authentication required — uses HMAC token verification.
-         *     Sets the alert's active flag to false.
-         *     Returns an HTML confirmation page.
+         * Get Searches Over Time
+         * @description Get time-series search data grouped by period.
          */
-        get: operations["unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get"];
+        get: operations["get_searches_over_time_v1_analytics_searches_over_time_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/analytics/top-dimensions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Top Dimensions
+         * @description Get top UFs and sectors by search count.
+         */
+        get: operations["get_top_dimensions_v1_analytics_top_dimensions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/analytics/trial-value": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Trial Value
+         * @description Get value generated during trial period (GTM-010 AC1).
+         *
+         *     Returns aggregated statistics of opportunities analyzed during the user's trial.
+         *     Used by TrialConversionScreen to show personalized conversion messaging.
+         */
+        get: operations["get_trial_value_v1_analytics_trial_value_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1618,66 +825,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/analytics/searches-over-time": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Searches Over Time
-         * @description Get time-series search data grouped by period.
-         */
-        get: operations["get_searches_over_time_v1_analytics_searches_over_time_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Analytics Summary
-         * @description Get overall user analytics summary.
-         */
-        get: operations["get_analytics_summary_v1_analytics_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/top-dimensions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Top Dimensions
-         * @description Get top UFs and sectors by search count.
-         */
-        get: operations["get_top_dimensions_v1_analytics_top_dimensions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/analytics/track-cta": {
         parameters: {
             query?: never;
@@ -1695,29 +842,6 @@ export interface paths {
          *     Fire-and-forget — always returns 204.
          */
         post: operations["track_cta_event_v1_analytics_track_cta_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/trial-value": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Trial Value
-         * @description Get value generated during trial period (GTM-010 AC1).
-         *
-         *     Returns aggregated statistics of opportunities analyzed during the user's trial.
-         *     Used by TrialConversionScreen to show personalized conversion messaging.
-         */
-        get: operations["get_trial_value_v1_analytics_trial_value_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1923,7 +1047,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/api/features/me": {
+    "/v1/buscar-progress/{search_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1931,16 +1055,26 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get My Features
-         * @description Get current user's enabled features.
+         * Buscar Progress Stream
+         * @description SSE endpoint for real-time search progress updates.
          *
-         *     CACHING STRATEGY (STORY-217: unified pool):
-         *     - Redis cache with 5-minute TTL via shared pool
-         *     - Cache key: ``features:{user_id}``
-         *     - Cache miss: Fetch from Supabase (JOIN user_subscriptions + plan_features)
-         *     - Graceful degradation via InMemoryCache fallback
+         *     The client opens this connection simultaneously with POST /buscar,
+         *     using the same search_id to correlate progress events.
+         *
+         *     GTM-GO-002 AC6: Max 3 simultaneous SSE connections per user.
+         *
+         *     Events:
+         *         - connecting (5%): Initial setup
+         *         - fetching (10-55%): Per-UF progress with uf_index/uf_total
+         *         - filtering (60-70%): Filter application
+         *         - llm (75-90%): LLM summary generation
+         *         - excel (92-98%): Excel report generation
+         *         - complete (100%): Search finished
+         *         - partial_results: Non-terminal — intermediate results during background fetch (A-04)
+         *         - refresh_available (100%): Background fetch complete, new data available (A-04)
+         *         - error: Search failed
          */
-        get: operations["get_my_features_v1_api_features_me_get"];
+        get: operations["buscar_progress_stream_v1_buscar_progress__search_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1949,33 +1083,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/api/messages/conversations": {
+    "/v1/search/{search_id}/status": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** List Conversations */
-        get: operations["list_conversations_v1_api_messages_conversations_get"];
-        put?: never;
-        /** Create Conversation */
-        post: operations["create_conversation_v1_api_messages_conversations_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/api/messages/conversations/{conversation_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Conversation */
-        get: operations["get_conversation_v1_api_messages_conversations__conversation_id__get"];
+        /**
+         * Search Status Endpoint
+         * @description GTM-STAB-009 AC3: Enriched status response for polling.
+         *
+         *     LIGHTWEIGHT (<50ms): Reads from in-memory progress tracker + state machine.
+         *     Falls back to DB-based get_search_status only if in-memory state is unavailable.
+         *
+         *     Called by frontend when SSE disconnects (AC12) or for async polling.
+         */
+        get: operations["search_status_endpoint_v1_search__search_id__status_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1984,7 +1108,98 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/api/messages/conversations/{conversation_id}/reply": {
+    "/v1/search/{search_id}/timeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search Timeline Endpoint
+         * @description AC7: Return all state transitions for audit trail.
+         */
+        get: operations["search_timeline_endpoint_v1_search__search_id__timeline_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/buscar-results/{search_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Search Results
+         * @description Return results of a background fetch or async search.
+         *
+         *     A-04 AC5: Called by frontend when user clicks "Atualizar resultados" banner.
+         *     GTM-ARCH-001 AC3: Also serves results from ARQ Worker (via Redis).
+         *     Returns 404 if search_id not found or expired.
+         */
+        get: operations["get_search_results_v1_buscar_results__search_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Search Results V1
+         * @description GTM-STAB-009 AC4: Return results of async search.
+         *
+         *     - 200 with BuscaResponse when results are ready
+         *     - 202 with status when still processing
+         *     - 404 when search_id not found or expired
+         */
+        get: operations["get_search_results_v1_v1_search__search_id__results_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/zero-match": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Zero Match Results Endpoint
+         * @description Return items approved by background zero-match LLM classification.
+         *
+         *     - 200: Results ready (may be empty list if none approved)
+         *     - 404: Job not yet completed or results expired
+         */
+        get: operations["get_zero_match_results_endpoint_v1_search__search_id__zero_match_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/regenerate-excel": {
         parameters: {
             query?: never;
             header?: never;
@@ -1993,15 +1208,21 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Reply To Conversation */
-        post: operations["reply_to_conversation_v1_api_messages_conversations__conversation_id__reply_post"];
+        /**
+         * Regenerate Excel Endpoint
+         * @description STORY-364 AC7-AC8: Regenerate Excel from stored results without re-running search.
+         *
+         *     - 202: Excel generation job enqueued
+         *     - 404: Results not found or expired
+         */
+        post: operations["regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/messages/conversations/{conversation_id}/status": {
+    "/v1/search/{search_id}/retry": {
         parameters: {
             query?: never;
             header?: never;
@@ -2010,23 +1231,493 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        post?: never;
+        /**
+         * Retry Search
+         * @description CRIT-006 AC4-5: Retry search with only missing/failed UFs.
+         */
+        post: operations["retry_search_v1_search__search_id__retry_post"];
         delete?: never;
         options?: never;
         head?: never;
-        /** Update Conversation Status */
-        patch: operations["update_conversation_status_v1_api_messages_conversations__conversation_id__status_patch"];
+        patch?: never;
         trace?: never;
     };
-    "/v1/api/messages/unread-count": {
+    "/v1/search/{search_id}/cancel": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Unread Count */
-        get: operations["get_unread_count_v1_api_messages_unread_count_get"];
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Search
+         * @description CRIT-006 AC16-17: Cancel an in-progress search.
+         */
+        post: operations["cancel_search_v1_search__search_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/buscar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Buscar Licitacoes
+         * @description Main search endpoint — thin wrapper that delegates to SearchPipeline.
+         *
+         *     GTM-RESILIENCE-A04: Cache-first progressive delivery.
+         *     When cache exists for this search, returns cached data immediately with
+         *     `live_fetch_in_progress=True` and dispatches background live fetch.
+         *     When no cache, runs synchronous pipeline as before (AC10).
+         *
+         *     The wrapper handles:
+         *     - Cache-first check and immediate response (A-04 AC1)
+         *     - Background task dispatch (A-04 AC2)
+         *     - SSE tracker lifecycle (create, cleanup on error)
+         *     - Exception mapping (PNCPRateLimitError → 503, PNCPAPIError → 502, etc.)
+         *     - Dependency injection (passing module-level names for test mock compatibility)
+         *
+         *     STORY-291 AC5: require_active_plan() moved INSIDE try block, AFTER tracker
+         *     creation. Previously, when it failed the frontend was left in limbo — POST
+         *     failed but SSE was waiting for a tracker that never existed.
+         */
+        post: operations["buscar_licitacoes_v1_buscar_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Change Password
+         * @description Change current user's password.
+         */
+        post: operations["change_password_v1_change_password_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description Get current user profile with plan capabilities and quota status.
+         *
+         *     Uses admin client (get_db) because it needs db.auth.admin.get_user_by_id()
+         *     to fetch the user's email from auth.users — an admin-only operation.
+         */
+        get: operations["get_profile_v1_me_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Account
+         * @description Delete entire user account and all associated data (LGPD Art. 18 VI).
+         *
+         *     Uses admin client (get_db) because it needs db.auth.admin.delete_user()
+         *     and must delete across multiple tables regardless of RLS.
+         *
+         *     Strategy:
+         *     1. Cancel active Stripe subscription (external side-effect, must be first)
+         *     2. Delete from profiles (CASCADE propagates to most child tables)
+         *     3. Delete from remaining tables that reference auth.users directly
+         *     4. Delete auth user via Supabase admin API
+         *     5. Log anonymized audit entry
+         *
+         *     If auth user deletion fails (step 4), we do NOT roll back the profile
+         *     deletion — the user's data is already gone and a dangling auth entry
+         *     is preferable to leaving personal data behind (LGPD Art. 18 VI).
+         */
+        delete: operations["delete_account_v1_me_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Trial Status
+         * @description Get detailed trial status for conversion flow (GTM-010 AC3).
+         *
+         *     Returns days remaining, usage stats, and expiration info.
+         */
+        get: operations["get_trial_status_v1_trial_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/user/recommended-plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Recommended Plan
+         * @description STORY-BIZ-002 AC2: return the upsell-eligible plan for the current user.
+         *
+         *     Detects consultancy profiles by CNAE primário (divisions 70.2 / 74.9 / 82.9)
+         *     and recommends the higher-ARPU Consultoria plan. Non-consultancies see the
+         *     default Pro recommendation. Cached in Redis for 24h keyed by user_id.
+         */
+        get: operations["get_recommended_plan_v1_user_recommended_plan_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/profile/context": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile Context
+         * @description Get business context from profile (STORY-247 AC3).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
+         *     ensures users can only read their own profile row.
+         */
+        get: operations["get_profile_context_v1_profile_context_get"];
+        /**
+         * Save Profile Context
+         * @description Save business context from onboarding wizard (STORY-247 AC2).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
+         *     ensures users can only update their own profile row.
+         *     Stores context_data as JSONB in profiles table.
+         */
+        put: operations["save_profile_context_v1_profile_context_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/profile/completeness": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile Completeness
+         * @description STORY-260 AC3: Calculate profile completeness and suggest next question.
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS ensures user can only
+         *     read their own profile.
+         */
+        get: operations["get_profile_completeness_v1_profile_completeness_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/profile/alert-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Alert Preferences
+         * @description Get user's alert preferences (STORY-278 AC6).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
+         *     ensures users can only read their own preferences.
+         */
+        get: operations["get_alert_preferences_v1_profile_alert_preferences_get"];
+        /**
+         * Update Alert Preferences
+         * @description Update user's alert preferences (STORY-278 AC6).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
+         *     ensures users can only modify their own preferences.
+         */
+        put: operations["update_alert_preferences_v1_profile_alert_preferences_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/me/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export User Data
+         * @description Export all user data as JSON file (LGPD Art. 18 V — data portability).
+         *
+         *     Uses admin client (get_db) because it queries across multiple tables
+         *     and needs unrestricted access to gather all user data for export.
+         *
+         *     Returns a downloadable JSON file containing:
+         *     - Profile information
+         *     - Search history (sessions)
+         *     - Subscription history
+         *     - Messages
+         */
+        get: operations["export_user_data_v1_me_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial/exit-survey": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Exit Survey
+         * @description STORY-369 AC2: Submit exit survey when trial expires.
+         *     Returns 409 if user already submitted a survey.
+         */
+        post: operations["submit_exit_survey_v1_trial_exit_survey_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/trial-exit-surveys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Exit Surveys Admin
+         * @description STORY-369 AC6: Admin endpoint — exit survey counts grouped by reason.
+         */
+        get: operations["get_exit_surveys_admin_v1_admin_trial_exit_surveys_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/plans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Plans
+         * @description Get available subscription plans with billing period pricing.
+         *
+         *     STORY-360 AC1: Single source of truth — DB (synced from Stripe) is master.
+         *     Returns per-period pricing from plan_billing_periods table.
+         *     Stripe price IDs stripped from response (STORY-210 AC11).
+         */
+        get: operations["get_plans_v1_plans_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Checkout
+         * @description Create Stripe Checkout session for a plan purchase.
+         */
+        post: operations["create_checkout_v1_checkout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing-portal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Billing Portal Session
+         * @description Create Stripe Billing Portal session (GTM-FIX-007 AC6-AC7).
+         *
+         *     Allows users to update payment methods, view invoices, and manage subscriptions.
+         *
+         *     Returns:
+         *         dict: {"url": "https://billing.stripe.com/..."}
+         */
+        post: operations["create_billing_portal_session_v1_billing_portal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/subscription/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Subscription Status
+         * @description Check subscription activation status (GTM-FIX-016).
+         *
+         *     Used by obrigado page to poll for webhook completion.
+         *     Returns current subscription state from DB, with Stripe API fallback.
+         */
+        get: operations["get_subscription_status_v1_subscription_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/setup-intent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Setup Intent
+         * @description Create a Stripe SetupIntent for pre-signup card capture (CONV-003b AC2).
+         *
+         *     Anonymous endpoint: called before the Supabase user exists, so we cannot
+         *     attach a customer yet. The returned ``payment_method`` (from
+         *     ``stripe.confirmSetup()`` client-side) is forwarded to
+         *     ``POST /v1/auth/signup`` which then creates the Customer and attaches
+         *     the PM server-side via ``services.stripe_signup``.
+         *
+         *     Rate-limited via the same bucket as signup (3 req / 10 min per IP) to
+         *     block abuse. Returns the publishable key alongside the client secret so
+         *     the frontend does not need a second round-trip to ``/config`` (keeps
+         *     the signup flow to 2 network calls: setup-intent → signup).
+         */
+        post: operations["create_setup_intent_v1_billing_setup_intent_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sessions
+         * @description Get user's search session history.
+         */
+        get: operations["get_sessions_v1_sessions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sessions/{search_id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download Session Excel
+         * @description Download Excel for a previously completed search session.
+         *
+         *     Zero-Churn P2 §2.2: Allows downloads within DATA_RETENTION_DAYS even
+         *     after trial/subscription expires. Bypasses quota checks — only previously
+         *     generated data can be downloaded.
+         */
+        get: operations["download_session_excel_v1_sessions__search_id__download_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2065,7 +1756,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/cancel": {
+    "/v1/emails/send-welcome": {
         parameters: {
             query?: never;
             header?: never;
@@ -2075,21 +1766,144 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Cancel Subscription
-         * @description Cancel subscription at period end.
+         * Send Welcome Email
+         * @description Send welcome email to authenticated user (idempotent).
          *
-         *     GTM-FIX-006: User-initiated cancellation flow.
-         *     UX-308: Accepts optional cancellation reason for retention analytics.
-         *     Sets cancel_at_period_end=True in Stripe, updates status to 'canceling'.
+         *     AC7: Triggered after successful signup (both email and Google OAuth).
+         *     Frontend calls this after signup confirmation.
+         *     Idempotent: checks profiles.welcome_email_sent_at before sending.
          */
-        post: operations["cancel_subscription_v1_api_subscriptions_cancel_post"];
+        post: operations["send_welcome_email_v1_emails_send_welcome_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/cancel-feedback": {
+    "/v1/emails/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unsubscribe Email
+         * @description Unsubscribe from marketing emails.
+         *
+         *     AC15: Unsubscribe mechanism in all marketing emails (LGPD + CAN-SPAM).
+         *     AC16: Updates user preference in database.
+         *     AC17: Transactional emails exempt (payment, security).
+         */
+        get: operations["unsubscribe_email_v1_emails_unsubscribe_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/pipeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Pipeline Items
+         * @description List pipeline items for the authenticated user (AC3).
+         *
+         *     ISSUE-021 fix: Switched to admin client (get_supabase) — user-scoped client
+         *     (get_user_db) had fragile JWT header mutation that silently failed, causing
+         *     PostgREST to evaluate RLS as anonymous user and return 0 rows.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access,
+         *     consistent with POST/PATCH/DELETE handlers.
+         *
+         *     STORY-265 AC3: Trial expired can VIEW pipeline (read-only).
+         *     Supports filtering by stage and pagination via limit/offset.
+         */
+        get: operations["list_pipeline_items_v1_pipeline_get"];
+        put?: never;
+        /**
+         * Create Pipeline Item
+         * @description Add a procurement opportunity to the user's pipeline (AC2).
+         *
+         *     ISSUE-021 fix: Reverted to admin client (get_supabase) — user-scoped client
+         *     caused HTTP 500 due to fragile session header mutation in get_user_db.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
+         *     STORY-265 AC2: Trial expired cannot add items.
+         *     STORY-356: Enforce pipeline item limit (trial: 5 items max).
+         *     Returns 409 if the item already exists (UNIQUE constraint on user_id + pncp_id).
+         */
+        post: operations["create_pipeline_item_v1_pipeline_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/pipeline/{item_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Pipeline Item
+         * @description Remove an item from the pipeline (AC5).
+         *
+         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
+         *     STORY-265 AC2: Trial expired cannot delete items.
+         *     Returns 404 if item doesn't exist or doesn't belong to user.
+         */
+        delete: operations["delete_pipeline_item_v1_pipeline__item_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Pipeline Item
+         * @description Update stage and/or notes of a pipeline item (AC4).
+         *
+         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
+         *     STORY-265 AC2: Trial expired cannot modify items.
+         *     Validates that stage is a valid enum value.
+         *     Returns 404 if item doesn't exist or doesn't belong to user.
+         */
+        patch: operations["update_pipeline_item_v1_pipeline__item_id__patch"];
+        trace?: never;
+    };
+    "/v1/pipeline/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Pipeline Alerts
+         * @description Get pipeline items with deadlines within 7 days (DEBT-127 AC1).
+         *
+         *     STORY-265 AC3: Trial expired can view alerts (read-only).
+         *     Returns items where data_encerramento < now() + 7 days
+         *     and stage is NOT in ('enviada', 'resultado').
+         */
+        get: operations["get_pipeline_alerts_v1_pipeline_alerts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/first-analysis": {
         parameters: {
             query?: never;
             header?: never;
@@ -2099,19 +1913,21 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Submit Cancel Feedback
-         * @description Submit post-cancellation feedback (UX-308 AC6).
+         * First Analysis
+         * @description Execute first automatic analysis based on onboarding profile.
          *
-         *     Logs feedback as a user action for analytics. Fire-and-forget — never blocks UX.
+         *     STORY-265 AC5: Trial expired cannot initiate analysis.
+         *     GTM-004 AC1-4: Maps CNAE to sector, builds BuscaRequest automatically,
+         *     executes search in background, and returns search_id for SSE tracking.
          */
-        post: operations["submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post"];
+        post: operations["first_analysis_v1_first_analysis_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/update-billing-period": {
+    "/v1/onboarding/tour-event": {
         parameters: {
             query?: never;
             header?: never;
@@ -2121,20 +1937,19 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Update Billing Period
-         * @description Update subscription billing period (monthly / semiannual / annual).
+         * Track Tour Event
+         * @description Persist onboarding tour completion/skip events (STORY-313 AC18).
          *
-         *     GTM-002: Simplified flow — Stripe handles proration automatically.
-         *     No deferral logic, no manual credit calculations.
+         *     Fire-and-forget tracking — always returns 204 regardless of metric state.
          */
-        post: operations["update_billing_period_v1_api_subscriptions_update_billing_period_post"];
+        post: operations["track_tour_event_v1_onboarding_tour_event_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/upgrade-to-lifetime": {
+    "/v1/auth/validate-signup-email": {
         parameters: {
             query?: never;
             header?: never;
@@ -2144,32 +1959,44 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Upgrade To Lifetime
-         * @description Upgrade Pro mensal -> Lifetime founder (#1011 / UPGRADE-PATH-013).
+         * Validate Signup Email
+         * @description STORY-258 AC3: Backend disposable email validation (defense-in-depth).
          *
-         *     Flow:
-         *       1. Re-check founder cap via existing ``check_founding_availability()`` RPC
-         *          (race-guarded, atomic). Reject 410 if cap reached.
-         *       2. Reject 409 if ``profiles.is_founder`` is already TRUE (idempotent).
-         *       3. Cancel the active Stripe subscription with ``prorate=True``. Stripe
-         *          issues a credit balance to the customer automatically — no custom
-         *          prorata math.
-         *       4. Create a Stripe Checkout Session in ``mode='payment'`` for the
-         *          R$997 one-time founder price (``FOUNDING_ONE_TIME_PRICE_ID``).
-         *          Customer balance is consumed automatically by Stripe.
-         *       5. Return checkout URL. The existing webhook handler
-         *          (``webhooks/handlers/founding.py::_activate_lifetime_founder_entitlement``)
-         *          flips ``is_founder=TRUE`` once payment completes — DO NOT duplicate.
-         *       6. Audit log via ``audit_logger`` for billing.subscription_change.
+         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
+         *     Returns 422 if email domain is disposable.
          */
-        post: operations["upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post"];
+        post: operations["validate_signup_email_v1_auth_validate_signup_email_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/upgrade-to-lifetime/preview": {
+    "/v1/auth/resend-confirmation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resend Confirmation
+         * @description Resend signup confirmation email with 60s rate limiting.
+         *
+         *     CONV-INST-003: Cooldown persisted in Supabase user_email_actions table.
+         *     In-memory _resend_timestamps used as fallback when DB is unavailable.
+         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
+         */
+        post: operations["resend_confirmation_v1_auth_resend_confirmation_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -2177,15 +2004,321 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Upgrade To Lifetime Preview
-         * @description Preview pro-rata math for the upgrade-to-lifetime modal (#1011).
+         * Auth Status
+         * @description Check if a signup email has been confirmed.
          *
-         *     Returns ``eligible=False`` with a structured ``reason`` whenever the user
-         *     is not allowed to upgrade (already founder, no active sub, cap reached,
-         *     feature flag off). Front-end uses this to render the right copy without
-         *     parsing free text.
+         *     AC8: Returns { confirmed: boolean, user_id?: string }.
+         *     AC7/AC9: Frontend polls this every 5s for auto-redirect.
+         *     CONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side
+         *     on first confirmation (idempotent via user_email_actions table).
          */
-        get: operations["upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get"];
+        get: operations["auth_status_v1_auth_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Signup
+         * @description STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.
+         *
+         *     Returns 200 with `SignupResponse`. Error modes:
+         *
+         *     - 400: disposable email domain or weak password.
+         *     - 400: invalid `stripe_payment_method_id` shape (Pydantic regex).
+         *     - 409: email already registered (detected via Supabase error).
+         *     - 500: Supabase auth.create_user failed (NOT Stripe — Stripe fails open).
+         */
+        post: operations["signup_v1_auth_signup_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/login-attempt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record Login Attempt
+         * @description MFA-EXT-001 AC5/AC6: track password attempts to drive MFA enforcement.
+         *
+         *     Frontend (``AuthProvider``) calls this endpoint immediately after a
+         *     Supabase ``signInWithPassword`` call to report the outcome:
+         *
+         *       * ``success=true``  -> reset counter to 0, set ``last_success_at``
+         *       * ``success=false`` -> increment counter; if it crosses
+         *         ``BRUTEFORCE_FAIL_THRESHOLD`` (3), set
+         *         ``profiles.force_mfa_enrollment_until = NOW() + 7d`` and email
+         *         the user.
+         *
+         *     Trust model: the endpoint is unauthenticated; an attacker can lie
+         *     about the outcome but gains nothing — self-reported success without
+         *     a real session never produces a forced MFA window. Documented in
+         *     ADR-MFA-EXT-001.
+         *
+         *     Always returns 200 (no user-existence oracle).
+         */
+        post: operations["record_login_attempt_v1_auth_login_attempt_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * System Health
+         * @description GTM-STAB-008 AC3: Comprehensive system health endpoint (AC4: internal, detailed).
+         *
+         *     Returns component-level statuses (Redis, Supabase, ARQ Worker, PNCP)
+         *     and overall health classification (healthy / degraded / unhealthy).
+         */
+        get: operations["system_health_v1_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Public Status
+         * @description STORY-316 AC3: Public status endpoint (no auth required).
+         *
+         *     Returns per-source status, component health, uptime percentages,
+         *     and last incident timestamp.
+         */
+        get: operations["public_status_v1_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/status/incidents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Recent Incidents
+         * @description STORY-316 AC13: Recent incidents for status page.
+         */
+        get: operations["recent_incidents_v1_status_incidents_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/status/uptime-history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Uptime History
+         * @description STORY-316 AC12: Daily uptime data for status page chart.
+         */
+        get: operations["uptime_history_v1_status_uptime_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Background Tasks Health
+         * @description DEBT-014 SYS-006: Background task health via TaskRegistry.
+         */
+        get: operations["background_tasks_health_v1_health_tasks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Sources Health
+         * @description UX-428 AC5: Health status for all configured procurement sources.
+         *
+         *     Returns enabled/disabled state and availability for each source.
+         *     Read-only — no side effects.
+         */
+        get: operations["sources_health_v1_health_sources_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/cache": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cache Health
+         * @description AC7: Health check for all cache levels.
+         *
+         *     Returns status of Supabase, Redis/InMemory, and Local file caches
+         *     with latency measurements and error details.
+         *     B-03 AC9: Includes degraded_keys_count and avg_fail_streak from health metadata.
+         *     Note: warmup_coverage removed 2026-04-18 (STORY-CIG-BE-cache-warming-deprecate).
+         */
+        get: operations["cache_health_v1_health_cache_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/sitemap": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Sitemap Health
+         * @description SEO-SITEMAP-TELEMETRY-001: Health check for all sitemap materialized views.
+         *
+         *     Returns per-MV status (ok/empty/error) and overall status (ok/degraded).
+         *     Used by Sentry monitors and Railway probes to detect empty sitemap
+         *     responses before they reach GSC.
+         */
+        get: operations["sitemap_health_v1_health_sitemap_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feedback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Feedback
+         * @description AC1: Submit classification feedback for a search result.
+         *
+         *     AC5: Upserts — if user already gave feedback for this search_id + bid_id, update it.
+         *     AC3: Captures context fields (setor_id, bid_objeto, etc.) from the request body.
+         */
+        post: operations["submit_feedback_v1_feedback_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feedback/{feedback_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Feedback
+         * @description AC9: Delete own feedback for LGPD compliance.
+         */
+        delete: operations["delete_feedback_v1_feedback__feedback_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/feedback/patterns": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Feedback Patterns
+         * @description AC6: Admin endpoint for feedback pattern analysis.
+         *
+         *     Requires admin role (via require_admin dependency).
+         */
+        get: operations["feedback_patterns_v1_admin_feedback_patterns_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2244,141 +2377,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/auth/login-attempt": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Record Login Attempt
-         * @description MFA-EXT-001 AC5/AC6: track password attempts to drive MFA enforcement.
-         *
-         *     Frontend (``AuthProvider``) calls this endpoint immediately after a
-         *     Supabase ``signInWithPassword`` call to report the outcome:
-         *
-         *       * ``success=true``  -> reset counter to 0, set ``last_success_at``
-         *       * ``success=false`` -> increment counter; if it crosses
-         *         ``BRUTEFORCE_FAIL_THRESHOLD`` (3), set
-         *         ``profiles.force_mfa_enrollment_until = NOW() + 7d`` and email
-         *         the user.
-         *
-         *     Trust model: the endpoint is unauthenticated; an attacker can lie
-         *     about the outcome but gains nothing — self-reported success without
-         *     a real session never produces a forced MFA window. Documented in
-         *     ADR-MFA-EXT-001.
-         *
-         *     Always returns 200 (no user-existence oracle).
-         */
-        post: operations["record_login_attempt_v1_auth_login_attempt_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/resend-confirmation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Resend Confirmation
-         * @description Resend signup confirmation email with 60s rate limiting.
-         *
-         *     CONV-INST-003: Cooldown persisted in Supabase user_email_actions table.
-         *     In-memory _resend_timestamps used as fallback when DB is unavailable.
-         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
-         */
-        post: operations["resend_confirmation_v1_auth_resend_confirmation_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/signup": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Signup
-         * @description STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.
-         *
-         *     Returns 200 with `SignupResponse`. Error modes:
-         *
-         *     - 400: disposable email domain or weak password.
-         *     - 400: invalid `stripe_payment_method_id` shape (Pydantic regex).
-         *     - 409: email already registered (detected via Supabase error).
-         *     - 500: Supabase auth.create_user failed (NOT Stripe — Stripe fails open).
-         */
-        post: operations["signup_v1_auth_signup_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Auth Status
-         * @description Check if a signup email has been confirmed.
-         *
-         *     AC8: Returns { confirmed: boolean, user_id?: string }.
-         *     AC7/AC9: Frontend polls this every 5s for auto-redirect.
-         *     CONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side
-         *     on first confirmation (idempotent via user_email_actions table).
-         */
-        get: operations["auth_status_v1_auth_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/validate-signup-email": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Validate Signup Email
-         * @description STORY-258 AC3: Backend disposable email validation (defense-in-depth).
-         *
-         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
-         *     Returns 422 if email domain is disposable.
-         */
-        post: operations["validate_signup_email_v1_auth_validate_signup_email_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/bid-analysis/{bid_id}": {
         parameters: {
             query?: never;
@@ -2402,97 +2400,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/billing-portal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Billing Portal Session
-         * @description Create Stripe Billing Portal session (GTM-FIX-007 AC6-AC7).
-         *
-         *     Allows users to update payment methods, view invoices, and manage subscriptions.
-         *
-         *     Returns:
-         *         dict: {"url": "https://billing.stripe.com/..."}
-         */
-        post: operations["create_billing_portal_session_v1_billing_portal_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/billing/setup-intent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Setup Intent
-         * @description Create a Stripe SetupIntent for pre-signup card capture (CONV-003b AC2).
-         *
-         *     Anonymous endpoint: called before the Supabase user exists, so we cannot
-         *     attach a customer yet. The returned ``payment_method`` (from
-         *     ``stripe.confirmSetup()`` client-side) is forwarded to
-         *     ``POST /v1/auth/signup`` which then creates the Customer and attaches
-         *     the PM server-side via ``services.stripe_signup``.
-         *
-         *     Rate-limited via the same bucket as signup (3 req / 10 min per IP) to
-         *     block abuse. Returns the publishable key alongside the client secret so
-         *     the frontend does not need a second round-trip to ``/config`` (keeps
-         *     the signup flow to 2 network calls: setup-intent → signup).
-         */
-        post: operations["create_setup_intent_v1_billing_setup_intent_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/daily/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest diario atual (publico) */
-        get: operations["daily_digest_latest_v1_blog_daily_latest_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/daily/{date}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest diario para uma data especifica (publico) */
-        get: operations["daily_digest_by_date_v1_blog_daily__date__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/cidade/{cidade}": {
+    "/v1/alerts": {
         parameters: {
             query?: never;
             header?: never;
@@ -2500,686 +2408,28 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Cidade Stats
-         * @description City stats: count, frequent buying orgs, avg values.
+         * List Alerts
+         * @description List all alerts for the authenticated user, ordered by created_at desc.
          *
-         *     Public (no auth). Cached 6h.
-         *     Uses the first sector with results to get city data.
+         *     AC2: Includes sent_count (number of items sent for each alert).
          */
-        get: operations["get_cidade_stats_v1_blog_stats_cidade__cidade__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/cidade/{cidade}/setor/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Cidade Sector Stats
-         * @description City × Sector stats: cross-reference city with sector keywords.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_cidade_sector_stats_v1_blog_stats_cidade__cidade__setor__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/cidade/{cidade}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Cidade Stats
-         * @description City-level contract stats (all sectors) — fallback for blog cidade pages.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/cidade/{cidade}/setor/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Cidade Setor Stats
-         * @description City × Sector contract stats — fallback for blog cidade×setor pages.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Setor Stats
-         * @description National contract stats by sector from pncp_supplier_contracts.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_setor_stats_v1_blog_stats_contratos__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/{setor_id}/uf/{uf}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Setor Uf Stats
-         * @description Sector × UF contract stats — fallback for blog pages with zero open editais.
-         *
-         *     Queries pncp_supplier_contracts filtered by uf (idx_psc_uf_data) and sector
-         *     keywords. Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_setor_uf_stats_v1_blog_stats_contratos__setor_id__uf__uf__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/panorama/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Panorama Stats
-         * @description National panorama: totals, seasonality, estimated YoY growth.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_panorama_stats_v1_blog_stats_panorama__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/setor/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Sector Blog Stats
-         * @description Sector overview: count, value range, top modalities, top UFs, 90d trend.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_sector_blog_stats_v1_blog_stats_setor__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/setor/{setor_id}/uf/{uf}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Sector Uf Stats
-         * @description Sector × UF detail: count, avg value, top 5 recent opportunities.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/weekly/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest semanal atual (público) */
-        get: operations["weekly_digest_latest_v1_blog_weekly_latest_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/weekly/{year}/{week}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest semanal para um período específico (público) */
-        get: operations["weekly_digest_by_week_v1_blog_weekly__year___week__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/buscar": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
+        get: operations["list_alerts_v1_alerts_get"];
         put?: never;
         /**
-         * Buscar Licitacoes
-         * @description Main search endpoint — thin wrapper that delegates to SearchPipeline.
+         * Create Alert
+         * @description Create a new email alert for the authenticated user.
          *
-         *     GTM-RESILIENCE-A04: Cache-first progressive delivery.
-         *     When cache exists for this search, returns cached data immediately with
-         *     `live_fetch_in_progress=True` and dispatches background live fetch.
-         *     When no cache, runs synchronous pipeline as before (AC10).
-         *
-         *     The wrapper handles:
-         *     - Cache-first check and immediate response (A-04 AC1)
-         *     - Background task dispatch (A-04 AC2)
-         *     - SSE tracker lifecycle (create, cleanup on error)
-         *     - Exception mapping (PNCPRateLimitError → 503, PNCPAPIError → 502, etc.)
-         *     - Dependency injection (passing module-level names for test mock compatibility)
-         *
-         *     STORY-291 AC5: require_active_plan() moved INSIDE try block, AFTER tracker
-         *     creation. Previously, when it failed the frontend was left in limbo — POST
-         *     failed but SSE was waiting for a tracker that never existed.
+         *     AC1: Persists alert definition with filter criteria.
+         *     Enforces a per-user limit to prevent abuse.
          */
-        post: operations["buscar_licitacoes_v1_buscar_post"];
+        post: operations["create_alert_v1_alerts_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/buscar-progress/{search_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Buscar Progress Stream
-         * @description SSE endpoint for real-time search progress updates.
-         *
-         *     The client opens this connection simultaneously with POST /buscar,
-         *     using the same search_id to correlate progress events.
-         *
-         *     GTM-GO-002 AC6: Max 3 simultaneous SSE connections per user.
-         *
-         *     Events:
-         *         - connecting (5%): Initial setup
-         *         - fetching (10-55%): Per-UF progress with uf_index/uf_total
-         *         - filtering (60-70%): Filter application
-         *         - llm (75-90%): LLM summary generation
-         *         - excel (92-98%): Excel report generation
-         *         - complete (100%): Search finished
-         *         - partial_results: Non-terminal — intermediate results during background fetch (A-04)
-         *         - refresh_available (100%): Background fetch complete, new data available (A-04)
-         *         - error: Search failed
-         */
-        get: operations["buscar_progress_stream_v1_buscar_progress__search_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/buscar-results/{search_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Search Results
-         * @description Return results of a background fetch or async search.
-         *
-         *     A-04 AC5: Called by frontend when user clicks "Atualizar resultados" banner.
-         *     GTM-ARCH-001 AC3: Also serves results from ARQ Worker (via Redis).
-         *     Returns 404 if search_id not found or expired.
-         */
-        get: operations["get_search_results_v1_buscar_results__search_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/calculadora/dados": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Dados reais PNCP para a calculadora de oportunidades (público) */
-        get: operations["calculadora_dados_v1_calculadora_dados_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/change-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Change Password
-         * @description Change current user's password.
-         */
-        post: operations["change_password_v1_change_password_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/checkout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Checkout
-         * @description Create Stripe Checkout session for a plan purchase.
-         */
-        post: operations["create_checkout_v1_checkout_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/comparador/bids": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Bids By Ids
-         * @description Fetch specific bids by pncp_id from datalake (public, no auth).
-         */
-        get: operations["get_bids_by_ids_v1_comparador_bids_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/comparador/buscar": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Buscar Editais
-         * @description Search bids by text query from datalake (public, no auth).
-         */
-        get: operations["buscar_editais_v1_comparador_buscar_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/compliance/{cnpj}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Perfil de due diligence B2G: CEIS + CNEP por CNPJ
-         * @description Agrega registros CEIS e CNEP do Portal da Transparencia para um CNPJ.
-         *
-         *     Publico, sem auth. Cache: 24h por CNPJ.
-         *     Em caso de falha do Portal da Transparencia, retorna dados parciais.
-         */
-        get: operations["compliance_profile_v1_compliance__cnpj__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/conta/cancelar-trial": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Cancel Trial Info
-         * @description Return trial metadata for the confirmation UI.
-         *
-         *     Does NOT mutate state. Intended to be called by the frontend confirmation
-         *     page (STORY-CONV-003c frontend).
-         */
-        get: operations["cancel_trial_info_v1_conta_cancelar_trial_get"];
-        put?: never;
-        /**
-         * Cancel Trial Execute
-         * @description Cancel the user's active trial subscription.
-         *
-         *     Idempotent: if already cancelled, returns ``cancelled=true`` + ``already_cancelled=true``.
-         *     Fail-safe: Stripe errors are swallowed but profile is marked ``canceled_trial``
-         *     so the downgrade still happens if the Stripe-side cancel retries succeed out-of-band
-         *     via billing reconciliation (STORY-314).
-         */
-        post: operations["cancel_trial_execute_v1_conta_cancelar_trial_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/contratos/orgao/{cnpj}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Perfil de contratos de um orgao publico (por CNPJ) */
-        get: operations["orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/contratos/{setor}/{uf}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Estatisticas de contratos publicos por setor e UF */
-        get: operations["contratos_stats_v1_contratos__setor___uf__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/dados/agregados": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Dados agregados do PNCP para o painel público (sem autenticação) */
-        get: operations["dados_agregados_v1_dados_agregados_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/emails/send-welcome": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Send Welcome Email
-         * @description Send welcome email to authenticated user (idempotent).
-         *
-         *     AC7: Triggered after successful signup (both email and Google OAuth).
-         *     Frontend calls this after signup confirmation.
-         *     Idempotent: checks profiles.welcome_email_sent_at before sending.
-         */
-        post: operations["send_welcome_email_v1_emails_send_welcome_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/emails/unsubscribe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Unsubscribe Email
-         * @description Unsubscribe from marketing emails.
-         *
-         *     AC15: Unsubscribe mechanism in all marketing emails (LGPD + CAN-SPAM).
-         *     AC16: Updates user preference in database.
-         *     AC17: Transactional emails exempt (payment, security).
-         */
-        get: operations["unsubscribe_email_v1_emails_unsubscribe_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/empresa/{cnpj}/perfil-b2g": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Perfil B2G público de uma empresa por CNPJ */
-        get: operations["perfil_b2g_v1_empresa__cnpj__perfil_b2g_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/export/pdf": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Export Edital Pdf
-         * @description Generate and return a 1-page A4 PDF for a single bid.
-         *
-         *     Trial users get a watermark footer.
-         *     Synchronous generation wrapped in asyncio.to_thread with 10s timeout.
-         */
-        post: operations["export_edital_pdf_v1_export_pdf_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feature-flags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Public Feature Flags
-         * @description List all feature flags with current values (authenticated users).
-         *
-         *     DEBT-205 / DEBT-SYS-009: Public endpoint consumed by frontend via SWR.
-         *     Returns flag name, value, description, and category — no admin metadata.
-         */
-        get: operations["list_public_feature_flags_v1_feature_flags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feature-flags/experiments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Experiments
-         * @description Return active experiment variants for the authenticated user.
-         */
-        get: operations["get_experiments_v1_feature_flags_experiments_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feedback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Submit Feedback
-         * @description AC1: Submit classification feedback for a search result.
-         *
-         *     AC5: Upserts — if user already gave feedback for this search_id + bid_id, update it.
-         *     AC3: Captures context fields (setor_id, bid_objeto, etc.) from the request body.
-         */
-        post: operations["submit_feedback_v1_feedback_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feedback/{feedback_id}": {
+    "/v1/alerts/{alert_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -3190,16 +2440,119 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Delete Feedback
-         * @description AC9: Delete own feedback for LGPD compliance.
+         * Delete Alert
+         * @description Delete an alert and its sent-item history.
+         *
+         *     AC4: Cascading delete removes associated alert_sent_items.
+         *     Validates that the alert belongs to the authenticated user.
          */
-        delete: operations["delete_feedback_v1_feedback__feedback_id__delete"];
+        delete: operations["delete_alert_v1_alerts__alert_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Alert
+         * @description Update an existing alert (partial update).
+         *
+         *     AC3: Only name, filters, and active status can be updated.
+         *     Validates that the alert belongs to the authenticated user.
+         */
+        patch: operations["update_alert_v1_alerts__alert_id__patch"];
+        trace?: never;
+    };
+    "/v1/alerts/{alert_id}/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unsubscribe Alert
+         * @description One-click unsubscribe from an email alert (RFC 8058).
+         *
+         *     AC9: No authentication required — uses HMAC token verification.
+         *     Sets the alert's active flag to false.
+         *     Returns an HTML confirmation page.
+         */
+        get: operations["unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/first-analysis": {
+    "/v1/alerts/{alert_id}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Preview Alert
+         * @description Preview what opportunities an alert would match (dry-run).
+         *
+         *     STORY-315 AC12: Executes matching without sending email.
+         *     Returns opportunities that would be sent, useful for validating filters.
+         */
+        get: operations["preview_alert_v1_alerts__alert_id__preview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/alerts/{alert_id}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Alert History
+         * @description Paginated history of items sent for this alert.
+         *
+         *     AC13: Returns alert_sent_items ordered by sent_at desc.
+         *     Only accessible if the alert belongs to the authenticated user.
+         */
+        get: operations["alert_history_v1_alerts__alert_id__history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial-emails/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unsubscribe Trial Emails
+         * @description AC2/AC5: One-click unsubscribe from trial marketing emails.
+         *     Zero-churn P2 §1.2: Only disables marketing/promotional emails.
+         *     Critical conversion emails (Day 7/10/13/16) remain active unless
+         *     user explicitly opts out of those too.
+         */
+        get: operations["unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial-emails/webhook": {
         parameters: {
             query?: never;
             header?: never;
@@ -3209,21 +2562,33 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * First Analysis
-         * @description Execute first automatic analysis based on onboarding profile.
+         * Resend Webhook
+         * @description Handle Resend webhook events for email tracking.
          *
-         *     STORY-265 AC5: Trial expired cannot initiate analysis.
-         *     GTM-004 AC1-4: Maps CNAE to sector, builds BuscaRequest automatically,
-         *     executes search in background, and returns search_id for SSE tracking.
+         *     Security: Svix HMAC-SHA256 signature verified against `TRIAL_EMAILS_WEBHOOK_SECRET`
+         *     (or legacy alias `RESEND_WEBHOOK_SECRET`).
+         *     Replay protection: timestamp must be within 5 minutes of now.
+         *     Fail-closed — missing secret or invalid signature returns 401.
+         *
+         *     Accepts the full delivery lifecycle (sent → delivered → opened → clicked)
+         *     plus failure paths (bounced, complained, delivery_delayed, failed) so the
+         *     admin funnel dashboard can distinguish "email never arrived" from "email
+         *     arrived but wasn't engaged". Service handler
+         *     (`services.trial_email_sequence.handle_resend_webhook`) populates the
+         *     columns added in migration 20260424180000_trial_email_delivery_tracking.
+         *
+         *     Returns 200 for processed/ignored/skipped so Resend doesn't retry; 401 on
+         *     signature failure (Resend will retry — desired so legitimate events aren't
+         *     lost during transient secret rotation).
          */
-        post: operations["first_analysis_v1_first_analysis_post"];
+        post: operations["resend_webhook_v1_trial_emails_webhook_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/fornecedores/{cnpj}/profile": {
+    "/v1/admin/trial-emails/preview": {
         parameters: {
             query?: never;
             header?: never;
@@ -3231,13 +2596,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Perfil completo de um fornecedor do governo (por CNPJ)
-         * @description Agrega historico de contratos do PNCP + dados cadastrais (BrasilAPI via
-         *     enriched_entities) para a pagina /fornecedores/{cnpj}.
-         *
-         *     Publico, sem auth. Cache: 24h TTL em memoria (5min em fallback partial).
+         * Preview Trial Emails
+         * @description AC15: Preview all 6 trial email templates.
          */
-        get: operations["fornecedor_profile_v1_fornecedores__cnpj__profile_get"];
+        get: operations["preview_trial_emails_v1_admin_trial_emails_preview_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3246,48 +2608,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/fornecedores/{setor}/{uf}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Ranking de fornecedores do governo por setor e UF */
-        get: operations["fornecedores_stats_v1_fornecedores__setor___uf__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/availability": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founding Availability
-         * @description Public seat counter + countdown feed.
-         *
-         *     No auth — the landing page calls this anonymously to render the
-         *     countdown and the X/50 seat counter. Falls open with ``available=False``
-         *     on transient DB error so the CTA is disabled rather than over-selling.
-         */
-        get: operations["founding_availability_v1_founding_availability_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/checkout": {
+    "/v1/admin/trial-emails/test-send": {
         parameters: {
             query?: never;
             header?: never;
@@ -3297,651 +2618,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Founding Checkout
-         * @description Create a founding-customer Stripe Checkout Session (v2 one-time payment).
-         *
-         *     BIZ-FOUND-002 gate:
-         *     - Calls ``check_founding_availability()`` BEFORE creating the lead row.
-         *     - On ``available=false`` returns 410 Gone with structured ``error_code`` +
-         *       ``error_reason`` so the frontend can render the right copy.
-         *
-         *     #783 changes:
-         *     - Uses ``mode='payment'`` (one-time) with ``FOUNDING_ONE_TIME_PRICE_ID``.
-         *     - Accepts ``card`` and ``boleto`` payment methods.
-         *     - No coupon / discounts applied.
-         *     - Expanded metadata: ``offer_version``, ``offer_mode``, ``price_brl_cents``,
-         *       ``checkout_source`` (resolved from ``src`` or ``utm_source`` query param).
-         *
-         *     Side effects (when available):
-         *     - Inserts a ``founding_leads`` row with ``checkout_status='pending'``.
-         *     - Subsequent webhook events (``checkout.session.completed`` / ``expired``)
-         *       update it. The webhook also re-checks availability for race guard
-         *       (handled in webhooks.handlers.founding).
+         * Test Send Trial Email
+         * @description AC14: Send a test trial email to the admin's own email.
          */
-        post: operations["founding_checkout_v1_founding_checkout_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/checkout/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founding Checkout Status
-         * @description Return Stripe checkout session status for the founding purchase confirmation page.
-         *
-         *     No auth required — Stripe ``cs_*`` session IDs are long random tokens that
-         *     are unguessable. Only ``status`` and ``payment_status`` are returned so no
-         *     PII is exposed. Used by ``/fundadores/obrigado`` to poll until payment is
-         *     confirmed (max 20 × 3 s = 60 s).
-         */
-        get: operations["founding_checkout_status_v1_founding_checkout_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/session-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founding Session Status
-         * @description Enriched session status for the /fundadores/obrigado confirmation page (#865).
-         *
-         *     No auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.
-         *     Returns masked email, ``has_account``, and ``invite_sent`` so the frontend
-         *     can render the right post-purchase CTA without polling Stripe directly.
-         *
-         *     Expiry guard: sessions with checkout_status != 'completed' that are older
-         *     than 24 h return ``status='pending'`` to prevent infinite polling.
-         */
-        get: operations["founding_session_status_v1_founding_session_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * System Health
-         * @description GTM-STAB-008 AC3: Comprehensive system health endpoint (AC4: internal, detailed).
-         *
-         *     Returns component-level statuses (Redis, Supabase, ARQ Worker, PNCP)
-         *     and overall health classification (healthy / degraded / unhealthy).
-         */
-        get: operations["system_health_v1_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/cache": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Cache Health
-         * @description AC7: Health check for all cache levels.
-         *
-         *     Returns status of Supabase, Redis/InMemory, and Local file caches
-         *     with latency measurements and error details.
-         *     B-03 AC9: Includes degraded_keys_count and avg_fail_streak from health metadata.
-         *     Note: warmup_coverage removed 2026-04-18 (STORY-CIG-BE-cache-warming-deprecate).
-         */
-        get: operations["cache_health_v1_health_cache_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/sitemap": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Sitemap Health
-         * @description SEO-SITEMAP-TELEMETRY-001: Health check for all sitemap materialized views.
-         *
-         *     Returns per-MV status (ok/empty/error) and overall status (ok/degraded).
-         *     Used by Sentry monitors and Railway probes to detect empty sitemap
-         *     responses before they reach GSC.
-         */
-        get: operations["sitemap_health_v1_health_sitemap_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/sources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Sources Health
-         * @description UX-428 AC5: Health status for all configured procurement sources.
-         *
-         *     Returns enabled/disabled state and availability for each source.
-         *     Read-only — no side effects.
-         */
-        get: operations["sources_health_v1_health_sources_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/tasks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Background Tasks Health
-         * @description DEBT-014 SYS-006: Background task health via TaskRegistry.
-         */
-        get: operations["background_tasks_health_v1_health_tasks_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/indice-municipal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ranking de transparência municipal em compras públicas (público)
-         * @description Ranking nacional ou por UF de transparência municipal. Dados do PNCP.
-         */
-        get: operations["get_ranking_v1_indice_municipal_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/indice-municipal/periodos": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Períodos disponíveis no Índice Municipal (público)
-         * @description Lista trimestres com dados calculados no índice.
-         */
-        get: operations["get_periodos_v1_indice_municipal_periodos_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/indice-municipal/{municipio_slug}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Índice de transparência de um município (público)
-         * @description Retorna índice de transparência de um município (slug: sao-paulo-sp).
-         */
-        get: operations["get_municipio_v1_indice_municipal__municipio_slug__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Intel Report Purchases
-         * @description List all Intel Report purchases for the authenticated user.
-         */
-        get: operations["list_intel_report_purchases_v1_intel_reports__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/checkout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Intel Report Checkout
-         * @description Create a Stripe Checkout session for an Intel Report one-time purchase.
-         *
-         *     product_type:
-         *         - "cnpj"       → R$197.00 — Company analysis report (INTEL-REPORT-001)
-         *         - "sector_uf"  → R$147.00 — Sector/UF market report (INTEL-REPORT-002)
-         *
-         *     entity_key:
-         *         - For cnpj:       the CNPJ string (e.g. "12345678000195")
-         *         - For sector_uf:  "sector:uf" (e.g. "limpeza:SP")
-         *
-         *     Returns checkout_url (redirect user) and session_id (for polling).
-         */
-        post: operations["create_intel_report_checkout_v1_intel_reports_checkout_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/{purchase_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Intel Report Status
-         * @description Poll status of an Intel Report purchase.
-         *
-         *     Frontend uses this endpoint after being redirected back from Stripe
-         *     (/intel-reports/{CHECKOUT_SESSION_ID}?status=processing).
-         *     Poll until status is "ready" or "failed".
-         *
-         *     Returns:
-         *     - 404 if purchase does not exist
-         *     - 403 if purchase belongs to a different user
-         */
-        get: operations["get_intel_report_status_v1_intel_reports__purchase_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/{purchase_id}/download": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Download Intel Report
-         * @description Stream the Intel Report PDF.
-         *
-         *     Requires:
-         *     - Authentication
-         *     - Ownership: purchase must belong to the authenticated user
-         *     - Status: purchase must be "ready" (pdf_url present)
-         *
-         *     Returns:
-         *     - 401 if not authenticated
-         *     - 404 if purchase does not exist
-         *     - 403 if purchase belongs to a different user
-         *     - 400 if purchase status is not "ready"
-         *     - PDF stream if all checks pass
-         */
-        get: operations["download_intel_report_v1_intel_reports__purchase_id__download_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/itens/{catmat}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Benchmark de precos governamentais por codigo CATMAT
-         * @description Calcula P10/P50/P90 de contratos do PNCP datalake para um item CATMAT.
-         *
-         *     Publico, sem auth. Cache: 24h. Substitui o Painel de Precos do ComprasGov
-         *     (descontinuado jul/2025).
-         */
-        get: operations["item_profile_v1_itens__catmat__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/lead-capture": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Capture Lead
-         * @description Store a lead capture from a non-authenticated visitor.
-         *
-         *     - New sources (COPY-COP-006): stored in ``lead_captures`` table
-         *     - Old sources (backward compat): stored in ``leads`` table
-         *     - Rate limited to 3 requests/min per IP
-         *     - Fail-open: returns success even if DB storage fails
-         *     - Lead magnet PDF delivery enqueued for legacy sources (LEAD-MAGNET-001)
-         *
-         *     Returns 201 on success.
-         */
-        post: operations["capture_lead_v1_lead_capture_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/lead-magnet/{magnet_type}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Lead Magnet
-         * @description Return a placeholder PDF for the requested lead magnet type.
-         *
-         *     This is a minimal/stub implementation — the real LLM-generated content
-         *     will replace the placeholder text in a future story.
-         */
-        get: operations["get_lead_magnet_v1_lead_magnet__magnet_type__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/me": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile
-         * @description Get current user profile with plan capabilities and quota status.
-         *
-         *     Uses admin client (get_db) because it needs db.auth.admin.get_user_by_id()
-         *     to fetch the user's email from auth.users — an admin-only operation.
-         */
-        get: operations["get_profile_v1_me_get"];
-        put?: never;
-        post?: never;
-        /**
-         * Delete Account
-         * @description Delete entire user account and all associated data (LGPD Art. 18 VI).
-         *
-         *     Uses admin client (get_db) because it needs db.auth.admin.delete_user()
-         *     and must delete across multiple tables regardless of RLS.
-         *
-         *     Strategy:
-         *     1. Cancel active Stripe subscription (external side-effect, must be first)
-         *     2. Delete from profiles (CASCADE propagates to most child tables)
-         *     3. Delete from remaining tables that reference auth.users directly
-         *     4. Delete auth user via Supabase admin API
-         *     5. Log anonymized audit entry
-         *
-         *     If auth user deletion fails (step 4), we do NOT roll back the profile
-         *     deletion — the user's data is already gone and a dangling auth entry
-         *     is preferable to leaving personal data behind (LGPD Art. 18 VI).
-         */
-        delete: operations["delete_account_v1_me_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/me/export": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Export User Data
-         * @description Export all user data as JSON file (LGPD Art. 18 V — data portability).
-         *
-         *     Uses admin client (get_db) because it queries across multiple tables
-         *     and needs unrestricted access to gather all user data for export.
-         *
-         *     Returns a downloadable JSON file containing:
-         *     - Profile information
-         *     - Search history (sessions)
-         *     - Subscription history
-         *     - Messages
-         */
-        get: operations["export_user_data_v1_me_export_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/metrics/daily-volume": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Daily Volume
-         * @description STORY-358 AC3: Return average bids processed per day.
-         *
-         *     Public endpoint (no authentication required). Used by InstitutionalSidebar
-         *     to display a verified bids/day count instead of a hardcoded number.
-         *
-         *     Queries search_sessions for the specified window and computes daily average
-         *     from total_raw (bids fetched before filtering).
-         */
-        get: operations["get_daily_volume_v1_metrics_daily_volume_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/metrics/discard-rate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Discard Rate
-         * @description Return the moving-average filter discard rate.
-         *
-         *     Public endpoint (no authentication required). Used by the landing page
-         *     to display a verified discard rate instead of a hardcoded number.
-         */
-        get: operations["get_discard_rate_v1_metrics_discard_rate_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/metrics/sse-fallback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Report Sse Fallback
-         * @description STORY-359 AC4: Frontend reports SSE fallback to simulated progress.
-         *
-         *     Lightweight fire-and-forget endpoint — no auth, no body, just increments counter.
-         */
-        post: operations["report_sse_fallback_v1_metrics_sse_fallback_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/mfa/enroll": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enroll Totp
-         * @description Issue #639 AC1: Enrol a TOTP MFA factor for the current user.
-         *
-         *     Returns the QR code URI (otpauth://...), the base32 secret, and 10 fresh
-         *     one-time backup codes. The user adds the URI/secret to an authenticator
-         *     app and then calls /verify-totp with a generated code to complete enrolment.
-         *
-         *     Backup codes are returned ONCE — the client must persist them.
-         */
-        post: operations["enroll_totp_v1_mfa_enroll_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/mfa/recovery-codes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Recovery Codes
-         * @description AC5: Generate 10 recovery codes after MFA enrollment.
-         *
-         *     This should be called immediately after successful MFA enrollment.
-         *     Stores bcrypt-hashed codes in the database, returns plaintext once.
-         */
-        post: operations["generate_recovery_codes_v1_mfa_recovery_codes_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/mfa/regenerate-recovery": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Regenerate Recovery Codes
-         * @description AC8: Regenerate recovery codes (requires aal2).
-         *
-         *     Invalidates all existing codes and generates a fresh set.
-         */
-        post: operations["regenerate_recovery_codes_v1_mfa_regenerate_recovery_post"];
+        post: operations["test_send_trial_email_v1_admin_trial_emails_test_send_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3972,6 +2652,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/mfa/recovery-codes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Recovery Codes
+         * @description AC5: Generate 10 recovery codes after MFA enrollment.
+         *
+         *     This should be called immediately after successful MFA enrollment.
+         *     Stores bcrypt-hashed codes in the database, returns plaintext once.
+         */
+        post: operations["generate_recovery_codes_v1_mfa_recovery_codes_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/mfa/verify-recovery": {
         parameters: {
             query?: never;
@@ -3989,6 +2692,32 @@ export interface paths {
          *     On success: marks code as used, returns remaining count.
          */
         post: operations["verify_recovery_code_v1_mfa_verify_recovery_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/mfa/enroll": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enroll Totp
+         * @description Issue #639 AC1: Enrol a TOTP MFA factor for the current user.
+         *
+         *     Returns the QR code URI (otpauth://...), the base32 secret, and 10 fresh
+         *     one-time backup codes. The user adds the URI/secret to an authenticator
+         *     app and then calls /verify-totp with a generated code to complete enrolment.
+         *
+         *     Backup codes are returned ONCE — the client must persist them.
+         */
+        post: operations["enroll_totp_v1_mfa_enroll_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4022,28 +2751,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/municipios/{slug}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Perfil de municipio com licitacoes abertas (por slug)
-         * @description Agrega licitacoes abertas do PNCP datalake + dados IBGE para a pagina
-         *     /municipios/{slug}. Publico, sem auth. Cache: 24h TTL em memoria.
-         */
-        get: operations["municipio_profile_v1_municipios__slug__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/network-events/record": {
+    "/v1/mfa/regenerate-recovery": {
         parameters: {
             query?: never;
             header?: never;
@@ -4053,139 +2761,12 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Record Network Event
-         * @description Record an anonymized network event.
+         * Regenerate Recovery Codes
+         * @description AC8: Regenerate recovery codes (requires aal2).
          *
-         *     Only collects data if user has explicitly opted in
-         *     (profiles.allow_network_analytics = true). LGPD Art. 6, I.
+         *     Invalidates all existing codes and generates a fresh set.
          */
-        post: operations["record_network_event_v1_network_events_record_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/network-events/top": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Top Network Events
-         * @description Get top dimension values for a given event type.
-         *
-         *     Public endpoint — returns only anonymized aggregated data.
-         */
-        get: operations["get_top_network_events_v1_network_events_top_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/notifications/new-bids-count": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get New Bids Count
-         * @description Return count of new bids available for the user since last check.
-         *
-         *     Returns 0 when no Redis key exists (cron not yet run, or badge was cleared).
-         */
-        get: operations["get_new_bids_count_v1_notifications_new_bids_count_get"];
-        put?: never;
-        post?: never;
-        /**
-         * Clear New Bids Count
-         * @description Clear the new-bids badge for the user (called after they run a search).
-         *
-         *     Idempotent — safe to call even if the key does not exist.
-         */
-        delete: operations["clear_new_bids_count_v1_notifications_new_bids_count_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/observatorio/relatorio/{mes}/{ano}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Relatório mensal do Observatório de Licitações (público) */
-        get: operations["get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/observatorio/relatorio/{mes}/{ano}/csv": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Download CSV do relatório mensal (público) */
-        get: operations["get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/onboarding/tour-event": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Track Tour Event
-         * @description Persist onboarding tour completion/skip events (STORY-313 AC18).
-         *
-         *     Fire-and-forget tracking — always returns 204 regardless of metric state.
-         */
-        post: operations["track_tour_event_v1_onboarding_tour_event_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/organizations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Org
-         * @description Create organization (owner = current user).
-         */
-        post: operations["create_org_v1_organizations_post"];
+        post: operations["regenerate_recovery_codes_v1_mfa_regenerate_recovery_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4212,6 +2793,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Org
+         * @description Create organization (owner = current user).
+         */
+        post: operations["create_org_v1_organizations_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/{org_id}": {
         parameters: {
             query?: never;
@@ -4226,6 +2827,26 @@ export interface paths {
         get: operations["get_org_v1_organizations__org_id__get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/{org_id}/invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Invite Org Member
+         * @description Invite a member to the organization (owner/admin only).
+         */
+        post: operations["invite_org_member_v1_organizations__org_id__invite_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4252,6 +2873,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations/{org_id}/members/{target_user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove Org Member
+         * @description Remove a member from the organization (owner/admin only).
+         */
+        delete: operations["remove_org_member_v1_organizations__org_id__members__target_user_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/{org_id}/dashboard": {
         parameters: {
             query?: never;
@@ -4266,26 +2907,6 @@ export interface paths {
         get: operations["get_org_dashboard_endpoint_v1_organizations__org_id__dashboard_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/organizations/{org_id}/invite": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Invite Org Member
-         * @description Invite a member to the organization (owner/admin only).
-         */
-        post: operations["invite_org_member_v1_organizations__org_id__invite_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4315,43 +2936,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/organizations/{org_id}/members/{target_user_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Remove Org Member
-         * @description Remove a member from the organization (owner/admin only).
-         */
-        delete: operations["remove_org_member_v1_organizations__org_id__members__target_user_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/orgao/{cnpj}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Estatísticas públicas de um órgão comprador por CNPJ */
-        get: operations["orgao_stats_v1_orgao__cnpj__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/partner/dashboard": {
         parameters: {
             query?: never;
@@ -4374,7 +2958,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/pipeline": {
+    "/v1/admin/partners": {
         parameters: {
             query?: never;
             header?: never;
@@ -4382,39 +2966,23 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Pipeline Items
-         * @description List pipeline items for the authenticated user (AC3).
-         *
-         *     ISSUE-021 fix: Switched to admin client (get_supabase) — user-scoped client
-         *     (get_user_db) had fragile JWT header mutation that silently failed, causing
-         *     PostgREST to evaluate RLS as anonymous user and return 0 rows.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access,
-         *     consistent with POST/PATCH/DELETE handlers.
-         *
-         *     STORY-265 AC3: Trial expired can VIEW pipeline (read-only).
-         *     Supports filtering by stage and pagination via limit/offset.
+         * List Partners Endpoint
+         * @description AC10: List all partners. Admin only.
          */
-        get: operations["list_pipeline_items_v1_pipeline_get"];
+        get: operations["list_partners_endpoint_v1_admin_partners_get"];
         put?: never;
         /**
-         * Create Pipeline Item
-         * @description Add a procurement opportunity to the user's pipeline (AC2).
-         *
-         *     ISSUE-021 fix: Reverted to admin client (get_supabase) — user-scoped client
-         *     caused HTTP 500 due to fragile session header mutation in get_user_db.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
-         *     STORY-265 AC2: Trial expired cannot add items.
-         *     STORY-356: Enforce pipeline item limit (trial: 5 items max).
-         *     Returns 409 if the item already exists (UNIQUE constraint on user_id + pncp_id).
+         * Create Partner Endpoint
+         * @description AC11: Create a new partner. Admin only.
          */
-        post: operations["create_pipeline_item_v1_pipeline_post"];
+        post: operations["create_partner_endpoint_v1_admin_partners_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/pipeline/alerts": {
+    "/v1/admin/partners/{partner_id}/referrals": {
         parameters: {
             query?: never;
             header?: never;
@@ -4422,14 +2990,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Pipeline Alerts
-         * @description Get pipeline items with deadlines within 7 days (DEBT-127 AC1).
-         *
-         *     STORY-265 AC3: Trial expired can view alerts (read-only).
-         *     Returns items where data_encerramento < now() + 7 days
-         *     and stage is NOT in ('enviada', 'resultado').
+         * Get Partner Referrals Endpoint
+         * @description AC12: Get referrals for a specific partner. Admin only.
          */
-        get: operations["get_pipeline_alerts_v1_pipeline_alerts_get"];
+        get: operations["get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4438,42 +3002,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/pipeline/{item_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Pipeline Item
-         * @description Remove an item from the pipeline (AC5).
-         *
-         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
-         *     STORY-265 AC2: Trial expired cannot delete items.
-         *     Returns 404 if item doesn't exist or doesn't belong to user.
-         */
-        delete: operations["delete_pipeline_item_v1_pipeline__item_id__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Pipeline Item
-         * @description Update stage and/or notes of a pipeline item (AC4).
-         *
-         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
-         *     STORY-265 AC2: Trial expired cannot modify items.
-         *     Validates that stage is a valid enum value.
-         *     Returns 404 if item doesn't exist or doesn't belong to user.
-         */
-        patch: operations["update_pipeline_item_v1_pipeline__item_id__patch"];
-        trace?: never;
-    };
-    "/v1/plans": {
+    "/v1/admin/partners/{partner_id}/revenue": {
         parameters: {
             query?: never;
             header?: never;
@@ -4481,475 +3010,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Plans
-         * @description Get available subscription plans with billing period pricing.
-         *
-         *     STORY-360 AC1: Single source of truth — DB (synced from Stripe) is master.
-         *     Returns per-period pricing from plan_billing_periods table.
-         *     Stripe price IDs stripped from response (STORY-210 AC11).
+         * Get Partner Revenue Endpoint
+         * @description AC13: Get revenue share for a partner in a given month. Admin only.
          */
-        get: operations["get_plans_v1_plans_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/predict/seasonal-calendar": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Calendario sazonal de compras por UF
-         * @description Retorna um calendario sazonal de 12 meses com base no historico de contratos e licitacoes da UF. Inclui volume medio, quantidade, setor dominante, orgaos principais, indice de sazonalidade, tendencia e variacao anual para cada mes.
-         */
-        get: operations["get_seasonal_calendar_v1_predict_seasonal_calendar_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/products": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Products
-         * @description List active digital products available for one-time purchase.
-         *
-         *     Public (no auth required). Results cached in Redis for 1 hour.
-         */
-        get: operations["list_products_v1_products_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/profile/alert-preferences": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Alert Preferences
-         * @description Get user's alert preferences (STORY-278 AC6).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
-         *     ensures users can only read their own preferences.
-         */
-        get: operations["get_alert_preferences_v1_profile_alert_preferences_get"];
-        /**
-         * Update Alert Preferences
-         * @description Update user's alert preferences (STORY-278 AC6).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
-         *     ensures users can only modify their own preferences.
-         */
-        put: operations["update_alert_preferences_v1_profile_alert_preferences_put"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/profile/completeness": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile Completeness
-         * @description STORY-260 AC3: Calculate profile completeness and suggest next question.
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS ensures user can only
-         *     read their own profile.
-         */
-        get: operations["get_profile_completeness_v1_profile_completeness_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/profile/context": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile Context
-         * @description Get business context from profile (STORY-247 AC3).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
-         *     ensures users can only read their own profile row.
-         */
-        get: operations["get_profile_context_v1_profile_context_get"];
-        /**
-         * Save Profile Context
-         * @description Save business context from onboarding wizard (STORY-247 AC2).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
-         *     ensures users can only update their own profile row.
-         *     Stores context_data as JSONB in profiles table.
-         */
-        put: operations["save_profile_context_v1_profile_context_put"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/pseo/recent-editais": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 5 últimos editais abertos no setor (público)
-         * @description Most recent open editais for sector+UF.
-         *
-         *     Returns orgao, objeto, valor_estimado, data_limite, link_interno.
-         *     link_interno = /licitacoes/{setor}?query={orgao}
-         *     Cache: 6h InMemory.
-         */
-        get: operations["get_recent_editais_v1_pseo_recent_editais_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/pseo/top-suppliers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Top 5 fornecedores por volume de contratos no setor (público)
-         * @description Top suppliers by contract volume in sector, last 12 months.
-         *
-         *     Returns cnpj, razao_social, contratos_count, valor_total.
-         *     If total contracts < 10, returns empty list (avoid weak social proof).
-         *     Cache: 6h InMemory.
-         */
-        get: operations["get_top_suppliers_v1_pseo_top_suppliers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/referral/code": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Referral Code
-         * @description Return the authenticated user's referral code (create if missing).
-         */
-        get: operations["get_referral_code_v1_referral_code_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/referral/redeem": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Redeem Referral
-         * @description Register a referral redemption during signup.
-         *
-         *     The authenticated user is the *referred* user. We look up the row
-         *     owned by the referrer (matched by code) and link the referred_user_id
-         *     while promoting status to 'signed_up'. If no such row exists we
-         *     silently succeed to avoid leaking code existence.
-         */
-        post: operations["redeem_referral_v1_referral_redeem_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/referral/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Referral Stats
-         * @description Aggregate stats for the authenticated user's referrals.
-         */
-        get: operations["get_referral_stats_v1_referral_stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/relatorio-2026-t1/request": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Request Relatorio
-         * @description Capture a report lead and dispatch the delivery email.
-         *
-         *     Flow:
-         *       1. Upsert row into `report_leads` on (email, source).
-         *       2. Attempt to send the delivery email via Resend (best-effort).
-         *       3. Return the download URL + email_queued flag.
-         *
-         *     Persistence failure -> 500. Email failure -> 200 with email_queued=False.
-         */
-        post: operations["request_relatorio_v1_relatorio_2026_t1_request_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/reports/diagnostico": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Diagnostico
-         * @description Generate a PDF diagnostico report for a completed search.
-         *
-         *     Fetches the results from a previous search (by search_id), applies
-         *     viability scoring if not already present, selects the top N opportunities,
-         *     and streams a styled PDF back to the caller as a file download.
-         *
-         *     Request Body:
-         *         {
-         *             "search_id": "uuid-of-completed-search",
-         *             "client_name": "Empresa ABC Ltda",  // optional
-         *             "max_items": 20                       // 1-50
-         *         }
-         *
-         *     Returns:
-         *         PDF file as a streaming attachment:
-         *         Content-Disposition: attachment; filename="diagnostico-<setor>-<date>.pdf"
-         *
-         *     Errors:
-         *         400 Bad Request: search_id is not a valid UUID
-         *         404 Not Found: search not found or expired
-         *         500 Internal Server Error: PDF generation failed
-         */
-        post: operations["generate_diagnostico_v1_reports_diagnostico_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/cancel": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Cancel Search
-         * @description CRIT-006 AC16-17: Cancel an in-progress search.
-         */
-        post: operations["cancel_search_v1_search__search_id__cancel_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/regenerate-excel": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Regenerate Excel Endpoint
-         * @description STORY-364 AC7-AC8: Regenerate Excel from stored results without re-running search.
-         *
-         *     - 202: Excel generation job enqueued
-         *     - 404: Results not found or expired
-         */
-        post: operations["regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/results": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Search Results V1
-         * @description GTM-STAB-009 AC4: Return results of async search.
-         *
-         *     - 200 with BuscaResponse when results are ready
-         *     - 202 with status when still processing
-         *     - 404 when search_id not found or expired
-         */
-        get: operations["get_search_results_v1_v1_search__search_id__results_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/retry": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Retry Search
-         * @description CRIT-006 AC4-5: Retry search with only missing/failed UFs.
-         */
-        post: operations["retry_search_v1_search__search_id__retry_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Search Status Endpoint
-         * @description GTM-STAB-009 AC3: Enriched status response for polling.
-         *
-         *     LIGHTWEIGHT (<50ms): Reads from in-memory progress tracker + state machine.
-         *     Falls back to DB-based get_search_status only if in-memory state is unavailable.
-         *
-         *     Called by frontend when SSE disconnects (AC12) or for async polling.
-         */
-        get: operations["search_status_endpoint_v1_search__search_id__status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Search Timeline Endpoint
-         * @description AC7: Return all state transitions for audit trail.
-         */
-        get: operations["search_timeline_endpoint_v1_search__search_id__timeline_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/zero-match": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Zero Match Results Endpoint
-         * @description Return items approved by background zero-match LLM classification.
-         *
-         *     - 200: Results ready (may be empty list if none approved)
-         *     - 404: Job not yet completed or results expired
-         */
-        get: operations["get_zero_match_results_endpoint_v1_search__search_id__zero_match_get"];
+        get: operations["get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5023,7 +3087,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/segment/save": {
+    "/v1/reports/diagnostico": {
         parameters: {
             query?: never;
             header?: never;
@@ -5033,22 +3097,37 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Save Segment
-         * @description Save user segmentation data to profile context_data (CONV-018).
+         * Generate Diagnostico
+         * @description Generate a PDF diagnostico report for a completed search.
          *
-         *     Merges the new fields into the existing ``context_data`` JSONB column
-         *     on the ``profiles`` table without overwriting other fields.
+         *     Fetches the results from a previous search (by search_id), applies
+         *     viability scoring if not already present, selects the top N opportunities,
+         *     and streams a styled PDF back to the caller as a file download.
          *
-         *     Returns the full updated context_data on success.
+         *     Request Body:
+         *         {
+         *             "search_id": "uuid-of-completed-search",
+         *             "client_name": "Empresa ABC Ltda",  // optional
+         *             "max_items": 20                       // 1-50
+         *         }
+         *
+         *     Returns:
+         *         PDF file as a streaming attachment:
+         *         Content-Disposition: attachment; filename="diagnostico-<setor>-<date>.pdf"
+         *
+         *     Errors:
+         *         400 Bad Request: search_id is not a valid UUID
+         *         404 Not Found: search not found or expired
+         *         500 Internal Server Error: PDF generation failed
          */
-        post: operations["save_segment_v1_segment_save_post"];
+        post: operations["generate_diagnostico_v1_reports_diagnostico_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/seo/coverage-manifest": {
+    "/v1/blog/stats/setor/{setor_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -5056,14 +3135,12 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Per-slug coverage status for sitemap gate (SEO-COVERAGE-MANIFEST-001)
-         * @description Return the latest seo_coverage_manifest rows as a keyed dict.
+         * Get Sector Blog Stats
+         * @description Sector overview: count, value range, top modalities, top UFs, 90d trend.
          *
-         *     AC1: <2s response time (served from 1h in-memory cache after first build).
-         *     AC7: historical_empty slugs are included — sitemap gate uses priority=0.3,
-         *          not excluded, so /observatorio/raio-x-marco-2026 stays accessible.
+         *     Public (no auth). Cached 6h.
          */
-        get: operations["get_coverage_manifest_v1_seo_coverage_manifest_get"];
+        get: operations["get_sector_blog_stats_v1_blog_stats_setor__setor_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5072,7 +3149,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/sessions": {
+    "/v1/blog/stats/setor/{setor_id}/uf/{uf}": {
         parameters: {
             query?: never;
             header?: never;
@@ -5080,34 +3157,12 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Sessions
-         * @description Get user's search session history.
-         */
-        get: operations["get_sessions_v1_sessions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sessions/{search_id}/download": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Download Session Excel
-         * @description Download Excel for a previously completed search session.
+         * Get Sector Uf Stats
+         * @description Sector × UF detail: count, avg value, top 5 recent opportunities.
          *
-         *     Zero-Churn P2 §2.2: Allows downloads within DATA_RETENTION_DAYS even
-         *     after trial/subscription expires. Bypasses quota checks — only previously
-         *     generated data can be downloaded.
+         *     Public (no auth). Cached 6h.
          */
-        get: operations["download_session_excel_v1_sessions__search_id__download_get"];
+        get: operations["get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5116,7 +3171,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/setores": {
+    "/v1/blog/stats/cidade/{cidade}": {
         parameters: {
             query?: never;
             header?: never;
@@ -5124,10 +3179,373 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Listar Setores
-         * @description Return available procurement sectors for frontend dropdown.
+         * Get Cidade Stats
+         * @description City stats: count, frequent buying orgs, avg values.
+         *
+         *     Public (no auth). Cached 6h.
+         *     Uses the first sector with results to get city data.
          */
-        get: operations["listar_setores_v1_setores_get"];
+        get: operations["get_cidade_stats_v1_blog_stats_cidade__cidade__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/cidade/{cidade}/setor/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Cidade Sector Stats
+         * @description City × Sector stats: cross-reference city with sector keywords.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_cidade_sector_stats_v1_blog_stats_cidade__cidade__setor__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/panorama/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Panorama Stats
+         * @description National panorama: totals, seasonality, estimated YoY growth.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_panorama_stats_v1_blog_stats_panorama__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Setor Stats
+         * @description National contract stats by sector from pncp_supplier_contracts.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_setor_stats_v1_blog_stats_contratos__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/{setor_id}/uf/{uf}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Setor Uf Stats
+         * @description Sector × UF contract stats — fallback for blog pages with zero open editais.
+         *
+         *     Queries pncp_supplier_contracts filtered by uf (idx_psc_uf_data) and sector
+         *     keywords. Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_setor_uf_stats_v1_blog_stats_contratos__setor_id__uf__uf__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/cidade/{cidade}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Cidade Stats
+         * @description City-level contract stats (all sectors) — fallback for blog cidade pages.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/cidade/{cidade}/setor/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Cidade Setor Stats
+         * @description City × Sector contract stats — fallback for blog cidade×setor pages.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/metrics/discard-rate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Discard Rate
+         * @description Return the moving-average filter discard rate.
+         *
+         *     Public endpoint (no authentication required). Used by the landing page
+         *     to display a verified discard rate instead of a hardcoded number.
+         */
+        get: operations["get_discard_rate_v1_metrics_discard_rate_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/metrics/daily-volume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Daily Volume
+         * @description STORY-358 AC3: Return average bids processed per day.
+         *
+         *     Public endpoint (no authentication required). Used by InstitutionalSidebar
+         *     to display a verified bids/day count instead of a hardcoded number.
+         *
+         *     Queries search_sessions for the specified window and computes daily average
+         *     from total_raw (bids fetched before filtering).
+         */
+        get: operations["get_daily_volume_v1_metrics_daily_volume_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/metrics/sse-fallback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Report Sse Fallback
+         * @description STORY-359 AC4: Frontend reports SSE fallback to simulated progress.
+         *
+         *     Lightweight fire-and-forget endpoint — no auth, no body, just increments counter.
+         */
+        post: operations["report_sse_fallback_v1_metrics_sse_fallback_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/feature-flags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Feature Flags
+         * @description List all registered feature flags with current values and sources.
+         *
+         *     Returns each flag's effective value, where it comes from (redis override,
+         *     env var, or default), its description, and registry metadata.
+         *
+         *     Admin only.
+         */
+        get: operations["list_feature_flags_v1_admin_feature_flags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/feature-flags/{flag_name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Feature Flag
+         * @description Update a feature flag value at runtime (admin only).
+         *
+         *     The new value is persisted to Redis (if available) and stored in-memory.
+         *     Takes effect immediately -- no container restart required.
+         *
+         *     The change persists across process restarts as long as Redis is available.
+         *     Use POST /admin/feature-flags/reload to clear all overrides.
+         */
+        patch: operations["update_feature_flag_v1_admin_feature_flags__flag_name__patch"];
+        trace?: never;
+    };
+    "/v1/admin/feature-flags/reload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reload Flags Endpoint
+         * @description Reload all feature flags from environment variables (admin only).
+         *
+         *     This clears:
+         *     1. All Redis overrides (smartlic:ff:* keys)
+         *     2. All in-memory overrides
+         *     3. The feature flag TTL cache
+         *
+         *     After reload, flags return to their env var or registry default values.
+         *     Useful after updating env vars via Railway dashboard without restarting.
+         */
+        post: operations["reload_flags_endpoint_v1_admin_feature_flags_reload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feature-flags/experiments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Experiments
+         * @description Return active experiment variants for the authenticated user.
+         */
+        get: operations["get_experiments_v1_feature_flags_experiments_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feature-flags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Public Feature Flags
+         * @description List all feature flags with current values (authenticated users).
+         *
+         *     DEBT-205 / DEBT-SYS-009: Public endpoint consumed by frontend via SWR.
+         *     Returns flag name, value, description, and category — no admin metadata.
+         */
+        get: operations["list_public_feature_flags_v1_feature_flags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/calculadora/dados": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Dados reais PNCP para a calculadora de oportunidades (público) */
+        get: operations["calculadora_dados_v1_calculadora_dados_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/empresa/{cnpj}/perfil-b2g": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Perfil B2G público de uma empresa por CNPJ */
+        get: operations["perfil_b2g_v1_empresa__cnpj__perfil_b2g_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5176,24 +3594,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/sitemap/cnpjs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** CNPJs com ≥1 licitação no datalake (para sitemap) */
-        get: operations["sitemap_cnpjs_v1_sitemap_cnpjs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/contratos-orgao-indexable": {
+    "/v1/referral/code": {
         parameters: {
             query?: never;
             header?: never;
@@ -5201,16 +3602,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Órgãos compradores com contratos em pncp_supplier_contracts (para sitemap /contratos/orgao/)
-         * @description Retorna CNPJs de órgãos com ≥1 contrato ativo em pncp_supplier_contracts.
-         *
-         *     Diferente de /sitemap/orgaos (que usa mv_sitemap_orgaos/pncp_raw_bids), este
-         *     endpoint consulta pncp_supplier_contracts — a tabela que alimenta
-         *     /contratos/orgao/{cnpj}/stats. Garante que o sitemap só inclui URLs
-         *     que retornam 200, eliminando os 794 404s reportados no GSC.
-         *     Cache: 24h em memória.
+         * Get Referral Code
+         * @description Return the authenticated user's referral code (create if missing).
          */
-        get: operations["sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get"];
+        get: operations["get_referral_code_v1_referral_code_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5219,7 +3614,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/sitemap/fornecedores-cnpj": {
+    "/v1/referral/stats": {
         parameters: {
             query?: never;
             header?: never;
@@ -5227,15 +3622,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Top CNPJs de fornecedores com contratos no datalake (para sitemap)
-         * @description Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.
-         *
-         *     SEO-SITEMAP-MV-001: agora usa mv_sitemap_fornecedores (MV pré-agregada).
-         *     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
-         *     Limite: 5.000 CNPJs por volume de contratos.
-         *     Cache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).
+         * Get Referral Stats
+         * @description Aggregate stats for the authenticated user's referrals.
          */
-        get: operations["sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get"];
+        get: operations["get_referral_stats_v1_referral_stats_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5244,207 +3634,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/sitemap/itens": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Lista de codigos CATMAT para sitemap.xml */
-        get: operations["sitemap_itens_v1_sitemap_itens_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/licitacoes-do-dia-indexable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)
-         * @description Retorna apenas datas com bids suficientes para ter pagina renderizavel.
-         *
-         *     Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
-         */
-        get: operations["sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/licitacoes-indexable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Combos setor×UF indexáveis (público — sitemap)
-         * @description Retorna combos setor×UF com bids OR contracts suficientes.
-         */
-        get: operations["get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/municipios": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Lista de slugs de municipios para sitemap.xml
-         * @description Retorna slugs dos municipios pre-cadastrados para o sitemap.xml.
-         *     Cache: 24h em memoria.
-         */
-        get: operations["sitemap_municipios_v1_sitemap_municipios_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/orgaos": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Órgãos compradores com ≥1 licitação no datalake (para sitemap) */
-        get: operations["sitemap_orgaos_v1_sitemap_orgaos_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/stats/public": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Estatísticas públicas agregadas do PNCP (sem auth) */
-        get: operations["stats_public_v1_stats_public_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Public Status
-         * @description STORY-316 AC3: Public status endpoint (no auth required).
-         *
-         *     Returns per-source status, component health, uptime percentages,
-         *     and last incident timestamp.
-         */
-        get: operations["public_status_v1_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/status/incidents": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Recent Incidents
-         * @description STORY-316 AC13: Recent incidents for status page.
-         */
-        get: operations["recent_incidents_v1_status_incidents_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/status/uptime-history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Uptime History
-         * @description STORY-316 AC12: Daily uptime data for status page chart.
-         */
-        get: operations["uptime_history_v1_status_uptime_history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/subscription/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Subscription Status
-         * @description Check subscription activation status (GTM-FIX-016).
-         *
-         *     Used by obrigado page to poll for webhook completion.
-         *     Returns current subscription state from DB, with Stripe API fallback.
-         */
-        get: operations["get_subscription_status_v1_subscription_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/survey/export-time-saved": {
+    "/v1/referral/redeem": {
         parameters: {
             query?: never;
             header?: never;
@@ -5454,44 +3644,22 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Submit Export Time Saved Survey
-         * @description Persist one row in ``export_time_saved_survey``.
+         * Redeem Referral
+         * @description Register a referral redemption during signup.
          *
-         *     Auth required. The row is owned by ``user.id`` (RLS: users only ever
-         *     see their own submissions). Returns 503 if the database is
-         *     unavailable so the frontend can retry on next export.
+         *     The authenticated user is the *referred* user. We look up the row
+         *     owned by the referrer (matched by code) and link the referred_user_id
+         *     while promoting status to 'signed_up'. If no such row exists we
+         *     silently succeed to avoid leaking code existence.
          */
-        post: operations["submit_export_time_saved_survey_v1_survey_export_time_saved_post"];
+        post: operations["redeem_referral_v1_referral_redeem_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/trial-emails/unsubscribe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Unsubscribe Trial Emails
-         * @description AC2/AC5: One-click unsubscribe from trial marketing emails.
-         *     Zero-churn P2 §1.2: Only disables marketing/promotional emails.
-         *     Critical conversion emails (Day 7/10/13/16) remain active unless
-         *     user explicitly opts out of those too.
-         */
-        get: operations["unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial-emails/webhook": {
+    "/v1/relatorio-2026-t1/request": {
         parameters: {
             query?: never;
             header?: never;
@@ -5501,69 +3669,17 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Resend Webhook
-         * @description Handle Resend webhook events for email tracking.
+         * Request Relatorio
+         * @description Capture a report lead and dispatch the delivery email.
          *
-         *     Security: Svix HMAC-SHA256 signature verified against `TRIAL_EMAILS_WEBHOOK_SECRET`
-         *     (or legacy alias `RESEND_WEBHOOK_SECRET`).
-         *     Replay protection: timestamp must be within 5 minutes of now.
-         *     Fail-closed — missing secret or invalid signature returns 401.
+         *     Flow:
+         *       1. Upsert row into `report_leads` on (email, source).
+         *       2. Attempt to send the delivery email via Resend (best-effort).
+         *       3. Return the download URL + email_queued flag.
          *
-         *     Accepts the full delivery lifecycle (sent → delivered → opened → clicked)
-         *     plus failure paths (bounced, complained, delivery_delayed, failed) so the
-         *     admin funnel dashboard can distinguish "email never arrived" from "email
-         *     arrived but wasn't engaged". Service handler
-         *     (`services.trial_email_sequence.handle_resend_webhook`) populates the
-         *     columns added in migration 20260424180000_trial_email_delivery_tracking.
-         *
-         *     Returns 200 for processed/ignored/skipped so Resend doesn't retry; 401 on
-         *     signature failure (Resend will retry — desired so legitimate events aren't
-         *     lost during transient secret rotation).
+         *     Persistence failure -> 500. Email failure -> 200 with email_queued=False.
          */
-        post: operations["resend_webhook_v1_trial_emails_webhook_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Trial Status
-         * @description Get detailed trial status for conversion flow (GTM-010 AC3).
-         *
-         *     Returns days remaining, usage stats, and expiration info.
-         */
-        get: operations["get_trial_status_v1_trial_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial/exit-survey": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Submit Exit Survey
-         * @description STORY-369 AC2: Submit exit survey when trial expires.
-         *     Returns 409 if user already submitted a survey.
-         */
-        post: operations["submit_exit_survey_v1_trial_exit_survey_post"];
+        post: operations["request_relatorio_v1_relatorio_2026_t1_request_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5610,7 +3726,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/user/recommended-plan": {
+    "/v1/blog/weekly/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest semanal atual (público) */
+        get: operations["weekly_digest_latest_v1_blog_weekly_latest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/weekly/{year}/{week}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest semanal para um período específico (público) */
+        get: operations["weekly_digest_by_week_v1_blog_weekly__year___week__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/stats/public": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Estatísticas públicas agregadas do PNCP (sem auth) */
+        get: operations["stats_public_v1_stats_public_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/dados/agregados": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Dados agregados do PNCP para o painel público (sem autenticação) */
+        get: operations["dados_agregados_v1_dados_agregados_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/alertas/{setor_id}/uf/{uf}": {
         parameters: {
             query?: never;
             header?: never;
@@ -5618,16 +3802,1771 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Recommended Plan
-         * @description STORY-BIZ-002 AC2: return the upsell-eligible plan for the current user.
-         *
-         *     Detects consultancy profiles by CNAE primário (divisions 70.2 / 74.9 / 82.9)
-         *     and recommends the higher-ARPU Consultoria plan. Non-consultancies see the
-         *     default Pro recommendation. Cached in Redis for 24h keyed by user_id.
+         * Get Alertas
+         * @description Return latest 20 bids for sector × UF from datalake (public, no auth).
          */
-        get: operations["get_recommended_plan_v1_user_recommended_plan_get"];
+        get: operations["get_alertas_v1_alertas__setor_id__uf__uf__get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/lead-capture": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Capture Lead
+         * @description Store a lead capture from a non-authenticated visitor.
+         *
+         *     - New sources (COPY-COP-006): stored in ``lead_captures`` table
+         *     - Old sources (backward compat): stored in ``leads`` table
+         *     - Rate limited to 3 requests/min per IP
+         *     - Fail-open: returns success even if DB storage fails
+         *     - Lead magnet PDF delivery enqueued for legacy sources (LEAD-MAGNET-001)
+         *
+         *     Returns 201 on success.
+         */
+        post: operations["capture_lead_v1_lead_capture_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/lead-magnet/{magnet_type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Lead Magnet
+         * @description Return a placeholder PDF for the requested lead magnet type.
+         *
+         *     This is a minimal/stub implementation — the real LLM-generated content
+         *     will replace the placeholder text in a future story.
+         */
+        get: operations["get_lead_magnet_v1_lead_magnet__magnet_type__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/comparador/buscar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Buscar Editais
+         * @description Search bids by text query from datalake (public, no auth).
+         */
+        get: operations["buscar_editais_v1_comparador_buscar_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/comparador/bids": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Bids By Ids
+         * @description Fetch specific bids by pncp_id from datalake (public, no auth).
+         */
+        get: operations["get_bids_by_ids_v1_comparador_bids_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/seo-metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Seo Metrics
+         * @description Return SEO metrics for the last N days (legacy S14 daily rollup). Admin-only.
+         */
+        get: operations["get_seo_metrics_v1_admin_seo_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/seo/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Gsc Summary
+         * @description Return aggregated GSC analytics from gsc_metrics cache. Admin-only.
+         *
+         *     STORY-SEO-005 AC4. Populated weekly by backend/jobs/cron/gsc_sync.py.
+         */
+        get: operations["get_gsc_summary_v1_admin_seo_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/revalidate-seo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Admin Revalidate Seo
+         * @description Manually trigger ISR revalidation for the given frontend paths.
+         *
+         *     Calls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).
+         *     Fire-and-forget — the HTTP call is made but result is not awaited for
+         *     user-facing errors.  Any failure is logged as a warning.
+         *
+         *     Requires admin role.  Raises HTTP 400 if ``paths`` is empty.
+         */
+        post: operations["admin_revalidate_seo_v1_admin_revalidate_seo_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/cnpjs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** CNPJs com ≥1 licitação no datalake (para sitemap) */
+        get: operations["sitemap_cnpjs_v1_sitemap_cnpjs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/fornecedores-cnpj": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Top CNPJs de fornecedores com contratos no datalake (para sitemap)
+         * @description Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.
+         *
+         *     SEO-SITEMAP-MV-001: agora usa mv_sitemap_fornecedores (MV pré-agregada).
+         *     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
+         *     Limite: 5.000 CNPJs por volume de contratos.
+         *     Cache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).
+         */
+        get: operations["sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/orgaos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Órgãos compradores com ≥1 licitação no datalake (para sitemap) */
+        get: operations["sitemap_orgaos_v1_sitemap_orgaos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/contratos-orgao-indexable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Órgãos compradores com contratos em pncp_supplier_contracts (para sitemap /contratos/orgao/)
+         * @description Retorna CNPJs de órgãos com ≥1 contrato ativo em pncp_supplier_contracts.
+         *
+         *     Diferente de /sitemap/orgaos (que usa mv_sitemap_orgaos/pncp_raw_bids), este
+         *     endpoint consulta pncp_supplier_contracts — a tabela que alimenta
+         *     /contratos/orgao/{cnpj}/stats. Garante que o sitemap só inclui URLs
+         *     que retornam 200, eliminando os 794 404s reportados no GSC.
+         *     Cache: 24h em memória.
+         */
+        get: operations["sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/orgao/{cnpj}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Estatísticas públicas de um órgão comprador por CNPJ */
+        get: operations["orgao_stats_v1_orgao__cnpj__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contratos/orgao/{cnpj}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Perfil de contratos de um orgao publico (por CNPJ) */
+        get: operations["orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contratos/{setor}/{uf}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Estatisticas de contratos publicos por setor e UF */
+        get: operations["contratos_stats_v1_contratos__setor___uf__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/fornecedores/{setor}/{uf}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ranking de fornecedores do governo por setor e UF */
+        get: operations["fornecedores_stats_v1_fornecedores__setor___uf__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/fornecedores/{cnpj}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Perfil completo de um fornecedor do governo (por CNPJ)
+         * @description Agrega historico de contratos do PNCP + dados cadastrais (BrasilAPI via
+         *     enriched_entities) para a pagina /fornecedores/{cnpj}.
+         *
+         *     Publico, sem auth. Cache: 24h TTL em memoria (5min em fallback partial).
+         */
+        get: operations["fornecedor_profile_v1_fornecedores__cnpj__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/daily/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest diario atual (publico) */
+        get: operations["daily_digest_latest_v1_blog_daily_latest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/daily/{date}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest diario para uma data especifica (publico) */
+        get: operations["daily_digest_by_date_v1_blog_daily__date__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/municipios/{slug}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Perfil de municipio com licitacoes abertas (por slug)
+         * @description Agrega licitacoes abertas do PNCP datalake + dados IBGE para a pagina
+         *     /municipios/{slug}. Publico, sem auth. Cache: 24h TTL em memoria.
+         */
+        get: operations["municipio_profile_v1_municipios__slug__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/municipios": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Lista de slugs de municipios para sitemap.xml
+         * @description Retorna slugs dos municipios pre-cadastrados para o sitemap.xml.
+         *     Cache: 24h em memoria.
+         */
+        get: operations["sitemap_municipios_v1_sitemap_municipios_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/compliance/{cnpj}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Perfil de due diligence B2G: CEIS + CNEP por CNPJ
+         * @description Agrega registros CEIS e CNEP do Portal da Transparencia para um CNPJ.
+         *
+         *     Publico, sem auth. Cache: 24h por CNPJ.
+         *     Em caso de falha do Portal da Transparencia, retorna dados parciais.
+         */
+        get: operations["compliance_profile_v1_compliance__cnpj__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/itens/{catmat}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Benchmark de precos governamentais por codigo CATMAT
+         * @description Calcula P10/P50/P90 de contratos do PNCP datalake para um item CATMAT.
+         *
+         *     Publico, sem auth. Cache: 24h. Substitui o Painel de Precos do ComprasGov
+         *     (descontinuado jul/2025).
+         */
+        get: operations["item_profile_v1_itens__catmat__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/itens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lista de codigos CATMAT para sitemap.xml */
+        get: operations["sitemap_itens_v1_sitemap_itens_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/observatorio/relatorio/{mes}/{ano}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Relatório mensal do Observatório de Licitações (público) */
+        get: operations["get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/observatorio/relatorio/{mes}/{ano}/csv": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download CSV do relatório mensal (público) */
+        get: operations["get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/licitacoes-indexable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Combos setor×UF indexáveis (público — sitemap)
+         * @description Retorna combos setor×UF com bids OR contracts suficientes.
+         */
+        get: operations["get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/sitemap-cache/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Force-refresh sitemap combos cache (admin only)
+         * @description Clears the 24h in-memory sitemap cache and recomputes indexable combos immediately.
+         */
+        post: operations["refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/licitacoes-do-dia-indexable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)
+         * @description Retorna apenas datas com bids suficientes para ter pagina renderizavel.
+         *
+         *     Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
+         */
+        get: operations["sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/indice-municipal/periodos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Períodos disponíveis no Índice Municipal (público)
+         * @description Lista trimestres com dados calculados no índice.
+         */
+        get: operations["get_periodos_v1_indice_municipal_periodos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/indice-municipal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ranking de transparência municipal em compras públicas (público)
+         * @description Ranking nacional ou por UF de transparência municipal. Dados do PNCP.
+         */
+        get: operations["get_ranking_v1_indice_municipal_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/indice-municipal/{municipio_slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Índice de transparência de um município (público)
+         * @description Retorna índice de transparência de um município (slug: sao-paulo-sp).
+         */
+        get: operations["get_municipio_v1_indice_municipal__municipio_slug__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/notifications/new-bids-count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get New Bids Count
+         * @description Return count of new bids available for the user since last check.
+         *
+         *     Returns 0 when no Redis key exists (cron not yet run, or badge was cleared).
+         */
+        get: operations["get_new_bids_count_v1_notifications_new_bids_count_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Clear New Bids Count
+         * @description Clear the new-bids badge for the user (called after they run a search).
+         *
+         *     Idempotent — safe to call even if the key does not exist.
+         */
+        delete: operations["clear_new_bids_count_v1_notifications_new_bids_count_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/export/pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Export Edital Pdf
+         * @description Generate and return a 1-page A4 PDF for a single bid.
+         *
+         *     Trial users get a watermark footer.
+         *     Synchronous generation wrapped in asyncio.to_thread with 10s timeout.
+         */
+        post: operations["export_edital_pdf_v1_export_pdf_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Availability
+         * @description Public seat counter + countdown feed.
+         *
+         *     No auth — the landing page calls this anonymously to render the
+         *     countdown and the X/50 seat counter. Falls open with ``available=False``
+         *     on transient DB error so the CTA is disabled rather than over-selling.
+         */
+        get: operations["founding_availability_v1_founding_availability_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/checkout/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Checkout Status
+         * @description Return Stripe checkout session status for the founding purchase confirmation page.
+         *
+         *     No auth required — Stripe ``cs_*`` session IDs are long random tokens that
+         *     are unguessable. Only ``status`` and ``payment_status`` are returned so no
+         *     PII is exposed. Used by ``/fundadores/obrigado`` to poll until payment is
+         *     confirmed (max 20 × 3 s = 60 s).
+         */
+        get: operations["founding_checkout_status_v1_founding_checkout_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/session-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Session Status
+         * @description Enriched session status for the /fundadores/obrigado confirmation page (#865).
+         *
+         *     No auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.
+         *     Returns masked email, ``has_account``, and ``invite_sent`` so the frontend
+         *     can render the right post-purchase CTA without polling Stripe directly.
+         *
+         *     Expiry guard: sessions with checkout_status != 'completed' that are older
+         *     than 24 h return ``status='pending'`` to prevent infinite polling.
+         */
+        get: operations["founding_session_status_v1_founding_session_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Founding Checkout
+         * @description Create a founding-customer Stripe Checkout Session (v2 one-time payment).
+         *
+         *     BIZ-FOUND-002 gate:
+         *     - Calls ``check_founding_availability()`` BEFORE creating the lead row.
+         *     - On ``available=false`` returns 410 Gone with structured ``error_code`` +
+         *       ``error_reason`` so the frontend can render the right copy.
+         *
+         *     #783 changes:
+         *     - Uses ``mode='payment'`` (one-time) with ``FOUNDING_ONE_TIME_PRICE_ID``.
+         *     - Accepts ``card`` and ``boleto`` payment methods.
+         *     - No coupon / discounts applied.
+         *     - Expanded metadata: ``offer_version``, ``offer_mode``, ``price_brl_cents``,
+         *       ``checkout_source`` (resolved from ``src`` or ``utm_source`` query param).
+         *
+         *     Side effects (when available):
+         *     - Inserts a ``founding_leads`` row with ``checkout_status='pending'``.
+         *     - Subsequent webhook events (``checkout.session.completed`` / ``expired``)
+         *       update it. The webhook also re-checks availability for race guard
+         *       (handled in webhooks.handlers.founding).
+         */
+        post: operations["founding_checkout_v1_founding_checkout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/conta/cancelar-trial": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cancel Trial Info
+         * @description Return trial metadata for the confirmation UI.
+         *
+         *     Does NOT mutate state. Intended to be called by the frontend confirmation
+         *     page (STORY-CONV-003c frontend).
+         */
+        get: operations["cancel_trial_info_v1_conta_cancelar_trial_get"];
+        put?: never;
+        /**
+         * Cancel Trial Execute
+         * @description Cancel the user's active trial subscription.
+         *
+         *     Idempotent: if already cancelled, returns ``cancelled=true`` + ``already_cancelled=true``.
+         *     Fail-safe: Stripe errors are swallowed but profile is marked ``canceled_trial``
+         *     so the downgrade still happens if the Stripe-side cancel retries succeed out-of-band
+         *     via billing reconciliation (STORY-314).
+         */
+        post: operations["cancel_trial_execute_v1_conta_cancelar_trial_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/survey/export-time-saved": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Export Time Saved Survey
+         * @description Persist one row in ``export_time_saved_survey``.
+         *
+         *     Auth required. The row is owned by ``user.id`` (RLS: users only ever
+         *     see their own submissions). Returns 503 if the database is
+         *     unavailable so the frontend can retry on next export.
+         */
+        post: operations["submit_export_time_saved_survey_v1_survey_export_time_saved_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Intel Report Checkout
+         * @description Create a Stripe Checkout session for an Intel Report one-time purchase.
+         *
+         *     product_type:
+         *         - "cnpj"       → R$197.00 — Company analysis report (INTEL-REPORT-001)
+         *         - "sector_uf"  → R$147.00 — Sector/UF market report (INTEL-REPORT-002)
+         *
+         *     entity_key:
+         *         - For cnpj:       the CNPJ string (e.g. "12345678000195")
+         *         - For sector_uf:  "sector:uf" (e.g. "limpeza:SP")
+         *
+         *     Returns checkout_url (redirect user) and session_id (for polling).
+         */
+        post: operations["create_intel_report_checkout_v1_intel_reports_checkout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Intel Report Purchases
+         * @description List all Intel Report purchases for the authenticated user.
+         */
+        get: operations["list_intel_report_purchases_v1_intel_reports__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/{purchase_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Intel Report Status
+         * @description Poll status of an Intel Report purchase.
+         *
+         *     Frontend uses this endpoint after being redirected back from Stripe
+         *     (/intel-reports/{CHECKOUT_SESSION_ID}?status=processing).
+         *     Poll until status is "ready" or "failed".
+         *
+         *     Returns:
+         *     - 404 if purchase does not exist
+         *     - 403 if purchase belongs to a different user
+         */
+        get: operations["get_intel_report_status_v1_intel_reports__purchase_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/{purchase_id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download Intel Report
+         * @description Stream the Intel Report PDF.
+         *
+         *     Requires:
+         *     - Authentication
+         *     - Ownership: purchase must belong to the authenticated user
+         *     - Status: purchase must be "ready" (pdf_url present)
+         *
+         *     Returns:
+         *     - 401 if not authenticated
+         *     - 404 if purchase does not exist
+         *     - 403 if purchase belongs to a different user
+         *     - 400 if purchase status is not "ready"
+         *     - PDF stream if all checks pass
+         */
+        get: operations["download_intel_report_v1_intel_reports__purchase_id__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/pseo/top-suppliers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Top 5 fornecedores por volume de contratos no setor (público)
+         * @description Top suppliers by contract volume in sector, last 12 months.
+         *
+         *     Returns cnpj, razao_social, contratos_count, valor_total.
+         *     If total contracts < 10, returns empty list (avoid weak social proof).
+         *     Cache: 6h InMemory.
+         */
+        get: operations["get_top_suppliers_v1_pseo_top_suppliers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/pseo/recent-editais": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 5 últimos editais abertos no setor (público)
+         * @description Most recent open editais for sector+UF.
+         *
+         *     Returns orgao, objeto, valor_estimado, data_limite, link_interno.
+         *     link_interno = /licitacoes/{setor}?query={orgao}
+         *     Cache: 6h InMemory.
+         */
+        get: operations["get_recent_editais_v1_pseo_recent_editais_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/seo/coverage-manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Per-slug coverage status for sitemap gate (SEO-COVERAGE-MANIFEST-001)
+         * @description Return the latest seo_coverage_manifest rows as a keyed dict.
+         *
+         *     AC1: <2s response time (served from 1h in-memory cache after first build).
+         *     AC7: historical_empty slugs are included — sitemap gate uses priority=0.3,
+         *          not excluded, so /observatorio/raio-x-marco-2026 stays accessible.
+         */
+        get: operations["get_coverage_manifest_v1_seo_coverage_manifest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Products
+         * @description List active digital products available for one-time purchase.
+         *
+         *     Public (no auth required). Results cached in Redis for 1 hour.
+         */
+        get: operations["list_products_v1_products_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/predict/seasonal-calendar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Calendario sazonal de compras por UF
+         * @description Retorna um calendario sazonal de 12 meses com base no historico de contratos e licitacoes da UF. Inclui volume medio, quantidade, setor dominante, orgaos principais, indice de sazonalidade, tendencia e variacao anual para cada mes.
+         */
+        get: operations["get_seasonal_calendar_v1_predict_seasonal_calendar_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/network-events/record": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record Network Event
+         * @description Record an anonymized network event.
+         *
+         *     Only collects data if user has explicitly opted in
+         *     (profiles.allow_network_analytics = true). LGPD Art. 6, I.
+         */
+        post: operations["record_network_event_v1_network_events_record_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/network-events/top": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Top Network Events
+         * @description Get top dimension values for a given event type.
+         *
+         *     Public endpoint — returns only anonymized aggregated data.
+         */
+        get: operations["get_top_network_events_v1_network_events_top_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/segment/save": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Save Segment
+         * @description Save user segmentation data to profile context_data (CONV-018).
+         *
+         *     Merges the new fields into the existing ``context_data`` JSONB column
+         *     on the ``profiles`` table without overwriting other fields.
+         *
+         *     Returns the full updated context_data on success.
+         */
+        post: operations["save_segment_v1_segment_save_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/trigger-contracts-backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Contracts Backfill
+         * @description Enqueue contracts_full_crawl_job to ARQ Worker.
+         *
+         *     Runs on Railway Worker (better network for PNCP).
+         *     Safe to call multiple times — ARQ deduplicates by job name.
+         */
+        post: operations["trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/trigger-bids-backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Bids Backfill
+         * @description Enqueue ingestion_backfill_job to ARQ Worker.
+         *
+         *     One-time historical crawl: fetches up to 365 days of PNCP bids
+         *     to capture all currently open opportunities.
+         *     Expected runtime: 4-8h. Safe to call multiple times (ARQ dedup).
+         */
+        post: operations["trigger_bids_backfill_v1_admin_trigger_bids_backfill_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/clear-contracts-checkpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clear Contracts Checkpoints
+         * @description Clear all Redis checkpoints for contracts crawler.
+         *
+         *     Use before re-triggering a full crawl when stale checkpoints
+         *     cause windows to be incorrectly skipped.
+         */
+        post: operations["clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/search-trace/{search_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Search Trace
+         * @description Reconstruct complete search journey from search_id.
+         *
+         *     Aggregates:
+         *     - Progress tracker state (if still active)
+         *     - Cache entries matching this search
+         *     - Job queue results (if ARQ available)
+         */
+        get: operations["get_search_trace_v1_admin_search_trace__search_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cb/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset Circuit Breakers
+         * @description STORY-416 AC5: Reset all segregated Supabase CBs to CLOSED.
+         *
+         *     Intended for on-call use after an upstream incident has been mitigated
+         *     and the CBs are still in OPEN/HALF_OPEN due to the cooldown. Returns
+         *     the previous state per category so the action is auditable in logs.
+         *     Admin only — never expose this without authentication.
+         */
+        post: operations["reset_circuit_breakers_v1_admin_cb_reset_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/schema-contract-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Schema Contract Status
+         * @description STORY-414 AC4: Expose the last schema-contract validation result.
+         *
+         *     Returns the cached result from the startup check plus a ``stale``
+         *     flag that tells callers whether a fresh run is advisable (the cache
+         *     lives for ``schemas.contract.STATUS_CACHE_TTL`` seconds — 5 min by
+         *     default). Forcing a re-validation is out of scope here because it
+         *     would defeat the point of the cache on a polled dashboard.
+         */
+        get: operations["get_schema_contract_status_v1_admin_schema_contract_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cron-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Cron Status
+         * @description Return the pg_cron health snapshot.
+         *
+         *     Calls ``public.get_cron_health()`` (SECURITY DEFINER) via the backend's
+         *     service-role Supabase client. Response shape::
+         *
+         *         {
+         *             "queried_at": "2026-04-14T12:00:00+00:00",
+         *             "jobs": [
+         *                 {
+         *                     "jobname": "purge-old-bids",
+         *                     "schedule": "0 7 * * *",
+         *                     "active": true,
+         *                     "last_status": "succeeded",
+         *                     "last_run_at": "2026-04-14T07:00:04+00:00",
+         *                     "runs_24h": 1,
+         *                     "failures_24h": 0,
+         *                     "latency_avg_ms": 120,
+         *                     "last_return_message": null
+         *                 },
+         *                 ...
+         *             ],
+         *             "count": 6
+         *         }
+         *
+         *     On transient failure (Supabase CB open, RPC error) returns ``status=error``
+         *     with ``jobs=[]`` so that dashboards degrade gracefully instead of 500-ing.
+         */
+        get: operations["get_cron_status_v1_admin_cron_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cnae-mapping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Cnae Mappings
+         * @description List CNAE mappings, optionally filtered by ``setor``.
+         */
+        get: operations["list_cnae_mappings_v1_admin_cnae_mapping_get"];
+        put?: never;
+        /**
+         * Create Cnae Mapping
+         * @description Create a new CNAE -> setor mapping.
+         */
+        post: operations["create_cnae_mapping_v1_admin_cnae_mapping_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cnae-mapping/{cnae_code}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Cnae Mapping
+         * @description Soft delete: marks ``notes='deleted'`` so audit trail is preserved.
+         *
+         *     The DB lookup in ``utils.cnae_mapping._db_lookup`` skips rows with
+         *     ``notes = 'deleted'`` and the LRU cache is invalidated so the next
+         *     request falls back to the hardcoded dict (if present there).
+         */
+        delete: operations["delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Cnae Mapping
+         * @description Patch an existing mapping. Fields not present in the body are untouched.
+         */
+        patch: operations["update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch"];
+        trace?: never;
+    };
+    "/v1/admin/llm-cost": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Admin Llm Cost
+         * @description Return LLM cost snapshot para o mês corrente (admin-only).
+         *
+         *     Response shape::
+         *
+         *         {
+         *             "month_to_date_usd": 42.1234,
+         *             "budget_usd": 100.0,
+         *             "pct_used": 42.12,
+         *             "projected_end_of_month_usd": 78.55,
+         *             "month": "llm_cost_month_2026_04",
+         *             "exceeded": false
+         *         }
+         *
+         *     Em caso de Redis indisponível, retorna zeros (graceful degradation).
+         */
+        get: operations["admin_llm_cost_v1_admin_llm_cost_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/survey/export-time-saved": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Export Surveys Aggregate
+         * @description Aggregated histogram + summary stats for the calibration dashboard.
+         */
+        get: operations["list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/config/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Patch App Config
+         * @description Update one row in ``app_config``. Whitelist enforced.
+         *
+         *     On success the in-process TTL cache for *key* is invalidated so
+         *     the new value becomes visible in this worker on the next read
+         *     (other workers see it after their TTL expires).
+         */
+        patch: operations["patch_app_config_v1_admin_config__key__patch"];
+        trace?: never;
+    };
+    "/v1/admin/calibration/recalibrate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Recalibrate
+         * @description Compute new ``hours_saved_per_search`` from survey distribution.
+         *
+         *     Eligibility rules (mirrors AC6 + risk R3):
+         *         * After IQR outlier removal there must be >= MIN_SAMPLE_SIZE rows.
+         *         * The new median must be in (0, 50].
+         *
+         *     When ``apply=true`` and eligible, persists the new value via
+         *     ``app_config`` and drops the cache.
+         */
+        post: operations["recalibrate_v1_admin_calibration_recalibrate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/billing-sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Billing Sync Rows
+         * @description Return every plan_billing_periods row enriched with drift_status.
+         */
+        get: operations["list_billing_sync_rows_v1_admin_plans_billing_sync_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/reconciliation-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Reconciliation Runs */
+        get: operations["list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/{plan_billing_period_id}/sync-to-stripe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync To Stripe
+         * @description AC8/AC9: Push DB price -> Stripe by creating a new Price + archiving old.
+         */
+        post: operations["sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/reconcile-now": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reconcile Now */
+        post: operations["reconcile_now_v1_admin_plans_reconcile_now_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Founding Policy
+         * @description Snapshot of the canonical policy + live seat usage.
+         */
+        get: operations["get_founding_policy_v1_admin_founding_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/leads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Founding Leads
+         * @description List founding leads ordered by creation desc.
+         *
+         *     Optional ``status`` filter restricts to one of the checkout_status enum
+         *     values (pending|completed|abandoned|failed|cap_violated).
+         */
+        get: operations["list_founding_leads_v1_admin_founding_leads_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pause Founding
+         * @description Soft-pause founding checkouts. Idempotent.
+         */
+        post: operations["pause_founding_v1_admin_founding_pause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Founding
+         * @description Resume founding checkouts (clear paused_at + paused_by + paused_reason).
+         */
+        post: operations["resume_founding_v1_admin_founding_resume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/slo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Slo Dashboard
+         * @description AC7-AC9: SLO compliance data for admin dashboard.
+         *
+         *     Returns all SLO statuses, alert evaluations, and metadata.
+         */
+        get: operations["get_slo_dashboard_v1_admin_slo_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/slo/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Slo Alerts
+         * @description Return current alert evaluation results.
+         */
+        get: operations["get_slo_alerts_v1_admin_slo_alerts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/founders/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founders Availability
+         * @description Public seat counter + countdown feed (issue #1002).
+         */
+        get: operations["founders_availability_api_founders_availability_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/founders/hall": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Hall Listing
+         * @description Public Hall of Founders listing (issue #1008).
+         *
+         *     Anonymous endpoint consumed by ``/fundadores/hall`` (ISR revalidate=300s).
+         *     Returns up to 100 founders that opted in via
+         *     ``founder_public_listing_consent=TRUE``.
+         */
+        get: operations["get_hall_listing_api_founders_hall_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/founders/hall/consent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Toggle Consent
+         * @description Authenticated opt-in / opt-out toggle (issue #1008).
+         *
+         *     Updates ``profiles.founder_public_listing_consent`` for the caller and,
+         *     on opt-in, also persists optional display name and logo URL. Logs an
+         *     LGPD audit event regardless of direction.
+         */
+        post: operations["toggle_consent_api_founders_hall_consent_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5677,6 +5616,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Root
+         * @description API root — navigation and version info.
+         */
+        get: operations["root__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/setores": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Listar Setores
+         * @description Return available procurement sectors for frontend dropdown.
+         */
+        get: operations["listar_setores_v1_setores_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debug/pncp-test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Debug Pncp Test
+         * @description Diagnostic: test if PNCP API is reachable from this server. Admin only.
+         */
+        get: operations["debug_pncp_test_debug_pncp_test_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -5688,60 +5687,60 @@ export interface components {
         AdminAssignPlanResponse: {
             /** Assigned */
             assigned: boolean;
-            /** Plan Id */
-            plan_id: string;
             /** User Id */
             user_id: string;
+            /** Plan Id */
+            plan_id: string;
         };
         /**
          * AdminCacheTraceState
          * @description ``cache`` field of the search-trace response.
          */
         AdminCacheTraceState: {
-            /** Error */
-            error?: string | null;
             /** Is Revalidating */
             is_revalidating?: boolean | null;
             /** Redis */
             redis?: string | null;
+            /** Error */
+            error?: string | null;
         };
         /**
          * AdminCircuitBreakerResetResponse
          * @description Response for POST /v1/admin/cb/reset (STORY-416 AC5).
          */
         AdminCircuitBreakerResetResponse: {
+            /** Status */
+            status: string;
             /** Previous States */
             previous_states: {
                 [key: string]: unknown;
             };
             /** Reset By */
             reset_by?: string | null;
-            /** Status */
-            status: string;
         };
         /**
          * AdminClearCheckpointsResponse
          * @description Response for POST /v1/admin/clear-contracts-checkpoints.
          */
         AdminClearCheckpointsResponse: {
+            /** Status */
+            status: string;
             /** Checkpoints Deleted */
             checkpoints_deleted?: number | null;
             /** Detail */
             detail?: string | null;
-            /** Status */
-            status: string;
         };
         /**
          * AdminCreateUserResponse
          * @description Response for POST /admin/users.
          */
         AdminCreateUserResponse: {
+            /** User Id */
+            user_id: string;
             /** Email */
             email: string;
             /** Plan Id */
             plan_id?: string | null;
-            /** User Id */
-            user_id: string;
         };
         /**
          * AdminCronStatusResponse
@@ -5752,16 +5751,16 @@ export interface components {
          *     gracefully instead of 500-ing.
          */
         AdminCronStatusResponse: {
-            /** Count */
-            count: number;
-            /** Detail */
-            detail?: string | null;
-            /** Jobs */
-            jobs: components["schemas"]["CronJobHealthRow"][];
-            /** Queried At */
-            queried_at: string;
             /** Status */
             status: string;
+            /** Queried At */
+            queried_at: string;
+            /** Count */
+            count: number;
+            /** Jobs */
+            jobs: components["schemas"]["CronJobHealthRow"][];
+            /** Detail */
+            detail?: string | null;
         };
         /**
          * AdminDeleteUserResponse
@@ -5782,12 +5781,12 @@ export interface components {
          *     when the lookup itself raised.
          */
         AdminJobTraceState: {
-            /** Error */
-            error?: string | null;
-            /** Excel Generation */
-            excel_generation?: string | null;
             /** Llm Summary */
             llm_summary?: string | null;
+            /** Excel Generation */
+            excel_generation?: string | null;
+            /** Error */
+            error?: string | null;
         };
         /**
          * AdminJobTriggerResponse
@@ -5798,14 +5797,14 @@ export interface components {
          *     ``detail`` carries the operator-facing reason string when non-OK.
          */
         AdminJobTriggerResponse: {
-            /** Detail */
-            detail?: string | null;
-            /** Job Id */
-            job_id?: string | null;
             /** Status */
             status: string;
+            /** Job Id */
+            job_id?: string | null;
             /** Timeout S */
             timeout_s?: number | null;
+            /** Detail */
+            detail?: string | null;
         };
         /**
          * AdminLlmCostResponse
@@ -5817,22 +5816,15 @@ export interface components {
          */
         AdminLlmCostResponse: {
             /**
-             * Budget Usd
-             * @default 0
-             */
-            budget_usd: number;
-            /**
-             * Exceeded
-             * @default false
-             */
-            exceeded: boolean;
-            /** Month */
-            month: string;
-            /**
              * Month To Date Usd
              * @default 0
              */
             month_to_date_usd: number;
+            /**
+             * Budget Usd
+             * @default 0
+             */
+            budget_usd: number;
             /**
              * Pct Used
              * @default 0
@@ -5843,6 +5835,13 @@ export interface components {
              * @default 0
              */
             projected_end_of_month_usd: number;
+            /** Month */
+            month: string;
+            /**
+             * Exceeded
+             * @default false
+             */
+            exceeded: boolean;
         };
         /**
          * AdminProgressTraceState
@@ -5850,18 +5849,18 @@ export interface components {
          *     is still in memory. ``mode`` is ``"redis"`` or ``"in-memory"``.
          */
         AdminProgressTraceState: {
-            /** Created At */
-            created_at?: number | null;
-            /** Error */
-            error?: string | null;
-            /** Is Complete */
-            is_complete?: boolean | null;
-            /** Mode */
-            mode?: string | null;
             /** Uf Count */
             uf_count?: number | null;
             /** Ufs Completed */
             ufs_completed?: number | null;
+            /** Is Complete */
+            is_complete?: boolean | null;
+            /** Created At */
+            created_at?: number | null;
+            /** Mode */
+            mode?: string | null;
+            /** Error */
+            error?: string | null;
         };
         /**
          * AdminResetPasswordResponse
@@ -5878,28 +5877,28 @@ export interface components {
          * @description Response for GET /v1/admin/schema-contract-status (STORY-414 AC4).
          */
         AdminSchemaContractStatusResponse: {
+            /** Passed */
+            passed?: boolean | null;
+            /**
+             * Missing
+             * @default []
+             */
+            missing: string[];
+            /**
+             * Strict Mode
+             * @default false
+             */
+            strict_mode: boolean;
             /**
              * Checked At
              * @default 0
              */
             checked_at: number;
             /**
-             * Missing
-             * @default []
-             */
-            missing: string[];
-            /** Passed */
-            passed?: boolean | null;
-            /**
              * Stale
              * @default true
              */
             stale: boolean;
-            /**
-             * Strict Mode
-             * @default false
-             */
-            strict_mode: boolean;
         };
         /**
          * AdminSearchTraceResponse
@@ -5910,29 +5909,29 @@ export interface components {
          *     payload instead of failing the whole response.
          */
         AdminSearchTraceResponse: {
-            cache?: components["schemas"]["AdminCacheTraceState"] | null;
-            jobs?: components["schemas"]["AdminJobTraceState"] | null;
-            progress?: components["schemas"]["AdminProgressTraceState"] | null;
-            /** Queried At */
-            queried_at: string;
             /** Search Id */
             search_id: string;
+            /** Queried At */
+            queried_at: string;
+            progress?: components["schemas"]["AdminProgressTraceState"] | null;
+            cache?: components["schemas"]["AdminCacheTraceState"] | null;
+            jobs?: components["schemas"]["AdminJobTraceState"] | null;
         };
         /**
          * AdminUpdateCreditsResponse
          * @description Response for PUT /admin/users/{user_id}/credits.
          */
         AdminUpdateCreditsResponse: {
+            /** Success */
+            success: boolean;
+            /** User Id */
+            user_id: string;
             /** Credits */
             credits: number;
             /** Previous Credits */
             previous_credits?: number | null;
             /** Subscription Created */
             subscription_created?: boolean | null;
-            /** Success */
-            success: boolean;
-            /** User Id */
-            user_id: string;
         };
         /**
          * AdminUpdateUserResponse
@@ -5949,27 +5948,22 @@ export interface components {
          * @description Response for GET /admin/users.
          */
         AdminUsersListResponse: {
-            /** Limit */
-            limit: number;
-            /** Offset */
-            offset: number;
-            /** Total */
-            total: number;
             /** Users */
             users: {
                 [key: string]: unknown;
             }[];
+            /** Total */
+            total: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
         };
         /**
          * AlertFilters
          * @description Filter criteria that define which bids match this alert.
          */
         AlertFilters: {
-            /**
-             * Keywords
-             * @description Extra keyword filters
-             */
-            keywords?: string[] | null;
             /**
              * Setor
              * @description Sector ID from sectors_data.yaml
@@ -5981,22 +5975,27 @@ export interface components {
              */
             ufs?: string[] | null;
             /**
+             * Valor Min
+             * @description Minimum estimated value
+             */
+            valor_min?: number | null;
+            /**
              * Valor Max
              * @description Maximum estimated value
              */
             valor_max?: number | null;
             /**
-             * Valor Min
-             * @description Minimum estimated value
+             * Keywords
+             * @description Extra keyword filters
              */
-            valor_min?: number | null;
+            keywords?: string[] | null;
         };
         /** AlertHistoryItem */
         AlertHistoryItem: {
-            /** Alert Id */
-            alert_id: string;
             /** Id */
             id: string;
+            /** Alert Id */
+            alert_id: string;
             /** Item Id */
             item_id: string;
             /** Sent At */
@@ -6006,12 +6005,12 @@ export interface components {
         AlertHistoryResponse: {
             /** Items */
             items: components["schemas"]["AlertHistoryItem"][];
+            /** Total */
+            total: number;
             /** Limit */
             limit: number;
             /** Offset */
             offset: number;
-            /** Total */
-            total: number;
         };
         /** AlertListResponse */
         AlertListResponse: {
@@ -6023,22 +6022,22 @@ export interface components {
         /** AlertPreferencesRequest */
         AlertPreferencesRequest: {
             /**
-             * Enabled
-             * @default true
-             */
-            enabled: boolean;
-            /**
              * Frequency
              * @default daily
              */
             frequency: string;
+            /**
+             * Enabled
+             * @default true
+             */
+            enabled: boolean;
         };
         /** AlertPreferencesResponse */
         AlertPreferencesResponse: {
-            /** Enabled */
-            enabled: boolean;
             /** Frequency */
             frequency: string;
+            /** Enabled */
+            enabled: boolean;
             /** Last Digest Sent At */
             last_digest_sent_at?: string | null;
         };
@@ -6046,30 +6045,30 @@ export interface components {
         AlertPreviewItem: {
             /** Id */
             id: string;
-            /**
-             * Link Pncp
-             * @default
-             */
-            link_pncp: string;
-            /**
-             * Modalidade
-             * @default
-             */
-            modalidade: string;
-            /** Orgao */
-            orgao: string;
             /** Titulo */
             titulo: string;
+            /** Orgao */
+            orgao: string;
+            /**
+             * Valor Estimado
+             * @default 0
+             */
+            valor_estimado: number;
             /**
              * Uf
              * @default
              */
             uf: string;
             /**
-             * Valor Estimado
-             * @default 0
+             * Modalidade
+             * @default
              */
-            valor_estimado: number;
+            modalidade: string;
+            /**
+             * Link Pncp
+             * @default
+             */
+            link_pncp: string;
             /** Viability Score */
             viability_score?: number | null;
         };
@@ -6081,84 +6080,84 @@ export interface components {
             alert_name: string;
             /** Items */
             items: components["schemas"]["AlertPreviewItem"][];
-            /** Message */
-            message: string;
             /** Total */
             total: number;
+            /** Message */
+            message: string;
         };
         /** AlertResponse */
         AlertResponse: {
-            /** Active */
-            active: boolean;
-            /** Created At */
-            created_at: string;
+            /** Id */
+            id: string;
+            /** User Id */
+            user_id: string;
+            /** Name */
+            name: string;
             /** Filters */
             filters: {
                 [key: string]: unknown;
             };
-            /** Id */
-            id: string;
-            /** Name */
-            name: string;
+            /** Active */
+            active: boolean;
             /**
              * Sent Count
              * @default 0
              */
             sent_count: number;
+            /** Created At */
+            created_at: string;
             /** Updated At */
             updated_at: string;
-            /** User Id */
-            user_id: string;
         };
         /** AlertaBid */
         AlertaBid: {
-            /** Data Abertura */
-            data_abertura?: string | null;
+            /** Titulo */
+            titulo: string;
+            /** Orgao */
+            orgao: string;
+            /** Valor */
+            valor?: number | null;
+            /** Uf */
+            uf: string;
+            /**
+             * Municipio
+             * @default
+             */
+            municipio: string;
+            /**
+             * Modalidade
+             * @default
+             */
+            modalidade: string;
             /** Data Publicacao */
             data_publicacao: string;
+            /** Data Abertura */
+            data_abertura?: string | null;
             /**
              * Link Pncp
              * @default
              */
             link_pncp: string;
             /**
-             * Modalidade
-             * @default
-             */
-            modalidade: string;
-            /**
-             * Municipio
-             * @default
-             */
-            municipio: string;
-            /** Orgao */
-            orgao: string;
-            /**
              * Pncp Id
              * @default
              */
             pncp_id: string;
-            /** Titulo */
-            titulo: string;
-            /** Uf */
-            uf: string;
-            /** Valor */
-            valor?: number | null;
         };
         /** AlertasResponse */
         AlertasResponse: {
-            /** Bids */
-            bids: components["schemas"]["AlertaBid"][];
-            /** Last Updated */
-            last_updated: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Total */
-            total: number;
             /** Uf */
             uf: string;
+            /** Bids */
+            bids: components["schemas"]["AlertaBid"][];
+            /** Total */
+            total: number;
+            /** Last Updated */
+            last_updated: string;
         };
         /**
          * AppConfigPatchRequest
@@ -6166,28 +6165,28 @@ export interface components {
          */
         AppConfigPatchRequest: {
             /**
-             * Description
-             * @description Optional updated description
-             */
-            description?: string | null;
-            /**
              * Value
              * @description New JSONB value (scalar/array/object)
              */
             value: unknown;
+            /**
+             * Description
+             * @description Optional updated description
+             */
+            description?: string | null;
         };
         /** AppConfigRow */
         AppConfigRow: {
-            /** Description */
-            description?: string | null;
             /** Key */
             key: string;
+            /** Value */
+            value: unknown;
+            /** Description */
+            description?: string | null;
             /** Updated At */
             updated_at?: string | null;
             /** Updated By */
             updated_by?: string | null;
-            /** Value */
-            value: unknown;
         };
         /**
          * AtividadeRecenteData
@@ -6207,8 +6206,11 @@ export interface components {
              * @default 0
              */
             contagem_90d: number;
-            /** Sazonalidade Mes Pico */
-            sazonalidade_mes_pico?: number | null;
+            /**
+             * Valor Total 30D
+             * @default 0
+             */
+            valor_total_30d: number;
             /**
              * Tendencia 12M
              * @default stable
@@ -6221,11 +6223,8 @@ export interface components {
             tendencia_percentual: number;
             /** Ultimo Evento Data */
             ultimo_evento_data?: string | null;
-            /**
-             * Valor Total 30D
-             * @default 0
-             */
-            valor_total_30d: number;
+            /** Sazonalidade Mes Pico */
+            sazonalidade_mes_pico?: number | null;
         };
         /** AuthStatusResponse */
         AuthStatusResponse: {
@@ -6273,38 +6272,38 @@ export interface components {
         };
         /** BillingSyncRow */
         BillingSyncRow: {
+            /** Id */
+            id: string;
+            /** Plan Id */
+            plan_id: string;
             /** Billing Period */
             billing_period: string;
+            /** Price Cents */
+            price_cents: number;
             /**
              * Discount Percent
              * @default 0
              */
             discount_percent: number;
+            /** Stripe Price Id */
+            stripe_price_id?: string | null;
+            /** Stripe Product Id */
+            stripe_product_id?: string | null;
+            /** Last Forward Synced At */
+            last_forward_synced_at?: string | null;
+            /** Last Reverse Synced At */
+            last_reverse_synced_at?: string | null;
+            /**
+             * Is Archived
+             * @default false
+             */
+            is_archived: boolean;
             /**
              * Drift Status
              * @description in_sync | drift_recent | drift_stale | unknown
              * @default unknown
              */
             drift_status: string;
-            /** Id */
-            id: string;
-            /**
-             * Is Archived
-             * @default false
-             */
-            is_archived: boolean;
-            /** Last Forward Synced At */
-            last_forward_synced_at?: string | null;
-            /** Last Reverse Synced At */
-            last_reverse_synced_at?: string | null;
-            /** Plan Id */
-            plan_id: string;
-            /** Price Cents */
-            price_cents: number;
-            /** Stripe Price Id */
-            stripe_price_id?: string | null;
-            /** Stripe Product Id */
-            stripe_product_id?: string | null;
         };
         /**
          * BuscaRequest
@@ -6362,17 +6361,14 @@ export interface components {
          */
         BuscaRequest: {
             /**
-             * Check Sanctions
-             * @description When true, verify supplier CNPJs against CEIS/CNEP sanctions databases. Adds supplier_sanctions field to each result. Performance impact: ~1s per unique CNPJ.
-             * @default false
+             * Ufs
+             * @description List of Brazilian state codes (e.g., ['SP', 'RJ', 'MG'])
+             * @example [
+             *       "SP",
+             *       "RJ"
+             *     ]
              */
-            check_sanctions: boolean;
-            /**
-             * Data Final
-             * @description End date in YYYY-MM-DD format. The date range may span at most 30 days.
-             * @example 2025-01-31
-             */
-            data_final: string;
+            ufs: string[];
             /**
              * Data Inicial
              * @description Start date in YYYY-MM-DD format. The date range may span at most 30 days.
@@ -6380,35 +6376,53 @@ export interface components {
              */
             data_inicial: string;
             /**
-             * Esferas
-             * @description Lista de esferas governamentais ('F'=Federal, 'E'=Estadual, 'M'=Municipal). None = todas as esferas.
-             * @example [
-             *       "M",
-             *       "E"
-             *     ]
+             * Data Final
+             * @description End date in YYYY-MM-DD format. The date range may span at most 30 days.
+             * @example 2025-01-31
              */
-            esferas?: components["schemas"]["EsferaGovernamental"][] | null;
+            data_final: string;
+            /**
+             * Setor Id
+             * @description Sector ID for keyword filtering (e.g., 'vestuario', 'alimentos', 'informatica'). None when searching by 'Termos Específicos' (custom keywords only).
+             * @example vestuario
+             * @example null
+             */
+            setor_id?: string | null;
+            /**
+             * Termos Busca
+             * @description Custom search terms. Use commas to separate multi-word phrases (e.g., 'levantamento topográfico, terraplenagem, drenagem'). Without commas, spaces separate individual keywords (legacy mode).
+             * @example jaleco avental
+             * @example levantamento topográfico, terraplenagem, drenagem
+             */
+            termos_busca?: string | null;
+            /**
+             * Show All Matches
+             * @description When True, bypasses minimum match floor and returns all results with at least 1 keyword match (for 'show hidden results' feature).
+             * @default false
+             */
+            show_all_matches: boolean | null;
             /**
              * Exclusion Terms
              * @description Custom exclusion terms. Overrides sector exclusions when provided.
              */
             exclusion_terms?: string[] | null;
             /**
-             * Force Fresh
-             * @description When true, bypass result cache and always query primary sources. Cache write-through still happens on successful results.
-             * @default false
+             * Modo Busca
+             * @description Modo de busca: 'abertas' (padrão) busca licitações com prazo aberto nos últimos 180 dias; 'publicacao' usa datas enviadas pelo frontend.
+             * @default abertas
+             * @example abertas
+             * @example publicacao
              */
-            force_fresh: boolean;
+            modo_busca: string | null;
             /**
-             * Itens Por Pagina
-             * @description Quantidade de itens por página. Valores permitidos: 10, 20, 50, 100. Padrão: 20.
-             * @default 20
-             * @example 10
-             * @example 20
-             * @example 50
-             * @example 100
+             * @description Status da licitação para filtrar. Padrão: 'todos' (sem filtro de status). IMPORTANTE: Filtro de status desabilitado por padrão devido a valores inconsistentes na API PNCP. Use 'todos' para máxima cobertura de resultados.
+             * @default todos
+             * @example todos
+             * @example recebendo_proposta
+             * @example em_julgamento
+             * @example encerrada
              */
-            itens_por_pagina: number;
+            status: components["schemas"]["StatusLicitacao"];
             /**
              * Modalidades
              * @description Lista de códigos de modalidade conforme API PNCP. Códigos válidos: 1 (Leilão Eletrônico), 2 (Diálogo Competitivo), 3 (Concurso), 4 (Concorrência Eletrônica), 5 (Concorrência Presencial), 6 (Pregão Eletrônico), 7 (Pregão Presencial), 8 (Dispensa), 10 (Manifestação de Interesse), 11 (Pré-qualificação), 12 (Credenciamento), 13 (Leilão Presencial), 15 (Chamada Pública). None = modalidades padrão [4, 5, 6, 7]. EXCLUÍDOS: 9 (Inexigibilidade) e 14 (Inaplicabilidade) — vencedor pré-definido.
@@ -6421,13 +6435,26 @@ export interface components {
              */
             modalidades?: number[] | null;
             /**
-             * Modo Busca
-             * @description Modo de busca: 'abertas' (padrão) busca licitações com prazo aberto nos últimos 180 dias; 'publicacao' usa datas enviadas pelo frontend.
-             * @default abertas
-             * @example abertas
-             * @example publicacao
+             * Valor Minimo
+             * @description Valor mínimo estimado da licitação em BRL. None = sem limite inferior.
+             * @example 50000
              */
-            modo_busca: string | null;
+            valor_minimo?: number | null;
+            /**
+             * Valor Maximo
+             * @description Valor máximo estimado da licitação em BRL. None = sem limite superior. Ceiling: 1e15 (R$ 1 quatrilhão) — STORY-419 incident guard to match NUMERIC(18,2) on search_sessions.valor_total.
+             * @example 5000000
+             */
+            valor_maximo?: number | null;
+            /**
+             * Esferas
+             * @description Lista de esferas governamentais ('F'=Federal, 'E'=Estadual, 'M'=Municipal). None = todas as esferas.
+             * @example [
+             *       "M",
+             *       "E"
+             *     ]
+             */
+            esferas?: components["schemas"]["EsferaGovernamental"][] | null;
             /**
              * Municipios
              * @description Lista de códigos IBGE de municípios para filtrar. None = todos os municípios das UFs selecionadas.
@@ -6465,60 +6492,32 @@ export interface components {
              */
             pagina: number;
             /**
+             * Itens Por Pagina
+             * @description Quantidade de itens por página. Valores permitidos: 10, 20, 50, 100. Padrão: 20.
+             * @default 20
+             * @example 10
+             * @example 20
+             * @example 50
+             * @example 100
+             */
+            itens_por_pagina: number;
+            /**
              * Search Id
              * @description Client-generated UUID for SSE progress tracking via /buscar-progress/{search_id}.
              */
             search_id?: string | null;
             /**
-             * Setor Id
-             * @description Sector ID for keyword filtering (e.g., 'vestuario', 'alimentos', 'informatica'). None when searching by 'Termos Específicos' (custom keywords only).
-             * @example vestuario
-             * @example null
-             */
-            setor_id?: string | null;
-            /**
-             * Show All Matches
-             * @description When True, bypasses minimum match floor and returns all results with at least 1 keyword match (for 'show hidden results' feature).
+             * Check Sanctions
+             * @description When true, verify supplier CNPJs against CEIS/CNEP sanctions databases. Adds supplier_sanctions field to each result. Performance impact: ~1s per unique CNPJ.
              * @default false
              */
-            show_all_matches: boolean | null;
+            check_sanctions: boolean;
             /**
-             * @description Status da licitação para filtrar. Padrão: 'todos' (sem filtro de status). IMPORTANTE: Filtro de status desabilitado por padrão devido a valores inconsistentes na API PNCP. Use 'todos' para máxima cobertura de resultados.
-             * @default todos
-             * @example todos
-             * @example recebendo_proposta
-             * @example em_julgamento
-             * @example encerrada
+             * Force Fresh
+             * @description When true, bypass result cache and always query primary sources. Cache write-through still happens on successful results.
+             * @default false
              */
-            status: components["schemas"]["StatusLicitacao"];
-            /**
-             * Termos Busca
-             * @description Custom search terms. Use commas to separate multi-word phrases (e.g., 'levantamento topográfico, terraplenagem, drenagem'). Without commas, spaces separate individual keywords (legacy mode).
-             * @example jaleco avental
-             * @example levantamento topográfico, terraplenagem, drenagem
-             */
-            termos_busca?: string | null;
-            /**
-             * Ufs
-             * @description List of Brazilian state codes (e.g., ['SP', 'RJ', 'MG'])
-             * @example [
-             *       "SP",
-             *       "RJ"
-             *     ]
-             */
-            ufs: string[];
-            /**
-             * Valor Maximo
-             * @description Valor máximo estimado da licitação em BRL. None = sem limite superior. Ceiling: 1e15 (R$ 1 quatrilhão) — STORY-419 incident guard to match NUMERIC(18,2) on search_sessions.valor_total.
-             * @example 5000000
-             */
-            valor_maximo?: number | null;
-            /**
-             * Valor Minimo
-             * @description Valor mínimo estimado da licitação em BRL. None = sem limite inferior.
-             * @example 50000
-             */
-            valor_minimo?: number | null;
+            force_fresh: boolean;
         };
         /**
          * BuscaResponse
@@ -6551,65 +6550,20 @@ export interface components {
          */
         BuscaResponse: {
             /**
-             * Cache Date Range
-             * @description STORY-306 AC5: Date of the cached data when cache_fallback=True (e.g. '2026-02-20')
+             * Resumo
+             * @description Strategic executive summary with actionable recommendations (AI-generated or fallback)
              */
-            cache_date_range?: string | null;
+            resumo: components["schemas"]["ResumoEstrategico"] | components["schemas"]["ResumoLicitacoes"];
             /**
-             * Cache Fallback
-             * @description STORY-306 AC5: True when serving cached data from a different date range than requested
-             * @default false
+             * Licitacoes
+             * @description List of individual bids for display. FREE tier shows 5-10 fully, rest blurred.
              */
-            cache_fallback: boolean;
+            licitacoes?: components["schemas"]["LicitacaoItem"][];
             /**
-             * Cache Level
-             * @description UX-303 AC2: Which cache level served the data — 'supabase', 'redis', or 'local'
+             * Excel Base64
+             * @description Excel file encoded as base64 string (None if plan doesn't allow or storage used)
              */
-            cache_level?: string | null;
-            /**
-             * Cache Status
-             * @description UX-303 AC5: Cache freshness status — 'fresh' (0-6h) or 'stale' (6-24h)
-             */
-            cache_status?: string | null;
-            /**
-             * Cached
-             * @description True when results are served from cache (STORY-257A AC9)
-             * @default false
-             */
-            cached: boolean;
-            /**
-             * Cached At
-             * @description ISO timestamp of when cached results were generated
-             */
-            cached_at?: string | null;
-            /**
-             * Cached Sources
-             * @description GTM-FIX-010 AC5r: Source codes that contributed to cached data (e.g. ['PNCP','PORTAL_COMPRAS'])
-             */
-            cached_sources?: string[] | null;
-            /** @description GTM-RESILIENCE-C03: Consolidated coverage metadata for frontend display */
-            coverage_metadata?: components["schemas"]["CoverageMetadata"] | null;
-            /**
-             * Coverage Pct
-             * @description GTM-RESILIENCE-A05 AC1: Coverage percentage (succeeded_ufs / total_ufs_requested * 100)
-             * @default 100
-             */
-            coverage_pct: number;
-            /**
-             * Data Sources
-             * @description Detailed status breakdown of each data source (None for backward compatibility)
-             */
-            data_sources?: components["schemas"]["DataSourceStatus"][] | null;
-            /**
-             * Degradation Guidance
-             * @description GTM-RESILIENCE-A01: User-facing guidance when response_state is 'empty_failure' or 'degraded'
-             */
-            degradation_guidance?: string | null;
-            /**
-             * Degradation Reason
-             * @description Human-readable explanation of partial results (e.g., 'PNCP indisponível, resultados de fontes alternativas')
-             */
-            degradation_reason?: string | null;
+            excel_base64?: string | null;
             /**
              * Download Url
              * @description Signed URL for direct Excel download (60min TTL, preferred over base64)
@@ -6621,127 +6575,47 @@ export interface components {
              */
             excel_available: boolean;
             /**
-             * Excel Base64
-             * @description Excel file encoded as base64 string (None if plan doesn't allow or storage used)
+             * Quota Used
+             * @description Monthly searches used after this request
              */
-            excel_base64?: string | null;
-            /**
-             * Excel Status
-             * @description Excel generation status: 'ready' (inline), 'processing' (background job running), 'skipped' (plan does not allow), 'failed' (job failed), None (legacy)
-             */
-            excel_status?: string | null;
-            /**
-             * Failed Ufs
-             * @description List of UF codes that failed during fetch (timeout or error)
-             */
-            failed_ufs?: string[] | null;
-            /**
-             * Filter Relaxed
-             * @description True if the minimum match filter was relaxed from strict to 1 due to zero results
-             */
-            filter_relaxed?: boolean | null;
-            /** @description Breakdown of filter rejection reasons */
-            filter_stats?: components["schemas"]["FilterStats"] | null;
-            /**
-             * Filter Summary
-             * @description GTM-STAB-005 AC3: Human-readable filter summary (e.g. '3 rejeitadas por UF, 12 por keyword')
-             */
-            filter_summary?: string | null;
-            /**
-             * From Cache
-             * @description GTM-INFRA-003 AC6: True when response came 100% from cache (quota was NOT consumed)
-             * @default false
-             */
-            from_cache: boolean;
-            /**
-             * Hidden By Min Match
-             * @description Number of bids that matched at least 1 term but were below the minimum match floor
-             */
-            hidden_by_min_match?: number | null;
-            /**
-             * Is Partial
-             * @description True when not all configured data sources responded successfully (some timed out/failed)
-             * @default false
-             */
-            is_partial: boolean;
-            /**
-             * Is Simplified
-             * @description GTM-STAB-003 AC4: True when time budget forced simplified (LLM/viability skipped)
-             * @default false
-             */
-            is_simplified: boolean;
-            /**
-             * Is Truncated
-             * @description True when at least one UF hit the max_pages limit (data may be incomplete)
-             * @default false
-             */
-            is_truncated: boolean;
-            /**
-             * Licitacoes
-             * @description List of individual bids for display. FREE tier shows 5-10 fully, rest blurred.
-             */
-            licitacoes?: components["schemas"]["LicitacaoItem"][];
-            /**
-             * Live Fetch In Progress
-             * @description A-04 AC1: True when cache-first response returned and live fetch is running in background
-             * @default false
-             */
-            live_fetch_in_progress: boolean;
-            /**
-             * Llm Source
-             * @description CRIT-005 AC13: Source of the summary — 'ai' (GPT-generated), 'fallback' (heuristic), 'processing' (in progress)
-             */
-            llm_source?: ("ai" | "fallback" | "processing") | null;
-            /**
-             * Llm Status
-             * @description LLM summary status: 'ready' (inline), 'processing' (background job running), None (legacy)
-             */
-            llm_status?: string | null;
-            /**
-             * Match Relaxed
-             * @description STORY-267 AC15: True when min_match_floor was relaxed, enabling 'expanded matching' badge in frontend
-             * @default false
-             */
-            match_relaxed: boolean;
-            /**
-             * Paywall Applied
-             * @description STORY-320 AC3: True when results were truncated due to trial paywall
-             * @default false
-             */
-            paywall_applied: boolean;
-            /**
-             * Pending Review Count
-             * @description STORY-354 AC2: Number of bids awaiting AI reclassification (LLM was temporarily unavailable)
-             * @default 0
-             */
-            pending_review_count: number;
+            quota_used: number;
             /**
              * Quota Remaining
              * @description Monthly searches remaining
              */
             quota_remaining: number;
             /**
-             * Quota Used
-             * @description Monthly searches used after this request
+             * Total Raw
+             * @description Total records fetched from PNCP API (before filtering)
              */
-            quota_used: number;
+            total_raw: number;
             /**
-             * Relaxation Level
-             * @description GTM-STAB-005 AC4: 0=normal, 1=no floor, 2=no density, 3=top by value
+             * Total Filtrado
+             * @description Records after applying filters (UF, value, keywords, deadline)
              */
-            relaxation_level?: number | null;
+            total_filtrado: number;
+            /** @description Breakdown of filter rejection reasons */
+            filter_stats?: components["schemas"]["FilterStats"] | null;
             /**
-             * Response State
-             * @description Semantic state of the response: 'live' (fresh data), 'cached' (stale cache served), 'degraded' (partial data), 'empty_failure' (all sources failed, no cache), 'degraded_expired' (all sources failed, expired cache >24h served as last resort)
-             * @default live
-             * @enum {string}
+             * Termos Utilizados
+             * @description Keywords effectively used for filtering (after stopword removal)
              */
-            response_state: "live" | "cached" | "degraded" | "empty_failure" | "degraded_expired";
+            termos_utilizados?: string[] | null;
             /**
-             * Resumo
-             * @description Strategic executive summary with actionable recommendations (AI-generated or fallback)
+             * Stopwords Removidas
+             * @description Stopwords stripped from user input (for transparency)
              */
-            resumo: components["schemas"]["ResumoEstrategico"] | components["schemas"]["ResumoLicitacoes"];
+            stopwords_removidas?: string[] | null;
+            /**
+             * Upgrade Message
+             * @description Message shown when Excel is blocked, encouraging upgrade
+             */
+            upgrade_message?: string | null;
+            /**
+             * Sources Used
+             * @description List of source codes that returned data (e.g., ['PNCP', 'PORTAL_COMPRAS'])
+             */
+            sources_used?: string[] | null;
             /**
              * Source Stats
              * @description Per-source fetch metrics when multi-source is active
@@ -6750,50 +6624,42 @@ export interface components {
                 [key: string]: unknown;
             }[] | null;
             /**
+             * Is Partial
+             * @description True when not all configured data sources responded successfully (some timed out/failed)
+             * @default false
+             */
+            is_partial: boolean;
+            /**
+             * Data Sources
+             * @description Detailed status breakdown of each data source (None for backward compatibility)
+             */
+            data_sources?: components["schemas"]["DataSourceStatus"][] | null;
+            /**
+             * Degradation Reason
+             * @description Human-readable explanation of partial results (e.g., 'PNCP indisponível, resultados de fontes alternativas')
+             */
+            degradation_reason?: string | null;
+            /**
              * Sources Degraded
              * @description CRIT-053: Source codes that are degraded (e.g., canary timeout). Not counted as succeeded.
              */
             sources_degraded?: string[] | null;
             /**
-             * Sources Used
-             * @description List of source codes that returned data (e.g., ['PNCP', 'PORTAL_COMPRAS'])
+             * Failed Ufs
+             * @description List of UF codes that failed during fetch (timeout or error)
              */
-            sources_used?: string[] | null;
-            /**
-             * Stopwords Removidas
-             * @description Stopwords stripped from user input (for transparency)
-             */
-            stopwords_removidas?: string[] | null;
+            failed_ufs?: string[] | null;
             /**
              * Succeeded Ufs
              * @description List of UF codes that returned data successfully
              */
             succeeded_ufs?: string[] | null;
             /**
-             * Termos Utilizados
-             * @description Keywords effectively used for filtering (after stopword removal)
+             * Is Truncated
+             * @description True when at least one UF hit the max_pages limit (data may be incomplete)
+             * @default false
              */
-            termos_utilizados?: string[] | null;
-            /**
-             * Total Before Paywall
-             * @description STORY-320 AC3: Total results before paywall truncation (shown as 'See all N results')
-             */
-            total_before_paywall?: number | null;
-            /**
-             * Total Filtrado
-             * @description Records after applying filters (UF, value, keywords, deadline)
-             */
-            total_filtrado: number;
-            /**
-             * Total Raw
-             * @description Total records fetched from PNCP API (before filtering)
-             */
-            total_raw: number;
-            /**
-             * Total Ufs Requested
-             * @description Total number of UFs in the original request
-             */
-            total_ufs_requested?: number | null;
+            is_truncated: boolean;
             /**
              * Truncated Ufs
              * @description UF codes where results were truncated due to max_pages limit
@@ -6807,20 +6673,147 @@ export interface components {
                 [key: string]: boolean;
             } | null;
             /**
+             * Total Ufs Requested
+             * @description Total number of UFs in the original request
+             */
+            total_ufs_requested?: number | null;
+            /**
+             * Cached
+             * @description True when results are served from cache (STORY-257A AC9)
+             * @default false
+             */
+            cached: boolean;
+            /**
+             * From Cache
+             * @description GTM-INFRA-003 AC6: True when response came 100% from cache (quota was NOT consumed)
+             * @default false
+             */
+            from_cache: boolean;
+            /**
+             * Cached At
+             * @description ISO timestamp of when cached results were generated
+             */
+            cached_at?: string | null;
+            /**
+             * Cached Sources
+             * @description GTM-FIX-010 AC5r: Source codes that contributed to cached data (e.g. ['PNCP','PORTAL_COMPRAS'])
+             */
+            cached_sources?: string[] | null;
+            /**
+             * Cache Status
+             * @description UX-303 AC5: Cache freshness status — 'fresh' (0-6h) or 'stale' (6-24h)
+             */
+            cache_status?: string | null;
+            /**
+             * Cache Level
+             * @description UX-303 AC2: Which cache level served the data — 'supabase', 'redis', or 'local'
+             */
+            cache_level?: string | null;
+            /**
+             * Cache Fallback
+             * @description STORY-306 AC5: True when serving cached data from a different date range than requested
+             * @default false
+             */
+            cache_fallback: boolean;
+            /**
+             * Cache Date Range
+             * @description STORY-306 AC5: Date of the cached data when cache_fallback=True (e.g. '2026-02-20')
+             */
+            cache_date_range?: string | null;
+            /**
+             * Response State
+             * @description Semantic state of the response: 'live' (fresh data), 'cached' (stale cache served), 'degraded' (partial data), 'empty_failure' (all sources failed, no cache), 'degraded_expired' (all sources failed, expired cache >24h served as last resort)
+             * @default live
+             * @enum {string}
+             */
+            response_state: "live" | "cached" | "degraded" | "empty_failure" | "degraded_expired";
+            /**
+             * Live Fetch In Progress
+             * @description A-04 AC1: True when cache-first response returned and live fetch is running in background
+             * @default false
+             */
+            live_fetch_in_progress: boolean;
+            /**
+             * Degradation Guidance
+             * @description GTM-RESILIENCE-A01: User-facing guidance when response_state is 'empty_failure' or 'degraded'
+             */
+            degradation_guidance?: string | null;
+            /**
+             * Coverage Pct
+             * @description GTM-RESILIENCE-A05 AC1: Coverage percentage (succeeded_ufs / total_ufs_requested * 100)
+             * @default 100
+             */
+            coverage_pct: number;
+            /**
              * Ufs Status Detail
              * @description GTM-RESILIENCE-A05 AC2: Per-UF status breakdown with results count
              */
             ufs_status_detail?: components["schemas"]["UfStatusDetail"][] | null;
+            /** @description GTM-RESILIENCE-C03: Consolidated coverage metadata for frontend display */
+            coverage_metadata?: components["schemas"]["CoverageMetadata"] | null;
+            /**
+             * Hidden By Min Match
+             * @description Number of bids that matched at least 1 term but were below the minimum match floor
+             */
+            hidden_by_min_match?: number | null;
+            /**
+             * Filter Relaxed
+             * @description True if the minimum match filter was relaxed from strict to 1 due to zero results
+             */
+            filter_relaxed?: boolean | null;
             /**
              * Ultima Atualizacao
              * @description ISO timestamp of when search results were generated
              */
             ultima_atualizacao?: string | null;
             /**
-             * Upgrade Message
-             * @description Message shown when Excel is blocked, encouraging upgrade
+             * Pending Review Count
+             * @description STORY-354 AC2: Number of bids awaiting AI reclassification (LLM was temporarily unavailable)
+             * @default 0
              */
-            upgrade_message?: string | null;
+            pending_review_count: number;
+            /**
+             * Llm Status
+             * @description LLM summary status: 'ready' (inline), 'processing' (background job running), None (legacy)
+             */
+            llm_status?: string | null;
+            /**
+             * Excel Status
+             * @description Excel generation status: 'ready' (inline), 'processing' (background job running), 'skipped' (plan does not allow), 'failed' (job failed), None (legacy)
+             */
+            excel_status?: string | null;
+            /**
+             * Llm Source
+             * @description CRIT-005 AC13: Source of the summary — 'ai' (GPT-generated), 'fallback' (heuristic), 'processing' (in progress)
+             */
+            llm_source?: ("ai" | "fallback" | "processing") | null;
+            /**
+             * Match Relaxed
+             * @description STORY-267 AC15: True when min_match_floor was relaxed, enabling 'expanded matching' badge in frontend
+             * @default false
+             */
+            match_relaxed: boolean;
+            /**
+             * Filter Summary
+             * @description GTM-STAB-005 AC3: Human-readable filter summary (e.g. '3 rejeitadas por UF, 12 por keyword')
+             */
+            filter_summary?: string | null;
+            /**
+             * Is Simplified
+             * @description GTM-STAB-003 AC4: True when time budget forced simplified (LLM/viability skipped)
+             * @default false
+             */
+            is_simplified: boolean;
+            /**
+             * Relaxation Level
+             * @description GTM-STAB-005 AC4: 0=normal, 1=no floor, 2=no density, 3=top by value
+             */
+            relaxation_level?: number | null;
+            /**
+             * Zero Match Job Id
+             * @description CRIT-059 AC6: Job ID for background zero-match classification (None when sync or disabled)
+             */
+            zero_match_job_id?: string | null;
             /**
              * Zero Match Candidates Count
              * @description CRIT-059 AC6: Number of zero-match candidates pending background classification
@@ -6828,10 +6821,16 @@ export interface components {
              */
             zero_match_candidates_count: number;
             /**
-             * Zero Match Job Id
-             * @description CRIT-059 AC6: Job ID for background zero-match classification (None when sync or disabled)
+             * Paywall Applied
+             * @description STORY-320 AC3: True when results were truncated due to trial paywall
+             * @default false
              */
-            zero_match_job_id?: string | null;
+            paywall_applied: boolean;
+            /**
+             * Total Before Paywall
+             * @description STORY-320 AC3: Total results before paywall truncation (shown as 'See all N results')
+             */
+            total_before_paywall?: number | null;
         };
         /** CTAEventRequest */
         CTAEventRequest: {
@@ -6845,18 +6844,18 @@ export interface components {
          * @description B-03/AC9 cache degradation aggregates.
          */
         CacheDegradationInfo: {
-            /** Avg Fail Streak */
-            avg_fail_streak?: number | null;
             /** Degraded Keys Count */
             degraded_keys_count?: number | null;
-            /** Error */
-            error?: string | null;
+            /** Avg Fail Streak */
+            avg_fail_streak?: number | null;
             /** Keys With Failures */
             keys_with_failures?: number | null;
             /** Priority Distribution */
             priority_distribution?: {
                 [key: string]: number;
             } | null;
+            /** Error */
+            error?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -6865,14 +6864,14 @@ export interface components {
          * @description UX-303 AC7: Cache health envelope across all levels.
          */
         CacheHealthResponse: {
-            degradation?: components["schemas"]["CacheDegradationInfo"] | null;
-            local?: components["schemas"]["CacheLevelHealth"] | null;
-            /** Overall */
-            overall?: string | null;
-            redis?: components["schemas"]["CacheLevelHealth"] | null;
-            supabase?: components["schemas"]["CacheLevelHealth"] | null;
             /** Timestamp */
             timestamp?: string | null;
+            /** Overall */
+            overall?: string | null;
+            supabase?: components["schemas"]["CacheLevelHealth"] | null;
+            redis?: components["schemas"]["CacheLevelHealth"] | null;
+            local?: components["schemas"]["CacheLevelHealth"] | null;
+            degradation?: components["schemas"]["CacheDegradationInfo"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -6881,17 +6880,19 @@ export interface components {
          * @description Per-level cache health (supabase / redis / local).
          */
         CacheLevelHealth: {
-            /** Last Error */
-            last_error?: string | null;
-            /** Latency Ms */
-            latency_ms?: number | null;
             /** Status */
             status?: string | null;
+            /** Latency Ms */
+            latency_ms?: number | null;
+            /** Last Error */
+            last_error?: string | null;
         } & {
             [key: string]: unknown;
         };
         /** CalculadoraDadosResponse */
         CalculadoraDadosResponse: {
+            /** Total Editais Mes */
+            total_editais_mes: number;
             /** Avg Value */
             avg_value: number;
             /** P25 Value */
@@ -6900,8 +6901,6 @@ export interface components {
             p75_value: number;
             /** Setor Name */
             setor_name: string;
-            /** Total Editais Mes */
-            total_editais_mes: number;
             /** Uf */
             uf: string;
         };
@@ -6921,10 +6920,10 @@ export interface components {
          * @description Response for cancellation feedback.
          */
         CancelFeedbackResponse: {
-            /** Message */
-            message: string;
             /** Success */
             success: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * CancelSubscriptionRequest
@@ -6942,23 +6941,20 @@ export interface components {
          * @description Response for subscription cancellation.
          */
         CancelSubscriptionResponse: {
+            /** Success */
+            success: boolean;
             /** Ends At */
             ends_at: string;
             /** Message */
             message: string;
-            /** Success */
-            success: boolean;
         };
         /**
          * CancelTrialInfoResponse
          * @description Returned by GET /cancelar-trial to populate the confirmation UI.
          */
         CancelTrialInfoResponse: {
-            /**
-             * Already Cancelled
-             * @default false
-             */
-            already_cancelled: boolean;
+            /** User Id */
+            user_id: string;
             /** Email */
             email: string;
             /** Plan Name */
@@ -6968,8 +6964,11 @@ export interface components {
              * @description Unix epoch seconds when trial ends
              */
             trial_end_ts?: number | null;
-            /** User Id */
-            user_id: string;
+            /**
+             * Already Cancelled
+             * @default false
+             */
+            already_cancelled: boolean;
         };
         /** CancelTrialRequest */
         CancelTrialRequest: {
@@ -6981,6 +6980,8 @@ export interface components {
         };
         /** CancelTrialResponse */
         CancelTrialResponse: {
+            /** Cancelled */
+            cancelled: boolean;
             /**
              * Access Until
              * @description Unix epoch seconds — trial access remains until this timestamp
@@ -6991,8 +6992,6 @@ export interface components {
              * @default false
              */
             already_cancelled: boolean;
-            /** Cancelled */
-            cancelled: boolean;
         };
         /**
          * CheckEmailResponse
@@ -7001,10 +7000,10 @@ export interface components {
         CheckEmailResponse: {
             /** Available */
             available: boolean;
-            /** Corporate */
-            corporate: boolean;
             /** Disposable */
             disposable: boolean;
+            /** Corporate */
+            corporate: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -7019,23 +7018,8 @@ export interface components {
             [key: string]: unknown;
         };
         /**
-         * CheckoutRequest
-         * @description Request body for POST /api/checkout/one-time.
-         */
-        CheckoutRequest: {
-            /**
-             * Context
-             * @default {}
-             */
-            context: {
-                [key: string]: unknown;
-            };
-            /** Sku */
-            sku: string;
-        };
-        /**
          * CheckoutResponse
-         * @description Response for a successful checkout session creation.
+         * @description Response for POST /checkout.
          */
         CheckoutResponse: {
             /** Checkout Url */
@@ -7043,10 +7027,43 @@ export interface components {
         };
         /** CidadeSectorStats */
         CidadeSectorStats: {
-            /** Avg Value */
-            avg_value: number;
             /** Cidade */
             cidade: string;
+            /** Uf */
+            uf: string;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Total Editais */
+            total_editais: number;
+            /** Avg Value */
+            avg_value: number;
+            /**
+             * Value Range Min
+             * @default 0
+             */
+            value_range_min: number;
+            /**
+             * Value Range Max
+             * @default 0
+             */
+            value_range_max: number;
+            /**
+             * Top Modalidades
+             * @default []
+             */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /**
+             * Orgaos Frequentes
+             * @default []
+             */
+            orgaos_frequentes: components["schemas"]["TopEntry"][];
+            /**
+             * Top Oportunidades
+             * @default []
+             */
+            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
             /**
              * Has Sufficient Data
              * @default false
@@ -7054,54 +7071,21 @@ export interface components {
             has_sufficient_data: boolean;
             /** Last Updated */
             last_updated: string;
-            /**
-             * Orgaos Frequentes
-             * @default []
-             */
-            orgaos_frequentes: components["schemas"]["TopEntry"][];
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /**
-             * Top Modalidades
-             * @default []
-             */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /**
-             * Top Oportunidades
-             * @default []
-             */
-            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
-            /** Total Editais */
-            total_editais: number;
-            /** Uf */
-            uf: string;
-            /**
-             * Value Range Max
-             * @default 0
-             */
-            value_range_max: number;
-            /**
-             * Value Range Min
-             * @default 0
-             */
-            value_range_min: number;
         };
         /** CidadeStats */
         CidadeStats: {
-            /** Avg Value */
-            avg_value: number;
             /** Cidade */
             cidade: string;
-            /** Last Updated */
-            last_updated: string;
-            /** Orgaos Frequentes */
-            orgaos_frequentes: components["schemas"]["TopEntry"][];
-            /** Total Editais */
-            total_editais: number;
             /** Uf */
             uf: string;
+            /** Total Editais */
+            total_editais: number;
+            /** Orgaos Frequentes */
+            orgaos_frequentes: components["schemas"]["TopEntry"][];
+            /** Avg Value */
+            avg_value: number;
+            /** Last Updated */
+            last_updated: string;
         };
         /** ClearNewBidsCountResponse */
         ClearNewBidsCountResponse: {
@@ -7112,6 +7096,8 @@ export interface components {
         CnaeMappingCreate: {
             /** Cnae Code */
             cnae_code: string;
+            /** Setor Id */
+            setor_id: string;
             /**
              * Confidence
              * @default 1
@@ -7121,8 +7107,6 @@ export interface components {
             fallback_setor_id?: string | null;
             /** Notes */
             notes?: string | null;
-            /** Setor Id */
-            setor_id: string;
         };
         /** CnaeMappingListResponse */
         CnaeMappingListResponse: {
@@ -7135,16 +7119,16 @@ export interface components {
         CnaeMappingRow: {
             /** Cnae Code */
             cnae_code: string;
+            /** Setor Id */
+            setor_id: string;
             /** Confidence */
             confidence: number;
-            /** Created At */
-            created_at?: string | null;
             /** Fallback Setor Id */
             fallback_setor_id?: string | null;
             /** Notes */
             notes?: string | null;
-            /** Setor Id */
-            setor_id: string;
+            /** Created At */
+            created_at?: string | null;
             /** Updated At */
             updated_at?: string | null;
             /** Updated By */
@@ -7152,46 +7136,46 @@ export interface components {
         };
         /** CnaeMappingUpdate */
         CnaeMappingUpdate: {
+            /** Setor Id */
+            setor_id?: string | null;
             /** Confidence */
             confidence?: number | null;
             /** Fallback Setor Id */
             fallback_setor_id?: string | null;
             /** Notes */
             notes?: string | null;
-            /** Setor Id */
-            setor_id?: string | null;
         };
         /** ComparadorBid */
         ComparadorBid: {
-            /** Data Abertura */
-            data_abertura?: string | null;
-            /** Data Publicacao */
-            data_publicacao: string;
-            /**
-             * Link Pncp
-             * @default
-             */
-            link_pncp: string;
-            /**
-             * Modalidade
-             * @default
-             */
-            modalidade: string;
+            /** Pncp Id */
+            pncp_id: string;
+            /** Titulo */
+            titulo: string;
+            /** Orgao */
+            orgao: string;
+            /** Valor */
+            valor?: number | null;
+            /** Uf */
+            uf: string;
             /**
              * Municipio
              * @default
              */
             municipio: string;
-            /** Orgao */
-            orgao: string;
-            /** Pncp Id */
-            pncp_id: string;
-            /** Titulo */
-            titulo: string;
-            /** Uf */
-            uf: string;
-            /** Valor */
-            valor?: number | null;
+            /**
+             * Modalidade
+             * @default
+             */
+            modalidade: string;
+            /** Data Publicacao */
+            data_publicacao: string;
+            /** Data Abertura */
+            data_abertura?: string | null;
+            /**
+             * Link Pncp
+             * @default
+             */
+            link_pncp: string;
         };
         /** ComparadorBidsResponse */
         ComparadorBidsResponse: {
@@ -7202,192 +7186,192 @@ export interface components {
         };
         /** ComparadorSearchResponse */
         ComparadorSearchResponse: {
-            /** Bids */
-            bids: components["schemas"]["ComparadorBid"][];
             /** Query */
             query: string;
-            /** Total */
-            total: number;
             /** Uf */
             uf: string | null;
+            /** Bids */
+            bids: components["schemas"]["ComparadorBid"][];
+            /** Total */
+            total: number;
         };
         /** ComplianceProfileResponse */
         ComplianceProfileResponse: {
-            /** Aviso Legal */
-            aviso_legal: string;
             /** Cnpj */
             cnpj: string;
-            /** Fonte Dados */
-            fonte_dados: string;
-            /** Last Updated */
-            last_updated: string;
             /** Razao Social */
             razao_social: string;
-            /** Sancoes */
-            sancoes: components["schemas"]["SancaoEntry"][];
             /** Situacao Geral */
             situacao_geral: string;
             /** Total Sancoes Ceis */
             total_sancoes_ceis: number;
             /** Total Sancoes Cnep */
             total_sancoes_cnep: number;
+            /** Sancoes */
+            sancoes: components["schemas"]["SancaoEntry"][];
+            /** Fonte Dados */
+            fonte_dados: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Aviso Legal */
+            aviso_legal: string;
         };
         /** ContratoPublico */
         ContratoPublico: {
+            /** Orgao */
+            orgao: string;
+            /** Orgao Cnpj */
+            orgao_cnpj?: string | null;
+            /** Valor */
+            valor?: number | null;
             /** Data Inicio */
             data_inicio?: string | null;
             /** Descricao */
             descricao: string;
             /** Esfera */
             esfera?: string | null;
-            /** Orgao */
-            orgao: string;
-            /** Orgao Cnpj */
-            orgao_cnpj?: string | null;
             /** Uf */
             uf?: string | null;
-            /** Valor */
-            valor?: number | null;
         };
         /** ContratoReferencia */
         ContratoReferencia: {
-            /** Data Assinatura */
-            data_assinatura: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
-            /** Uf */
-            uf: string;
             /** Valor */
             valor: number;
+            /** Data Assinatura */
+            data_assinatura: string;
+            /** Uf */
+            uf: string;
         };
         /**
          * ContratosCidadeSetorStats
          * @description City × Sector filtered contract stats for zero-editais cidade×setor pages.
          */
         ContratosCidadeSetorStats: {
-            /** Avg Value */
-            avg_value: number;
             /** Cidade */
             cidade: string;
-            /** Last Updated */
-            last_updated: string;
+            /** Uf */
+            uf: string;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Value */
+            total_value: number;
+            /** Avg Value */
+            avg_value: number;
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
             /** Monthly Trend */
             monthly_trend: components["schemas"]["ContratosSetorTrend"][];
-            /**
-             * N Unique Fornecedores
-             * @default 0
-             */
-            n_unique_fornecedores: number;
+            /** Last Updated */
+            last_updated: string;
             /**
              * N Unique Orgaos
              * @default 0
              */
             n_unique_orgaos: number;
             /**
+             * N Unique Fornecedores
+             * @default 0
+             */
+            n_unique_fornecedores: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Total Contracts */
-            total_contracts: number;
-            /** Total Value */
-            total_value: number;
-            /** Uf */
-            uf: string;
         };
         /**
          * ContratosCidadeStats
          * @description City-level contract stats (all sectors) for zero-editais cidade blog pages.
          */
         ContratosCidadeStats: {
-            /** Avg Value */
-            avg_value: number;
             /** Cidade */
             cidade: string;
-            /** Last Updated */
-            last_updated: string;
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
-            /**
-             * N Unique Fornecedores
-             * @default 0
-             */
-            n_unique_fornecedores: number;
-            /**
-             * N Unique Orgaos
-             * @default 0
-             */
-            n_unique_orgaos: number;
-            /**
-             * Sample Contracts
-             * @default []
-             */
-            sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Uf */
+            uf: string;
             /** Total Contracts */
             total_contracts: number;
             /** Total Value */
             total_value: number;
-            /** Uf */
-            uf: string;
-        };
-        /** ContratosSetorStats */
-        ContratosSetorStats: {
             /** Avg Value */
             avg_value: number;
-            /** By Uf */
-            by_uf: components["schemas"]["ContratosSetorUfEntry"][];
-            /** Last Updated */
-            last_updated: string;
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
             /** Monthly Trend */
             monthly_trend: components["schemas"]["ContratosSetorTrend"][];
-            /**
-             * N Unique Fornecedores
-             * @default 0
-             */
-            n_unique_fornecedores: number;
+            /** Last Updated */
+            last_updated: string;
             /**
              * N Unique Orgaos
              * @default 0
              */
             n_unique_orgaos: number;
             /**
+             * N Unique Fornecedores
+             * @default 0
+             */
+            n_unique_fornecedores: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
+        };
+        /** ContratosSetorStats */
+        ContratosSetorStats: {
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
             /** Total Contracts */
             total_contracts: number;
             /** Total Value */
             total_value: number;
+            /** Avg Value */
+            avg_value: number;
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
+            /** By Uf */
+            by_uf: components["schemas"]["ContratosSetorUfEntry"][];
+            /** Last Updated */
+            last_updated: string;
+            /**
+             * N Unique Orgaos
+             * @default 0
+             */
+            n_unique_orgaos: number;
+            /**
+             * N Unique Fornecedores
+             * @default 0
+             */
+            n_unique_fornecedores: number;
+            /**
+             * Sample Contracts
+             * @default []
+             */
+            sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
         };
         /** ContratosSetorTopEntry */
         ContratosSetorTopEntry: {
-            /** Cnpj */
-            cnpj: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -7395,19 +7379,19 @@ export interface components {
         };
         /** ContratosSetorTrend */
         ContratosSetorTrend: {
-            /** Count */
-            count: number;
             /** Month */
             month: string;
+            /** Count */
+            count: number;
             /** Value */
             value: number;
         };
         /** ContratosSetorUfEntry */
         ContratosSetorUfEntry: {
-            /** Total Contratos */
-            total_contratos: number;
             /** Uf */
             uf: string;
+            /** Total Contratos */
+            total_contratos: number;
             /** Valor Total */
             valor_total: number;
         };
@@ -7416,78 +7400,78 @@ export interface components {
          * @description Sector × UF filtered contract stats (fallback for zero-editais blog pages).
          */
         ContratosSetorUfStats: {
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Uf */
+            uf: string;
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Value */
+            total_value: number;
             /** Avg Value */
             avg_value: number;
-            /** Last Updated */
-            last_updated: string;
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
             /** Monthly Trend */
             monthly_trend: components["schemas"]["ContratosSetorTrend"][];
-            /**
-             * N Unique Fornecedores
-             * @default 0
-             */
-            n_unique_fornecedores: number;
+            /** Last Updated */
+            last_updated: string;
             /**
              * N Unique Orgaos
              * @default 0
              */
             n_unique_orgaos: number;
             /**
+             * N Unique Fornecedores
+             * @default 0
+             */
+            n_unique_fornecedores: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
+        };
+        /** ContratosStatsResponse */
+        ContratosStatsResponse: {
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Uf */
+            uf: string;
             /** Total Contracts */
             total_contracts: number;
             /** Total Value */
             total_value: number;
-            /** Uf */
-            uf: string;
-        };
-        /** ContratosStatsResponse */
-        ContratosStatsResponse: {
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Avg Value */
             avg_value: number;
-            /** Aviso Legal */
-            aviso_legal: string;
-            /** Last Updated */
-            last_updated: string;
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["OrgaoRank"][];
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["FornecedorRank"][];
             /** Monthly Trend */
             monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
             /** Sample Contracts */
             sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["FornecedorRank"][];
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["OrgaoRank"][];
-            /** Total Contracts */
-            total_contracts: number;
-            /** Total Value */
-            total_value: number;
-            /** Uf */
-            uf: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
         };
         /**
          * ConversationCategory
@@ -7500,27 +7484,27 @@ export interface components {
          * @description Full conversation with messages thread.
          */
         ConversationDetail: {
-            /** Category */
-            category: string;
-            /** Created At */
-            created_at: string;
             /** Id */
             id: string;
+            /** User Id */
+            user_id: string;
+            /** User Email */
+            user_email?: string | null;
+            /** Subject */
+            subject: string;
+            /** Category */
+            category: string;
+            /** Status */
+            status: string;
             /** Last Message At */
             last_message_at: string;
+            /** Created At */
+            created_at: string;
             /**
              * Messages
              * @default []
              */
             messages: components["schemas"]["MessageResponse"][];
-            /** Status */
-            status: string;
-            /** Subject */
-            subject: string;
-            /** User Email */
-            user_email?: string | null;
-            /** User Id */
-            user_id: string;
         };
         /**
          * ConversationStatus
@@ -7533,27 +7517,27 @@ export interface components {
          * @description Summary of a conversation for list views.
          */
         ConversationSummary: {
-            /** Category */
-            category: string;
-            /** Created At */
-            created_at: string;
             /** Id */
             id: string;
-            /** Last Message At */
-            last_message_at: string;
-            /** Status */
-            status: string;
+            /** User Id */
+            user_id: string;
+            /** User Email */
+            user_email?: string | null;
             /** Subject */
             subject: string;
+            /** Category */
+            category: string;
+            /** Status */
+            status: string;
+            /** Last Message At */
+            last_message_at: string;
+            /** Created At */
+            created_at: string;
             /**
              * Unread Count
              * @default 0
              */
             unread_count: number;
-            /** User Email */
-            user_email?: string | null;
-            /** User Id */
-            user_id: string;
         };
         /**
          * ConversationsListResponse
@@ -7567,24 +7551,24 @@ export interface components {
         };
         /** CoverageEntry */
         CoverageEntry: {
-            /** Bid Count */
-            bid_count: number;
             /**
              * Coverage Status
              * @enum {string}
              */
             coverage_status: "full" | "partial" | "empty" | "historical_empty";
+            /** Bid Count */
+            bid_count: number;
             /** Last Updated */
             last_updated: string;
         };
         /** CoverageManifestResponse */
         CoverageManifestResponse: {
-            /** Generated At */
-            generated_at: string;
             /** Manifest */
             manifest: {
                 [key: string]: components["schemas"]["CoverageEntry"];
             };
+            /** Generated At */
+            generated_at: string;
             /** Total Entities */
             total_entities: number;
         };
@@ -7593,6 +7577,33 @@ export interface components {
          * @description GTM-RESILIENCE-C03 AC1: Consolidated coverage metadata.
          */
         CoverageMetadata: {
+            /**
+             * Ufs Requested
+             * @description UFs solicitadas pelo usuario
+             */
+            ufs_requested: string[];
+            /**
+             * Ufs Processed
+             * @description UFs que retornaram dados com sucesso
+             */
+            ufs_processed: string[];
+            /**
+             * Ufs Failed
+             * @description UFs que falharam (timeout/erro)
+             */
+            ufs_failed?: string[];
+            /**
+             * Ufs Empty
+             * @description ISSUE-073: UFs processadas com 0 resultados pos-filtragem
+             */
+            ufs_empty?: string[];
+            /**
+             * Uf Result Counts
+             * @description ISSUE-073: contagem de resultados por UF
+             */
+            uf_result_counts?: {
+                [key: string]: number;
+            };
             /**
              * Coverage Pct
              * @description Porcentagem de cobertura (1 decimal)
@@ -7609,53 +7620,26 @@ export interface components {
              * @enum {string}
              */
             freshness: "live" | "cached_fresh" | "cached_stale";
-            /**
-             * Uf Result Counts
-             * @description ISSUE-073: contagem de resultados por UF
-             */
-            uf_result_counts?: {
-                [key: string]: number;
-            };
-            /**
-             * Ufs Empty
-             * @description ISSUE-073: UFs processadas com 0 resultados pos-filtragem
-             */
-            ufs_empty?: string[];
-            /**
-             * Ufs Failed
-             * @description UFs que falharam (timeout/erro)
-             */
-            ufs_failed?: string[];
-            /**
-             * Ufs Processed
-             * @description UFs que retornaram dados com sucesso
-             */
-            ufs_processed: string[];
-            /**
-             * Ufs Requested
-             * @description UFs solicitadas pelo usuario
-             */
-            ufs_requested: string[];
         };
         /** CreateAlertRequest */
         CreateAlertRequest: {
-            filters: components["schemas"]["AlertFilters"];
             /**
              * Name
              * @description Alert display name
              */
             name: string;
+            filters: components["schemas"]["AlertFilters"];
         };
         /**
          * CreateConversationRequest
          * @description Request to create a new conversation with first message.
          */
         CreateConversationRequest: {
-            /** Body */
-            body: string;
-            category: components["schemas"]["ConversationCategory"];
             /** Subject */
             subject: string;
+            category: components["schemas"]["ConversationCategory"];
+            /** Body */
+            body: string;
         };
         /**
          * CreateConversationResponse
@@ -7674,181 +7658,181 @@ export interface components {
         };
         /** CreatePartnerRequest */
         CreatePartnerRequest: {
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
             /** Contact Email */
             contact_email: string;
             /** Contact Name */
             contact_name?: string | null;
-            /** Name */
-            name: string;
+            /** Stripe Coupon Id */
+            stripe_coupon_id?: string | null;
             /**
              * Revenue Share Pct
              * @default 20
              */
             revenue_share_pct: number;
-            /** Slug */
-            slug: string;
-            /** Stripe Coupon Id */
-            stripe_coupon_id?: string | null;
         };
         /** CreateUserRequest */
         CreateUserRequest: {
-            /** Company */
-            company?: string | null;
             /**
              * Email
              * @description User email
              */
             email: string;
-            /** Full Name */
-            full_name?: string | null;
             /**
              * Password
              * @description User password (min 8 chars, 1 uppercase, 1 digit)
              */
             password: string;
+            /** Full Name */
+            full_name?: string | null;
             /**
              * Plan Id
              * @description Initial plan
              * @default free_trial
              */
             plan_id: string | null;
+            /** Company */
+            company?: string | null;
         };
         /**
          * CronJobHealthRow
          * @description One row of ``public.get_cron_health()`` (STORY-1.1).
          */
         CronJobHealthRow: {
-            /** Active */
-            active?: boolean | null;
-            /**
-             * Failures 24H
-             * @default 0
-             */
-            failures_24h: number;
             /** Jobname */
             jobname?: string | null;
-            /** Last Return Message */
-            last_return_message?: string | null;
-            /** Last Run At */
-            last_run_at?: string | null;
+            /** Schedule */
+            schedule?: string | null;
+            /** Active */
+            active?: boolean | null;
             /** Last Status */
             last_status?: string | null;
-            /** Latency Avg Ms */
-            latency_avg_ms?: number | null;
+            /** Last Run At */
+            last_run_at?: string | null;
             /**
              * Runs 24H
              * @default 0
              */
             runs_24h: number;
-            /** Schedule */
-            schedule?: string | null;
+            /**
+             * Failures 24H
+             * @default 0
+             */
+            failures_24h: number;
+            /** Latency Avg Ms */
+            latency_avg_ms?: number | null;
+            /** Last Return Message */
+            last_return_message?: string | null;
         };
         /** DadosAgregadosResponse */
         DadosAgregadosResponse: {
+            /** Updated At */
+            updated_at: string;
+            /** Period */
+            period: string;
+            /** Period Start */
+            period_start: string;
+            /** Period End */
+            period_end: string;
+            /** Total Bids */
+            total_bids: number;
+            /** Total Value */
+            total_value: number;
             /** Avg Value */
             avg_value: number;
-            /** By Modalidade */
-            by_modalidade: components["schemas"]["ModalidadeAggregate"][];
             /** By Sector */
             by_sector: components["schemas"]["SectorAggregate"][];
             /** By Uf */
             by_uf: components["schemas"]["UfAggregate"][];
-            /** Period */
-            period: string;
-            /** Period End */
-            period_end: string;
-            /** Period Start */
-            period_start: string;
+            /** By Modalidade */
+            by_modalidade: components["schemas"]["ModalidadeAggregate"][];
+            /** Trend 30D */
+            trend_30d: components["schemas"]["routes__dados_publicos__TrendPoint"][];
+        };
+        /** DailyDigestResponse */
+        DailyDigestResponse: {
+            /** Date */
+            date: string;
+            /** Title */
+            title: string;
             /** Total Bids */
             total_bids: number;
             /** Total Value */
             total_value: number;
-            /** Trend 30D */
-            trend_30d: components["schemas"]["routes__dados_publicos__TrendPoint"][];
-            /** Updated At */
-            updated_at: string;
-        };
-        /** DailyDigestResponse */
-        DailyDigestResponse: {
             /** Avg Value */
             avg_value: number;
-            /** By Modalidade */
-            by_modalidade: components["schemas"]["DailyModalidade"][];
             /** By Sector */
             by_sector: components["schemas"]["DailySector"][];
             /** By Uf */
             by_uf: components["schemas"]["DailyUf"][];
-            /** Date */
-            date: string;
+            /** By Modalidade */
+            by_modalidade: components["schemas"]["DailyModalidade"][];
             /** Highlights */
             highlights: components["schemas"]["DailyHighlight"][];
-            /** Title */
-            title: string;
             /** Top Sector */
             top_sector: string;
             /** Top Uf */
             top_uf: string;
-            /** Total Bids */
-            total_bids: number;
-            /** Total Value */
-            total_value: number;
             /** Updated At */
             updated_at: string;
         };
         /** DailyHighlight */
         DailyHighlight: {
-            /** Orgao */
-            orgao: string;
-            /** Setor */
-            setor: string;
             /** Titulo */
             titulo: string;
-            /** Uf */
-            uf: string;
+            /** Orgao */
+            orgao: string;
             /** Valor */
             valor?: number | null;
+            /** Uf */
+            uf: string;
+            /** Setor */
+            setor: string;
         };
         /** DailyModalidade */
         DailyModalidade: {
-            /** Count */
-            count: number;
             /** Modalidade */
             modalidade: string;
+            /** Count */
+            count: number;
             /** Pct */
             pct: number;
         };
         /** DailySector */
         DailySector: {
-            /** Avg Value */
-            avg_value: number;
-            /** Count */
-            count: number;
-            /** Sector Id */
-            sector_id: string;
             /** Sector Name */
             sector_name: string;
+            /** Sector Id */
+            sector_id: string;
+            /** Count */
+            count: number;
+            /** Avg Value */
+            avg_value: number;
         };
         /** DailyUf */
         DailyUf: {
+            /** Uf */
+            uf: string;
             /** Count */
             count: number;
             /** Total Value */
             total_value: number;
-            /** Uf */
-            uf: string;
         };
         /** DailyVolumeResponse */
         DailyVolumeResponse: {
             /** Avg Bids Per Day */
             avg_bids_per_day: number;
-            /** Days With Data */
-            days_with_data: number;
-            /** Display Value */
-            display_value: string;
             /** Total Bids 30D */
             total_bids_30d: number;
             /** Total Sessions 30D */
             total_sessions_30d: number;
+            /** Days With Data */
+            days_with_data: number;
+            /** Display Value */
+            display_value: string;
         };
         /**
          * DataSourceStatus
@@ -7859,12 +7843,6 @@ export interface components {
          */
         DataSourceStatus: {
             /**
-             * Records
-             * @description Number of records successfully returned by this source
-             * @default 0
-             */
-            records: number;
-            /**
              * Source
              * @description Data source identifier (e.g., 'pncp', 'compras_gov', 'portal')
              */
@@ -7874,47 +7852,65 @@ export interface components {
              * @description Source status: 'ok' (success), 'timeout' (timed out), 'error' (failed), 'skipped' (not attempted)
              */
             status: string;
+            /**
+             * Records
+             * @description Number of records successfully returned by this source
+             * @default 0
+             */
+            records: number;
         };
         /**
          * DebugPNCPResponse
          * @description Response for GET /debug/pncp-test endpoint.
          */
         DebugPNCPResponse: {
-            /** Elapsed Ms */
-            elapsed_ms: number;
-            /** Error */
-            error?: string | null;
-            /** Error Type */
-            error_type?: string | null;
-            /** Items Returned */
-            items_returned?: number | null;
             /** Success */
             success: boolean;
             /** Total Registros */
             total_registros?: number | null;
+            /** Items Returned */
+            items_returned?: number | null;
+            /** Error */
+            error?: string | null;
+            /** Error Type */
+            error_type?: string | null;
+            /** Elapsed Ms */
+            elapsed_ms: number;
         };
         /**
          * DeepAnalysisRequest
          * @description Request body for deep analysis.
          */
         DeepAnalysisRequest: {
+            /** Search Id */
+            search_id: string;
             /** Bid Data */
             bid_data?: {
                 [key: string]: unknown;
             } | null;
-            /** Search Id */
-            search_id: string;
         };
         /**
          * DeepBidAnalysis
          * @description Level 2: Deep on-demand analysis (STORY-259 AC8).
          */
         DeepBidAnalysis: {
+            /** Bid Id */
+            bid_id: string;
             /**
-             * Analise Competitividade
-             * @default
+             * Score
+             * @default 5
              */
-            analise_competitividade: string;
+            score: number;
+            /**
+             * Decisao Sugerida
+             * @default AVALIAR COM CAUTELA
+             */
+            decisao_sugerida: string;
+            /**
+             * Compatibilidade Pct
+             * @default 50
+             */
+            compatibilidade_pct: number;
             /**
              * Analise Prazo
              * @default
@@ -7922,50 +7918,40 @@ export interface components {
             analise_prazo: string;
             /** Analise Requisitos */
             analise_requisitos?: string[];
-            /** Bid Id */
-            bid_id: string;
             /**
-             * Compatibilidade Pct
-             * @default 50
+             * Analise Competitividade
+             * @default
              */
-            compatibilidade_pct: number;
-            /**
-             * Decisao Sugerida
-             * @default AVALIAR COM CAUTELA
-             */
-            decisao_sugerida: string;
-            /** Justificativas Contra */
-            justificativas_contra?: string[];
+            analise_competitividade: string;
+            /** Riscos */
+            riscos?: string[];
             /** Justificativas Favoraveis */
             justificativas_favoraveis?: string[];
+            /** Justificativas Contra */
+            justificativas_contra?: string[];
             /**
              * Recomendacao Final
              * @default
              */
             recomendacao_final: string;
-            /** Riscos */
-            riscos?: string[];
-            /**
-             * Score
-             * @default 5
-             */
-            score: number;
         };
         /**
          * DeleteAccountResponse
          * @description Response for DELETE /me.
          */
         DeleteAccountResponse: {
-            /** Message */
-            message: string;
             /** Success */
             success: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * DiagnosticoRequest
          * @description Request body for PDF diagnostico report generation.
          */
         DiagnosticoRequest: {
+            /** Search Id */
+            search_id: string;
             /** Client Name */
             client_name?: string | null;
             /**
@@ -7973,25 +7959,20 @@ export interface components {
              * @default 20
              */
             max_items: number;
-            /** Search Id */
-            search_id: string;
         };
         /**
          * DigitalProductOut
          * @description Public representation of a digital product for checkout.
          */
         DigitalProductOut: {
-            /**
-             * Delivery Config
-             * @default {}
-             */
-            delivery_config: {
-                [key: string]: unknown;
-            };
-            /** Description */
-            description?: string | null;
+            /** Sku */
+            sku: string;
             /** Name */
             name: string;
+            /** Description */
+            description?: string | null;
+            /** Price Brl */
+            price_brl: number;
             /**
              * Preview Config
              * @default {}
@@ -7999,17 +7980,20 @@ export interface components {
             preview_config: {
                 [key: string]: unknown;
             };
-            /** Price Brl */
-            price_brl: number;
-            /** Sku */
-            sku: string;
+            /**
+             * Delivery Config
+             * @default {}
+             */
+            delivery_config: {
+                [key: string]: unknown;
+            };
         };
         /** DimensionItem */
         DimensionItem: {
-            /** Count */
-            count: number;
             /** Name */
             name: string;
+            /** Count */
+            count: number;
             /** Value */
             value: number;
         };
@@ -8020,44 +8004,44 @@ export interface components {
         DiscardRateResponse: {
             /** Discard Rate */
             discard_rate?: number | null;
-            /** Discarded */
-            discarded?: number | null;
             /** Period Days */
             period_days?: number | null;
             /** Total Searches */
             total_searches?: number | null;
+            /** Discarded */
+            discarded?: number | null;
         } & {
             [key: string]: unknown;
         };
         /** EditaisAmostra */
         EditaisAmostra: {
-            /** Data Encerramento */
-            data_encerramento?: string | null;
-            /** Descricao */
-            descricao: string;
-            /** Modalidade */
-            modalidade?: string | null;
             /** Orgao */
             orgao: string;
-            /** Uf */
-            uf?: string | null;
+            /** Descricao */
+            descricao: string;
             /** Valor Estimado */
             valor_estimado?: number | null;
+            /** Data Encerramento */
+            data_encerramento?: string | null;
+            /** Uf */
+            uf?: string | null;
+            /** Modalidade */
+            modalidade?: string | null;
         };
         /** EmpresaInfo */
         EmpresaInfo: {
-            /** Cnae Principal */
-            cnae_principal: string;
-            /** Cnpj */
-            cnpj: string;
-            /** Porte */
-            porte: string;
             /** Razao Social */
             razao_social: string;
-            /** Situacao */
-            situacao: string;
+            /** Cnpj */
+            cnpj: string;
+            /** Cnae Principal */
+            cnae_principal: string;
+            /** Porte */
+            porte: string;
             /** Uf */
             uf: string;
+            /** Situacao */
+            situacao: string;
         };
         /**
          * EsferaGovernamental
@@ -8079,10 +8063,10 @@ export interface components {
         };
         /** ExitSurveyResponse */
         ExitSurveyResponse: {
-            /** Created At */
-            created_at: string;
             /** Id */
             id: string;
+            /** Created At */
+            created_at: string;
         };
         /**
          * ExperienciaLicitacoes
@@ -8108,35 +8092,35 @@ export interface components {
          */
         ExportTimeSavedSurveyRequest: {
             /**
-             * Bid Count
-             * @description Number of bids included in the export
+             * Export Type
+             * @description excel | pdf | sheets
              */
-            bid_count?: number | null;
+            export_type: string;
             /**
              * Estimated Manual Hours
              * @description User-reported manual-equivalent hours (range [0.1, 50])
              */
             estimated_manual_hours: number;
             /**
+             * Search Id
+             * @description Search session id this export came from
+             */
+            search_id?: string | null;
+            /**
              * Export Id
              * @description Export job/download identifier
              */
             export_id?: string | null;
             /**
-             * Export Type
-             * @description excel | pdf | sheets
+             * Bid Count
+             * @description Number of bids included in the export
              */
-            export_type: string;
+            bid_count?: number | null;
             /**
              * Free Text
              * @description Optional free-text answer ('how would you have done this before?')
              */
             free_text?: string | null;
-            /**
-             * Search Id
-             * @description Search session id this export came from
-             */
-            search_id?: string | null;
         };
         /**
          * ExportTimeSavedSurveyResponse
@@ -8160,23 +8144,23 @@ export interface components {
         ExtendResponse: {
             /** Days Added */
             days_added: number;
-            /** New Expires At */
-            new_expires_at?: string | null;
             /** Total Extended */
             total_extended: number;
+            /** New Expires At */
+            new_expires_at?: string | null;
         };
         /** ExtensionItem */
         ExtensionItem: {
-            /** Claimed */
-            claimed: boolean;
             /** Condition */
             condition: string;
-            /** Days */
-            days: number;
-            /** Eligible */
-            eligible: boolean;
             /** Label */
             label: string;
+            /** Days */
+            days: number;
+            /** Claimed */
+            claimed: boolean;
+            /** Eligible */
+            eligible: boolean;
         };
         /** ExtensionsStatusResponse */
         ExtensionsStatusResponse: {
@@ -8184,6 +8168,8 @@ export interface components {
             enabled: boolean;
             /** Extensions */
             extensions: components["schemas"]["ExtensionItem"][];
+            /** Total Extended */
+            total_extended: number;
             /** Max Extension */
             max_extension: number;
             /**
@@ -8191,36 +8177,43 @@ export interface components {
              * @default 0
              */
             remaining: number;
-            /** Total Extended */
-            total_extended: number;
         };
         /**
          * FPKeywordSuggestion
          * @description Keyword appearing frequently in false positives.
          */
         FPKeywordSuggestion: {
-            /** Count */
-            count: number;
             /** Keyword */
             keyword: string;
+            /** Count */
+            count: number;
             /** Suggestion */
             suggestion: string;
         };
         /** FaqItem */
         FaqItem: {
-            /** Answer */
-            answer: string;
             /** Question */
             question: string;
+            /** Answer */
+            answer: string;
         };
         /** FeatureFlagItem */
         FeatureFlagItem: {
             /**
-             * Default
-             * @description Registry default value
-             * @default
+             * Name
+             * @description Flag name (e.g. LLM_ARBITER_ENABLED)
              */
-            default: string;
+            name: string;
+            /**
+             * Value
+             * @description Current effective value
+             */
+            value: boolean;
+            /**
+             * Source
+             * @description Value source: redis, memory, env, or default
+             */
+            source: string;
             /**
              * Description
              * @description Human-readable description
@@ -8233,26 +8226,23 @@ export interface components {
              * @default
              */
             env_var: string;
+            /**
+             * Default
+             * @description Registry default value
+             * @default
+             */
+            default: string;
             /** @description Flag lifecycle metadata */
             lifecycle?: components["schemas"]["FeatureFlagLifecycle"] | null;
-            /**
-             * Name
-             * @description Flag name (e.g. LLM_ARBITER_ENABLED)
-             */
-            name: string;
-            /**
-             * Source
-             * @description Value source: redis, memory, env, or default
-             */
-            source: string;
-            /**
-             * Value
-             * @description Current effective value
-             */
-            value: boolean;
         };
         /** FeatureFlagLifecycle */
         FeatureFlagLifecycle: {
+            /**
+             * Owner
+             * @description Team/domain that owns this flag
+             * @default
+             */
+            owner: string;
             /**
              * Category
              * @description Flag category (llm, filter, source, cache, etc.)
@@ -8260,23 +8250,17 @@ export interface components {
              */
             category: string;
             /**
-             * Created
-             * @description Month created (YYYY-MM)
-             * @default
-             */
-            created: string;
-            /**
              * Lifecycle
              * @description permanent | experimental | ops-toggle | gate | deprecating
              * @default
              */
             lifecycle: string;
             /**
-             * Owner
-             * @description Team/domain that owns this flag
+             * Created
+             * @description Month created (YYYY-MM)
              * @default
              */
-            owner: string;
+            created: string;
             /**
              * Remove After
              * @description Planned removal date (YYYY-MM) if deprecating
@@ -8287,23 +8271,23 @@ export interface components {
         FeatureFlagListResponse: {
             /** Flags */
             flags: components["schemas"]["FeatureFlagItem"][];
-            /** Redis Available */
-            redis_available: boolean;
             /** Total */
             total: number;
+            /** Redis Available */
+            redis_available: boolean;
         };
         /** FeatureFlagReloadResponse */
         FeatureFlagReloadResponse: {
+            /** Success */
+            success: boolean;
             /** Flags */
             flags: {
                 [key: string]: boolean;
             };
-            /** Message */
-            message: string;
             /** Overrides Cleared */
             overrides_cleared: number;
-            /** Success */
-            success: boolean;
+            /** Message */
+            message: string;
         };
         /** FeatureFlagUpdateRequest */
         FeatureFlagUpdateRequest: {
@@ -8317,24 +8301,24 @@ export interface components {
         FeatureFlagUpdateResponse: {
             /** Name */
             name: string;
-            /** Previous Source */
-            previous_source: string;
-            /** Previous Value */
-            previous_value: boolean;
-            /** Source */
-            source: string;
             /** Value */
             value: boolean;
+            /** Source */
+            source: string;
+            /** Previous Value */
+            previous_value: boolean;
+            /** Previous Source */
+            previous_source: string;
         };
         /**
          * FeatureInfo
          * @description Single feature flag information.
          */
         FeatureInfo: {
-            /** Enabled */
-            enabled: boolean;
             /** Key */
             key: string;
+            /** Enabled */
+            enabled: boolean;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -8368,34 +8352,34 @@ export interface components {
              */
             correct: number;
             /**
-             * False Negative
-             * @default 0
-             */
-            false_negative: number;
-            /**
              * False Positive
              * @default 0
              */
             false_positive: number;
+            /**
+             * False Negative
+             * @default 0
+             */
+            false_negative: number;
         };
         /**
          * FeedbackPatternsResponse
          * @description GET /v1/admin/feedback/patterns response body.
          */
         FeedbackPatternsResponse: {
+            /** Total Feedbacks */
+            total_feedbacks: number;
             breakdown: components["schemas"]["FeedbackPatternBreakdown"];
+            /** Precision Estimate */
+            precision_estimate?: number | null;
             /** Fp Categories */
             fp_categories?: {
                 [key: string]: number;
             };
-            /** Precision Estimate */
-            precision_estimate?: number | null;
-            /** Suggested Exclusions */
-            suggested_exclusions?: string[];
             /** Top Fp Keywords */
             top_fp_keywords?: components["schemas"]["FPKeywordSuggestion"][];
-            /** Total Feedbacks */
-            total_feedbacks: number;
+            /** Suggested Exclusions */
+            suggested_exclusions?: string[];
         };
         /**
          * FeedbackRequest
@@ -8403,34 +8387,34 @@ export interface components {
          */
         FeedbackRequest: {
             /**
+             * Search Id
+             * @description UUID of the search session
+             */
+            search_id: string;
+            /**
              * Bid Id
              * @description ID of the bid being rated
              */
             bid_id: string;
-            /** Bid Objeto */
-            bid_objeto?: string | null;
-            /** Bid Uf */
-            bid_uf?: string | null;
-            /** Bid Valor */
-            bid_valor?: number | null;
-            category?: components["schemas"]["FeedbackCategory"] | null;
-            /** Confidence Score */
-            confidence_score?: number | null;
+            user_verdict: components["schemas"]["FeedbackVerdict"];
             /**
              * Reason
              * @description Free-text reason (optional)
              */
             reason?: string | null;
-            /** Relevance Source */
-            relevance_source?: string | null;
-            /**
-             * Search Id
-             * @description UUID of the search session
-             */
-            search_id: string;
+            category?: components["schemas"]["FeedbackCategory"] | null;
             /** Setor Id */
             setor_id?: string | null;
-            user_verdict: components["schemas"]["FeedbackVerdict"];
+            /** Bid Objeto */
+            bid_objeto?: string | null;
+            /** Bid Valor */
+            bid_valor?: number | null;
+            /** Bid Uf */
+            bid_uf?: string | null;
+            /** Confidence Score */
+            confidence_score?: number | null;
+            /** Relevance Source */
+            relevance_source?: string | null;
         };
         /**
          * FeedbackResponse
@@ -8459,29 +8443,17 @@ export interface components {
          */
         FilterStats: {
             /**
-             * Llm Zero Match Aprovadas
-             * @description Zero-match bids approved by LLM
+             * Rejeitadas Uf
+             * @description Rejected by UF filter
              * @default 0
              */
-            llm_zero_match_aprovadas: number;
+            rejeitadas_uf: number;
             /**
-             * Llm Zero Match Calls
-             * @description Number of LLM calls for zero-keyword-match bids
+             * Rejeitadas Valor
+             * @description Rejected by value range
              * @default 0
              */
-            llm_zero_match_calls: number;
-            /**
-             * Llm Zero Match Rejeitadas
-             * @description Zero-match bids rejected by LLM
-             * @default 0
-             */
-            llm_zero_match_rejeitadas: number;
-            /**
-             * Llm Zero Match Skipped Short
-             * @description Zero-match bids skipped due to objeto < 20 chars
-             * @default 0
-             */
-            llm_zero_match_skipped_short: number;
+            rejeitadas_valor: number;
             /**
              * Rejeitadas Keyword
              * @description Rejected by keyword match (zero matches)
@@ -8495,29 +8467,41 @@ export interface components {
              */
             rejeitadas_min_match: number;
             /**
-             * Rejeitadas Outros
-             * @description Rejected by other reasons
-             * @default 0
-             */
-            rejeitadas_outros: number;
-            /**
              * Rejeitadas Prazo
              * @description Rejected by deadline
              * @default 0
              */
             rejeitadas_prazo: number;
             /**
-             * Rejeitadas Uf
-             * @description Rejected by UF filter
+             * Rejeitadas Outros
+             * @description Rejected by other reasons
              * @default 0
              */
-            rejeitadas_uf: number;
+            rejeitadas_outros: number;
             /**
-             * Rejeitadas Valor
-             * @description Rejected by value range
+             * Llm Zero Match Calls
+             * @description Number of LLM calls for zero-keyword-match bids
              * @default 0
              */
-            rejeitadas_valor: number;
+            llm_zero_match_calls: number;
+            /**
+             * Llm Zero Match Aprovadas
+             * @description Zero-match bids approved by LLM
+             * @default 0
+             */
+            llm_zero_match_aprovadas: number;
+            /**
+             * Llm Zero Match Rejeitadas
+             * @description Zero-match bids rejected by LLM
+             * @default 0
+             */
+            llm_zero_match_rejeitadas: number;
+            /**
+             * Llm Zero Match Skipped Short
+             * @description Zero-match bids skipped due to objeto < 20 chars
+             * @default 0
+             */
+            llm_zero_match_skipped_short: number;
             /**
              * Zero Match Budget Exceeded
              * @description Zero-match bids deferred due to time budget
@@ -8525,17 +8509,17 @@ export interface components {
              */
             zero_match_budget_exceeded: number;
             /**
-             * Zero Match Cap Value
-             * @description Cap value applied to zero-match pool
-             * @default 200
-             */
-            zero_match_cap_value: number;
-            /**
              * Zero Match Capped
              * @description Whether zero-match pool was capped
              * @default false
              */
             zero_match_capped: boolean;
+            /**
+             * Zero Match Cap Value
+             * @description Cap value applied to zero-match pool
+             * @default 200
+             */
+            zero_match_cap_value: number;
         };
         /**
          * FirstAnalysisRequest
@@ -8548,16 +8532,6 @@ export interface components {
              */
             cnae: string;
             /**
-             * Faixa Valor Max
-             * @description Max contract value in BRL (not cents)
-             */
-            faixa_valor_max?: number | null;
-            /**
-             * Faixa Valor Min
-             * @description Min contract value in BRL (not cents)
-             */
-            faixa_valor_min?: number | null;
-            /**
              * Objetivo Principal
              * @description User's primary objective
              * @default
@@ -8568,6 +8542,16 @@ export interface components {
              * @description States of operation
              */
             ufs: string[];
+            /**
+             * Faixa Valor Min
+             * @description Min contract value in BRL (not cents)
+             */
+            faixa_valor_min?: number | null;
+            /**
+             * Faixa Valor Max
+             * @description Max contract value in BRL (not cents)
+             */
+            faixa_valor_max?: number | null;
         };
         /**
          * FirstAnalysisResponse
@@ -8575,80 +8559,80 @@ export interface components {
          */
         FirstAnalysisResponse: {
             /**
-             * Message
-             * @description User-facing status message
-             * @default
-             */
-            message: string;
-            /**
              * Search Id
              * @description UUID for tracking search progress via SSE
              */
             search_id: string;
-            /**
-             * Setor Id
-             * @description Resolved sector ID from CNAE mapping
-             * @default vestuario
-             */
-            setor_id: string;
             /**
              * Status
              * @description Search status
              * @default in_progress
              */
             status: string;
+            /**
+             * Message
+             * @description User-facing status message
+             * @default
+             */
+            message: string;
+            /**
+             * Setor Id
+             * @description Resolved sector ID from CNAE mapping
+             * @default vestuario
+             */
+            setor_id: string;
         };
         /** FornecedorProfileResponse */
         FornecedorProfileResponse: {
-            /** Anos Atividade */
-            anos_atividade: number[];
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
-            /** Aviso Legal */
-            aviso_legal: string;
-            /** Cnae Descricao */
-            cnae_descricao: string;
             /** Cnpj */
             cnpj: string;
+            /** Razao Social */
+            razao_social: string;
+            /** Cnae Descricao */
+            cnae_descricao: string;
+            /** Municipio */
+            municipio: string;
+            /** Uf Sede */
+            uf_sede: string;
+            /** Simples Nacional */
+            simples_nacional: boolean;
+            /** Mei */
+            mei: boolean;
+            /** Total Contratos */
+            total_contratos: number;
+            /** Valor Total */
+            valor_total: number;
+            /** Ufs Atuantes */
+            ufs_atuantes: string[];
+            /** Anos Atividade */
+            anos_atividade: number[];
+            /** Top Compradores */
+            top_compradores: components["schemas"]["OrgaoRank"][];
             /** Contratos Recentes */
             contratos_recentes: components["schemas"]["RecentContract"][];
             /** Faq Items */
             faq_items: components["schemas"]["FaqItem"][];
             /** Last Updated */
             last_updated: string;
-            /** Mei */
-            mei: boolean;
-            /** Municipio */
-            municipio: string;
-            /** Razao Social */
-            razao_social: string;
-            /** Simples Nacional */
-            simples_nacional: boolean;
-            /** Top Compradores */
-            top_compradores: components["schemas"]["OrgaoRank"][];
-            /** Total Contratos */
-            total_contratos: number;
-            /** Uf Sede */
-            uf_sede: string;
-            /** Ufs Atuantes */
-            ufs_atuantes: string[];
-            /** Valor Total */
-            valor_total: number;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
         };
         /** FornecedorRank */
         FornecedorRank: {
-            /** Cnpj */
-            cnpj: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -8656,10 +8640,10 @@ export interface components {
         };
         /** FornecedorTop */
         FornecedorTop: {
-            /** Cnpj */
-            cnpj: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -8667,32 +8651,32 @@ export interface components {
         };
         /** FornecedoresStatsResponse */
         FornecedoresStatsResponse: {
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
-            /** Aviso Legal */
-            aviso_legal: string;
-            /** Last Updated */
-            last_updated: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
+            /** Uf */
+            uf: string;
+            /** Total Suppliers */
+            total_suppliers: number;
             /** Supplier Ranking */
             supplier_ranking: components["schemas"]["SupplierEntry"][];
             /** Top Orgaos Compradores */
             top_orgaos_compradores: components["schemas"]["OrgaoRank"][];
-            /** Total Suppliers */
-            total_suppliers: number;
-            /** Uf */
-            uf: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
         };
         /**
          * FounderConsentRequest
@@ -8724,14 +8708,14 @@ export interface components {
             consent: boolean;
             /** Display Name */
             display_name?: string | null;
+            /** Logo Url */
+            logo_url?: string | null;
             /**
              * Is Founder
              * @description Reflects profiles.is_founder so the UI can show context.
              * @default false
              */
             is_founder: boolean;
-            /** Logo Url */
-            logo_url?: string | null;
         };
         /**
          * FounderHallEntry
@@ -8744,25 +8728,25 @@ export interface components {
              */
             display_name: string;
             /**
-             * Founder Since
-             * @description ISO-8601 timestamp of when the user became a founder.
+             * Uf
+             * @description State code (2 letters).
              */
-            founder_since?: string | null;
-            /**
-             * Logo Url
-             * @description Optional logo URL.
-             */
-            logo_url?: string | null;
+            uf?: string | null;
             /**
              * Setor
              * @description Sector / category derived from CNAE (best-effort).
              */
             setor?: string | null;
             /**
-             * Uf
-             * @description State code (2 letters).
+             * Logo Url
+             * @description Optional logo URL.
              */
-            uf?: string | null;
+            logo_url?: string | null;
+            /**
+             * Founder Since
+             * @description ISO-8601 timestamp of when the user became a founder.
+             */
+            founder_since?: string | null;
         };
         /**
          * FoundersAvailabilityResponse
@@ -8774,38 +8758,37 @@ export interface components {
          */
         FoundersAvailabilityResponse: {
             /**
-             * Deadline
-             * @description ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).
-             * @default 2026-06-30T23:59:59-03:00
+             * Vagasrestantes
+             * @description Seats still available (50 - taken). NULL when fallback=true.
              */
-            deadline: string;
+            vagasRestantes?: number | null;
+            /**
+             * Vagastotal
+             * @description Hard cap (50).
+             * @default 50
+             */
+            vagasTotal: number;
+            /**
+             * Vagaspreenchidas
+             * @description Seats already taken (count of is_founder=TRUE profiles).
+             */
+            vagasPreenchidas?: number | null;
             /**
              * Diasrestantes
              * @description Whole days until the deadline.
              */
             diasRestantes?: number | null;
             /**
-             * Fallback
-             * @description TRUE when DB or Redis is unavailable. Frontend should render the conservative copy without a number.
-             * @default false
-             */
-            fallback: boolean;
-            /**
              * Horasrestantes
              * @description Whole hours until the deadline.
              */
             horasRestantes?: number | null;
             /**
-             * Message
-             * @description Conservative copy returned when fallback=true.
+             * Deadline
+             * @description ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).
+             * @default 2026-06-30T23:59:59-03:00
              */
-            message?: string | null;
-            /**
-             * Sold Out
-             * @description TRUE when vagasPreenchidas >= cap (50).
-             * @default false
-             */
-            sold_out: boolean;
+            deadline: string;
             /**
              * Ultimavagaem
              * @description ISO-8601 timestamp of the most recent founder_since.
@@ -8817,27 +8800,30 @@ export interface components {
              */
             ultimasVagasOptIn?: components["schemas"]["UltimaVagaOptIn"][];
             /**
-             * Vagaspreenchidas
-             * @description Seats already taken (count of is_founder=TRUE profiles).
+             * Sold Out
+             * @description TRUE when vagasPreenchidas >= cap (50).
+             * @default false
              */
-            vagasPreenchidas?: number | null;
+            sold_out: boolean;
             /**
-             * Vagasrestantes
-             * @description Seats still available (50 - taken). NULL when fallback=true.
+             * Fallback
+             * @description TRUE when DB or Redis is unavailable. Frontend should render the conservative copy without a number.
+             * @default false
              */
-            vagasRestantes?: number | null;
+            fallback: boolean;
             /**
-             * Vagastotal
-             * @description Hard cap (50).
-             * @default 50
+             * Message
+             * @description Conservative copy returned when fallback=true.
              */
-            vagasTotal: number;
+            message?: string | null;
         };
         /**
          * FoundersHallResponse
          * @description Response shape for ``GET /api/founders/hall``.
          */
         FoundersHallResponse: {
+            /** Founders */
+            founders?: components["schemas"]["FounderHallEntry"][];
             /**
              * Count
              * @description Number of opt-in founders.
@@ -8850,8 +8836,6 @@ export interface components {
              * @default false
              */
             fallback: boolean;
-            /** Founders */
-            founders?: components["schemas"]["FounderHallEntry"][];
         };
         /**
          * FoundingAvailabilityResponse
@@ -8860,10 +8844,20 @@ export interface components {
         FoundingAvailabilityResponse: {
             /** Available */
             available: boolean;
-            /** Coupon Code */
-            coupon_code: string;
+            /** Seats Total */
+            seats_total: number;
+            /** Seats Remaining */
+            seats_remaining: number;
+            /** Seats Taken */
+            seats_taken: number;
             /** Deadline At */
             deadline_at: string | null;
+            /** Paused */
+            paused: boolean;
+            /** Reason */
+            reason: string;
+            /** Coupon Code */
+            coupon_code: string;
             /** Discount Pct */
             discount_pct: number;
             /**
@@ -8872,35 +8866,25 @@ export interface components {
              * @default lifetime
              */
             offer_mode: string;
-            /** Paused */
-            paused: boolean;
             /**
              * Price Brl Cents
              * @description Price in BRL cents
              * @default 99700
              */
             price_brl_cents: number;
-            /** Reason */
-            reason: string;
-            /** Seats Remaining */
-            seats_remaining: number;
-            /** Seats Taken */
-            seats_taken: number;
-            /** Seats Total */
-            seats_total: number;
         };
         /** FoundingCheckoutRequest */
         FoundingCheckoutRequest: {
-            /** Cnpj */
-            cnpj: string;
             /** Email */
             email: string;
-            /** Motivo */
-            motivo: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Razao Social */
             razao_social?: string | null;
+            /** Motivo */
+            motivo: string;
         };
         /** FoundingCheckoutResponse */
         FoundingCheckoutResponse: {
@@ -8920,42 +8904,42 @@ export interface components {
          * @description Response model for GET /v1/founding/checkout/status.
          */
         FoundingCheckoutStatusResponse: {
-            /** Payment Status */
-            payment_status: string;
             /** Status */
             status: string;
+            /** Payment Status */
+            payment_status: string;
         };
         /** FoundingLeadEntry */
         FoundingLeadEntry: {
-            /** Checkout Status */
-            checkout_status: string;
-            /** Cnpj */
-            cnpj: string;
-            /** Completed At */
-            completed_at?: string | null;
-            /** Created At */
-            created_at: string;
-            /** Email */
-            email: string;
             /** Id */
             id: string;
+            /** Email */
+            email: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Razao Social */
             razao_social?: string | null;
+            /** Checkout Status */
+            checkout_status: string;
+            /** Created At */
+            created_at: string;
+            /** Completed At */
+            completed_at?: string | null;
             /** Stripe Customer Id */
             stripe_customer_id?: string | null;
         };
         /** FoundingLeadsListResponse */
         FoundingLeadsListResponse: {
-            /** Completed Count */
-            completed_count: number;
             /** Count */
             count: number;
-            /** Leads */
-            leads: components["schemas"]["FoundingLeadEntry"][];
+            /** Completed Count */
+            completed_count: number;
             /** Pending Count */
             pending_count: number;
+            /** Leads */
+            leads: components["schemas"]["FoundingLeadEntry"][];
         };
         /** FoundingPauseRequest */
         FoundingPauseRequest: {
@@ -8975,26 +8959,16 @@ export interface components {
         };
         /** FoundingPolicySnapshot */
         FoundingPolicySnapshot: {
-            /** Active */
-            active: boolean;
-            /** Completion Pct */
-            completion_pct: number;
-            /**
-             * Consulting Discount Pct
-             * @default 50
-             */
-            consulting_discount_pct: number;
-            /** Coupon Code */
-            coupon_code: string;
+            /** Seat Limit */
+            seat_limit: number;
             /** Deadline At */
             deadline_at: string;
             /** Discount Pct */
             discount_pct: number;
-            /**
-             * Offer Mode
-             * @default lifetime
-             */
-            offer_mode: string;
+            /** Coupon Code */
+            coupon_code: string;
+            /** Active */
+            active: boolean;
             /** Paused */
             paused: boolean;
             /** Paused At */
@@ -9003,17 +8977,27 @@ export interface components {
             paused_by: string | null;
             /** Paused Reason */
             paused_reason: string | null;
+            /** Seats Taken */
+            seats_taken: number;
+            /** Seats Remaining */
+            seats_remaining: number;
+            /** Completion Pct */
+            completion_pct: number;
+            /**
+             * Offer Mode
+             * @default lifetime
+             */
+            offer_mode: string;
             /**
              * Price Brl Cents
              * @default 99700
              */
             price_brl_cents: number;
-            /** Seat Limit */
-            seat_limit: number;
-            /** Seats Remaining */
-            seats_remaining: number;
-            /** Seats Taken */
-            seats_taken: number;
+            /**
+             * Consulting Discount Pct
+             * @default 50
+             */
+            consulting_discount_pct: number;
         };
         /**
          * FoundingSessionStatusResponse
@@ -9023,6 +9007,11 @@ export interface components {
          *     render the correct post-purchase CTA without exposing full PII.
          */
         FoundingSessionStatusResponse: {
+            /**
+             * Status
+             * @description 'completed' | 'pending' | 'not_found'
+             */
+            status: string;
             /**
              * Email
              * @description Masked email (2 chars before @ + **** + domain).
@@ -9038,63 +9027,58 @@ export interface components {
              * @description True if magic_link_sent_at IS NOT NULL.
              */
             invite_sent: boolean;
-            /**
-             * Status
-             * @description 'completed' | 'pending' | 'not_found'
-             */
-            status: string;
         };
         /** GSCLowCTROpportunity */
         GSCLowCTROpportunity: {
+            /** Page */
+            page: string;
+            /** Impressions */
+            impressions: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
-            /** Impressions */
-            impressions: number;
-            /** Page */
-            page: string;
         };
         /** GSCPageRow */
         GSCPageRow: {
+            /** Page */
+            page: string;
+            /** Impressions */
+            impressions: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
-            /** Impressions */
-            impressions: number;
-            /** Page */
-            page: string;
             /** Position */
             position: number;
         };
         /** GSCQueryRow */
         GSCQueryRow: {
+            /** Query */
+            query: string;
+            /** Impressions */
+            impressions: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
-            /** Impressions */
-            impressions: number;
             /** Position */
             position: number;
-            /** Query */
-            query: string;
         };
         /** GSCSummaryResponse */
         GSCSummaryResponse: {
+            /** Top Queries */
+            top_queries: components["schemas"]["GSCQueryRow"][];
+            /** Top Pages Ctr */
+            top_pages_ctr: components["schemas"]["GSCPageRow"][];
+            /** Low Ctr Opportunities */
+            low_ctr_opportunities: components["schemas"]["GSCLowCTROpportunity"][];
+            /** Last Sync At */
+            last_sync_at?: string | null;
             /** Days */
             days: number;
             /** Enabled */
             enabled: boolean;
-            /** Last Sync At */
-            last_sync_at?: string | null;
-            /** Low Ctr Opportunities */
-            low_ctr_opportunities: components["schemas"]["GSCLowCTROpportunity"][];
-            /** Top Pages Ctr */
-            top_pages_ctr: components["schemas"]["GSCPageRow"][];
-            /** Top Queries */
-            top_queries: components["schemas"]["GSCQueryRow"][];
         };
         /**
          * GoogleSheetsExportHistory
@@ -9102,22 +9086,10 @@ export interface components {
          */
         GoogleSheetsExportHistory: {
             /**
-             * Created At
-             * @description Creation timestamp (ISO 8601)
-             */
-            created_at: string;
-            /**
              * Id
              * @description Export record UUID
              */
             id: string;
-            /**
-             * Search Params
-             * @description Search parameters snapshot
-             */
-            search_params: {
-                [key: string]: unknown;
-            };
             /**
              * Spreadsheet Id
              * @description Google Sheets spreadsheet ID
@@ -9129,10 +9101,22 @@ export interface components {
              */
             spreadsheet_url: string;
             /**
+             * Search Params
+             * @description Search parameters snapshot
+             */
+            search_params: {
+                [key: string]: unknown;
+            };
+            /**
              * Total Rows
              * @description Number of rows exported
              */
             total_rows: number;
+            /**
+             * Created At
+             * @description Creation timestamp (ISO 8601)
+             */
+            created_at: string;
             /**
              * Updated At
              * @description Last update timestamp (ISO 8601)
@@ -9170,6 +9154,11 @@ export interface components {
                 [key: string]: unknown;
             }[];
             /**
+             * Title
+             * @description Spreadsheet title
+             */
+            title: string;
+            /**
              * Mode
              * @description 'create' for new spreadsheet, 'update' for existing
              * @default create
@@ -9180,17 +9169,18 @@ export interface components {
              * @description Google Sheets spreadsheet ID (required for mode='update')
              */
             spreadsheet_id?: string | null;
-            /**
-             * Title
-             * @description Spreadsheet title
-             */
-            title: string;
         };
         /**
          * GoogleSheetsExportResponse
          * @description Response schema for successful Google Sheets export.
          */
         GoogleSheetsExportResponse: {
+            /**
+             * Success
+             * @description Export success indicator
+             * @default true
+             */
+            success: boolean;
             /**
              * Spreadsheet Id
              * @description Google Sheets spreadsheet ID
@@ -9201,12 +9191,6 @@ export interface components {
              * @description Full shareable URL to the spreadsheet
              */
             spreadsheet_url: string;
-            /**
-             * Success
-             * @description Export success indicator
-             * @default true
-             */
-            success: boolean;
             /**
              * Total Rows
              * @description Number of contracts exported
@@ -9225,10 +9209,10 @@ export interface components {
         };
         /** HistogramBucket */
         HistogramBucket: {
-            /** Count */
-            count: number;
             /** Range Label */
             range_label: string;
+            /** Count */
+            count: number;
         };
         /**
          * IncidentEntry
@@ -9261,51 +9245,51 @@ export interface components {
         };
         /** IndiceResult */
         IndiceResult: {
-            /** Calculado Em */
-            calculado_em: string;
             /** Municipio Nome */
             municipio_nome: string;
             /** Municipio Slug */
             municipio_slug: string;
-            /** Percentil */
-            percentil?: number | null;
-            /** Periodo */
-            periodo: string;
-            /** Ranking Nacional */
-            ranking_nacional?: number | null;
-            /** Ranking Uf */
-            ranking_uf?: number | null;
-            /** Score Consistencia */
-            score_consistencia: number;
-            /** Score Diversidade Mercado */
-            score_diversidade_mercado: number;
-            /** Score Eficiencia Temporal */
-            score_eficiencia_temporal: number;
-            /** Score Total */
-            score_total: number;
-            /** Score Transparencia Digital */
-            score_transparencia_digital: number;
-            /** Score Volume Publicacao */
-            score_volume_publicacao: number;
-            /** Total Editais */
-            total_editais: number;
             /** Uf */
             uf: string;
             /** Uf Nome */
             uf_nome: string;
+            /** Periodo */
+            periodo: string;
+            /** Score Total */
+            score_total: number;
+            /** Score Volume Publicacao */
+            score_volume_publicacao: number;
+            /** Score Eficiencia Temporal */
+            score_eficiencia_temporal: number;
+            /** Score Diversidade Mercado */
+            score_diversidade_mercado: number;
+            /** Score Transparencia Digital */
+            score_transparencia_digital: number;
+            /** Score Consistencia */
+            score_consistencia: number;
+            /** Total Editais */
+            total_editais: number;
+            /** Ranking Nacional */
+            ranking_nacional?: number | null;
+            /** Ranking Uf */
+            ranking_uf?: number | null;
+            /** Percentil */
+            percentil?: number | null;
+            /** Calculado Em */
+            calculado_em: string;
         };
         /**
          * IntelReportCheckoutRequest
          * @description Request body for POST /v1/intel-reports/checkout.
          */
         IntelReportCheckoutRequest: {
-            /** Entity Key */
-            entity_key: string;
             /**
              * Product Type
              * @enum {string}
              */
             product_type: "cnpj" | "sector_uf";
+            /** Entity Key */
+            entity_key: string;
         };
         /**
          * IntelReportCheckoutResponse
@@ -9322,34 +9306,34 @@ export interface components {
          * @description Represents a row in intel_report_purchases table.
          */
         IntelReportPurchase: {
-            /** Created At */
-            created_at: string;
-            /** Entity Key */
-            entity_key: string;
-            /** Expires At */
-            expires_at?: string | null;
             /** Id */
             id: string;
-            /** Pdf Url */
-            pdf_url?: string | null;
-            /** Product Type */
-            product_type: string;
-            /** Status */
-            status: string;
             /** User Id */
             user_id: string;
+            /** Product Type */
+            product_type: string;
+            /** Entity Key */
+            entity_key: string;
+            /** Status */
+            status: string;
+            /** Pdf Url */
+            pdf_url?: string | null;
+            /** Created At */
+            created_at: string;
+            /** Expires At */
+            expires_at?: string | null;
         };
         /**
          * IntelReportStatusResponse
          * @description Response for GET /v1/intel-reports/{purchase_id}.
          */
         IntelReportStatusResponse: {
-            /** Expires At */
-            expires_at?: string | null;
-            /** Pdf Url */
-            pdf_url?: string | null;
             /** Status */
             status: string;
+            /** Pdf Url */
+            pdf_url?: string | null;
+            /** Expires At */
+            expires_at?: string | null;
         };
         /** InviteMemberRequest */
         InviteMemberRequest: {
@@ -9358,34 +9342,34 @@ export interface components {
         };
         /** ItemProfileResponse */
         ItemProfileResponse: {
-            /** Aviso Legal */
-            aviso_legal: string;
-            /** Categoria */
-            categoria: string;
             /** Catmat */
             catmat: string;
-            /** Contratos Referencia */
-            contratos_referencia: components["schemas"]["ContratoReferencia"][];
-            /** Faq Items */
-            faq_items: components["schemas"]["FaqItem"][];
-            /** Last Updated */
-            last_updated: string;
             /** Nome Item */
             nome_item: string;
-            /** Periodo Referencia */
-            periodo_referencia: string;
+            /** Categoria */
+            categoria: string;
             /** Total Contratos */
             total_contratos: number;
-            /** Unidade Referencia */
-            unidade_referencia: string;
-            /** Valor Medio */
-            valor_medio?: number | null;
             /** Valor P10 */
             valor_p10?: number | null;
             /** Valor P50 */
             valor_p50?: number | null;
             /** Valor P90 */
             valor_p90?: number | null;
+            /** Valor Medio */
+            valor_medio?: number | null;
+            /** Unidade Referencia */
+            unidade_referencia: string;
+            /** Contratos Referencia */
+            contratos_referencia: components["schemas"]["ContratoReferencia"][];
+            /** Faq Items */
+            faq_items: components["schemas"]["FaqItem"][];
+            /** Periodo Referencia */
+            periodo_referencia: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Aviso Legal */
+            aviso_legal: string;
         };
         /**
          * LeadCaptureRequest
@@ -9394,46 +9378,46 @@ export interface components {
          *     Supports both old (backward compat) and new (COPY-COP-006) sources.
          */
         LeadCaptureRequest: {
-            /** Captured At */
-            captured_at?: string | null;
-            /** Cnpj */
-            cnpj?: string | null;
             /** Email */
             email: string;
-            /** Empresa */
-            empresa?: string | null;
-            /** Mensagem */
-            mensagem?: string | null;
-            /** Modalidade Interesse */
-            modalidade_interesse?: ("radar" | "report" | "intel" | "nao_sei") | null;
-            /** Nome */
-            nome?: string | null;
-            /** Origin Url */
-            origin_url?: string | null;
-            /** Referer Path */
-            referer_path?: string | null;
-            /** Sector */
-            sector?: string | null;
             /** Source */
             source: string;
-            /** Telefone */
-            telefone?: string | null;
+            /** Sector */
+            sector?: string | null;
+            /** Origin Url */
+            origin_url?: string | null;
             /** Uf */
             uf?: string | null;
-            /** Utm Campaign */
-            utm_campaign?: string | null;
+            /** Captured At */
+            captured_at?: string | null;
+            /** Nome */
+            nome?: string | null;
+            /** Empresa */
+            empresa?: string | null;
+            /** Cnpj */
+            cnpj?: string | null;
+            /** Telefone */
+            telefone?: string | null;
+            /** Modalidade Interesse */
+            modalidade_interesse?: ("radar" | "report" | "intel" | "nao_sei") | null;
+            /** Mensagem */
+            mensagem?: string | null;
             /** Utm Source */
             utm_source?: string | null;
+            /** Utm Campaign */
+            utm_campaign?: string | null;
+            /** Referer Path */
+            referer_path?: string | null;
         };
         /**
          * LeadCaptureResponse
          * @description Body for POST /v1/lead-capture (201).
          */
         LeadCaptureResponse: {
-            /** Id */
-            id?: string | null;
             /** Success */
             success: boolean;
+            /** Id */
+            id?: string | null;
         };
         /**
          * LicitacaoItem
@@ -9456,80 +9440,10 @@ export interface components {
          */
         LicitacaoItem: {
             /**
-             * Source
-             * @description Source that provided this record
+             * Pncp Id
+             * @description Unique PNCP identifier
              */
-            _source?: string | null;
-            /**
-             * Value Source
-             * @description Whether the bid's estimated value was reported ('estimated') or missing ('missing')
-             */
-            _value_source?: ("estimated" | "missing") | null;
-            /**
-             * Cnpj Orgao
-             * @description CNPJ of the issuing government agency. UX-400 AC6.
-             */
-            cnpj_orgao?: string | null;
-            /**
-             * Confidence
-             * @description Confidence level derived from relevance_source: keyword=high, llm_standard=medium, llm_conservative/llm_zero_match=low
-             */
-            confidence?: ("high" | "medium" | "low") | null;
-            /**
-             * Confidence Score
-             * @description Classification confidence 0-100%. keyword=95, llm=varies, item_inspection=85, zero_match<=70
-             */
-            confidence_score?: number | null;
-            /**
-             * Data Abertura
-             * @description Proposal opening date
-             */
-            data_abertura?: string | null;
-            /**
-             * Data Encerramento
-             * @description Proposal submission deadline
-             */
-            data_encerramento?: string | null;
-            /**
-             * Data Publicacao
-             * @description Publication date
-             */
-            data_publicacao?: string | null;
-            /**
-             * Dias Restantes
-             * @description Days remaining until proposal deadline (negative if past)
-             */
-            dias_restantes?: number | null;
-            /**
-             * Link
-             * @description Direct link to bid source (priority: linkSistemaOrigem > constructed PNCP URL). Null when no link available (UX-400 AC2).
-             */
-            link?: string | null;
-            /**
-             * Llm Evidence
-             * @description Literal text excerpts from procurement description that support the classification (max 3)
-             */
-            llm_evidence?: string[] | null;
-            /**
-             * Matched Terms
-             * @description List of search terms that matched this bid
-             */
-            matched_terms?: string[] | null;
-            /**
-             * Modalidade
-             * @description Procurement modality
-             */
-            modalidade?: string | null;
-            /**
-             * Municipio
-             * @description Municipality name
-             */
-            municipio?: string | null;
-            /**
-             * Numero Compra
-             * @description Procurement number (e.g., edital number). UX-400 AC5.
-             */
-            numero_compra?: string | null;
+            pncp_id: string;
             /**
              * Objeto
              * @description Procurement object description
@@ -9541,37 +9455,112 @@ export interface components {
              */
             orgao: string;
             /**
-             * Pncp Id
-             * @description Unique PNCP identifier
-             */
-            pncp_id: string;
-            /**
-             * Relevance Score
-             * @description Relevance score 0.0-1.0 (only when custom terms active)
-             */
-            relevance_score?: number | null;
-            /**
-             * Relevance Source
-             * @description How relevance was determined: 'keyword' (density >5%), 'llm_standard' (2-5%), 'llm_conservative' (1-2%), 'llm_zero_match' (0% keyword match, LLM classified)
-             */
-            relevance_source?: string | null;
-            /** @description Sanctions check result (only when check_sanctions=true in request) */
-            supplier_sanctions?: components["schemas"]["SanctionsSummarySchema"] | null;
-            /**
              * Uf
              * @description State code (e.g., 'SP')
              */
             uf: string;
+            /**
+             * Municipio
+             * @description Municipality name
+             */
+            municipio?: string | null;
+            /**
+             * Valor
+             * @description Estimated total value in BRL. Null when source does not provide value data (e.g., PCP v2).
+             */
+            valor?: number | null;
+            /**
+             * Modalidade
+             * @description Procurement modality
+             */
+            modalidade?: string | null;
+            /**
+             * Data Publicacao
+             * @description Publication date
+             */
+            data_publicacao?: string | null;
+            /**
+             * Data Abertura
+             * @description Proposal opening date
+             */
+            data_abertura?: string | null;
+            /**
+             * Data Encerramento
+             * @description Proposal submission deadline
+             */
+            data_encerramento?: string | null;
+            /**
+             * Dias Restantes
+             * @description Days remaining until proposal deadline (negative if past)
+             */
+            dias_restantes?: number | null;
             /**
              * Urgencia
              * @description Urgency level: critica (<7d), alta (7-14d), media (14-30d), baixa (>30d), encerrada (past)
              */
             urgencia?: string | null;
             /**
-             * Valor
-             * @description Estimated total value in BRL. Null when source does not provide value data (e.g., PCP v2).
+             * Link
+             * @description Direct link to bid source (priority: linkSistemaOrigem > constructed PNCP URL). Null when no link available (UX-400 AC2).
              */
-            valor?: number | null;
+            link?: string | null;
+            /**
+             * Numero Compra
+             * @description Procurement number (e.g., edital number). UX-400 AC5.
+             */
+            numero_compra?: string | null;
+            /**
+             * Cnpj Orgao
+             * @description CNPJ of the issuing government agency. UX-400 AC6.
+             */
+            cnpj_orgao?: string | null;
+            /**
+             * Source
+             * @description Source that provided this record
+             */
+            _source?: string | null;
+            /**
+             * Relevance Score
+             * @description Relevance score 0.0-1.0 (only when custom terms active)
+             */
+            relevance_score?: number | null;
+            /**
+             * Matched Terms
+             * @description List of search terms that matched this bid
+             */
+            matched_terms?: string[] | null;
+            /** @description Sanctions check result (only when check_sanctions=true in request) */
+            supplier_sanctions?: components["schemas"]["SanctionsSummarySchema"] | null;
+            /**
+             * Relevance Source
+             * @description How relevance was determined: 'keyword' (density >5%), 'llm_standard' (2-5%), 'llm_conservative' (1-2%), 'llm_zero_match' (0% keyword match, LLM classified)
+             */
+            relevance_source?: string | null;
+            /**
+             * Confidence Score
+             * @description Classification confidence 0-100%. keyword=95, llm=varies, item_inspection=85, zero_match<=70
+             */
+            confidence_score?: number | null;
+            /**
+             * Llm Evidence
+             * @description Literal text excerpts from procurement description that support the classification (max 3)
+             */
+            llm_evidence?: string[] | null;
+            /**
+             * Confidence
+             * @description Confidence level derived from relevance_source: keyword=high, llm_standard=medium, llm_conservative/llm_zero_match=low
+             */
+            confidence?: ("high" | "medium" | "low") | null;
+            /**
+             * Viability Score
+             * @description Viability score 0-100 based on modalidade, timeline, value fit, and geography
+             */
+            viability_score?: number | null;
+            /**
+             * Viability Level
+             * @description Viability level: alta (>70), media (40-70), baixa (<40)
+             */
+            viability_level?: ("alta" | "media" | "baixa") | null;
             /**
              * Viability Factors
              * @description Breakdown of viability factors: modalidade, timeline, value_fit, geography (each 0-100 with label)
@@ -9580,15 +9569,10 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Viability Level
-             * @description Viability level: alta (>70), media (40-70), baixa (<40)
+             * Value Source
+             * @description Whether the bid's estimated value was reported ('estimated') or missing ('missing')
              */
-            viability_level?: ("alta" | "media" | "baixa") | null;
-            /**
-             * Viability Score
-             * @description Viability score 0-100 based on modalidade, timeline, value fit, and geography
-             */
-            viability_score?: number | null;
+            _value_source?: ("estimated" | "missing") | null;
         };
         /** LicitacoesIndexableResponse */
         LicitacoesIndexableResponse: {
@@ -9596,10 +9580,10 @@ export interface components {
             combos: {
                 [key: string]: unknown;
             }[];
-            /** Threshold */
-            threshold: number;
             /** Total */
             total: number;
+            /** Threshold */
+            threshold: number;
             /** Updated At */
             updated_at: string;
         };
@@ -9629,15 +9613,15 @@ export interface components {
          */
         LoginAttemptResponse: {
             /**
-             * Force Mfa Triggered
-             * @default false
-             */
-            force_mfa_triggered: boolean;
-            /**
              * Ok
              * @default true
              */
             ok: boolean;
+            /**
+             * Force Mfa Triggered
+             * @default false
+             */
+            force_mfa_triggered: boolean;
         };
         /**
          * MFAEnrollResponse
@@ -9648,11 +9632,6 @@ export interface components {
          *     one-time backup codes for recovery if the device is lost.
          */
         MFAEnrollResponse: {
-            /**
-             * Backup Codes
-             * @description 10 one-time recovery codes (XXXX-XXXX format). Shown ONCE — user must save them. Used as MFA bypass via /v1/mfa/verify-recovery.
-             */
-            backup_codes?: string[];
             /**
              * Factor Id
              * @description Supabase mfa_factors.id (UUID)
@@ -9668,6 +9647,11 @@ export interface components {
              * @description Base32-encoded TOTP shared secret. Provided so the user can manually enter it when the QR code cannot be scanned.
              */
             secret: string;
+            /**
+             * Backup Codes
+             * @description 10 one-time recovery codes (XXXX-XXXX format). Shown ONCE — user must save them. Used as MFA bypass via /v1/mfa/verify-recovery.
+             */
+            backup_codes?: string[];
         };
         /**
          * MFAVerifyRequest
@@ -9686,6 +9670,11 @@ export interface components {
          */
         MFAVerifyResponse: {
             /**
+             * Success
+             * @description True when the code matched and AAL was elevated to aal2
+             */
+            success: boolean;
+            /**
              * Aal Level
              * @description Authenticator Assurance Level after verification
              * @default aal2
@@ -9702,29 +9691,12 @@ export interface components {
              * @default
              */
             message: string;
-            /**
-             * Success
-             * @description True when the code matched and AAL was elevated to aal2
-             */
-            success: boolean;
         };
         /**
          * MemorySnapshot
          * @description Response for GET /admin/memory-snapshot (SEN-BE-010 AC0).
          */
         MemorySnapshot: {
-            /**
-             * Asyncio Tasks Pending
-             * @default 0
-             */
-            asyncio_tasks_pending: number;
-            /**
-             * Gc Objects Count
-             * @default 0
-             */
-            gc_objects_count: number;
-            /** Redis Pool Size */
-            redis_pool_size?: number | null;
             /** Rss Bytes */
             rss_bytes?: number | null;
             /** Rss Mb */
@@ -9739,6 +9711,18 @@ export interface components {
              * @default []
              */
             tracemalloc_top_25: components["schemas"]["TraceMallocEntry"][];
+            /**
+             * Asyncio Tasks Pending
+             * @default 0
+             */
+            asyncio_tasks_pending: number;
+            /**
+             * Gc Objects Count
+             * @default 0
+             */
+            gc_objects_count: number;
+            /** Redis Pool Size */
+            redis_pool_size?: number | null;
         };
         /**
          * MesCalendario
@@ -9746,20 +9730,15 @@ export interface components {
          */
         MesCalendario: {
             /**
-             * Indice Sazonalidade
-             * @description Seasonality index: 0 = at average, >0 = detectable seasonality
-             */
-            indice_sazonalidade: number;
-            /**
              * Mes
              * @description Month number (1-12)
              */
             mes: number;
             /**
-             * Orgaos Principais
-             * @description Top 5 public buyers in this month
+             * Volume Medio
+             * @description Average total contract value for this month
              */
-            orgaos_principais: string[];
+            volume_medio: number;
             /**
              * Quantidade Media
              * @description Average number of contracts/opportunities for this month
@@ -9771,6 +9750,16 @@ export interface components {
              */
             setor_dominante: string;
             /**
+             * Orgaos Principais
+             * @description Top 5 public buyers in this month
+             */
+            orgaos_principais: string[];
+            /**
+             * Indice Sazonalidade
+             * @description Seasonality index: 0 = at average, >0 = detectable seasonality
+             */
+            indice_sazonalidade: number;
+            /**
              * Tendencia
              * @description Trend direction: crescimento | estabilidade | declinio
              */
@@ -9780,106 +9769,101 @@ export interface components {
              * @description Year-over-year relative change in average volume
              */
             variacao_anual: number;
-            /**
-             * Volume Medio
-             * @description Average total contract value for this month
-             */
-            volume_medio: number;
         };
         /**
          * MessageResponse
          * @description Single message in a conversation thread.
          */
         MessageResponse: {
-            /** Body */
-            body: string;
-            /** Created At */
-            created_at: string;
             /** Id */
             id: string;
-            /** Is Admin Reply */
-            is_admin_reply: boolean;
-            /** Read By Admin */
-            read_by_admin: boolean;
-            /** Read By User */
-            read_by_user: boolean;
-            /** Sender Email */
-            sender_email?: string | null;
             /** Sender Id */
             sender_id: string;
+            /** Sender Email */
+            sender_email?: string | null;
+            /** Body */
+            body: string;
+            /** Is Admin Reply */
+            is_admin_reply: boolean;
+            /** Read By User */
+            read_by_user: boolean;
+            /** Read By Admin */
+            read_by_admin: boolean;
+            /** Created At */
+            created_at: string;
         };
         /** MfaStatusResponse */
         MfaStatusResponse: {
+            /** Mfa Enabled */
+            mfa_enabled: boolean;
+            /** Factors */
+            factors?: {
+                [key: string]: unknown;
+            }[];
             /**
              * Aal Level
              * @default aal1
              */
             aal_level: string;
-            /** Enforce Reason */
-            enforce_reason?: string | null;
-            /** Factors */
-            factors?: {
-                [key: string]: unknown;
-            }[];
-            /** Force Mfa Enrollment Until */
-            force_mfa_enrollment_until?: string | null;
-            /** Grace Days Remaining */
-            grace_days_remaining?: number | null;
-            /** Mfa Enabled */
-            mfa_enabled: boolean;
             /**
              * Mfa Required
              * @default false
              */
             mfa_required: boolean;
+            /** Enforce Reason */
+            enforce_reason?: string | null;
+            /** Force Mfa Enrollment Until */
+            force_mfa_enrollment_until?: string | null;
+            /** Grace Days Remaining */
+            grace_days_remaining?: number | null;
         };
         /** ModalidadeAggregate */
         ModalidadeAggregate: {
             /** Code */
             code: number;
-            /** Count */
-            count: number;
             /** Name */
             name: string;
+            /** Count */
+            count: number;
             /** Pct */
             pct: number;
         };
         /** MunicipioProfileResponse */
         MunicipioProfileResponse: {
+            /** Slug */
+            slug: string;
+            /** Nome */
+            nome: string;
+            /** Uf */
+            uf: string;
+            /** Ibge Code */
+            ibge_code: string;
+            /** Populacao */
+            populacao: number;
+            /** Pib Per Capita */
+            pib_per_capita?: number | null;
+            /** Total Licitacoes Abertas */
+            total_licitacoes_abertas: number;
+            /** Valor Total Licitacoes */
+            valor_total_licitacoes: number;
+            /** Licitacoes Recentes */
+            licitacoes_recentes: components["schemas"]["routes__municipios_publicos__LicitacaoRecente"][];
+            /** Faq Items */
+            faq_items: components["schemas"]["FaqItem"][];
+            /** Last Updated */
+            last_updated: string;
+            /** Aviso Legal */
+            aviso_legal: string;
             /**
              * @default {
              *       "contagem_30d": 0,
              *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
              *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
+             *       "tendencia_percentual": 0
              *     }
              */
             atividade_recente: components["schemas"]["AtividadeRecenteData"];
-            /** Aviso Legal */
-            aviso_legal: string;
-            /** Faq Items */
-            faq_items: components["schemas"]["FaqItem"][];
-            /** Ibge Code */
-            ibge_code: string;
-            /** Last Updated */
-            last_updated: string;
-            /** Licitacoes Recentes */
-            licitacoes_recentes: components["schemas"]["routes__municipios_publicos__LicitacaoRecente"][];
-            /** Nome */
-            nome: string;
-            /** Pib Per Capita */
-            pib_per_capita?: number | null;
-            /** Populacao */
-            populacao: number;
-            /** Slug */
-            slug: string;
-            /** Total Licitacoes Abertas */
-            total_licitacoes_abertas: number;
-            /** Uf */
-            uf: string;
-            /** Valor Total Licitacoes */
-            valor_total_licitacoes: number;
         };
         /** NewBidsCountResponse */
         NewBidsCountResponse: {
@@ -9893,14 +9877,14 @@ export interface components {
         NewOpportunitiesResponse: {
             /** Count */
             count: number;
-            /** Days Since Last Search */
-            days_since_last_search?: number | null;
             /** Has Previous Search */
             has_previous_search: boolean;
-            /** Label */
-            label?: string | null;
             /** Last Search At */
             last_search_at?: string | null;
+            /** Days Since Last Search */
+            days_since_last_search?: number | null;
+            /** Label */
+            label?: string | null;
         };
         /**
          * ObjetivoTipo
@@ -9927,16 +9911,16 @@ export interface components {
          * @description Aggregated dashboard for an org (extends over time).
          */
         OrganizationDashboardResponse: {
-            /** Members Count */
-            members_count?: number | null;
             /** Organization Id */
             organization_id?: string | null;
+            /** Members Count */
+            members_count?: number | null;
+            /** Seats Used */
+            seats_used?: number | null;
             /** Pipeline Count */
             pipeline_count?: number | null;
             /** Searches 30D */
             searches_30d?: number | null;
-            /** Seats Used */
-            seats_used?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -9945,14 +9929,14 @@ export interface components {
          * @description POST /organizations/{org_id}/invite response.
          */
         OrganizationInviteResponse: {
-            /** Expires At */
-            expires_at?: string | null;
             /** Invite Id */
             invite_id?: string | null;
             /** Invite Token */
             invite_token?: string | null;
             /** Invite Url */
             invite_url?: string | null;
+            /** Expires At */
+            expires_at?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -9961,10 +9945,10 @@ export interface components {
          * @description PUT /organizations/{org_id}/logo response.
          */
         OrganizationLogoUpdatedResponse: {
-            /** Logo Url */
-            logo_url?: string | null;
             /** Success */
             success?: boolean | null;
+            /** Logo Url */
+            logo_url?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -9973,10 +9957,10 @@ export interface components {
          * @description DELETE /organizations/{org_id}/members/{user_id} response.
          */
         OrganizationMemberRemovedResponse: {
-            /** Removed User Id */
-            removed_user_id?: string | null;
             /** Success */
             success?: boolean | null;
+            /** Removed User Id */
+            removed_user_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -9985,11 +9969,11 @@ export interface components {
          * @description `/organizations/me` returns membership + org info.
          */
         OrganizationMembershipResponse: {
-            organization?: components["schemas"]["OrganizationResponse"] | null;
             /** Organization Id */
             organization_id?: string | null;
             /** Role */
             role?: string | null;
+            organization?: components["schemas"]["OrganizationResponse"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -9998,8 +9982,6 @@ export interface components {
          * @description One organization row + denormalized fields the API may add.
          */
         OrganizationResponse: {
-            /** Created At */
-            created_at?: string | null;
             /** Id */
             id?: string | null;
             /** Name */
@@ -10010,48 +9992,50 @@ export interface components {
             plan_id?: string | null;
             /** Seats Used */
             seats_used?: number | null;
+            /** Created At */
+            created_at?: string | null;
         } & {
             [key: string]: unknown;
         };
         /** OrgaoContratosStatsResponse */
         OrgaoContratosStatsResponse: {
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
-            /** Avg Value */
-            avg_value: number;
-            /** Aviso Legal */
-            aviso_legal: string;
-            /** Last Updated */
-            last_updated: string;
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
-            /** Orgao Cnpj */
-            orgao_cnpj: string;
             /** Orgao Nome */
             orgao_nome: string;
-            /** Sample Contracts */
-            sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["FornecedorRank"][];
+            /** Orgao Cnpj */
+            orgao_cnpj: string;
             /** Total Contracts */
             total_contracts: number;
             /** Total Value */
             total_value: number;
+            /** Avg Value */
+            avg_value: number;
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["FornecedorRank"][];
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
+            /** Sample Contracts */
+            sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
+            /** Last Updated */
+            last_updated: string;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
         };
         /** OrgaoRank */
         OrgaoRank: {
-            /** Cnpj */
-            cnpj: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -10059,84 +10043,84 @@ export interface components {
         };
         /** OrgaoStatsResponse */
         OrgaoStatsResponse: {
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
-            /** Aviso Legal */
-            aviso_legal: string;
+            /** Nome */
+            nome: string;
             /** Cnpj */
             cnpj: string;
             /** Esfera */
             esfera: string;
-            /** Licitacoes 30D */
-            licitacoes_30d: number;
-            /** Licitacoes 365D */
-            licitacoes_365d: number;
-            /** Licitacoes 90D */
-            licitacoes_90d: number;
+            /** Uf */
+            uf: string;
             /** Municipio */
             municipio: string;
-            /** Nome */
-            nome: string;
+            /** Total Licitacoes */
+            total_licitacoes: number;
+            /** Licitacoes 30D */
+            licitacoes_30d: number;
+            /** Licitacoes 90D */
+            licitacoes_90d: number;
+            /** Licitacoes 365D */
+            licitacoes_365d: number;
+            /** Valor Medio Estimado */
+            valor_medio_estimado: number;
+            /** Valor Total Estimado */
+            valor_total_estimado: number;
+            /** Top Modalidades */
+            top_modalidades: components["schemas"]["routes__orgao_publico__ModalidadeCount"][];
+            /** Top Setores */
+            top_setores: string[];
+            /** Ultimas Licitacoes */
+            ultimas_licitacoes: components["schemas"]["routes__orgao_publico__LicitacaoRecente"][];
             /**
              * Top Fornecedores
              * @default []
              */
             top_fornecedores: components["schemas"]["FornecedorTop"][];
-            /** Top Modalidades */
-            top_modalidades: components["schemas"]["routes__orgao_publico__ModalidadeCount"][];
-            /** Top Setores */
-            top_setores: string[];
             /**
              * Total Contratos 24M
              * @default 0
              */
             total_contratos_24m: number;
-            /** Total Licitacoes */
-            total_licitacoes: number;
-            /** Uf */
-            uf: string;
-            /** Ultimas Licitacoes */
-            ultimas_licitacoes: components["schemas"]["routes__orgao_publico__LicitacaoRecente"][];
-            /** Valor Medio Estimado */
-            valor_medio_estimado: number;
             /**
              * Valor Total Contratos 24M
              * @default 0
              */
             valor_total_contratos_24m: number;
-            /** Valor Total Estimado */
-            valor_total_estimado: number;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
         };
         /** PanoramaStats */
         PanoramaStats: {
-            /** Avg Value */
-            avg_value: number;
-            /** Crescimento Estimado Pct */
-            crescimento_estimado_pct: number;
-            /** Last Updated */
-            last_updated: string;
-            /** Sazonalidade */
-            sazonalidade: components["schemas"]["routes__blog_stats__TrendPoint"][];
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Top Modalidades */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /** Top Ufs */
-            top_ufs: components["schemas"]["TopEntry"][];
             /** Total Nacional */
             total_nacional: number;
             /** Total Value */
             total_value: number;
+            /** Avg Value */
+            avg_value: number;
+            /** Top Ufs */
+            top_ufs: components["schemas"]["TopEntry"][];
+            /** Top Modalidades */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /** Sazonalidade */
+            sazonalidade: components["schemas"]["routes__blog_stats__TrendPoint"][];
+            /** Crescimento Estimado Pct */
+            crescimento_estimado_pct: number;
+            /** Last Updated */
+            last_updated: string;
         };
         /**
          * PartnerCreateResponse
@@ -10159,10 +10143,12 @@ export interface components {
          * @description AC14: Partner self-service dashboard payload.
          */
         PartnerDashboardResponse: {
-            /** Name */
-            name?: string | null;
             /** Partner Id */
             partner_id?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Status */
+            status?: string | null;
             /** Referrals */
             referrals?: {
                 [key: string]: unknown;
@@ -10171,8 +10157,6 @@ export interface components {
             revenue?: {
                 [key: string]: unknown;
             } | null;
-            /** Status */
-            status?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -10181,18 +10165,18 @@ export interface components {
          * @description One partner referral record.
          */
         PartnerReferralEntry: {
-            /** Churned At */
-            churned_at?: string | null;
-            /** Converted At */
-            converted_at?: string | null;
             /** Id */
             id?: string | null;
+            /** User Id */
+            user_id?: string | null;
+            /** Converted At */
+            converted_at?: string | null;
+            /** Churned At */
+            churned_at?: string | null;
             /** Monthly Revenue */
             monthly_revenue?: number | null;
             /** Revenue Share Amount */
             revenue_share_amount?: number | null;
-            /** User Id */
-            user_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -10214,16 +10198,16 @@ export interface components {
          * @description AC13: Partner revenue share for a given month.
          */
         PartnerRevenueResponse: {
-            /** Month */
-            month?: number | null;
             /** Partner Id */
             partner_id?: string | null;
-            /** Revenue Share Amount */
-            revenue_share_amount?: number | null;
-            /** Total Revenue */
-            total_revenue?: number | null;
             /** Year */
             year?: number | null;
+            /** Month */
+            month?: number | null;
+            /** Total Revenue */
+            total_revenue?: number | null;
+            /** Revenue Share Amount */
+            revenue_share_amount?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -10232,24 +10216,24 @@ export interface components {
          * @description One partner row in the admin list.
          */
         PartnerSummary: {
-            /** Contact Email */
-            contact_email?: string | null;
             /** Id */
             id?: string | null;
-            /** Monthly Share */
-            monthly_share?: number | null;
             /** Name */
             name?: string | null;
-            /** Referrals Active */
-            referrals_active?: number | null;
-            /** Referrals Total */
-            referrals_total?: number | null;
-            /** Revenue Share Pct */
-            revenue_share_pct?: number | null;
             /** Slug */
             slug?: string | null;
             /** Status */
             status?: string | null;
+            /** Contact Email */
+            contact_email?: string | null;
+            /** Revenue Share Pct */
+            revenue_share_pct?: number | null;
+            /** Referrals Total */
+            referrals_total?: number | null;
+            /** Referrals Active */
+            referrals_active?: number | null;
+            /** Monthly Share */
+            monthly_share?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -10268,62 +10252,52 @@ export interface components {
         };
         /** PdfEditalRequest */
         PdfEditalRequest: {
-            /** Data Encerramento */
-            data_encerramento?: string | null;
-            /** Data Publicacao */
-            data_publicacao?: string | null;
-            /** Link */
-            link?: string | null;
-            /** Modalidade */
-            modalidade?: string | null;
-            /** Municipio */
-            municipio?: string | null;
-            /** Numero Compra */
-            numero_compra?: string | null;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
-            /** Pncp Id */
-            pncp_id?: string | null;
-            /** Recomendacao */
-            recomendacao?: string | null;
-            /** Resumo Executivo */
-            resumo_executivo?: string | null;
             /** Uf */
             uf: string;
+            /** Municipio */
+            municipio?: string | null;
             /** Valor */
             valor?: number | null;
-            /** Viability Factors */
-            viability_factors?: {
-                [key: string]: unknown;
-            } | null;
+            /** Data Encerramento */
+            data_encerramento?: string | null;
+            /** Data Publicacao */
+            data_publicacao?: string | null;
+            /** Modalidade */
+            modalidade?: string | null;
+            /** Link */
+            link?: string | null;
+            /** Numero Compra */
+            numero_compra?: string | null;
+            /** Pncp Id */
+            pncp_id?: string | null;
             /** Viability Level */
             viability_level?: string | null;
             /** Viability Score */
             viability_score?: number | null;
+            /** Viability Factors */
+            viability_factors?: {
+                [key: string]: unknown;
+            } | null;
+            /** Resumo Executivo */
+            resumo_executivo?: string | null;
+            /** Recomendacao */
+            recomendacao?: string | null;
         };
         /** PerfilB2GResponse */
         PerfilB2GResponse: {
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0,
-             *       "valor_total_30d": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
-            /** Aviso Legal */
-            aviso_legal: string;
-            /**
-             * Brasilapi Status
-             * @default ok
-             */
-            brasilapi_status: string;
+            empresa: components["schemas"]["EmpresaInfo"];
             /** Contratos */
             contratos: components["schemas"]["ContratoPublico"][];
+            /** Score */
+            score: string;
+            /** Setor Detectado */
+            setor_detectado: string;
+            /** Setor Nome */
+            setor_nome: string;
             /** Editais Abertos Setor */
             editais_abertos_setor: number;
             /**
@@ -10331,24 +10305,34 @@ export interface components {
              * @default []
              */
             editais_amostra: components["schemas"]["EditaisAmostra"][];
-            empresa: components["schemas"]["EmpresaInfo"];
+            /** Total Contratos 24M */
+            total_contratos_24m: number;
+            /** Valor Total 24M */
+            valor_total_24m: number;
+            /** Ufs Atuacao */
+            ufs_atuacao: string[];
+            /** Aviso Legal */
+            aviso_legal: string;
+            /**
+             * Brasilapi Status
+             * @default ok
+             */
+            brasilapi_status: string;
             /**
              * Partial
              * @default false
              */
             partial: boolean;
-            /** Score */
-            score: string;
-            /** Setor Detectado */
-            setor_detectado: string;
-            /** Setor Nome */
-            setor_nome: string;
-            /** Total Contratos 24M */
-            total_contratos_24m: number;
-            /** Ufs Atuacao */
-            ufs_atuacao: string[];
-            /** Valor Total 24M */
-            valor_total_24m: number;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "valor_total_30d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
         };
         /**
          * PerfilContexto
@@ -10358,6 +10342,61 @@ export interface components {
          *     Stored as JSONB in profiles.context_data.
          */
         PerfilContexto: {
+            /**
+             * Ufs Atuacao
+             * @description States where the company operates (e.g., ['SP', 'RJ', 'MG'])
+             * @example [
+             *       "SP",
+             *       "RJ"
+             *     ]
+             */
+            ufs_atuacao: string[];
+            /** @description Company size: ME, EPP, MEDIO, GRANDE */
+            porte_empresa: components["schemas"]["PorteEmpresa"];
+            /** @description Procurement experience level */
+            experiencia_licitacoes: components["schemas"]["ExperienciaLicitacoes"];
+            /**
+             * Faixa Valor Min
+             * @description Minimum contract value of interest (BRL)
+             */
+            faixa_valor_min?: number | null;
+            /**
+             * Faixa Valor Max
+             * @description Maximum contract value of interest (BRL)
+             */
+            faixa_valor_max?: number | null;
+            /**
+             * Modalidades Interesse
+             * @description Preferred procurement modality codes (PNCP API codes)
+             */
+            modalidades_interesse?: number[] | null;
+            /**
+             * Palavras Chave
+             * @description Business-specific keywords for relevance boosting
+             */
+            palavras_chave?: string[] | null;
+            /**
+             * Cnae
+             * @description CNAE code or business segment (e.g., '4781-4/00')
+             */
+            cnae?: string | null;
+            /**
+             * Objetivo Principal
+             * @description User's primary objective in free text
+             */
+            objetivo_principal?: string | null;
+            /**
+             * Segmento Principal
+             * @description Primary business sector ID for personalization (CONV-018)
+             */
+            segmento_principal?: number | null;
+            /** @description User's primary objective for journey routing (CONV-018) */
+            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
+            /**
+             * Ticket Medio Desejado
+             * @description Desired average ticket in BRL cents
+             */
+            ticket_medio_desejado?: number | null;
             /**
              * Atestados
              * @description Certifications held (e.g., ['crea', 'iso_9001'])
@@ -10369,65 +10408,10 @@ export interface components {
              */
             capacidade_funcionarios?: number | null;
             /**
-             * Cnae
-             * @description CNAE code or business segment (e.g., '4781-4/00')
-             */
-            cnae?: string | null;
-            /** @description Procurement experience level */
-            experiencia_licitacoes: components["schemas"]["ExperienciaLicitacoes"];
-            /**
-             * Faixa Valor Max
-             * @description Maximum contract value of interest (BRL)
-             */
-            faixa_valor_max?: number | null;
-            /**
-             * Faixa Valor Min
-             * @description Minimum contract value of interest (BRL)
-             */
-            faixa_valor_min?: number | null;
-            /**
              * Faturamento Anual
              * @description Annual revenue in BRL
              */
             faturamento_anual?: number | null;
-            /**
-             * Modalidades Interesse
-             * @description Preferred procurement modality codes (PNCP API codes)
-             */
-            modalidades_interesse?: number[] | null;
-            /**
-             * Objetivo Principal
-             * @description User's primary objective in free text
-             */
-            objetivo_principal?: string | null;
-            /** @description User's primary objective for journey routing (CONV-018) */
-            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
-            /**
-             * Palavras Chave
-             * @description Business-specific keywords for relevance boosting
-             */
-            palavras_chave?: string[] | null;
-            /** @description Company size: ME, EPP, MEDIO, GRANDE */
-            porte_empresa: components["schemas"]["PorteEmpresa"];
-            /**
-             * Segmento Principal
-             * @description Primary business sector ID for personalization (CONV-018)
-             */
-            segmento_principal?: number | null;
-            /**
-             * Ticket Medio Desejado
-             * @description Desired average ticket in BRL cents
-             */
-            ticket_medio_desejado?: number | null;
-            /**
-             * Ufs Atuacao
-             * @description States where the company operates (e.g., ['SP', 'RJ', 'MG'])
-             * @example [
-             *       "SP",
-             *       "RJ"
-             *     ]
-             */
-            ufs_atuacao: string[];
         };
         /**
          * PerfilContextoResponse
@@ -10435,18 +10419,18 @@ export interface components {
          */
         PerfilContextoResponse: {
             /**
-             * Completed
-             * @description Whether onboarding wizard has been completed
-             * @default false
-             */
-            completed: boolean;
-            /**
              * Context Data
              * @description Business context data from onboarding
              */
             context_data?: {
                 [key: string]: unknown;
             };
+            /**
+             * Completed
+             * @description Whether onboarding wizard has been completed
+             * @default false
+             */
+            completed: boolean;
         };
         /** PeriodosResponse */
         PeriodosResponse: {
@@ -10469,20 +10453,10 @@ export interface components {
          */
         PipelineItemCreate: {
             /**
-             * Data Encerramento
-             * @description Deadline ISO timestamp
+             * Pncp Id
+             * @description PNCP unique identifier
              */
-            data_encerramento?: string | null;
-            /**
-             * Link Pncp
-             * @description Direct PNCP link
-             */
-            link_pncp?: string | null;
-            /**
-             * Notes
-             * @description User notes
-             */
-            notes?: string | null;
+            pncp_id: string;
             /**
              * Objeto
              * @description Procurement object description
@@ -10494,22 +10468,6 @@ export interface components {
              */
             orgao?: string | null;
             /**
-             * Pncp Id
-             * @description PNCP unique identifier
-             */
-            pncp_id: string;
-            /**
-             * Search Id
-             * @description Search session that discovered this item (DEBT-120)
-             */
-            search_id?: string | null;
-            /**
-             * Stage
-             * @description Initial pipeline stage
-             * @default descoberta
-             */
-            stage: string | null;
-            /**
              * Uf
              * @description State code
              */
@@ -10519,40 +10477,66 @@ export interface components {
              * @description Estimated value in BRL
              */
             valor_estimado?: number | null;
+            /**
+             * Data Encerramento
+             * @description Deadline ISO timestamp
+             */
+            data_encerramento?: string | null;
+            /**
+             * Link Pncp
+             * @description Direct PNCP link
+             */
+            link_pncp?: string | null;
+            /**
+             * Stage
+             * @description Initial pipeline stage
+             * @default descoberta
+             */
+            stage: string | null;
+            /**
+             * Notes
+             * @description User notes
+             */
+            notes?: string | null;
+            /**
+             * Search Id
+             * @description Search session that discovered this item (DEBT-120)
+             */
+            search_id?: string | null;
         };
         /**
          * PipelineItemResponse
          * @description Single pipeline item response.
          */
         PipelineItemResponse: {
-            /** Created At */
-            created_at: string;
-            /** Data Encerramento */
-            data_encerramento?: string | null;
             /** Id */
             id: string;
-            /** Link Pncp */
-            link_pncp?: string | null;
-            /** Notes */
-            notes?: string | null;
+            /** User Id */
+            user_id: string;
+            /** Pncp Id */
+            pncp_id: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao?: string | null;
-            /** Pncp Id */
-            pncp_id: string;
-            /** Search Id */
-            search_id?: string | null;
-            /** Stage */
-            stage: string;
             /** Uf */
             uf?: string | null;
-            /** Updated At */
-            updated_at: string;
-            /** User Id */
-            user_id: string;
             /** Valor Estimado */
             valor_estimado?: number | null;
+            /** Data Encerramento */
+            data_encerramento?: string | null;
+            /** Link Pncp */
+            link_pncp?: string | null;
+            /** Stage */
+            stage: string;
+            /** Notes */
+            notes?: string | null;
+            /** Search Id */
+            search_id?: string | null;
+            /** Created At */
+            created_at: string;
+            /** Updated At */
+            updated_at: string;
             /**
              * Version
              * @default 1
@@ -10565,15 +10549,15 @@ export interface components {
          */
         PipelineItemUpdate: {
             /**
-             * Notes
-             * @description Updated notes
-             */
-            notes?: string | null;
-            /**
              * Stage
              * @description New pipeline stage
              */
             stage?: string | null;
+            /**
+             * Notes
+             * @description Updated notes
+             */
+            notes?: string | null;
             /**
              * Version
              * @description Current version for optimistic locking (STORY-307)
@@ -10587,12 +10571,12 @@ export interface components {
         PipelineListResponse: {
             /** Items */
             items: components["schemas"]["PipelineItemResponse"][];
+            /** Total */
+            total: number;
             /** Limit */
             limit: number;
             /** Offset */
             offset: number;
-            /** Total */
-            total: number;
         };
         /**
          * PlanDetails
@@ -10602,24 +10586,24 @@ export interface components {
          *     to prevent enumeration attacks on pricing infrastructure.
          */
         PlanDetails: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            /** Price Brl */
+            price_brl: number;
+            /** Duration Days */
+            duration_days: number;
+            /** Max Searches */
+            max_searches: number;
             /** Capabilities */
             capabilities: {
                 [key: string]: unknown;
             };
-            /** Description */
-            description: string;
-            /** Duration Days */
-            duration_days: number;
-            /** Id */
-            id: string;
             /** Is Active */
             is_active: boolean;
-            /** Max Searches */
-            max_searches: number;
-            /** Name */
-            name: string;
-            /** Price Brl */
-            price_brl: number;
         };
         /**
          * PlansResponse
@@ -10649,34 +10633,22 @@ export interface components {
         ProfileCompletenessResponse: {
             /** Completeness Pct */
             completeness_pct: number;
+            /** Total Fields */
+            total_fields: number;
             /** Filled Fields */
             filled_fields: number;
+            /** Missing Fields */
+            missing_fields?: string[];
+            /** Next Question */
+            next_question?: string | null;
             /**
              * Is Complete
              * @default false
              */
             is_complete: boolean;
-            /** Missing Fields */
-            missing_fields?: string[];
-            /** Next Question */
-            next_question?: string | null;
-            /** Total Fields */
-            total_fields: number;
         };
         /** PublicFeatureFlagItem */
         PublicFeatureFlagItem: {
-            /**
-             * Category
-             * @description Flag category
-             * @default
-             */
-            category: string;
-            /**
-             * Description
-             * @description Human-readable description
-             * @default
-             */
-            description: string;
             /**
              * Name
              * @description Flag name
@@ -10687,6 +10659,18 @@ export interface components {
              * @description Current effective value
              */
             value: boolean;
+            /**
+             * Description
+             * @description Human-readable description
+             * @default
+             */
+            description: string;
+            /**
+             * Category
+             * @description Flag category
+             * @default
+             */
+            category: string;
         };
         /** PublicFeatureFlagListResponse */
         PublicFeatureFlagListResponse: {
@@ -10709,30 +10693,28 @@ export interface components {
         };
         /** RankingResponse */
         RankingResponse: {
+            /** Periodo */
+            periodo: string;
+            /** Total */
+            total: number;
+            /** Resultados */
+            resultados: components["schemas"]["IndiceResult"][];
             /** Fonte */
             fonte: string;
             /** License */
             license: string;
-            /** Periodo */
-            periodo: string;
-            /** Resultados */
-            resultados: components["schemas"]["IndiceResult"][];
-            /** Total */
-            total: number;
         };
         /**
          * ReadinessResponse
          * @description Response for GET /health/ready endpoint (Issue #640).
          */
         ReadinessResponse: {
+            /** Ready */
+            ready: boolean;
             /** Checks */
             checks: {
                 [key: string]: unknown;
             };
-            /** Ready */
-            ready: boolean;
-            /** Shutting Down */
-            shutting_down?: boolean | null;
             /** Uptime Seconds */
             uptime_seconds: number;
             /**
@@ -10741,6 +10723,8 @@ export interface components {
              * @default unknown
              */
             wedge_risk: string;
+            /** Shutting Down */
+            shutting_down?: boolean | null;
         };
         /**
          * RecalibrateRequest
@@ -10748,86 +10732,86 @@ export interface components {
          */
         RecalibrateRequest: {
             /**
+             * Range Days
+             * @default 90
+             */
+            range_days: number;
+            /**
              * Apply
              * @description When true, writes the new median to app_config.
              * @default false
              */
             apply: boolean;
-            /**
-             * Range Days
-             * @default 90
-             */
-            range_days: number;
         };
         /** RecalibrateResponse */
         RecalibrateResponse: {
-            /** After Outlier Removal */
-            after_outlier_removal: number;
-            /** Applied */
-            applied: boolean;
-            /** Diff Pct */
-            diff_pct?: number | null;
-            /** Eligible */
-            eligible: boolean;
-            /** Median Bid Count */
-            median_bid_count?: number | null;
-            /** Median Per Bid */
-            median_per_bid?: number | null;
-            /** New Value */
-            new_value?: number | null;
-            /** Old Value */
-            old_value: number;
             /** Range Days */
             range_days: number;
-            /** Reason */
-            reason?: string | null;
             /** Sample Size */
             sample_size: number;
+            /** After Outlier Removal */
+            after_outlier_removal: number;
+            /** Eligible */
+            eligible: boolean;
+            /** Reason */
+            reason?: string | null;
+            /** Old Value */
+            old_value: number;
+            /** New Value */
+            new_value?: number | null;
+            /** Diff Pct */
+            diff_pct?: number | null;
+            /** Applied */
+            applied: boolean;
+            /** Median Per Bid */
+            median_per_bid?: number | null;
+            /** Median Bid Count */
+            median_bid_count?: number | null;
         };
         /** RecentContract */
         RecentContract: {
-            /** Data Assinatura */
-            data_assinatura: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
             /** Orgao Cnpj */
             orgao_cnpj?: string | null;
-            /** Uf */
-            uf: string;
             /** Valor */
             valor?: number | null;
+            /** Data Assinatura */
+            data_assinatura: string;
+            /** Uf */
+            uf: string;
         };
         /** RecentEditaisResponse */
         RecentEditaisResponse: {
-            /** Items */
-            items: components["schemas"]["RecentEditalItem"][];
-            /** Last Updated */
-            last_updated: string;
-            /** Municipio */
-            municipio?: string | null;
             /** Setor */
             setor: string;
-            /** Total */
-            total: number;
             /** Uf */
             uf?: string | null;
+            /** Municipio */
+            municipio?: string | null;
+            /** Items */
+            items: components["schemas"]["RecentEditalItem"][];
+            /** Total */
+            total: number;
+            /** Last Updated */
+            last_updated: string;
         };
         /** RecentEditalItem */
         RecentEditalItem: {
+            /** Orgao */
+            orgao: string;
+            /** Objeto */
+            objeto: string;
+            /** Valor Estimado */
+            valor_estimado?: number | null;
             /** Data Limite */
             data_limite?: string | null;
             /** Data Publicacao */
             data_publicacao?: string | null;
             /** Link Interno */
             link_interno: string;
-            /** Objeto */
-            objeto: string;
-            /** Orgao */
-            orgao: string;
-            /** Valor Estimado */
-            valor_estimado?: number | null;
         };
         /**
          * Recomendacao
@@ -10837,6 +10821,23 @@ export interface components {
          *     Each recommendation includes a concrete action and justification.
          */
         Recomendacao: {
+            /**
+             * Oportunidade
+             * @description Opportunity name (agency/object)
+             * @example Prefeitura de Porto Alegre - Uniformes Escolares
+             */
+            oportunidade: string;
+            /**
+             * Valor
+             * @description Estimated value in BRL
+             */
+            valor: number;
+            /**
+             * Urgencia
+             * @description Urgency level: alta (<3 days), media (3-7 days), baixa (>7 days)
+             * @enum {string}
+             */
+            urgencia: "alta" | "media" | "baixa";
             /**
              * Acao Sugerida
              * @description Concrete suggested action
@@ -10849,23 +10850,6 @@ export interface components {
              * @example Valor compatível com seu porte, órgão federal com bom histórico de pagamento.
              */
             justificativa: string;
-            /**
-             * Oportunidade
-             * @description Opportunity name (agency/object)
-             * @example Prefeitura de Porto Alegre - Uniformes Escolares
-             */
-            oportunidade: string;
-            /**
-             * Urgencia
-             * @description Urgency level: alta (<3 days), media (3-7 days), baixa (>7 days)
-             * @enum {string}
-             */
-            urgencia: "alta" | "media" | "baixa";
-            /**
-             * Valor
-             * @description Estimated value in BRL
-             */
-            valor: number;
         };
         /** RecommendedPlanResponse */
         RecommendedPlanResponse: {
@@ -10876,6 +10860,10 @@ export interface components {
         };
         /** ReconcileNowResponse */
         ReconcileNowResponse: {
+            /** Status */
+            status: string;
+            /** Dry Run */
+            dry_run: boolean;
             /**
              * Drifts Detected
              * @default 0
@@ -10891,55 +10879,51 @@ export interface components {
              * @default 0
              */
             drifts_manual: number;
-            /** Dry Run */
-            dry_run: boolean;
             /** Run Id */
             run_id?: string | null;
-            /** Status */
-            status: string;
         };
         /** ReconciliationRun */
         ReconciliationRun: {
-            /** Drift Report */
-            drift_report?: unknown;
+            /** Id */
+            id: string;
             /**
-             * Drifts Detected
-             * @default 0
+             * Started At
+             * Format: date-time
              */
-            drifts_detected: number;
-            /**
-             * Drifts Fixed
-             * @default 0
-             */
-            drifts_fixed: number;
-            /**
-             * Drifts Manual
-             * @default 0
-             */
-            drifts_manual: number;
+            started_at: string;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Status */
+            status: string;
             /**
              * Dry Run
              * @default false
              */
             dry_run: boolean;
-            /** Error Message */
-            error_message?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
-            /** Id */
-            id: string;
             /**
              * Rows Checked
              * @default 0
              */
             rows_checked: number;
             /**
-             * Started At
-             * Format: date-time
+             * Drifts Detected
+             * @default 0
              */
-            started_at: string;
-            /** Status */
-            status: string;
+            drifts_detected: number;
+            /**
+             * Drifts Fixed
+             * @default 0
+             */
+            drifts_fixed: number;
+            /**
+             * Drifts Manual
+             * @default 0
+             */
+            drifts_manual: number;
+            /** Drift Report */
+            drift_report?: unknown;
+            /** Error Message */
+            error_message?: string | null;
         };
         /** ReconciliationRunsResponse */
         ReconciliationRunsResponse: {
@@ -10948,6 +10932,11 @@ export interface components {
         };
         /** RecordEventRequest */
         RecordEventRequest: {
+            /**
+             * Evento Tipo
+             * @description Tipo do evento: search_query, sector_view, org_view, cnpj_lookup
+             */
+            evento_tipo: string;
             /**
              * Dimensao Tipo
              * @description Tipo da dimensao: setor, uf, modalidade, orgao
@@ -10959,11 +10948,6 @@ export interface components {
              */
             dimensao_valor: string;
             /**
-             * Evento Tipo
-             * @description Tipo do evento: search_query, sector_view, org_view, cnpj_lookup
-             */
-            evento_tipo: string;
-            /**
              * Metadados
              * @description Metadados adicionais (setores, ufs, modalidades). NUNCA PII.
              */
@@ -10974,15 +10958,15 @@ export interface components {
         /** RecordEventResponse */
         RecordEventResponse: {
             /**
-             * Message
-             * @default Evento registrado com sucesso
-             */
-            message: string;
-            /**
              * Success
              * @default true
              */
             success: boolean;
+            /**
+             * Message
+             * @default Evento registrado com sucesso
+             */
+            message: string;
         };
         /** RecoveryCodesResponse */
         RecoveryCodesResponse: {
@@ -11016,30 +11000,30 @@ export interface components {
         };
         /** ReferralRedeemResponse */
         ReferralRedeemResponse: {
-            /** Code */
-            code?: string | null;
             /** Status */
             status: string;
+            /** Code */
+            code?: string | null;
         };
         /** ReferralStatsResponse */
         ReferralStatsResponse: {
             /** Code */
             code: string;
             /**
-             * Credits Earned Months
+             * Total Signups
              * @default 0
              */
-            credits_earned_months: number;
+            total_signups: number;
             /**
              * Total Converted
              * @default 0
              */
             total_converted: number;
             /**
-             * Total Signups
+             * Credits Earned Months
              * @default 0
              */
-            total_signups: number;
+            credits_earned_months: number;
         };
         /** RegenerateRecoveryResponse */
         RegenerateRecoveryResponse: {
@@ -11053,53 +11037,48 @@ export interface components {
         };
         /** RelatorioMensal */
         RelatorioMensal: {
+            /** Mes */
+            mes: number;
             /** Ano */
             ano: number;
-            /** Coverage Window */
-            coverage_window?: {
-                [key: string]: unknown;
-            } | null;
-            /** Fonte */
-            fonte: string;
+            /** Mes Nome */
+            mes_nome: string;
+            /** Periodo */
+            periodo: string;
+            /** Total Editais */
+            total_editais: number;
+            /** Valor Total */
+            valor_total: number;
+            /** Valor Medio */
+            valor_medio: number;
+            /** Top Ufs */
+            top_ufs: components["schemas"]["UfCount"][];
+            /** Modalidades */
+            modalidades: components["schemas"]["routes__observatorio__ModalidadeCount"][];
+            /** Tendencia Semanal */
+            tendencia_semanal: components["schemas"]["routes__observatorio__MonthlyTrend"][];
+            /** Setores Em Alta */
+            setores_em_alta: components["schemas"]["SetorHighlight"][];
             /** Gerado Em */
             gerado_em: string;
+            /** Fonte */
+            fonte: string;
+            /** License */
+            license: string;
             /**
              * Is Empty Period
              * @default false
              */
             is_empty_period: boolean;
-            /** License */
-            license: string;
-            /** Mes */
-            mes: number;
-            /** Mes Nome */
-            mes_nome: string;
-            /** Modalidades */
-            modalidades: components["schemas"]["routes__observatorio__ModalidadeCount"][];
             /** Period Label */
             period_label?: string | null;
-            /** Periodo */
-            periodo: string;
-            /** Setores Em Alta */
-            setores_em_alta: components["schemas"]["SetorHighlight"][];
-            /** Tendencia Semanal */
-            tendencia_semanal: components["schemas"]["routes__observatorio__MonthlyTrend"][];
-            /** Top Ufs */
-            top_ufs: components["schemas"]["UfCount"][];
-            /** Total Editais */
-            total_editais: number;
-            /** Valor Medio */
-            valor_medio: number;
-            /** Valor Total */
-            valor_total: number;
+            /** Coverage Window */
+            coverage_window?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** RelatorioRequest */
         RelatorioRequest: {
-            /**
-             * Cargo
-             * @enum {string}
-             */
-            cargo: "diretor" | "gerente" | "analista" | "consultor" | "outro";
             /**
              * Email
              * Format: email
@@ -11107,6 +11086,11 @@ export interface components {
             email: string;
             /** Empresa */
             empresa: string;
+            /**
+             * Cargo
+             * @enum {string}
+             */
+            cargo: "diretor" | "gerente" | "analista" | "consultor" | "outro";
             /**
              * Newsletter Opt In
              * @default false
@@ -11146,10 +11130,10 @@ export interface components {
         };
         /** ResendResponse */
         ResendResponse: {
-            /** Message */
-            message: string;
             /** Success */
             success: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * ResumoEstrategico
@@ -11190,48 +11174,6 @@ export interface components {
          */
         ResumoEstrategico: {
             /**
-             * Alerta Urgencia
-             * @description Optional urgency alert for time-sensitive opportunities
-             * @example ⚠️ 5 licitações encerram em 24 horas
-             */
-            alerta_urgencia?: string | null;
-            /**
-             * Alertas Urgencia
-             * @description Multiple urgency alerts for time-sensitive opportunities
-             * @example [
-             *       "⚠️ 2 licitações encerram em 48h",
-             *       "📋 3 editais exigem certidão atualizada"
-             *     ]
-             */
-            alertas_urgencia?: string[];
-            /**
-             * Destaques
-             * @description Key highlights (2-5 bullet points)
-             * @example [
-             *       "3 licitações com prazo até 48h",
-             *       "Maior valor: R$ 500k em SP"
-             *     ]
-             */
-            destaques?: string[];
-            /**
-             * Insight Setorial
-             * @description Sector-level market context and trend insight
-             * @default
-             * @example Este mês há 20% mais oportunidades de vestuário que o mês anterior no RS.
-             */
-            insight_setorial: string;
-            /**
-             * Outlier Count
-             * @description Number of outlier values excluded from valor_total computation
-             * @default 0
-             */
-            outlier_count: number;
-            /**
-             * Recomendacoes
-             * @description Prioritized list of recommended opportunities with concrete actions
-             */
-            recomendacoes?: components["schemas"]["Recomendacao"][];
-            /**
              * Resumo Executivo
              * @description 1-2 sentence executive summary
              * @example Encontradas 15 licitações de uniformes em SP e RJ, totalizando R$ 2.3M.
@@ -11243,16 +11185,58 @@ export interface components {
              */
             total_oportunidades: number;
             /**
+             * Valor Total
+             * @description Total value of all opportunities in BRL
+             */
+            valor_total: number;
+            /**
+             * Destaques
+             * @description Key highlights (2-5 bullet points)
+             * @example [
+             *       "3 licitações com prazo até 48h",
+             *       "Maior valor: R$ 500k em SP"
+             *     ]
+             */
+            destaques?: string[];
+            /**
+             * Alerta Urgencia
+             * @description Optional urgency alert for time-sensitive opportunities
+             * @example ⚠️ 5 licitações encerram em 24 horas
+             */
+            alerta_urgencia?: string | null;
+            /**
+             * Outlier Count
+             * @description Number of outlier values excluded from valor_total computation
+             * @default 0
+             */
+            outlier_count: number;
+            /**
              * Valor Sanitizado
              * @description Whether outlier-robust sanitization was applied to valor_total
              * @default false
              */
             valor_sanitizado: boolean;
             /**
-             * Valor Total
-             * @description Total value of all opportunities in BRL
+             * Recomendacoes
+             * @description Prioritized list of recommended opportunities with concrete actions
              */
-            valor_total: number;
+            recomendacoes?: components["schemas"]["Recomendacao"][];
+            /**
+             * Alertas Urgencia
+             * @description Multiple urgency alerts for time-sensitive opportunities
+             * @example [
+             *       "⚠️ 2 licitações encerram em 48h",
+             *       "📋 3 editais exigem certidão atualizada"
+             *     ]
+             */
+            alertas_urgencia?: string[];
+            /**
+             * Insight Setorial
+             * @description Sector-level market context and trend insight
+             * @default
+             * @example Este mês há 20% mais oportunidades de vestuário que o mês anterior no RS.
+             */
+            insight_setorial: string;
         };
         /**
          * ResumoLicitacoes
@@ -11283,27 +11267,6 @@ export interface components {
          */
         ResumoLicitacoes: {
             /**
-             * Alerta Urgencia
-             * @description Optional urgency alert for time-sensitive opportunities
-             * @example ⚠️ 5 licitações encerram em 24 horas
-             */
-            alerta_urgencia?: string | null;
-            /**
-             * Destaques
-             * @description Key highlights (2-5 bullet points)
-             * @example [
-             *       "3 licitações com prazo até 48h",
-             *       "Maior valor: R$ 500k em SP"
-             *     ]
-             */
-            destaques?: string[];
-            /**
-             * Outlier Count
-             * @description Number of outlier values excluded from valor_total computation
-             * @default 0
-             */
-            outlier_count: number;
-            /**
              * Resumo Executivo
              * @description 1-2 sentence executive summary
              * @example Encontradas 15 licitações de uniformes em SP e RJ, totalizando R$ 2.3M.
@@ -11315,16 +11278,37 @@ export interface components {
              */
             total_oportunidades: number;
             /**
+             * Valor Total
+             * @description Total value of all opportunities in BRL
+             */
+            valor_total: number;
+            /**
+             * Destaques
+             * @description Key highlights (2-5 bullet points)
+             * @example [
+             *       "3 licitações com prazo até 48h",
+             *       "Maior valor: R$ 500k em SP"
+             *     ]
+             */
+            destaques?: string[];
+            /**
+             * Alerta Urgencia
+             * @description Optional urgency alert for time-sensitive opportunities
+             * @example ⚠️ 5 licitações encerram em 24 horas
+             */
+            alerta_urgencia?: string | null;
+            /**
+             * Outlier Count
+             * @description Number of outlier values excluded from valor_total computation
+             * @default 0
+             */
+            outlier_count: number;
+            /**
              * Valor Sanitizado
              * @description Whether outlier-robust sanitization was applied to valor_total
              * @default false
              */
             valor_sanitizado: boolean;
-            /**
-             * Valor Total
-             * @description Total value of all opportunities in BRL
-             */
-            valor_total: number;
         };
         /** RevalidateSEORequest */
         RevalidateSEORequest: {
@@ -11333,10 +11317,10 @@ export interface components {
         };
         /** RevalidateSEOResponse */
         RevalidateSEOResponse: {
-            /** Paths */
-            paths: string[];
             /** Status */
             status: string;
+            /** Paths */
+            paths: string[];
         };
         /** ReverseSyncRequest */
         ReverseSyncRequest: {
@@ -11351,34 +11335,38 @@ export interface components {
         };
         /** ReverseSyncResponse */
         ReverseSyncResponse: {
-            /** Audit Log Id */
-            audit_log_id?: string | null;
-            /** New Stripe Price Id */
-            new_stripe_price_id?: string | null;
-            /** Old Stripe Price Id */
-            old_stripe_price_id?: string | null;
-            /** Plan Billing Period Id */
-            plan_billing_period_id: string;
-            /** Skipped Reason */
-            skipped_reason?: string | null;
             /** Status */
             status: string;
+            /** Plan Billing Period Id */
+            plan_billing_period_id: string;
+            /** Old Stripe Price Id */
+            old_stripe_price_id?: string | null;
+            /** New Stripe Price Id */
+            new_stripe_price_id?: string | null;
+            /** Skipped Reason */
+            skipped_reason?: string | null;
+            /** Audit Log Id */
+            audit_log_id?: string | null;
         };
         /**
          * RevokeResponse
          * @description Response for revoke endpoint.
          */
         RevokeResponse: {
-            /** Message */
-            message: string;
             /** Success */
             success: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * RootResponse
          * @description Response for GET / root endpoint.
          */
         RootResponse: {
+            /** Name */
+            name: string;
+            /** Version */
+            version: string;
             /** Api Version */
             api_version: string;
             /** Description */
@@ -11387,57 +11375,53 @@ export interface components {
             endpoints: {
                 [key: string]: string;
             };
-            /** Name */
-            name: string;
-            /** Status */
-            status: string;
-            /** Version */
-            version: string;
             /** Versioning */
             versioning: {
                 [key: string]: unknown;
             };
+            /** Status */
+            status: string;
         };
         /** SEOMetricRow */
         SEOMetricRow: {
-            /** Avg Position */
-            avg_position: number;
-            /** Clicks */
-            clicks: number;
-            /** Ctr */
-            ctr: number;
             /** Date */
             date: string;
             /** Impressions */
             impressions: number;
+            /** Clicks */
+            clicks: number;
+            /** Ctr */
+            ctr: number;
+            /** Avg Position */
+            avg_position: number;
             /** Pages Indexed */
             pages_indexed: number;
-            /** Top Pages */
-            top_pages: unknown[];
             /** Top Queries */
             top_queries: unknown[];
+            /** Top Pages */
+            top_pages: unknown[];
         };
         /** SEOMetricsResponse */
         SEOMetricsResponse: {
-            /** Latest Date */
-            latest_date?: string | null;
             /** Metrics */
             metrics: components["schemas"]["SEOMetricRow"][];
             /** Total */
             total: number;
+            /** Latest Date */
+            latest_date?: string | null;
         };
         /** SancaoEntry */
         SancaoEntry: {
-            /** Data Fim */
-            data_fim?: string | null;
-            /** Data Inicio */
-            data_inicio: string;
-            /** Motivo */
-            motivo: string;
-            /** Orgao Sancionador */
-            orgao_sancionador: string;
             /** Tipo */
             tipo: string;
+            /** Orgao Sancionador */
+            orgao_sancionador: string;
+            /** Data Inicio */
+            data_inicio: string;
+            /** Data Fim */
+            data_fim?: string | null;
+            /** Motivo */
+            motivo: string;
             /** Valor Multa */
             valor_multa?: number | null;
         };
@@ -11449,39 +11433,39 @@ export interface components {
          */
         SanctionsSummarySchema: {
             /**
+             * Is Clean
+             * @description True if no active sanctions found
+             */
+            is_clean: boolean;
+            /**
              * Active Sanctions Count
              * @description Number of active sanctions
              * @default 0
              */
             active_sanctions_count: number;
             /**
-             * Checked At
-             * @description ISO timestamp of check
-             */
-            checked_at?: string | null;
-            /**
-             * Is Clean
-             * @description True if no active sanctions found
-             */
-            is_clean: boolean;
-            /**
              * Sanction Types
              * @description e.g. ['CEIS: Impedimento', 'CNEP: Multa']
              */
             sanction_types?: string[];
+            /**
+             * Checked At
+             * @description ISO timestamp of check
+             */
+            checked_at?: string | null;
         };
         /**
          * SaveSegmentRequest
          * @description Request body for POST /v1/segment/save (CONV-018).
          */
         SaveSegmentRequest: {
-            /** @description User's primary objective: vencer_licitacao, subcontratar, monitorar */
-            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
             /**
              * Segmento Principal
              * @description Primary business sector ID from sectors list
              */
             segmento_principal?: number | null;
+            /** @description User's primary objective: vencer_licitacao, subcontratar, monitorar */
+            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
         };
         /**
          * SaveSegmentResponse
@@ -11489,29 +11473,29 @@ export interface components {
          */
         SaveSegmentResponse: {
             /**
+             * Status
+             * @description Operation status, always 'ok' on success
+             */
+            status: string;
+            /**
              * Context Data
              * @description Full merged context_data after save
              */
             context_data: {
                 [key: string]: unknown;
             };
-            /**
-             * Status
-             * @description Operation status, always 'ok' on success
-             */
-            status: string;
         };
         /**
          * SearchActionResponse
          * @description Generic ack for `regenerate-excel`, `retry`, `cancel`.
          */
         SearchActionResponse: {
-            /** Message */
-            message?: string | null;
             /** Search Id */
             search_id?: string | null;
             /** Status */
             status?: string | null;
+            /** Message */
+            message?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -11520,6 +11504,8 @@ export interface components {
          * @description `GET /buscar-results/{id}` and `/search/{id}/results` — full envelope.
          */
         SearchResultsResponse: {
+            /** Search Id */
+            search_id?: string | null;
             /** Licitacoes */
             licitacoes?: {
                 [key: string]: unknown;
@@ -11528,8 +11514,6 @@ export interface components {
             resumo?: {
                 [key: string]: unknown;
             } | null;
-            /** Search Id */
-            search_id?: string | null;
             /** Total */
             total?: number | null;
         } & {
@@ -11546,32 +11530,31 @@ export interface components {
          */
         SearchStatusResponse: {
             /**
-             * Created At
-             * @description ISO timestamp when search was created
+             * Search Id
+             * @description UUID of the search
              */
-            created_at?: string | null;
+            search_id: string;
             /**
-             * Elapsed S
-             * @description Seconds since search started
-             * @default 0
+             * Status
+             * @description running, completed, failed, or timeout
              */
-            elapsed_s: number;
-            /**
-             * Excel Status
-             * @description Excel generation status: processing, ready, failed, skipped
-             */
-            excel_status?: string | null;
-            /**
-             * Excel Url
-             * @description Signed URL for Excel download (set when ready)
-             */
-            excel_url?: string | null;
+            status: string;
             /**
              * Progress Pct
              * @description Overall progress 0-100
              * @default 0
              */
             progress_pct: number;
+            /**
+             * Ufs Completed
+             * @description UFs that finished fetching
+             */
+            ufs_completed?: string[];
+            /**
+             * Ufs Pending
+             * @description UFs still being fetched
+             */
+            ufs_pending?: string[];
             /**
              * Results Count
              * @description Number of filtered results so far
@@ -11584,37 +11567,38 @@ export interface components {
              */
             results_url?: string | null;
             /**
-             * Search Id
-             * @description UUID of the search
+             * Elapsed S
+             * @description Seconds since search started
+             * @default 0
              */
-            search_id: string;
+            elapsed_s: number;
             /**
-             * Status
-             * @description running, completed, failed, or timeout
+             * Created At
+             * @description ISO timestamp when search was created
              */
-            status: string;
+            created_at?: string | null;
             /**
-             * Ufs Completed
-             * @description UFs that finished fetching
+             * Excel Url
+             * @description Signed URL for Excel download (set when ready)
              */
-            ufs_completed?: string[];
+            excel_url?: string | null;
             /**
-             * Ufs Pending
-             * @description UFs still being fetched
+             * Excel Status
+             * @description Excel generation status: processing, ready, failed, skipped
              */
-            ufs_pending?: string[];
+            excel_status?: string | null;
         };
         /**
          * SearchTimelineResponse
          * @description `GET /search/{id}/timeline` — list of progress events.
          */
         SearchTimelineResponse: {
+            /** Search Id */
+            search_id?: string | null;
             /** Events */
             events?: {
                 [key: string]: unknown;
             }[] | null;
-            /** Search Id */
-            search_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -11634,10 +11618,10 @@ export interface components {
         };
         /** SearchesOverTimeResponse */
         SearchesOverTimeResponse: {
-            /** Data */
-            data: components["schemas"]["TimeSeriesDataPoint"][];
             /** Period */
             period: string;
+            /** Data */
+            data: components["schemas"]["TimeSeriesDataPoint"][];
         };
         /**
          * SeasonalCalendarResponse
@@ -11658,10 +11642,20 @@ export interface components {
          */
         SeasonalCalendarStats: {
             /**
+             * Uf
+             * @description UF code (uppercase)
+             */
+            uf: string;
+            /**
              * Anos Analisados
              * @description Number of years analyzed
              */
             anos_analisados: number;
+            /**
+             * Total Contratos Base
+             * @description Total number of contracts/bids in the analysis base
+             */
+            total_contratos_base: number;
             /**
              * Mes Pico
              * @description Month with highest average volume
@@ -11672,93 +11666,113 @@ export interface components {
              * @description Month with lowest average volume
              */
             mes_vale?: number | null;
-            /**
-             * Total Contratos Base
-             * @description Total number of contracts/bids in the analysis base
-             */
-            total_contratos_base: number;
-            /**
-             * Uf
-             * @description UF code (uppercase)
-             */
-            uf: string;
         };
         /** SectorAggregate */
         SectorAggregate: {
-            /** Avg Value */
-            avg_value: number;
-            /** Count */
-            count: number;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
+            /** Count */
+            count: number;
             /** Total Value */
             total_value: number;
+            /** Avg Value */
+            avg_value: number;
         };
         /** SectorBlogStats */
         SectorBlogStats: {
-            /** Avg Value */
-            avg_value: number;
-            /** Last Updated */
-            last_updated: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
+            /** Total Editais */
+            total_editais: number;
+            /** Value Range Min */
+            value_range_min: number;
+            /** Value Range Max */
+            value_range_max: number;
+            /** Avg Value */
+            avg_value: number;
             /** Top Modalidades */
             top_modalidades: components["schemas"]["TopEntry"][];
             /** Top Ufs */
             top_ufs: components["schemas"]["TopEntry"][];
-            /** Total Editais */
-            total_editais: number;
             /** Trend 90D */
             trend_90d: components["schemas"]["routes__blog_stats__TrendPoint"][];
-            /** Value Range Max */
-            value_range_max: number;
-            /** Value Range Min */
-            value_range_min: number;
+            /** Last Updated */
+            last_updated: string;
         };
         /** SectorListItem */
         SectorListItem: {
-            /** Description */
-            description: string;
             /** Id */
             id: string;
-            /** Name */
-            name: string;
             /** Slug */
             slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
         };
         /** SectorStatsResponse */
         SectorStatsResponse: {
-            /** Avg Value */
-            avg_value: number;
-            /** Last Updated */
-            last_updated: string;
-            /** Sample Items */
-            sample_items: components["schemas"]["routes__sectors_public__SampleItem"][];
-            /** Sector Description */
-            sector_description: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
+            /** Sector Description */
+            sector_description: string;
             /** Slug */
             slug: string;
-            /** Top Modalidades */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /** Top Ufs */
-            top_ufs: components["schemas"]["TopEntry"][];
             /** Total Open */
             total_open: number;
             /** Total Value */
             total_value: number;
+            /** Avg Value */
+            avg_value: number;
+            /** Top Ufs */
+            top_ufs: components["schemas"]["TopEntry"][];
+            /** Top Modalidades */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /** Sample Items */
+            sample_items: components["schemas"]["routes__sectors_public__SampleItem"][];
+            /** Last Updated */
+            last_updated: string;
         };
         /** SectorUfStats */
         SectorUfStats: {
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Uf */
+            uf: string;
+            /** Total Editais */
+            total_editais: number;
             /** Avg Value */
             avg_value: number;
+            /**
+             * Value Range Min
+             * @default 0
+             */
+            value_range_min: number;
+            /**
+             * Value Range Max
+             * @default 0
+             */
+            value_range_max: number;
+            /**
+             * Top Modalidades
+             * @default []
+             */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /**
+             * Trend 90D
+             * @default []
+             */
+            trend_90d: components["schemas"]["routes__blog_stats__TrendPoint"][];
+            /** Top Oportunidades */
+            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
             /** Last Updated */
             last_updated: string;
             /** Most Recent Bid Date */
@@ -11768,59 +11782,29 @@ export interface components {
              * @default 0
              */
             municipios_ativos: number;
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
+            /** Vs Media Nacional Pct */
+            vs_media_nacional_pct?: number | null;
             /**
              * Top Compradores
              * @default []
              */
             top_compradores: components["schemas"]["TopComprador"][];
-            /**
-             * Top Modalidades
-             * @default []
-             */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /** Top Oportunidades */
-            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
-            /** Total Editais */
-            total_editais: number;
-            /**
-             * Trend 90D
-             * @default []
-             */
-            trend_90d: components["schemas"]["routes__blog_stats__TrendPoint"][];
-            /** Uf */
-            uf: string;
-            /**
-             * Value Range Max
-             * @default 0
-             */
-            value_range_max: number;
-            /**
-             * Value Range Min
-             * @default 0
-             */
-            value_range_min: number;
-            /** Vs Media Nacional Pct */
-            vs_media_nacional_pct?: number | null;
         };
         /**
          * SessionsListResponse
          * @description Response for GET /sessions.
          */
         SessionsListResponse: {
-            /** Limit */
-            limit: number;
-            /** Offset */
-            offset: number;
             /** Sessions */
             sessions: {
                 [key: string]: unknown;
             }[];
             /** Total */
             total: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
         };
         /** SetorHighlight */
         SetorHighlight: {
@@ -11828,10 +11812,10 @@ export interface components {
             setor_id: string;
             /** Setor Name */
             setor_name: string;
-            /** Total Anterior */
-            total_anterior: number;
             /** Total Atual */
             total_atual: number;
+            /** Total Anterior */
+            total_anterior: number;
             /** Variacao Pct */
             variacao_pct: number;
         };
@@ -11867,69 +11851,69 @@ export interface components {
         ShareAnaliseRequest: {
             /** Bid Id */
             bid_id: string;
-            /** Bid Modalidade */
-            bid_modalidade?: string | null;
-            /** Bid Orgao */
-            bid_orgao?: string | null;
             /** Bid Title */
             bid_title: string;
+            /** Bid Orgao */
+            bid_orgao?: string | null;
             /** Bid Uf */
             bid_uf?: string | null;
             /** Bid Valor */
             bid_valor?: number | null;
+            /** Bid Modalidade */
+            bid_modalidade?: string | null;
+            /** Viability Score */
+            viability_score: number;
+            /** Viability Level */
+            viability_level: string;
             /** Viability Factors */
             viability_factors?: {
                 [key: string]: unknown;
             };
-            /** Viability Level */
-            viability_level: string;
-            /** Viability Score */
-            viability_score: number;
         };
         /**
          * ShareAnaliseResponse
          * @description Response with the shareable URL.
          */
         ShareAnaliseResponse: {
-            /** Hash */
-            hash: string;
             /** Url */
             url: string;
+            /** Hash */
+            hash: string;
         };
         /**
          * SharedAnalisePublic
          * @description Public view of a shared analysis (no user_id exposed).
          */
         SharedAnalisePublic: {
+            /** Hash */
+            hash: string;
             /** Bid Id */
             bid_id: string;
-            /** Bid Modalidade */
-            bid_modalidade?: string | null;
-            /** Bid Orgao */
-            bid_orgao?: string | null;
             /** Bid Title */
             bid_title: string;
+            /** Bid Orgao */
+            bid_orgao?: string | null;
             /** Bid Uf */
             bid_uf?: string | null;
             /** Bid Valor */
             bid_valor?: number | null;
-            /** Created At */
-            created_at: string;
-            /** Hash */
-            hash: string;
+            /** Bid Modalidade */
+            bid_modalidade?: string | null;
+            /** Viability Score */
+            viability_score: number;
+            /** Viability Level */
+            viability_level: string;
             /** Viability Factors */
             viability_factors: {
                 [key: string]: unknown;
             };
-            /** Viability Level */
-            viability_level: string;
-            /** Viability Score */
-            viability_score: number;
             /**
              * View Count
              * @default 0
              */
             view_count: number;
+            /** Created At */
+            created_at: string;
         };
         /**
          * SignupRequest
@@ -11942,41 +11926,41 @@ export interface components {
          */
         SignupRequest: {
             /**
-             * Company
-             * @description Optional company name, stored in profiles.company
-             */
-            company?: string | null;
-            /**
              * Email
              * Format: email
              * @description User email (must be valid format, max 320 chars)
              */
             email: string;
             /**
-             * Full Name
-             * @description Optional display name, propagated to profiles.full_name
-             */
-            full_name?: string | null;
-            /**
              * Password
              * @description Password (min 8 chars — Supabase enforces complexity)
              */
             password: string;
             /**
-             * Ref
-             * @description Attribution ref slug (e.g. 'municipios-sao-paulo-sp')
+             * Stripe Payment Method Id
+             * @description Stripe PaymentMethod ID (pm_...) from frontend PaymentElement
              */
-            ref?: string | null;
+            stripe_payment_method_id?: string | null;
+            /**
+             * Full Name
+             * @description Optional display name, propagated to profiles.full_name
+             */
+            full_name?: string | null;
+            /**
+             * Company
+             * @description Optional company name, stored in profiles.company
+             */
+            company?: string | null;
             /**
              * Source
              * @description Attribution source (e.g. 'municipio-page', 'orgao-page')
              */
             source?: string | null;
             /**
-             * Stripe Payment Method Id
-             * @description Stripe PaymentMethod ID (pm_...) from frontend PaymentElement
+             * Ref
+             * @description Attribution ref slug (e.g. 'municipios-sao-paulo-sp')
              */
-            stripe_payment_method_id?: string | null;
+            ref?: string | null;
         };
         /**
          * SignupResponse
@@ -11984,17 +11968,21 @@ export interface components {
          */
         SignupResponse: {
             /**
+             * User Id
+             * @description Supabase auth.users.id UUID
+             */
+            user_id: string;
+            /**
              * Email
              * Format: email
              * @description Confirmed user email
              */
             email: string;
             /**
-             * Requires Email Confirmation
-             * @description Whether Supabase requires email confirmation before login
-             * @default true
+             * Trial End Ts
+             * @description Unix epoch seconds when trial ends. Sourced from Stripe when subscription created; otherwise computed locally (now + 14d).
              */
-            requires_email_confirmation: boolean;
+            trial_end_ts?: number | null;
             /**
              * Stripe Customer Id
              * @description Stripe Customer ID (cus_...) if card was attached
@@ -12012,15 +12000,11 @@ export interface components {
              */
             subscription_status: string;
             /**
-             * Trial End Ts
-             * @description Unix epoch seconds when trial ends. Sourced from Stripe when subscription created; otherwise computed locally (now + 14d).
+             * Requires Email Confirmation
+             * @description Whether Supabase requires email confirmation before login
+             * @default true
              */
-            trial_end_ts?: number | null;
-            /**
-             * User Id
-             * @description Supabase auth.users.id UUID
-             */
-            user_id: string;
+            requires_email_confirmation: boolean;
         };
         /**
          * SitemapCacheRefreshResponse
@@ -12029,10 +12013,10 @@ export interface components {
         SitemapCacheRefreshResponse: {
             /** Status */
             status?: string | null;
-            /** Threshold */
-            threshold?: number | null;
             /** Total Combos */
             total_combos?: number | null;
+            /** Threshold */
+            threshold?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -12071,14 +12055,14 @@ export interface components {
          *     HTTP 200 when all MVs are ok; HTTP 503 when any MV is empty or errored.
          */
         SitemapHealthResponse: {
-            /** Checks */
-            checks?: {
-                [key: string]: components["schemas"]["SitemapMvCheck"];
-            } | null;
             /** Status */
             status?: string | null;
             /** Timestamp */
             timestamp?: string | null;
+            /** Checks */
+            checks?: {
+                [key: string]: components["schemas"]["SitemapMvCheck"];
+            } | null;
         } & {
             [key: string]: unknown;
         };
@@ -12114,12 +12098,12 @@ export interface components {
          * @description Per-MV status entry for the sitemap health endpoint.
          */
         SitemapMvCheck: {
+            /** Status */
+            status?: string | null;
             /** Count */
             count?: number | null;
             /** Error */
             error?: string | null;
-            /** Status */
-            status?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -12151,26 +12135,26 @@ export interface components {
          * @description STORY-299 AC7-AC9: SLO compliance + alerts + definitions.
          */
         SloDashboardResponse: {
-            /** Alerts */
-            alerts?: {
-                [key: string]: unknown;
-            }[] | null;
             /** Compliance */
             compliance?: string | null;
-            /** Firing Count */
-            firing_count?: number | null;
-            /** Recording Rules */
-            recording_rules?: unknown | null;
-            /** Sentry Alerts */
-            sentry_alerts?: unknown | null;
-            /** Slo Definitions */
-            slo_definitions?: {
-                [key: string]: unknown;
-            } | null;
             /** Slos */
             slos?: {
                 [key: string]: unknown;
             } | null;
+            /** Alerts */
+            alerts?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Firing Count */
+            firing_count?: number | null;
+            /** Slo Definitions */
+            slo_definitions?: {
+                [key: string]: unknown;
+            } | null;
+            /** Recording Rules */
+            recording_rules?: unknown | null;
+            /** Sentry Alerts */
+            sentry_alerts?: unknown | null;
         } & {
             [key: string]: unknown;
         };
@@ -12179,12 +12163,12 @@ export interface components {
          * @description Per-source health state.
          */
         SourceHealthEntry: {
-            /** Available */
-            available?: boolean | null;
             /** Enabled */
             enabled?: boolean | null;
             /** Status */
             status?: string | null;
+            /** Available */
+            available?: boolean | null;
         } & {
             [key: string]: unknown;
         };
@@ -12195,16 +12179,16 @@ export interface components {
         SourceInfo: {
             /** Code */
             code: string;
-            /** Enabled */
-            enabled: boolean;
             /** Name */
             name: string;
+            /** Enabled */
+            enabled: boolean;
             /** Priority */
             priority: number;
-            /** Response Ms */
-            response_ms?: number | null;
             /** Status */
             status?: string | null;
+            /** Response Ms */
+            response_ms?: number | null;
         };
         /**
          * SourcesHealthMapResponse
@@ -12226,16 +12210,16 @@ export interface components {
          * @description Response for GET /sources/health endpoint.
          */
         SourcesHealthResponse: {
-            /** Checked At */
-            checked_at: string;
-            /** Multi Source Enabled */
-            multi_source_enabled: boolean;
             /** Sources */
             sources: components["schemas"]["SourceInfo"][];
-            /** Total Available */
-            total_available: number;
+            /** Multi Source Enabled */
+            multi_source_enabled: boolean;
             /** Total Enabled */
             total_enabled: number;
+            /** Total Available */
+            total_available: number;
+            /** Checked At */
+            checked_at: string;
         };
         /**
          * StatusLicitacao
@@ -12262,16 +12246,16 @@ export interface components {
          * @description GET /subscription/status — current plan + period info.
          */
         SubscriptionStatusResponse: {
-            /** Activated At */
-            activated_at?: string | null;
-            /** Cancel At Period End */
-            cancel_at_period_end?: boolean | null;
-            /** Current Period End */
-            current_period_end?: string | null;
-            /** Plan Id */
-            plan_id?: string | null;
             /** Status */
             status?: string | null;
+            /** Plan Id */
+            plan_id?: string | null;
+            /** Activated At */
+            activated_at?: string | null;
+            /** Current Period End */
+            current_period_end?: string | null;
+            /** Cancel At Period End */
+            cancel_at_period_end?: boolean | null;
             /** Trial End */
             trial_end?: string | null;
         } & {
@@ -12282,10 +12266,10 @@ export interface components {
          * @description Success response with message.
          */
         SuccessMessageResponse: {
-            /** Message */
-            message: string;
             /** Success */
             success: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * SuccessResponse
@@ -12297,29 +12281,29 @@ export interface components {
         };
         /** SummaryResponse */
         SummaryResponse: {
-            /** Avg Results Per Search */
-            avg_results_per_search: number;
-            /** Estimated Hours Saved */
-            estimated_hours_saved: number;
-            /** Member Since */
-            member_since: string;
-            /** Success Rate */
-            success_rate: number;
+            /** Total Searches */
+            total_searches: number;
             /** Total Downloads */
             total_downloads: number;
             /** Total Opportunities */
             total_opportunities: number;
-            /** Total Searches */
-            total_searches: number;
             /** Total Value Discovered */
             total_value_discovered: number;
+            /** Estimated Hours Saved */
+            estimated_hours_saved: number;
+            /** Avg Results Per Search */
+            avg_results_per_search: number;
+            /** Success Rate */
+            success_rate: number;
+            /** Member Since */
+            member_since: string;
         };
         /** SupplierEntry */
         SupplierEntry: {
-            /** Cnpj */
-            cnpj: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -12330,32 +12314,32 @@ export interface components {
          * @description GET /v1/admin/survey/export-time-saved response.
          */
         SurveyAggregateResponse: {
-            /** After Outlier Removal */
-            after_outlier_removal: number;
-            /** Current Constant */
-            current_constant: number;
-            /** Histogram */
-            histogram: components["schemas"]["HistogramBucket"][];
-            /** Iqr Lower Bound */
-            iqr_lower_bound?: number | null;
-            /** Iqr Q1 */
-            iqr_q1?: number | null;
-            /** Iqr Q3 */
-            iqr_q3?: number | null;
-            /** Iqr Upper Bound */
-            iqr_upper_bound?: number | null;
-            /** Mean Hours */
-            mean_hours?: number | null;
-            /** Median Bid Count */
-            median_bid_count?: number | null;
-            /** Median Hours */
-            median_hours?: number | null;
-            /** Median Per Bid */
-            median_per_bid?: number | null;
             /** Range Days */
             range_days: number;
             /** Sample Size */
             sample_size: number;
+            /** After Outlier Removal */
+            after_outlier_removal: number;
+            /** Median Hours */
+            median_hours?: number | null;
+            /** Mean Hours */
+            mean_hours?: number | null;
+            /** Iqr Q1 */
+            iqr_q1?: number | null;
+            /** Iqr Q3 */
+            iqr_q3?: number | null;
+            /** Iqr Lower Bound */
+            iqr_lower_bound?: number | null;
+            /** Iqr Upper Bound */
+            iqr_upper_bound?: number | null;
+            /** Median Per Bid */
+            median_per_bid?: number | null;
+            /** Median Bid Count */
+            median_bid_count?: number | null;
+            /** Histogram */
+            histogram: components["schemas"]["HistogramBucket"][];
+            /** Current Constant */
+            current_constant: number;
         };
         /**
          * SystemHealthResponse
@@ -12366,10 +12350,10 @@ export interface components {
          *     just see additional keys.
          */
         SystemHealthResponse: {
-            /** Overall */
-            overall?: string | null;
             /** Status */
             status?: string | null;
+            /** Overall */
+            overall?: string | null;
             /** Timestamp */
             timestamp?: string | null;
         } & {
@@ -12379,19 +12363,19 @@ export interface components {
         TimeSeriesDataPoint: {
             /** Label */
             label: string;
-            /** Opportunities */
-            opportunities: number;
             /** Searches */
             searches: number;
+            /** Opportunities */
+            opportunities: number;
             /** Value */
             value: number;
         };
         /** TopComprador */
         TopComprador: {
-            /** Cnpj */
-            cnpj: string;
             /** Nome */
             nome: string;
+            /** Cnpj */
+            cnpj: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -12399,88 +12383,93 @@ export interface components {
         };
         /** TopDimensionsResponse */
         TopDimensionsResponse: {
-            /** Top Sectors */
-            top_sectors: components["schemas"]["DimensionItem"][];
             /** Top Ufs */
             top_ufs: components["schemas"]["DimensionItem"][];
+            /** Top Sectors */
+            top_sectors: components["schemas"]["DimensionItem"][];
         };
         /** TopEntry */
         TopEntry: {
-            /** Count */
-            count: number;
             /** Name */
             name: string;
+            /** Count */
+            count: number;
         };
         /** TopItem */
         TopItem: {
-            /** Contagem */
-            contagem: number;
             /** Dimensao Valor */
             dimensao_valor: string;
+            /** Contagem */
+            contagem: number;
         };
         /** TopOpportunity */
         TopOpportunity: {
-            /** Data Encerramento */
-            data_encerramento?: string | null;
-            /** Dias Ate Encerramento */
-            dias_ate_encerramento?: number | null;
-            /** Modalidade */
-            modalidade?: string | null;
-            /** Numero Controle */
-            numero_controle?: string | null;
-            /** Objeto */
-            objeto?: string | null;
-            /** Orgao Nome */
-            orgao_nome?: string | null;
-            /** Setor */
-            setor?: string | null;
             /** Title */
             title: string;
             /** Value */
             value: number;
+            /** Objeto */
+            objeto?: string | null;
+            /** Orgao Nome */
+            orgao_nome?: string | null;
+            /** Numero Controle */
+            numero_controle?: string | null;
+            /** Data Encerramento */
+            data_encerramento?: string | null;
+            /** Dias Ate Encerramento */
+            dias_ate_encerramento?: number | null;
+            /** Setor */
+            setor?: string | null;
+            /** Modalidade */
+            modalidade?: string | null;
         };
         /** TopResponse */
         TopResponse: {
             /** Evento Tipo */
             evento_tipo: string;
-            /** Items */
-            items: components["schemas"]["TopItem"][];
-            /** Periodo Fim */
-            periodo_fim: string;
             /** Periodo Inicio */
             periodo_inicio: string;
+            /** Periodo Fim */
+            periodo_fim: string;
+            /** Items */
+            items: components["schemas"]["TopItem"][];
         };
         /** TopSupplierItem */
         TopSupplierItem: {
+            /** Razao Social */
+            razao_social: string;
             /** Cnpj */
             cnpj: string;
             /** Contratos Count */
             contratos_count: number;
-            /** Razao Social */
-            razao_social: string;
             /** Valor Total */
             valor_total: number;
         };
         /** TopSuppliersResponse */
         TopSuppliersResponse: {
-            /** Items */
-            items: components["schemas"]["TopSupplierItem"][];
-            /** Last Updated */
-            last_updated: string;
-            /** Municipio */
-            municipio?: string | null;
             /** Setor */
             setor: string;
-            /** Total Contracts In Scope */
-            total_contracts_in_scope: number;
             /** Uf */
             uf?: string | null;
+            /** Municipio */
+            municipio?: string | null;
+            /** Items */
+            items: components["schemas"]["TopSupplierItem"][];
+            /** Total Contracts In Scope */
+            total_contracts_in_scope: number;
+            /** Last Updated */
+            last_updated: string;
         };
         /**
          * TourEventRequest
          * @description Request for onboarding tour event tracking (STORY-313 AC18).
          */
         TourEventRequest: {
+            /**
+             * Tour Id
+             * @description Tour identifier (search, results, pipeline)
+             */
+            tour_id: string;
             /**
              * Event
              * @description Event type: completed or skipped
@@ -12491,50 +12480,45 @@ export interface components {
              * @description Number of steps the user saw before event
              */
             steps_seen: number;
-            /**
-             * Tour Id
-             * @description Tour identifier (search, results, pipeline)
-             */
-            tour_id: string;
         };
         /**
          * TraceMallocEntry
          * @description Single tracemalloc allocation entry.
          */
         TraceMallocEntry: {
-            /** Count */
-            count: number;
             /** Filename */
             filename: string;
             /** Lineno */
             lineno: number;
             /** Size Kb */
             size_kb: number;
+            /** Count */
+            count: number;
         };
         /** TrendingSector */
         TrendingSector: {
-            /** Count This Week */
-            count_this_week: number;
-            /** Name */
-            name: string;
             /** Slug */
             slug: string;
+            /** Name */
+            name: string;
+            /** Count This Week */
+            count_this_week: number;
         };
         /**
          * TrialExitSurveyEntry
          * @description One trial exit survey response row.
          */
         TrialExitSurveyEntry: {
-            /** Created At */
-            created_at?: string | null;
-            /** Feedback */
-            feedback?: string | null;
             /** Id */
             id?: string | null;
-            /** Reason */
-            reason?: string | null;
             /** User Id */
             user_id?: string | null;
+            /** Reason */
+            reason?: string | null;
+            /** Feedback */
+            feedback?: string | null;
+            /** Created At */
+            created_at?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -12543,10 +12527,10 @@ export interface components {
          * @description One {reason, count} aggregation row.
          */
         TrialExitSurveysReasonCount: {
-            /** Count */
-            count?: number | null;
             /** Reason */
             reason?: string | null;
+            /** Count */
+            count?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -12555,76 +12539,76 @@ export interface components {
          * @description GET /admin/trial-exit-surveys: aggregated reason counts.
          */
         TrialExitSurveysResponse: {
+            /** Total */
+            total?: number | null;
             /** By Reason */
             by_reason?: components["schemas"]["TrialExitSurveysReasonCount"][] | null;
             /** Surveys */
             surveys?: components["schemas"]["TrialExitSurveyEntry"][] | null;
-            /** Total */
-            total?: number | null;
         } & {
             [key: string]: unknown;
         };
         /** TrialStatusResponse */
         TrialStatusResponse: {
+            /** Plan */
+            plan: string;
             /** Days Remaining */
             days_remaining: number;
+            /** Searches Used */
+            searches_used: number;
+            /** Searches Limit */
+            searches_limit: number;
             /** Expires At */
             expires_at?: string | null;
             /** Is Expired */
             is_expired: boolean;
-            /** Plan */
-            plan: string;
             /**
              * Plan Features
              * @default []
              */
             plan_features: string[];
-            /** Searches Limit */
-            searches_limit: number;
-            /** Searches Used */
-            searches_used: number;
-            /**
-             * Trial Day
-             * @default 0
-             */
-            trial_day: number;
             /**
              * Trial Phase
              * @default full_access
              */
             trial_phase: string;
+            /**
+             * Trial Day
+             * @default 0
+             */
+            trial_day: number;
         };
         /** TrialValueResponse */
         TrialValueResponse: {
-            /** Avg Opportunity Value */
-            avg_opportunity_value: number;
-            /** Searches Executed */
-            searches_executed: number;
-            top_opportunity?: components["schemas"]["TopOpportunity"] | null;
             /** Total Opportunities */
             total_opportunities: number;
             /** Total Value */
             total_value: number;
+            /** Searches Executed */
+            searches_executed: number;
+            /** Avg Opportunity Value */
+            avg_opportunity_value: number;
+            top_opportunity?: components["schemas"]["TopOpportunity"] | null;
         };
         /** UfAggregate */
         UfAggregate: {
+            /** Uf */
+            uf: string;
             /** Count */
             count: number;
             /** Total Value */
             total_value: number;
-            /** Uf */
-            uf: string;
         };
         /** UfCount */
         UfCount: {
-            /** Pct */
-            pct: number;
-            /** Total */
-            total: number;
             /** Uf */
             uf: string;
             /** Uf Name */
             uf_name: string;
+            /** Total */
+            total: number;
+            /** Pct */
+            pct: number;
         };
         /**
          * UfStatusDetail
@@ -12632,11 +12616,10 @@ export interface components {
          */
         UfStatusDetail: {
             /**
-             * Results Count
-             * @description Number of results from this UF
-             * @default 0
+             * Uf
+             * @description State code (e.g., 'SP')
              */
-            results_count: number;
+            uf: string;
             /**
              * Status
              * @description UF fetch status
@@ -12644,10 +12627,11 @@ export interface components {
              */
             status: "ok" | "timeout" | "error" | "skipped";
             /**
-             * Uf
-             * @description State code (e.g., 'SP')
+             * Results Count
+             * @description Number of results from this UF
+             * @default 0
              */
-            uf: string;
+            results_count: number;
         };
         /**
          * UltimaVagaOptIn
@@ -12660,15 +12644,15 @@ export interface components {
              */
             empresa: string;
             /**
-             * Preenchidaem
-             * @description ISO-8601 timestamp.
-             */
-            preenchidaEm: string;
-            /**
              * Uf
              * @description State code, 2 letters.
              */
             uf: string;
+            /**
+             * Preenchidaem
+             * @description ISO-8601 timestamp.
+             */
+            preenchidaEm: string;
         };
         /**
          * UnreadCountResponse
@@ -12683,11 +12667,11 @@ export interface components {
          * @description Partial update — all fields optional.
          */
         UpdateAlertRequest: {
-            /** Active */
-            active?: boolean | null;
-            filters?: components["schemas"]["AlertFilters"] | null;
             /** Name */
             name?: string | null;
+            filters?: components["schemas"]["AlertFilters"] | null;
+            /** Active */
+            active?: boolean | null;
         };
         /**
          * UpdateBillingPeriodRequest
@@ -12706,14 +12690,14 @@ export interface components {
          * @description Response for billing period update.
          */
         UpdateBillingPeriodResponse: {
-            /** Message */
-            message: string;
+            /** Success */
+            success: boolean;
             /** New Billing Period */
             new_billing_period: string;
             /** Next Billing Date */
             next_billing_date: string;
-            /** Success */
-            success: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * UpdateConversationStatusRequest
@@ -12740,10 +12724,10 @@ export interface components {
         };
         /** UpdateUserRequest */
         UpdateUserRequest: {
-            /** Company */
-            company?: string | null;
             /** Full Name */
             full_name?: string | null;
+            /** Company */
+            company?: string | null;
             /** Plan Id */
             plan_id?: string | null;
         };
@@ -12759,33 +12743,13 @@ export interface components {
         UpgradeToLifetimePreviewResponse: {
             /** Eligible */
             eligible: boolean;
-            /**
-             * Estimated Credit Brl Cents
-             * @default 0
-             */
-            estimated_credit_brl_cents: number;
-            /**
-             * Has Active Subscription
-             * @default false
-             */
-            has_active_subscription: boolean;
-            /**
-             * Is Already Founder
-             * @default false
-             */
-            is_already_founder: boolean;
+            /** Reason */
+            reason: string;
             /**
              * Lifetime Price Brl Cents
              * @default 99700
              */
             lifetime_price_brl_cents: number;
-            /**
-             * Net Charge Brl Cents
-             * @default 99700
-             */
-            net_charge_brl_cents: number;
-            /** Reason */
-            reason: string;
             /**
              * Seats Remaining
              * @default 0
@@ -12796,6 +12760,26 @@ export interface components {
              * @default 0
              */
             seats_total: number;
+            /**
+             * Estimated Credit Brl Cents
+             * @default 0
+             */
+            estimated_credit_brl_cents: number;
+            /**
+             * Net Charge Brl Cents
+             * @default 99700
+             */
+            net_charge_brl_cents: number;
+            /**
+             * Has Active Subscription
+             * @default false
+             */
+            has_active_subscription: boolean;
+            /**
+             * Is Already Founder
+             * @default false
+             */
+            is_already_founder: boolean;
         };
         /**
          * UpgradeToLifetimeRequest
@@ -12813,6 +12797,8 @@ export interface components {
         UpgradeToLifetimeResponse: {
             /** Checkout Url */
             checkout_url: string;
+            /** Session Id */
+            session_id: string;
             /**
              * Estimated Credit Brl Cents
              * @default 0
@@ -12823,8 +12809,6 @@ export interface components {
              * @default 99700
              */
             net_charge_brl_cents: number;
-            /** Session Id */
-            session_id: string;
         };
         /**
          * UptimeHistoryEntry
@@ -12856,14 +12840,14 @@ export interface components {
          * @description Response containing user's enabled features.
          */
         UserFeaturesResponse: {
-            /** Billing Period */
-            billing_period: string;
-            /** Cached At */
-            cached_at?: string | null;
             /** Features */
             features: components["schemas"]["FeatureInfo"][];
             /** Plan Id */
             plan_id: string;
+            /** Billing Period */
+            billing_period: string;
+            /** Cached At */
+            cached_at?: string | null;
         };
         /**
          * UserProfileResponse
@@ -12873,58 +12857,10 @@ export interface components {
          *     necessary plan information for UI rendering.
          */
         UserProfileResponse: {
-            /**
-             * Capabilities
-             * @description Plan capabilities (max_history_days, allow_excel, etc.)
-             */
-            capabilities: {
-                [key: string]: unknown;
-            };
-            /**
-             * Consulting Discount Pct
-             * @description Consultoria discount % granted to this founder (default 50 for v2_lifetime). NULL = no consulting discount.
-             */
-            consulting_discount_pct?: number | null;
-            /**
-             * Days Since Failure
-             * @description STORY-309: Days since first payment failure (null if no failure)
-             */
-            days_since_failure?: number | null;
-            /**
-             * Dunning Phase
-             * @description STORY-309: Dunning phase — healthy, active_retries, grace_period, blocked
-             * @default healthy
-             */
-            dunning_phase: string;
+            /** User Id */
+            user_id: string;
             /** Email */
             email: string;
-            /**
-             * Founder Checkout Source
-             * @description utm_source or checkout source param from founding checkout metadata.
-             */
-            founder_checkout_source?: string | null;
-            /**
-             * Founder Offer Version
-             * @description Offer version string from checkout metadata (e.g. 'v2_lifetime').
-             */
-            founder_offer_version?: string | null;
-            /**
-             * Founder Since
-             * @description Timestamp of checkout.session.completed for the lifetime purchase.
-             */
-            founder_since?: string | null;
-            /**
-             * Is Admin
-             * @description Whether user has admin privileges
-             * @default false
-             */
-            is_admin: boolean;
-            /**
-             * Is Founder
-             * @description TRUE if user purchased the v2 lifetime Plano Fundadores (R$997). NOT set for v1 subscription founders (-50% monthly).
-             * @default false
-             */
-            is_founder: boolean;
             /**
              * Plan Id
              * @description Plan ID (e.g., 'consultor_agil')
@@ -12936,6 +12872,18 @@ export interface components {
              */
             plan_name: string;
             /**
+             * Capabilities
+             * @description Plan capabilities (max_history_days, allow_excel, etc.)
+             */
+            capabilities: {
+                [key: string]: unknown;
+            };
+            /**
+             * Quota Used
+             * @description Searches used this month
+             */
+            quota_used: number;
+            /**
              * Quota Remaining
              * @description Searches remaining this month
              */
@@ -12946,58 +12894,112 @@ export interface components {
              */
             quota_reset_date: string;
             /**
-             * Quota Used
-             * @description Searches used this month
+             * Trial Expires At
+             * @description ISO 8601 timestamp when trial expires (if applicable)
              */
-            quota_used: number;
-            /**
-             * Subscription End Date
-             * @description ISO 8601 — data real de renovação Stripe (current_period_end), null para trial/admin
-             */
-            subscription_end_date?: string | null;
+            trial_expires_at?: string | null;
             /**
              * Subscription Status
              * @description Status: 'trial', 'active', 'expired', or 'past_due'
              */
             subscription_status: string;
             /**
-             * Trial Expires At
-             * @description ISO 8601 timestamp when trial expires (if applicable)
+             * Is Admin
+             * @description Whether user has admin privileges
+             * @default false
              */
-            trial_expires_at?: string | null;
-            /** User Id */
-            user_id: string;
+            is_admin: boolean;
+            /**
+             * Dunning Phase
+             * @description STORY-309: Dunning phase — healthy, active_retries, grace_period, blocked
+             * @default healthy
+             */
+            dunning_phase: string;
+            /**
+             * Days Since Failure
+             * @description STORY-309: Days since first payment failure (null if no failure)
+             */
+            days_since_failure?: number | null;
+            /**
+             * Subscription End Date
+             * @description ISO 8601 — data real de renovação Stripe (current_period_end), null para trial/admin
+             */
+            subscription_end_date?: string | null;
+            /**
+             * Is Founder
+             * @description TRUE if user purchased the v2 lifetime Plano Fundadores (R$997). NOT set for v1 subscription founders (-50% monthly).
+             * @default false
+             */
+            is_founder: boolean;
+            /**
+             * Founder Since
+             * @description Timestamp of checkout.session.completed for the lifetime purchase.
+             */
+            founder_since?: string | null;
+            /**
+             * Founder Offer Version
+             * @description Offer version string from checkout metadata (e.g. 'v2_lifetime').
+             */
+            founder_offer_version?: string | null;
+            /**
+             * Founder Checkout Source
+             * @description utm_source or checkout source param from founding checkout metadata.
+             */
+            founder_checkout_source?: string | null;
+            /**
+             * Consulting Discount Pct
+             * @description Consultoria discount % granted to this founder (default 50 for v2_lifetime). NULL = no consulting discount.
+             */
+            consulting_discount_pct?: number | null;
+        };
+        /**
+         * UserSegmentsResponse
+         * @description Response for GET /admin/users/segments (LIFECYCLE-003).
+         */
+        UserSegmentsResponse: {
+            /** Count By State */
+            count_by_state: {
+                [key: string]: unknown;
+            };
+            /** Total Users */
+            total_users: number;
+            /** Transitions Last Week */
+            transitions_last_week: unknown[];
+            /** Power Users */
+            power_users: unknown[];
+            /** Queried At */
+            queried_at: string;
         };
         /**
          * ValidateSignupEmailResponse
          * @description POST /validate-signup-email response.
          */
         ValidateSignupEmailResponse: {
-            /** Available */
-            available?: boolean | null;
-            /** Corporate */
-            corporate?: boolean | null;
-            /** Disposable */
-            disposable?: boolean | null;
-            /** Reason */
-            reason?: string | null;
             /** Valid */
             valid?: boolean | null;
+            /** Available */
+            available?: boolean | null;
+            /** Disposable */
+            disposable?: boolean | null;
+            /** Corporate */
+            corporate?: boolean | null;
+            /** Reason */
+            reason?: string | null;
         } & {
             [key: string]: unknown;
         };
         /** ValidationError */
         ValidationError: {
-            /** Context */
-            ctx?: Record<string, never>;
-            /** Input */
-            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
         };
         /** VerifyRecoveryRequest */
         VerifyRecoveryRequest: {
@@ -13006,89 +13008,89 @@ export interface components {
         };
         /** VerifyRecoveryResponse */
         VerifyRecoveryResponse: {
-            /**
-             * Message
-             * @default
-             */
-            message: string;
+            /** Success */
+            success: boolean;
             /**
              * Remaining Codes
              * @default 0
              */
             remaining_codes: number;
-            /** Success */
-            success: boolean;
+            /**
+             * Message
+             * @default
+             */
+            message: string;
         };
         /** WeeklyDigestResponse */
         WeeklyDigestResponse: {
-            /** Avg Value */
-            avg_value: number;
-            /** By Modalidade */
-            by_modalidade: components["schemas"]["WeeklyModalidadeStat"][];
-            /** By Sector */
-            by_sector: components["schemas"]["WeeklyHighlight"][];
-            /** By Uf */
-            by_uf: components["schemas"]["WeeklyUfStat"][];
-            /** Period End */
-            period_end: string;
-            /** Period Start */
-            period_start: string;
+            /** Year */
+            year: number;
+            /** Week */
+            week: number;
             /** Slug */
             slug: string;
             /** Title */
             title: string;
-            /** Top Sector */
-            top_sector: string;
-            /** Top Uf */
-            top_uf: string;
+            /** Period Start */
+            period_start: string;
+            /** Period End */
+            period_end: string;
             /** Total Bids */
             total_bids: number;
             /** Total Value */
             total_value: number;
+            /** Avg Value */
+            avg_value: number;
+            /** By Sector */
+            by_sector: components["schemas"]["WeeklyHighlight"][];
+            /** By Uf */
+            by_uf: components["schemas"]["WeeklyUfStat"][];
+            /** By Modalidade */
+            by_modalidade: components["schemas"]["WeeklyModalidadeStat"][];
+            /** Top Sector */
+            top_sector: string;
+            /** Top Uf */
+            top_uf: string;
             /** Updated At */
             updated_at: string;
-            /** Week */
-            week: number;
-            /** Year */
-            year: number;
         };
         /** WeeklyHighlight */
         WeeklyHighlight: {
-            /** Avg Value */
-            avg_value: number;
-            /** Count */
-            count: number;
-            /** Sector Id */
-            sector_id: string;
             /** Sector Name */
             sector_name: string;
+            /** Sector Id */
+            sector_id: string;
+            /** Count */
+            count: number;
+            /** Avg Value */
+            avg_value: number;
             /** Trend */
             trend: string;
         };
         /** WeeklyModalidadeStat */
         WeeklyModalidadeStat: {
-            /** Count */
-            count: number;
             /** Modalidade */
             modalidade: string;
+            /** Count */
+            count: number;
             /** Pct */
             pct: number;
         };
         /** WeeklyUfStat */
         WeeklyUfStat: {
+            /** Uf */
+            uf: string;
             /** Count */
             count: number;
             /** Total Value */
             total_value: number;
-            /** Uf */
-            uf: string;
         };
         /** WelcomeEmailResponse */
         WelcomeEmailResponse: {
-            /** Message */
-            message: string;
             /** Sent */
             sent: boolean;
+            /** Message */
+            message: string;
         };
         /**
          * _LivenessResponse
@@ -13101,11 +13103,6 @@ export interface components {
              */
             live: boolean;
             /**
-             * Process Uptime Seconds
-             * @default 0
-             */
-            process_uptime_seconds: number;
-            /**
              * Ready
              * @default false
              */
@@ -13115,89 +13112,94 @@ export interface components {
              * @default 0
              */
             uptime_seconds: number;
+            /**
+             * Process Uptime Seconds
+             * @default 0
+             */
+            process_uptime_seconds: number;
         } & {
             [key: string]: unknown;
         };
         /** SampleContract */
         routes__blog_stats__SampleContract: {
-            /** Data Assinatura */
-            data_assinatura: string;
-            /** Fornecedor */
-            fornecedor: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
+            /** Fornecedor */
+            fornecedor: string;
             /** Valor */
             valor: number | null;
+            /** Data Assinatura */
+            data_assinatura: string;
         };
         /** SampleItem */
         routes__blog_stats__SampleItem: {
-            /** Data */
-            data: string;
+            /** Titulo */
+            titulo: string;
             /** Orgao */
             orgao: string;
             /** Orgao Cnpj */
             orgao_cnpj?: string | null;
-            /** Titulo */
-            titulo: string;
-            /** Uf */
-            uf: string;
             /** Valor */
             valor?: number | null;
+            /** Uf */
+            uf: string;
+            /** Data */
+            data: string;
         };
         /** TrendPoint */
         routes__blog_stats__TrendPoint: {
-            /** Avg Value */
-            avg_value: number;
-            /** Count */
-            count: number;
             /** Period */
             period: string;
+            /** Count */
+            count: number;
+            /** Avg Value */
+            avg_value: number;
         };
         /** MonthlyTrend */
         routes__contratos_publicos__MonthlyTrend: {
-            /** Count */
-            count: number;
             /** Month */
             month: string;
+            /** Count */
+            count: number;
             /** Value */
             value: number;
         };
         /** SampleContract */
         routes__contratos_publicos__SampleContract: {
-            /** Data Assinatura */
-            data_assinatura: string;
-            /** Fornecedor */
-            fornecedor: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
+            /** Fornecedor */
+            fornecedor: string;
             /** Valor */
             valor?: number | null;
+            /** Data Assinatura */
+            data_assinatura: string;
         };
         /** TrendPoint */
         routes__dados_publicos__TrendPoint: {
-            /** Count */
-            count: number;
             /** Date */
             date: string;
+            /** Count */
+            count: number;
             /** Value */
             value: number;
         };
         /** LicitacaoRecente */
         routes__municipios_publicos__LicitacaoRecente: {
-            /** Data Publicacao */
-            data_publicacao: string;
-            /** Modalidade */
-            modalidade: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
             /** Valor */
             valor?: number | null;
+            /** Data Publicacao */
+            data_publicacao: string;
+            /** Modalidade */
+            modalidade: string;
         };
         /** ModalidadeCount */
         routes__observatorio__ModalidadeCount: {
@@ -13205,10 +13207,10 @@ export interface components {
             modalidade_id: number;
             /** Modalidade Name */
             modalidade_name: string;
-            /** Pct */
-            pct: number;
             /** Total */
             total: number;
+            /** Pct */
+            pct: number;
         };
         /** MonthlyTrend */
         routes__observatorio__MonthlyTrend: {
@@ -13219,36 +13221,36 @@ export interface components {
         };
         /** LicitacaoRecente */
         routes__orgao_publico__LicitacaoRecente: {
-            /** Data Publicacao */
-            data_publicacao: string;
-            /** Modalidade Nome */
-            modalidade_nome: string;
             /** Objeto Compra */
             objeto_compra: string;
-            /** Uf */
-            uf: string;
+            /** Modalidade Nome */
+            modalidade_nome: string;
             /** Valor Total Estimado */
             valor_total_estimado?: number | null;
+            /** Data Publicacao */
+            data_publicacao: string;
+            /** Uf */
+            uf: string;
         };
         /** ModalidadeCount */
         routes__orgao_publico__ModalidadeCount: {
-            /** Count */
-            count: number;
             /** Nome */
             nome: string;
+            /** Count */
+            count: number;
         };
         /** SampleItem */
         routes__sectors_public__SampleItem: {
-            /** Data */
-            data: string;
-            /** Orgao */
-            orgao: string;
             /** Titulo */
             titulo: string;
-            /** Uf */
-            uf: string;
+            /** Orgao */
+            orgao: string;
             /** Valor */
             valor?: number | null;
+            /** Uf */
+            uf: string;
+            /** Data */
+            data: string;
         };
     };
     responses: never;
@@ -13259,172 +13261,6 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    root__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RootResponse"];
-                };
-            };
-        };
-    };
-    create_one_time_checkout_api_checkout_one_time_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CheckoutRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founders_availability_api_founders_availability_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundersAvailabilityResponse"];
-                };
-            };
-        };
-    };
-    get_hall_listing_api_founders_hall_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundersHallResponse"];
-                };
-            };
-        };
-    };
-    toggle_consent_api_founders_hall_consent_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FounderConsentRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FounderConsentResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    debug_pncp_test_debug_pncp_test_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DebugPNCPResponse"];
-                };
-            };
-        };
-    };
-    health_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SystemHealthResponse"];
-                };
-            };
-        };
-    };
     health_live_health_live_get: {
         parameters: {
             query?: never;
@@ -13465,6 +13301,26 @@ export interface operations {
             };
         };
     };
+    health_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemHealthResponse"];
+                };
+            };
+        };
+    };
     sources_health_sources_health_get: {
         parameters: {
             query?: never;
@@ -13481,1366 +13337,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SourcesHealthResponse"];
-                };
-            };
-        };
-    };
-    get_filter_stats_v1_admin_admin_filter_stats_get: {
-        parameters: {
-            query?: {
-                /** @description Number of days to look back */
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_at_risk_trials_v1_admin_at_risk_trials_get: {
-        parameters: {
-            query?: {
-                page?: number;
-                limit?: number;
-                risk_category?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_all_cache_endpoint_v1_admin_cache_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_cache_metrics_endpoint_v1_admin_cache_metrics_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    inspect_cache_entry_endpoint_v1_admin_cache__params_hash__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Cache entry hash */
-                params_hash: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_cache_entry_endpoint_v1_admin_cache__params_hash__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Cache entry hash */
-                params_hash: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    recalibrate_v1_admin_calibration_recalibrate_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RecalibrateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecalibrateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    reset_circuit_breakers_v1_admin_cb_reset_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminCircuitBreakerResetResponse"];
-                };
-            };
-        };
-    };
-    clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminClearCheckpointsResponse"];
-                };
-            };
-        };
-    };
-    list_cnae_mappings_v1_admin_cnae_mapping_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by setor_id */
-                setor?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_cnae_mapping_v1_admin_cnae_mapping_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CnaeMappingCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnae_code: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnae_code: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CnaeMappingUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    patch_app_config_v1_admin_config__key__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                key: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AppConfigPatchRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AppConfigRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cron_status_v1_admin_cron_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminCronStatusResponse"];
-                };
-            };
-        };
-    };
-    list_feature_flags_v1_admin_feature_flags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeatureFlagListResponse"];
-                };
-            };
-        };
-    };
-    reload_flags_endpoint_v1_admin_feature_flags_reload_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeatureFlagReloadResponse"];
-                };
-            };
-        };
-    };
-    update_feature_flag_v1_admin_feature_flags__flag_name__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Feature flag name from the registry */
-                flag_name: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FeatureFlagUpdateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeatureFlagUpdateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    feedback_patterns_v1_admin_feedback_patterns_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by sector ID */
-                setor_id?: string | null;
-                /** @description Look-back period in days */
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeedbackPatternsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_founding_leads_v1_admin_founding_leads_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingLeadsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    pause_founding_v1_admin_founding_pause_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["FoundingPauseRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_founding_policy_v1_admin_founding_policy_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingPolicySnapshot"];
-                };
-            };
-        };
-    };
-    resume_founding_v1_admin_founding_resume_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
-                };
-            };
-        };
-    };
-    admin_llm_cost_v1_admin_llm_cost_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminLlmCostResponse"];
-                };
-            };
-        };
-    };
-    memory_snapshot_v1_admin_memory_snapshot_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MemorySnapshot"];
-                };
-            };
-        };
-    };
-    list_partners_endpoint_v1_admin_partners_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by status: active, inactive, pending */
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnersListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_partner_endpoint_v1_admin_partners_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreatePartnerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerCreateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                partner_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerReferralsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get: {
-        parameters: {
-            query?: {
-                /** @description Year (default: current) */
-                year?: number;
-                /** @description Month 1-12 (default: current) */
-                month?: number;
-            };
-            header?: never;
-            path: {
-                partner_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerRevenueResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_billing_sync_rows_v1_admin_plans_billing_sync_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BillingSyncListResponse"];
-                };
-            };
-        };
-    };
-    reconcile_now_v1_admin_plans_reconcile_now_post: {
-        parameters: {
-            query?: {
-                dry_run?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReconcileNowResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReconciliationRunsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plan_billing_period_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReverseSyncRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReverseSyncResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_reconciliation_history_v1_admin_reconciliation_history_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    trigger_reconciliation_v1_admin_reconciliation_trigger_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    admin_revalidate_seo_v1_admin_revalidate_seo_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RevalidateSEORequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RevalidateSEOResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_schema_contract_status_v1_admin_schema_contract_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminSchemaContractStatusResponse"];
-                };
-            };
-        };
-    };
-    get_search_trace_v1_admin_search_trace__search_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminSearchTraceResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_seo_metrics_v1_admin_seo_metrics_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SEOMetricsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_gsc_summary_v1_admin_seo_summary_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GSCSummaryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapCacheRefreshResponse"];
-                };
-            };
-        };
-    };
-    get_slo_dashboard_v1_admin_slo_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SloDashboardResponse"];
-                };
-            };
-        };
-    };
-    get_slo_alerts_v1_admin_slo_alerts_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SloAlertsResponse"];
-                };
-            };
-        };
-    };
-    get_support_sla_v1_admin_support_sla_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get: {
-        parameters: {
-            query?: {
-                range_days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SurveyAggregateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    preview_trial_emails_v1_admin_trial_emails_preview_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    test_send_trial_email_v1_admin_trial_emails_test_send_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_exit_surveys_admin_v1_admin_trial_exit_surveys_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrialExitSurveysResponse"];
-                };
-            };
-        };
-    };
-    get_trial_metrics_v1_admin_trial_metrics_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    trigger_bids_backfill_v1_admin_trigger_bids_backfill_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
-                };
-            };
-        };
-    };
-    trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
                 };
             };
         };
@@ -14979,6 +13475,38 @@ export interface operations {
             };
         };
     };
+    reset_user_password_v1_admin_users__user_id__reset_password_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID to reset password for */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminResetPasswordResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     assign_plan_v1_admin_users__user_id__assign_plan_post: {
         parameters: {
             query: {
@@ -15050,449 +13578,11 @@ export interface operations {
             };
         };
     };
-    reset_user_password_v1_admin_users__user_id__reset_password_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description User UUID to reset password for */
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminResetPasswordResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_alertas_v1_alertas__setor_id__uf__uf__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertasResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_alerts_v1_alerts_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertListResponse"];
-                };
-            };
-        };
-    };
-    create_alert_v1_alerts_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateAlertRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_alert_v1_alerts__alert_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SuccessMessageResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_alert_v1_alerts__alert_id__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateAlertRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    alert_history_v1_alerts__alert_id__history_get: {
+    get_filter_stats_v1_admin_admin_filter_stats_get: {
         parameters: {
             query?: {
-                /** @description Items per page */
-                limit?: number;
-                /** @description Offset for pagination */
-                offset?: number;
-            };
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    preview_alert_v1_alerts__alert_id__preview_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertPreviewResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get: {
-        parameters: {
-            query: {
-                /** @description HMAC verification token */
-                token: string;
-            };
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/html": string;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_new_opportunities_v1_analytics_new_opportunities_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NewOpportunitiesResponse"];
-                };
-            };
-        };
-    };
-    get_searches_over_time_v1_analytics_searches_over_time_get: {
-        parameters: {
-            query?: {
-                period?: string;
-                range_days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchesOverTimeResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_analytics_summary_v1_analytics_summary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SummaryResponse"];
-                };
-            };
-        };
-    };
-    get_top_dimensions_v1_analytics_top_dimensions_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopDimensionsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    track_cta_event_v1_analytics_track_cta_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CTAEventRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_trial_value_v1_analytics_trial_value_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrialValueResponse"];
-                };
-            };
-        };
-    };
-    google_oauth_initiate_v1_api_auth_google_get: {
-        parameters: {
-            query?: {
-                /** @description Page to return to after auth */
-                redirect?: string;
+                /** @description Number of days to look back */
+                days?: number;
             };
             header?: never;
             path?: never;
@@ -15520,7 +13610,7 @@ export interface operations {
             };
         };
     };
-    google_oauth_revoke_v1_api_auth_google_delete: {
+    get_cache_metrics_endpoint_v1_admin_cache_metrics_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -15535,20 +13625,99 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RevokeResponse"];
+                    "application/json": unknown;
                 };
             };
         };
     };
-    google_oauth_callback_v1_api_auth_google_callback_get: {
+    inspect_cache_entry_endpoint_v1_admin_cache__params_hash__get: {
         parameters: {
-            query: {
-                /** @description Authorization code from Google */
-                code?: string | null;
-                /** @description CSRF state token */
-                state: string;
-                /** @description OAuth error (if any) */
-                error?: string | null;
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Cache entry hash */
+                params_hash: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_cache_entry_endpoint_v1_admin_cache__params_hash__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Cache entry hash */
+                params_hash: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_all_cache_endpoint_v1_admin_cache_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_reconciliation_history_v1_admin_reconciliation_history_get: {
+        parameters: {
+            query?: {
+                limit?: number;
             };
             header?: never;
             path?: never;
@@ -15576,18 +13745,14 @@ export interface operations {
             };
         };
     };
-    export_to_google_sheets_v1_api_export_google_sheets_post: {
+    trigger_reconciliation_v1_admin_reconciliation_trigger_post: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GoogleSheetsExportRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -15595,24 +13760,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GoogleSheetsExportResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": unknown;
                 };
             };
         };
     };
-    get_export_history_v1_api_export_google_sheets_history_get: {
+    get_support_sla_v1_admin_support_sla_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_trial_metrics_v1_admin_trial_metrics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_at_risk_trials_v1_admin_at_risk_trials_get: {
         parameters: {
             query?: {
+                page?: number;
                 limit?: number;
+                risk_category?: string | null;
             };
             header?: never;
             path?: never;
@@ -15626,7 +13824,199 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GoogleSheetsExportHistoryResponse"];
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    memory_snapshot_v1_admin_memory_snapshot_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MemorySnapshot"];
+                };
+            };
+        };
+    };
+    get_user_segments_v1_admin_users_segments_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSegmentsResponse"];
+                };
+            };
+        };
+    };
+    update_billing_period_v1_api_subscriptions_update_billing_period_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateBillingPeriodRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateBillingPeriodResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_subscription_v1_api_subscriptions_cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CancelSubscriptionRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelSubscriptionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CancelFeedbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelFeedbackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpgradeToLifetimePreviewResponse"];
+                };
+            };
+        };
+    };
+    upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpgradeToLifetimeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpgradeToLifetimeResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15847,7 +14237,7 @@ export interface operations {
             };
         };
     };
-    get_plans_with_capabilities_v1_api_plans_get: {
+    get_analytics_summary_v1_analytics_summary_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -15862,23 +14252,22 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PlansResponse"];
+                    "application/json": components["schemas"]["SummaryResponse"];
                 };
             };
         };
     };
-    cancel_subscription_v1_api_subscriptions_cancel_post: {
+    get_searches_over_time_v1_analytics_searches_over_time_get: {
         parameters: {
-            query?: never;
+            query?: {
+                period?: string;
+                range_days?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["CancelSubscriptionRequest"] | null;
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -15886,7 +14275,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CancelSubscriptionResponse"];
+                    "application/json": components["schemas"]["SearchesOverTimeResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15900,18 +14289,16 @@ export interface operations {
             };
         };
     };
-    submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post: {
+    get_top_dimensions_v1_analytics_top_dimensions_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CancelFeedbackRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -15919,7 +14306,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CancelFeedbackResponse"];
+                    "application/json": components["schemas"]["TopDimensionsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15933,73 +14320,7 @@ export interface operations {
             };
         };
     };
-    update_billing_period_v1_api_subscriptions_update_billing_period_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateBillingPeriodRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UpdateBillingPeriodResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpgradeToLifetimeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UpgradeToLifetimeResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get: {
+    get_trial_value_v1_analytics_trial_value_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -16014,15 +14335,123 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UpgradeToLifetimePreviewResponse"];
+                    "application/json": components["schemas"]["TrialValueResponse"];
                 };
             };
         };
     };
-    check_email_v1_auth_check_email_get: {
+    get_new_opportunities_v1_analytics_new_opportunities_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NewOpportunitiesResponse"];
+                };
+            };
+        };
+    };
+    track_cta_event_v1_analytics_track_cta_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CTAEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    google_oauth_initiate_v1_api_auth_google_get: {
+        parameters: {
+            query?: {
+                /** @description Page to return to after auth */
+                redirect?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    google_oauth_revoke_v1_api_auth_google_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RevokeResponse"];
+                };
+            };
+        };
+    };
+    google_oauth_callback_v1_api_auth_google_callback_get: {
         parameters: {
             query: {
-                email: string;
+                /** @description Authorization code from Google */
+                code?: string | null;
+                /** @description CSRF state token */
+                state: string;
+                /** @description OAuth error (if any) */
+                error?: string | null;
             };
             header?: never;
             path?: never;
@@ -16036,7 +14465,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CheckEmailResponse"];
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -16050,39 +14479,7 @@ export interface operations {
             };
         };
     };
-    check_phone_v1_auth_check_phone_get: {
-        parameters: {
-            query: {
-                phone: string;
-                company?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CheckPhoneResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    record_login_attempt_v1_auth_login_attempt_post: {
+    export_to_google_sheets_v1_api_export_google_sheets_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -16091,7 +14488,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["LoginAttemptRequest"];
+                "application/json": components["schemas"]["GoogleSheetsExportRequest"];
             };
         };
         responses: {
@@ -16101,7 +14498,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LoginAttemptResponse"];
+                    "application/json": components["schemas"]["GoogleSheetsExportResponse"];
                 };
             };
             /** @description Validation Error */
@@ -16115,77 +14512,10 @@ export interface operations {
             };
         };
     };
-    resend_confirmation_v1_auth_resend_confirmation_post: {
+    get_export_history_v1_api_export_google_sheets_history_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ResendRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResendResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    signup_v1_auth_signup_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SignupRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SignupResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    auth_status_v1_auth_status_get: {
-        parameters: {
-            query: {
-                /** @description Email to check */
-                email: string;
+            query?: {
+                limit?: number;
             };
             header?: never;
             path?: never;
@@ -16199,534 +14529,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AuthStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    validate_signup_email_v1_auth_validate_signup_email_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ResendRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidateSignupEmailResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    analyze_bid_v1_bid_analysis__bid_id__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                bid_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DeepAnalysisRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeepBidAnalysis"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_billing_portal_session_v1_billing_portal_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BillingPortalResponse"];
-                };
-            };
-        };
-    };
-    create_setup_intent_v1_billing_setup_intent_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SetupIntentResponse"];
-                };
-            };
-        };
-    };
-    daily_digest_latest_v1_blog_daily_latest_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DailyDigestResponse"];
-                };
-            };
-        };
-    };
-    daily_digest_by_date_v1_blog_daily__date__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                date: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DailyDigestResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cidade_stats_v1_blog_stats_cidade__cidade__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cidade: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CidadeStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cidade_sector_stats_v1_blog_stats_cidade__cidade__setor__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cidade: string;
-                setor_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CidadeSectorStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cidade: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosCidadeStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cidade: string;
-                setor_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosCidadeSetorStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_contratos_setor_stats_v1_blog_stats_contratos__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosSetorStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_contratos_setor_uf_stats_v1_blog_stats_contratos__setor_id__uf__uf__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosSetorUfStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_panorama_stats_v1_blog_stats_panorama__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PanoramaStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_sector_blog_stats_v1_blog_stats_setor__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SectorBlogStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SectorUfStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    weekly_digest_latest_v1_blog_weekly_latest_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WeeklyDigestResponse"];
-                };
-            };
-        };
-    };
-    weekly_digest_by_week_v1_blog_weekly__year___week__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                year: number;
-                week: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WeeklyDigestResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    buscar_licitacoes_v1_buscar_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BuscaRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BuscaResponse"];
+                    "application/json": components["schemas"]["GoogleSheetsExportHistoryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -16758,2714 +14561,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_search_results_v1_buscar_results__search_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchResultsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    calculadora_dados_v1_calculadora_dados_get: {
-        parameters: {
-            query: {
-                /** @description Sector ID (e.g. 'saude') */
-                setor: string;
-                /** @description UF sigla (e.g. 'SP') */
-                uf: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CalculadoraDadosResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    change_password_v1_change_password_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SuccessResponse"];
-                };
-            };
-        };
-    };
-    create_checkout_v1_checkout_post: {
-        parameters: {
-            query: {
-                plan_id: string;
-                billing_period?: string;
-                coupon?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_bids_by_ids_v1_comparador_bids_get: {
-        parameters: {
-            query: {
-                /** @description Comma-separated pncp_ids (max 5) */
-                ids: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ComparadorBidsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    buscar_editais_v1_comparador_buscar_get: {
-        parameters: {
-            query: {
-                /** @description Termo de busca (mínimo 3 caracteres) */
-                q: string;
-                /** @description Filtrar por UF (ex: SP, RJ) */
-                uf?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ComparadorSearchResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    compliance_profile_v1_compliance__cnpj__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ComplianceProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_trial_info_v1_conta_cancelar_trial_get: {
-        parameters: {
-            query: {
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelTrialInfoResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_trial_execute_v1_conta_cancelar_trial_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CancelTrialRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelTrialResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrgaoContratosStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    contratos_stats_v1_contratos__setor___uf__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    dados_agregados_v1_dados_agregados_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DadosAgregadosResponse"];
-                };
-            };
-        };
-    };
-    send_welcome_email_v1_emails_send_welcome_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WelcomeEmailResponse"];
-                };
-            };
-        };
-    };
-    unsubscribe_email_v1_emails_unsubscribe_get: {
-        parameters: {
-            query: {
-                /** @description User ID */
-                user_id: string;
-                /** @description Verification token */
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/html": string;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    perfil_b2g_v1_empresa__cnpj__perfil_b2g_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PerfilB2GResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    export_edital_pdf_v1_export_pdf_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PdfEditalRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_public_feature_flags_v1_feature_flags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PublicFeatureFlagListResponse"];
-                };
-            };
-        };
-    };
-    get_experiments_v1_feature_flags_experiments_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExperimentsListResponse"];
-                };
-            };
-        };
-    };
-    submit_feedback_v1_feedback_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FeedbackRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeedbackResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_feedback_v1_feedback__feedback_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                feedback_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeedbackDeleteResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    first_analysis_v1_first_analysis_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FirstAnalysisRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FirstAnalysisResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    fornecedor_profile_v1_fornecedores__cnpj__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FornecedorProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    fornecedores_stats_v1_fornecedores__setor___uf__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FornecedoresStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founding_availability_v1_founding_availability_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingAvailabilityResponse"];
-                };
-            };
-        };
-    };
-    founding_checkout_v1_founding_checkout_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FoundingCheckoutRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingCheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founding_checkout_status_v1_founding_checkout_status_get: {
-        parameters: {
-            query: {
-                session_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingCheckoutStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founding_session_status_v1_founding_session_status_get: {
-        parameters: {
-            query: {
-                session_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingSessionStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    system_health_v1_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SystemHealthResponse"];
-                };
-            };
-        };
-    };
-    cache_health_v1_health_cache_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CacheHealthResponse"];
-                };
-            };
-        };
-    };
-    sitemap_health_v1_health_sitemap_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapHealthResponse"];
-                };
-            };
-        };
-    };
-    sources_health_v1_health_sources_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SourcesHealthMapResponse"];
-                };
-            };
-        };
-    };
-    background_tasks_health_v1_health_tasks_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BackgroundTasksHealthResponse"];
-                };
-            };
-        };
-    };
-    get_ranking_v1_indice_municipal_get: {
-        parameters: {
-            query?: {
-                /** @description Período trimestral (ex: 2026-Q1) */
-                periodo?: string;
-                /** @description Filtrar por UF */
-                uf?: string | null;
-                limit?: number;
-                offset?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RankingResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_periodos_v1_indice_municipal_periodos_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PeriodosResponse"];
-                };
-            };
-        };
-    };
-    get_municipio_v1_indice_municipal__municipio_slug__get: {
-        parameters: {
-            query?: {
-                /** @description Período trimestral (ex: 2026-Q1) */
-                periodo?: string;
-            };
-            header?: never;
-            path: {
-                municipio_slug: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IndiceResult"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_intel_report_purchases_v1_intel_reports__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IntelReportPurchase"][];
-                };
-            };
-        };
-    };
-    create_intel_report_checkout_v1_intel_reports_checkout_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IntelReportCheckoutRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IntelReportCheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_intel_report_status_v1_intel_reports__purchase_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                purchase_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IntelReportStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    download_intel_report_v1_intel_reports__purchase_id__download_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                purchase_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    item_profile_v1_itens__catmat__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                catmat: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ItemProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    capture_lead_v1_lead_capture_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LeadCaptureRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LeadCaptureResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_lead_magnet_v1_lead_magnet__magnet_type__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                magnet_type: "guia-pratico" | "checklist-5-sinais";
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                    "application/pdf": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_profile_v1_me_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UserProfileResponse"];
-                };
-            };
-        };
-    };
-    delete_account_v1_me_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeleteAccountResponse"];
-                };
-            };
-        };
-    };
-    export_user_data_v1_me_export_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_daily_volume_v1_metrics_daily_volume_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DailyVolumeResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_discard_rate_v1_metrics_discard_rate_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DiscardRateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    report_sse_fallback_v1_metrics_sse_fallback_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    enroll_totp_v1_mfa_enroll_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MFAEnrollResponse"];
-                };
-            };
-        };
-    };
-    generate_recovery_codes_v1_mfa_recovery_codes_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecoveryCodesResponse"];
-                };
-            };
-        };
-    };
-    regenerate_recovery_codes_v1_mfa_regenerate_recovery_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RegenerateRecoveryResponse"];
-                };
-            };
-        };
-    };
-    get_mfa_status_v1_mfa_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MfaStatusResponse"];
-                };
-            };
-        };
-    };
-    verify_recovery_code_v1_mfa_verify_recovery_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["VerifyRecoveryRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VerifyRecoveryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    verify_totp_v1_mfa_verify_totp_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MFAVerifyRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MFAVerifyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    municipio_profile_v1_municipios__slug__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                slug: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MunicipioProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    record_network_event_v1_network_events_record_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RecordEventRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecordEventResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_top_network_events_v1_network_events_top_get: {
-        parameters: {
-            query: {
-                /** @description Tipo de evento para filtrar */
-                evento_tipo: string;
-                /** @description Dimensao para agregar */
-                dimensao_tipo?: string;
-                /** @description Janela em dias */
-                dias?: number;
-                /** @description Maximo de resultados */
-                limite?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_new_bids_count_v1_notifications_new_bids_count_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NewBidsCountResponse"];
-                };
-            };
-        };
-    };
-    clear_new_bids_count_v1_notifications_new_bids_count_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ClearNewBidsCountResponse"];
-                };
-            };
-        };
-    };
-    get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Mês (1-12) */
-                mes: number;
-                /** @description Ano */
-                ano: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RelatorioMensal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                mes: number;
-                ano: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    track_tour_event_v1_onboarding_tour_event_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TourEventRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_org_v1_organizations_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateOrgRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_my_org_v1_organizations_me_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationMembershipResponse"];
-                };
-            };
-        };
-    };
-    get_org_v1_organizations__org_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    accept_org_invite_v1_organizations__org_id__accept_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationAcceptResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_org_dashboard_endpoint_v1_organizations__org_id__dashboard_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationDashboardResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invite_org_member_v1_organizations__org_id__invite_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InviteMemberRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationInviteResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    upload_org_logo_v1_organizations__org_id__logo_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateLogoRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationLogoUpdatedResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    remove_org_member_v1_organizations__org_id__members__target_user_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-                target_user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationMemberRemovedResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    orgao_stats_v1_orgao__cnpj__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrgaoStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    partner_dashboard_v1_partner_dashboard_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerDashboardResponse"];
-                };
-            };
-        };
-    };
-    list_pipeline_items_v1_pipeline_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by stage */
-                stage?: string | null;
-                /** @description Items per page */
-                limit?: number;
-                /** @description Offset for pagination */
-                offset?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_pipeline_item_v1_pipeline_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PipelineItemCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineItemResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_pipeline_alerts_v1_pipeline_alerts_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineAlertsResponse"];
-                };
-            };
-        };
-    };
-    delete_pipeline_item_v1_pipeline__item_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                item_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SuccessMessageResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_pipeline_item_v1_pipeline__item_id__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                item_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PipelineItemUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineItemResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_plans_v1_plans_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BillingPlansResponse"];
-                };
-            };
-        };
-    };
-    get_seasonal_calendar_v1_predict_seasonal_calendar_get: {
-        parameters: {
-            query: {
-                /** @description UF (ex: SP, RJ, SC) */
-                uf: string;
-                /** @description Optional filter by sector slugs (e.g. engenharia, saude) */
-                setores?: string[] | null;
-                /** @description Number of historical years to analyze (1-20) */
-                anos_historico?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SeasonalCalendarResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_products_v1_products_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProductsResponse"];
-                };
-            };
-        };
-    };
-    get_alert_preferences_v1_profile_alert_preferences_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertPreferencesResponse"];
-                };
-            };
-        };
-    };
-    update_alert_preferences_v1_profile_alert_preferences_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AlertPreferencesRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertPreferencesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_profile_completeness_v1_profile_completeness_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProfileCompletenessResponse"];
-                };
-            };
-        };
-    };
-    get_profile_context_v1_profile_context_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PerfilContextoResponse"];
-                };
-            };
-        };
-    };
-    save_profile_context_v1_profile_context_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PerfilContexto"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PerfilContextoResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_recent_editais_v1_pseo_recent_editais_get: {
-        parameters: {
-            query: {
-                setor: string;
-                uf?: string | null;
-                municipio?: string | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecentEditaisResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_top_suppliers_v1_pseo_top_suppliers_get: {
-        parameters: {
-            query: {
-                setor: string;
-                uf?: string | null;
-                municipio?: string | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopSuppliersResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_referral_code_v1_referral_code_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReferralCodeResponse"];
-                };
-            };
-        };
-    };
-    redeem_referral_v1_referral_redeem_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReferralRedeemRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReferralRedeemResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_referral_stats_v1_referral_stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReferralStatsResponse"];
-                };
-            };
-        };
-    };
-    request_relatorio_v1_relatorio_2026_t1_request_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RelatorioRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RelatorioResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_diagnostico_v1_reports_diagnostico_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DiagnosticoRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_search_v1_search__search_id__cancel_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchActionResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_search_results_v1_v1_search__search_id__results_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    retry_search_v1_search__search_id__retry_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchActionResponse"];
                 };
             };
             /** @description Validation Error */
@@ -19541,6 +14636,68 @@ export interface operations {
             };
         };
     };
+    get_search_results_v1_buscar_results__search_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchResultsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_search_results_v1_v1_search__search_id__results_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_zero_match_results_endpoint_v1_search__search_id__zero_match_get: {
         parameters: {
             query?: never;
@@ -19559,6 +14716,2297 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SearchZeroMatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    retry_search_v1_search__search_id__retry_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchActionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_search_v1_search__search_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchActionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    buscar_licitacoes_v1_buscar_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BuscaRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuscaResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    change_password_v1_change_password_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessResponse"];
+                };
+            };
+        };
+    };
+    get_profile_v1_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfileResponse"];
+                };
+            };
+        };
+    };
+    delete_account_v1_me_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteAccountResponse"];
+                };
+            };
+        };
+    };
+    get_trial_status_v1_trial_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrialStatusResponse"];
+                };
+            };
+        };
+    };
+    get_recommended_plan_v1_user_recommended_plan_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecommendedPlanResponse"];
+                };
+            };
+        };
+    };
+    get_profile_context_v1_profile_context_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerfilContextoResponse"];
+                };
+            };
+        };
+    };
+    save_profile_context_v1_profile_context_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PerfilContexto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerfilContextoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_completeness_v1_profile_completeness_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileCompletenessResponse"];
+                };
+            };
+        };
+    };
+    get_alert_preferences_v1_profile_alert_preferences_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertPreferencesResponse"];
+                };
+            };
+        };
+    };
+    update_alert_preferences_v1_profile_alert_preferences_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AlertPreferencesRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertPreferencesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_user_data_v1_me_export_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    submit_exit_survey_v1_trial_exit_survey_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExitSurveyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExitSurveyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_exit_surveys_admin_v1_admin_trial_exit_surveys_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrialExitSurveysResponse"];
+                };
+            };
+        };
+    };
+    get_plans_v1_plans_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingPlansResponse"];
+                };
+            };
+        };
+    };
+    create_checkout_v1_checkout_post: {
+        parameters: {
+            query: {
+                plan_id: string;
+                billing_period?: string;
+                coupon?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_billing_portal_session_v1_billing_portal_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingPortalResponse"];
+                };
+            };
+        };
+    };
+    get_subscription_status_v1_subscription_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionStatusResponse"];
+                };
+            };
+        };
+    };
+    create_setup_intent_v1_billing_setup_intent_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetupIntentResponse"];
+                };
+            };
+        };
+    };
+    get_sessions_v1_sessions_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                /** @description Filter by session status (completed, failed, timed_out) */
+                status?: string | null;
+                /** @description UX-433 AC3: hide failed/timed_out entries older than 7 days from default listing */
+                hide_old_failures?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_session_excel_v1_sessions__search_id__download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_plans_with_capabilities_v1_api_plans_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlansResponse"];
+                };
+            };
+        };
+    };
+    send_welcome_email_v1_emails_send_welcome_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WelcomeEmailResponse"];
+                };
+            };
+        };
+    };
+    unsubscribe_email_v1_emails_unsubscribe_get: {
+        parameters: {
+            query: {
+                /** @description User ID */
+                user_id: string;
+                /** @description Verification token */
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_pipeline_items_v1_pipeline_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by stage */
+                stage?: string | null;
+                /** @description Items per page */
+                limit?: number;
+                /** @description Offset for pagination */
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_pipeline_item_v1_pipeline_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PipelineItemCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineItemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_pipeline_item_v1_pipeline__item_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_pipeline_item_v1_pipeline__item_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PipelineItemUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineItemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_pipeline_alerts_v1_pipeline_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineAlertsResponse"];
+                };
+            };
+        };
+    };
+    first_analysis_v1_first_analysis_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FirstAnalysisRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstAnalysisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    track_tour_event_v1_onboarding_tour_event_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TourEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    validate_signup_email_v1_auth_validate_signup_email_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidateSignupEmailResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resend_confirmation_v1_auth_resend_confirmation_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResendResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    auth_status_v1_auth_status_get: {
+        parameters: {
+            query: {
+                /** @description Email to check */
+                email: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    signup_v1_auth_signup_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignupRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_login_attempt_v1_auth_login_attempt_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginAttemptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LoginAttemptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    system_health_v1_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemHealthResponse"];
+                };
+            };
+        };
+    };
+    public_status_v1_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicStatusResponse"];
+                };
+            };
+        };
+    };
+    recent_incidents_v1_status_incidents_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IncidentsResponse"];
+                };
+            };
+        };
+    };
+    uptime_history_v1_status_uptime_history_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UptimeHistoryResponse"];
+                };
+            };
+        };
+    };
+    background_tasks_health_v1_health_tasks_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackgroundTasksHealthResponse"];
+                };
+            };
+        };
+    };
+    sources_health_v1_health_sources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SourcesHealthMapResponse"];
+                };
+            };
+        };
+    };
+    cache_health_v1_health_cache_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CacheHealthResponse"];
+                };
+            };
+        };
+    };
+    sitemap_health_v1_health_sitemap_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapHealthResponse"];
+                };
+            };
+        };
+    };
+    submit_feedback_v1_feedback_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FeedbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_feedback_v1_feedback__feedback_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                feedback_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    feedback_patterns_v1_admin_feedback_patterns_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by sector ID */
+                setor_id?: string | null;
+                /** @description Look-back period in days */
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackPatternsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    check_email_v1_auth_check_email_get: {
+        parameters: {
+            query: {
+                email: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckEmailResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    check_phone_v1_auth_check_phone_get: {
+        parameters: {
+            query: {
+                phone: string;
+                company?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckPhoneResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analyze_bid_v1_bid_analysis__bid_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bid_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeepAnalysisRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeepBidAnalysis"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_alerts_v1_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertListResponse"];
+                };
+            };
+        };
+    };
+    create_alert_v1_alerts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAlertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_alert_v1_alerts__alert_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_alert_v1_alerts__alert_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateAlertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get: {
+        parameters: {
+            query: {
+                /** @description HMAC verification token */
+                token: string;
+            };
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_alert_v1_alerts__alert_id__preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertPreviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    alert_history_v1_alerts__alert_id__history_get: {
+        parameters: {
+            query?: {
+                /** @description Items per page */
+                limit?: number;
+                /** @description Offset for pagination */
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get: {
+        parameters: {
+            query: {
+                /** @description User ID */
+                user_id: string;
+                /** @description HMAC unsubscribe token */
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resend_webhook_v1_trial_emails_webhook_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "svix-id"?: string | null;
+                "svix-timestamp"?: string | null;
+                "svix-signature"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_trial_emails_v1_admin_trial_emails_preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    test_send_trial_email_v1_admin_trial_emails_test_send_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_mfa_status_v1_mfa_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MfaStatusResponse"];
+                };
+            };
+        };
+    };
+    generate_recovery_codes_v1_mfa_recovery_codes_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryCodesResponse"];
+                };
+            };
+        };
+    };
+    verify_recovery_code_v1_mfa_verify_recovery_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VerifyRecoveryRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VerifyRecoveryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enroll_totp_v1_mfa_enroll_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MFAEnrollResponse"];
+                };
+            };
+        };
+    };
+    verify_totp_v1_mfa_verify_totp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MFAVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MFAVerifyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    regenerate_recovery_codes_v1_mfa_regenerate_recovery_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegenerateRecoveryResponse"];
+                };
+            };
+        };
+    };
+    get_my_org_v1_organizations_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationMembershipResponse"];
+                };
+            };
+        };
+    };
+    create_org_v1_organizations_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateOrgRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_org_v1_organizations__org_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    invite_org_member_v1_organizations__org_id__invite_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteMemberRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationInviteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    accept_org_invite_v1_organizations__org_id__accept_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationAcceptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_org_member_v1_organizations__org_id__members__target_user_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+                target_user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationMemberRemovedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_org_dashboard_endpoint_v1_organizations__org_id__dashboard_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationDashboardResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_org_logo_v1_organizations__org_id__logo_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateLogoRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationLogoUpdatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    partner_dashboard_v1_partner_dashboard_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerDashboardResponse"];
+                };
+            };
+        };
+    };
+    list_partners_endpoint_v1_admin_partners_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by status: active, inactive, pending */
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnersListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_partner_endpoint_v1_admin_partners_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePartnerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerCreateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                partner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerReferralsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get: {
+        parameters: {
+            query?: {
+                /** @description Year (default: current) */
+                year?: number;
+                /** @description Month 1-12 (default: current) */
+                month?: number;
+            };
+            header?: never;
+            path: {
+                partner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerRevenueResponse"];
                 };
             };
             /** @description Validation Error */
@@ -19643,7 +17091,7 @@ export interface operations {
             };
         };
     };
-    save_segment_v1_segment_save_post: {
+    generate_diagnostico_v1_reports_diagnostico_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -19652,96 +17100,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SaveSegmentRequest"];
+                "application/json": components["schemas"]["DiagnosticoRequest"];
             };
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SaveSegmentResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_coverage_manifest_v1_seo_coverage_manifest_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CoverageManifestResponse"];
-                };
-            };
-        };
-    };
-    get_sessions_v1_sessions_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                /** @description Filter by session status (completed, failed, timed_out) */
-                status?: string | null;
-                /** @description UX-433 AC3: hide failed/timed_out entries older than 7 days from default listing */
-                hide_old_failures?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SessionsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    download_session_excel_v1_sessions__search_id__download_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -19763,7 +17124,370 @@ export interface operations {
             };
         };
     };
-    listar_setores_v1_setores_get: {
+    get_sector_blog_stats_v1_blog_stats_setor__setor_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorBlogStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorUfStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cidade_stats_v1_blog_stats_cidade__cidade__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cidade: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CidadeStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cidade_sector_stats_v1_blog_stats_cidade__cidade__setor__setor_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cidade: string;
+                setor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CidadeSectorStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_panorama_stats_v1_blog_stats_panorama__setor_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PanoramaStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_contratos_setor_stats_v1_blog_stats_contratos__setor_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosSetorStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_contratos_setor_uf_stats_v1_blog_stats_contratos__setor_id__uf__uf__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosSetorUfStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cidade: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosCidadeStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cidade: string;
+                setor_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosCidadeSetorStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_discard_rate_v1_metrics_discard_rate_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiscardRateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_daily_volume_v1_metrics_daily_volume_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DailyVolumeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    report_sse_fallback_v1_metrics_sse_fallback_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_feature_flags_v1_admin_feature_flags_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -19778,7 +17502,168 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SetoresResponse"];
+                    "application/json": components["schemas"]["FeatureFlagListResponse"];
+                };
+            };
+        };
+    };
+    update_feature_flag_v1_admin_feature_flags__flag_name__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Feature flag name from the registry */
+                flag_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FeatureFlagUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeatureFlagUpdateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reload_flags_endpoint_v1_admin_feature_flags_reload_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeatureFlagReloadResponse"];
+                };
+            };
+        };
+    };
+    get_experiments_v1_feature_flags_experiments_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExperimentsListResponse"];
+                };
+            };
+        };
+    };
+    list_public_feature_flags_v1_feature_flags_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicFeatureFlagListResponse"];
+                };
+            };
+        };
+    };
+    calculadora_dados_v1_calculadora_dados_get: {
+        parameters: {
+            query: {
+                /** @description Sector ID (e.g. 'saude') */
+                setor: string;
+                /** @description UF sigla (e.g. 'SP') */
+                uf: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CalculadoraDadosResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    perfil_b2g_v1_empresa__cnpj__perfil_b2g_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerfilB2GResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -19847,7 +17732,7 @@ export interface operations {
             };
         };
     };
-    sitemap_cnpjs_v1_sitemap_cnpjs_get: {
+    get_referral_code_v1_referral_code_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -19862,12 +17747,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SitemapCnpjsResponse"];
+                    "application/json": components["schemas"]["ReferralCodeResponse"];
                 };
             };
         };
     };
-    sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get: {
+    get_referral_stats_v1_referral_stats_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -19882,244 +17767,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SitemapContratosOrgaoResponse"];
+                    "application/json": components["schemas"]["ReferralStatsResponse"];
                 };
             };
         };
     };
-    sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapFornecedoresCnpjResponse"];
-                };
-            };
-        };
-    };
-    sitemap_itens_v1_sitemap_itens_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapItensResponse"];
-                };
-            };
-        };
-    };
-    sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapLicitacoesDoDiaResponse"];
-                };
-            };
-        };
-    };
-    get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LicitacoesIndexableResponse"];
-                };
-            };
-        };
-    };
-    sitemap_municipios_v1_sitemap_municipios_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapMunicipiosResponse"];
-                };
-            };
-        };
-    };
-    sitemap_orgaos_v1_sitemap_orgaos_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapOrgaosResponse"];
-                };
-            };
-        };
-    };
-    stats_public_v1_stats_public_get: {
-        parameters: {
-            query?: {
-                /** @description json | embed | badge */
-                format?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    public_status_v1_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PublicStatusResponse"];
-                };
-            };
-        };
-    };
-    recent_incidents_v1_status_incidents_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IncidentsResponse"];
-                };
-            };
-        };
-    };
-    uptime_history_v1_status_uptime_history_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UptimeHistoryResponse"];
-                };
-            };
-        };
-    };
-    get_subscription_status_v1_subscription_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SubscriptionStatusResponse"];
-                };
-            };
-        };
-    };
-    submit_export_time_saved_survey_v1_survey_export_time_saved_post: {
+    redeem_referral_v1_referral_redeem_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -20128,17 +17781,17 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ExportTimeSavedSurveyRequest"];
+                "application/json": components["schemas"]["ReferralRedeemRequest"];
             };
         };
         responses: {
             /** @description Successful Response */
-            201: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ExportTimeSavedSurveyResponse"];
+                    "application/json": components["schemas"]["ReferralRedeemResponse"];
                 };
             };
             /** @description Validation Error */
@@ -20152,94 +17805,7 @@ export interface operations {
             };
         };
     };
-    unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get: {
-        parameters: {
-            query: {
-                /** @description User ID */
-                user_id: string;
-                /** @description HMAC unsubscribe token */
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    resend_webhook_v1_trial_emails_webhook_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "svix-id"?: string | null;
-                "svix-timestamp"?: string | null;
-                "svix-signature"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_trial_status_v1_trial_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrialStatusResponse"];
-                };
-            };
-        };
-    };
-    submit_exit_survey_v1_trial_exit_survey_post: {
+    request_relatorio_v1_relatorio_2026_t1_request_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -20248,17 +17814,17 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ExitSurveyRequest"];
+                "application/json": components["schemas"]["RelatorioRequest"];
             };
         };
         responses: {
             /** @description Successful Response */
-            201: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ExitSurveyResponse"];
+                    "application/json": components["schemas"]["RelatorioResponse"];
                 };
             };
             /** @description Validation Error */
@@ -20325,7 +17891,7 @@ export interface operations {
             };
         };
     };
-    get_recommended_plan_v1_user_recommended_plan_get: {
+    weekly_digest_latest_v1_blog_weekly_latest_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -20340,7 +17906,2370 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RecommendedPlanResponse"];
+                    "application/json": components["schemas"]["WeeklyDigestResponse"];
+                };
+            };
+        };
+    };
+    weekly_digest_by_week_v1_blog_weekly__year___week__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                year: number;
+                week: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WeeklyDigestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stats_public_v1_stats_public_get: {
+        parameters: {
+            query?: {
+                /** @description json | embed | badge */
+                format?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dados_agregados_v1_dados_agregados_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DadosAgregadosResponse"];
+                };
+            };
+        };
+    };
+    get_alertas_v1_alertas__setor_id__uf__uf__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertasResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    capture_lead_v1_lead_capture_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LeadCaptureRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LeadCaptureResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_lead_magnet_v1_lead_magnet__magnet_type__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                magnet_type: "guia-pratico" | "checklist-5-sinais";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "application/pdf": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    buscar_editais_v1_comparador_buscar_get: {
+        parameters: {
+            query: {
+                /** @description Termo de busca (mínimo 3 caracteres) */
+                q: string;
+                /** @description Filtrar por UF (ex: SP, RJ) */
+                uf?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComparadorSearchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_bids_by_ids_v1_comparador_bids_get: {
+        parameters: {
+            query: {
+                /** @description Comma-separated pncp_ids (max 5) */
+                ids: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComparadorBidsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_seo_metrics_v1_admin_seo_metrics_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SEOMetricsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gsc_summary_v1_admin_seo_summary_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GSCSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    admin_revalidate_seo_v1_admin_revalidate_seo_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RevalidateSEORequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RevalidateSEOResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sitemap_cnpjs_v1_sitemap_cnpjs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapCnpjsResponse"];
+                };
+            };
+        };
+    };
+    sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapFornecedoresCnpjResponse"];
+                };
+            };
+        };
+    };
+    sitemap_orgaos_v1_sitemap_orgaos_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapOrgaosResponse"];
+                };
+            };
+        };
+    };
+    sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapContratosOrgaoResponse"];
+                };
+            };
+        };
+    };
+    orgao_stats_v1_orgao__cnpj__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgaoStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgaoContratosStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    contratos_stats_v1_contratos__setor___uf__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fornecedores_stats_v1_fornecedores__setor___uf__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FornecedoresStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fornecedor_profile_v1_fornecedores__cnpj__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FornecedorProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    daily_digest_latest_v1_blog_daily_latest_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DailyDigestResponse"];
+                };
+            };
+        };
+    };
+    daily_digest_by_date_v1_blog_daily__date__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                date: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DailyDigestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    municipio_profile_v1_municipios__slug__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MunicipioProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sitemap_municipios_v1_sitemap_municipios_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapMunicipiosResponse"];
+                };
+            };
+        };
+    };
+    compliance_profile_v1_compliance__cnpj__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComplianceProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    item_profile_v1_itens__catmat__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                catmat: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ItemProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sitemap_itens_v1_sitemap_itens_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapItensResponse"];
+                };
+            };
+        };
+    };
+    get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Mês (1-12) */
+                mes: number;
+                /** @description Ano */
+                ano: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RelatorioMensal"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                mes: number;
+                ano: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LicitacoesIndexableResponse"];
+                };
+            };
+        };
+    };
+    refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapCacheRefreshResponse"];
+                };
+            };
+        };
+    };
+    sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapLicitacoesDoDiaResponse"];
+                };
+            };
+        };
+    };
+    get_periodos_v1_indice_municipal_periodos_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PeriodosResponse"];
+                };
+            };
+        };
+    };
+    get_ranking_v1_indice_municipal_get: {
+        parameters: {
+            query?: {
+                /** @description Período trimestral (ex: 2026-Q1) */
+                periodo?: string;
+                /** @description Filtrar por UF */
+                uf?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RankingResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_municipio_v1_indice_municipal__municipio_slug__get: {
+        parameters: {
+            query?: {
+                /** @description Período trimestral (ex: 2026-Q1) */
+                periodo?: string;
+            };
+            header?: never;
+            path: {
+                municipio_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IndiceResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_new_bids_count_v1_notifications_new_bids_count_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NewBidsCountResponse"];
+                };
+            };
+        };
+    };
+    clear_new_bids_count_v1_notifications_new_bids_count_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ClearNewBidsCountResponse"];
+                };
+            };
+        };
+    };
+    export_edital_pdf_v1_export_pdf_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PdfEditalRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_availability_v1_founding_availability_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingAvailabilityResponse"];
+                };
+            };
+        };
+    };
+    founding_checkout_status_v1_founding_checkout_status_get: {
+        parameters: {
+            query: {
+                session_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingCheckoutStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_session_status_v1_founding_session_status_get: {
+        parameters: {
+            query: {
+                session_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingSessionStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_checkout_v1_founding_checkout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FoundingCheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingCheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_trial_info_v1_conta_cancelar_trial_get: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelTrialInfoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_trial_execute_v1_conta_cancelar_trial_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CancelTrialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelTrialResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    submit_export_time_saved_survey_v1_survey_export_time_saved_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExportTimeSavedSurveyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExportTimeSavedSurveyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_intel_report_checkout_v1_intel_reports_checkout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IntelReportCheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelReportCheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_intel_report_purchases_v1_intel_reports__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelReportPurchase"][];
+                };
+            };
+        };
+    };
+    get_intel_report_status_v1_intel_reports__purchase_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                purchase_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelReportStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_intel_report_v1_intel_reports__purchase_id__download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                purchase_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_top_suppliers_v1_pseo_top_suppliers_get: {
+        parameters: {
+            query: {
+                setor: string;
+                uf?: string | null;
+                municipio?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopSuppliersResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_recent_editais_v1_pseo_recent_editais_get: {
+        parameters: {
+            query: {
+                setor: string;
+                uf?: string | null;
+                municipio?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecentEditaisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_coverage_manifest_v1_seo_coverage_manifest_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CoverageManifestResponse"];
+                };
+            };
+        };
+    };
+    list_products_v1_products_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductsResponse"];
+                };
+            };
+        };
+    };
+    get_seasonal_calendar_v1_predict_seasonal_calendar_get: {
+        parameters: {
+            query: {
+                /** @description UF (ex: SP, RJ, SC) */
+                uf: string;
+                /** @description Optional filter by sector slugs (e.g. engenharia, saude) */
+                setores?: string[] | null;
+                /** @description Number of historical years to analyze (1-20) */
+                anos_historico?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeasonalCalendarResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_network_event_v1_network_events_record_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordEventResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_top_network_events_v1_network_events_top_get: {
+        parameters: {
+            query: {
+                /** @description Tipo de evento para filtrar */
+                evento_tipo: string;
+                /** @description Dimensao para agregar */
+                dimensao_tipo?: string;
+                /** @description Janela em dias */
+                dias?: number;
+                /** @description Maximo de resultados */
+                limite?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_segment_v1_segment_save_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveSegmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SaveSegmentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
+                };
+            };
+        };
+    };
+    trigger_bids_backfill_v1_admin_trigger_bids_backfill_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
+                };
+            };
+        };
+    };
+    clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminClearCheckpointsResponse"];
+                };
+            };
+        };
+    };
+    get_search_trace_v1_admin_search_trace__search_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSearchTraceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_circuit_breakers_v1_admin_cb_reset_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminCircuitBreakerResetResponse"];
+                };
+            };
+        };
+    };
+    get_schema_contract_status_v1_admin_schema_contract_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSchemaContractStatusResponse"];
+                };
+            };
+        };
+    };
+    get_cron_status_v1_admin_cron_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminCronStatusResponse"];
+                };
+            };
+        };
+    };
+    list_cnae_mappings_v1_admin_cnae_mapping_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by setor_id */
+                setor?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_cnae_mapping_v1_admin_cnae_mapping_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CnaeMappingCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnae_code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnae_code: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CnaeMappingUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    admin_llm_cost_v1_admin_llm_cost_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminLlmCostResponse"];
+                };
+            };
+        };
+    };
+    list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get: {
+        parameters: {
+            query?: {
+                range_days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SurveyAggregateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    patch_app_config_v1_admin_config__key__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AppConfigPatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppConfigRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    recalibrate_v1_admin_calibration_recalibrate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RecalibrateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecalibrateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_billing_sync_rows_v1_admin_plans_billing_sync_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingSyncListResponse"];
+                };
+            };
+        };
+    };
+    list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReconciliationRunsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plan_billing_period_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReverseSyncRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReverseSyncResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reconcile_now_v1_admin_plans_reconcile_now_post: {
+        parameters: {
+            query?: {
+                dry_run?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReconcileNowResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_founding_policy_v1_admin_founding_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingPolicySnapshot"];
+                };
+            };
+        };
+    };
+    list_founding_leads_v1_admin_founding_leads_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingLeadsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pause_founding_v1_admin_founding_pause_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["FoundingPauseRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resume_founding_v1_admin_founding_resume_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
+                };
+            };
+        };
+    };
+    get_slo_dashboard_v1_admin_slo_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SloDashboardResponse"];
+                };
+            };
+        };
+    };
+    get_slo_alerts_v1_admin_slo_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SloAlertsResponse"];
+                };
+            };
+        };
+    };
+    founders_availability_api_founders_availability_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundersAvailabilityResponse"];
+                };
+            };
+        };
+    };
+    get_hall_listing_api_founders_hall_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundersHallResponse"];
+                };
+            };
+        };
+    };
+    toggle_consent_api_founders_hall_consent_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FounderConsentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FounderConsentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -20361,6 +20290,66 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    root__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RootResponse"];
+                };
+            };
+        };
+    };
+    listar_setores_v1_setores_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetoresResponse"];
+                };
+            };
+        };
+    };
+    debug_pncp_test_debug_pncp_test_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DebugPNCPResponse"];
                 };
             };
         };

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4,6 +4,162 @@
  */
 
 export interface paths {
+    "/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Root
+         * @description API root — navigation and version info.
+         */
+        get: operations["root__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/checkout/one-time": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create One Time Checkout
+         * @description Create a Stripe Checkout Session for a one-time digital product purchase.
+         *
+         *     Flow:
+         *         1. Validate SKU against digital_products table
+         *         2. Resolve or create Stripe Price
+         *         3. Create Stripe Checkout Session with card/boleto/PIX
+         *         4. Return checkout URL
+         *
+         *     Rate limited: 10 req/min per IP.
+         */
+        post: operations["create_one_time_checkout_api_checkout_one_time_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/founders/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founders Availability
+         * @description Public seat counter + countdown feed (issue #1002).
+         */
+        get: operations["founders_availability_api_founders_availability_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/founders/hall": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Hall Listing
+         * @description Public Hall of Founders listing (issue #1008).
+         *
+         *     Anonymous endpoint consumed by ``/fundadores/hall`` (ISR revalidate=300s).
+         *     Returns up to 100 founders that opted in via
+         *     ``founder_public_listing_consent=TRUE``.
+         */
+        get: operations["get_hall_listing_api_founders_hall_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/founders/hall/consent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Toggle Consent
+         * @description Authenticated opt-in / opt-out toggle (issue #1008).
+         *
+         *     Updates ``profiles.founder_public_listing_consent`` for the caller and,
+         *     on opt-in, also persists optional display name and logo URL. Logs an
+         *     LGPD audit event regardless of direction.
+         */
+        post: operations["toggle_consent_api_founders_hall_consent_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/debug/pncp-test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Debug Pncp Test
+         * @description Diagnostic: test if PNCP API is reachable from this server. Admin only.
+         */
+        get: operations["debug_pncp_test_debug_pncp_test_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Health
+         * @description Comprehensive health check with dependency status, circuit breakers, bulkheads.
+         */
+        get: operations["health_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health/live": {
         parameters: {
             query?: never;
@@ -46,26 +202,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Health
-         * @description Comprehensive health check with dependency status, circuit breakers, bulkheads.
-         */
-        get: operations["health_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/sources/health": {
         parameters: {
             query?: never;
@@ -79,124 +215,6 @@ export interface paths {
          */
         get: operations["sources_health_sources_health_get"];
         put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Users
-         * @description List all users with profiles and subscription info.
-         */
-        get: operations["list_users_v1_admin_users_get"];
-        put?: never;
-        /**
-         * Create User
-         * @description Create a new user with optional plan assignment.
-         */
-        post: operations["create_user_v1_admin_users_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Update User
-         * @description Update user profile or plan.
-         */
-        put: operations["update_user_v1_admin_users__user_id__put"];
-        post?: never;
-        /**
-         * Delete User
-         * @description Delete a user and all their data.
-         */
-        delete: operations["delete_user_v1_admin_users__user_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}/reset-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset User Password
-         * @description Reset a user's password (admin only).
-         */
-        post: operations["reset_user_password_v1_admin_users__user_id__reset_password_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}/assign-plan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Assign Plan
-         * @description Manually assign a plan to a user (bypasses payment).
-         */
-        post: operations["assign_plan_v1_admin_users__user_id__assign_plan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/users/{user_id}/credits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Update User Credits
-         * @description Manually adjust a user's credits (admin only).
-         *
-         *     Sets the credits_remaining value directly on the user's active subscription.
-         *     If no active subscription exists, creates one based on user's current plan.
-         *
-         *     Args:
-         *         user_id: UUID of the user
-         *         req.credits: New credit value (must be >= 0)
-         *
-         *     Returns:
-         *         Updated user info with new credit value
-         */
-        put: operations["update_user_credits_v1_admin_users__user_id__credits_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -231,6 +249,49 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/at-risk-trials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get At Risk Trials
+         * @description Paginated list of trial users with risk categorization.
+         */
+        get: operations["get_at_risk_trials_v1_admin_at_risk_trials_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cache": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete All Cache Endpoint
+         * @description B-05 AC6: Invalidate ALL cache entries (nuclear option).
+         *
+         *     Requires X-Confirm: delete-all header for safety.
+         *     Without header, returns 400 Bad Request.
+         */
+        delete: operations["delete_all_cache_endpoint_v1_admin_cache_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -291,7 +352,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/cache": {
+    "/v1/admin/calibration/recalibrate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Recalibrate
+         * @description Compute new ``hours_saved_per_search`` from survey distribution.
+         *
+         *     Eligibility rules (mirrors AC6 + risk R3):
+         *         * After IQR outlier removal there must be >= MIN_SAMPLE_SIZE rows.
+         *         * The new median must be in (0, 50].
+         *
+         *     When ``apply=true`` and eligible, persists the new value via
+         *     ``app_config`` and drops the cache.
+         */
+        post: operations["recalibrate_v1_admin_calibration_recalibrate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cb/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reset Circuit Breakers
+         * @description STORY-416 AC5: Reset all segregated Supabase CBs to CLOSED.
+         *
+         *     Intended for on-call use after an upstream incident has been mitigated
+         *     and the CBs are still in OPEN/HALF_OPEN due to the cooldown. Returns
+         *     the previous state per category so the action is auditable in logs.
+         *     Admin only — never expose this without authentication.
+         */
+        post: operations["reset_circuit_breakers_v1_admin_cb_reset_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/clear-contracts-checkpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clear Contracts Checkpoints
+         * @description Clear all Redis checkpoints for contracts crawler.
+         *
+         *     Use before re-triggering a full crawl when stale checkpoints
+         *     cause windows to be incorrectly skipped.
+         */
+        post: operations["clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cnae-mapping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Cnae Mappings
+         * @description List CNAE mappings, optionally filtered by ``setor``.
+         */
+        get: operations["list_cnae_mappings_v1_admin_cnae_mapping_get"];
+        put?: never;
+        /**
+         * Create Cnae Mapping
+         * @description Create a new CNAE -> setor mapping.
+         */
+        post: operations["create_cnae_mapping_v1_admin_cnae_mapping_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/cnae-mapping/{cnae_code}": {
         parameters: {
             query?: never;
             header?: never;
@@ -302,13 +462,465 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Delete All Cache Endpoint
-         * @description B-05 AC6: Invalidate ALL cache entries (nuclear option).
+         * Delete Cnae Mapping
+         * @description Soft delete: marks ``notes='deleted'`` so audit trail is preserved.
          *
-         *     Requires X-Confirm: delete-all header for safety.
-         *     Without header, returns 400 Bad Request.
+         *     The DB lookup in ``utils.cnae_mapping._db_lookup`` skips rows with
+         *     ``notes = 'deleted'`` and the LRU cache is invalidated so the next
+         *     request falls back to the hardcoded dict (if present there).
          */
-        delete: operations["delete_all_cache_endpoint_v1_admin_cache_delete"];
+        delete: operations["delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Cnae Mapping
+         * @description Patch an existing mapping. Fields not present in the body are untouched.
+         */
+        patch: operations["update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch"];
+        trace?: never;
+    };
+    "/v1/admin/config/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Patch App Config
+         * @description Update one row in ``app_config``. Whitelist enforced.
+         *
+         *     On success the in-process TTL cache for *key* is invalidated so
+         *     the new value becomes visible in this worker on the next read
+         *     (other workers see it after their TTL expires).
+         */
+        patch: operations["patch_app_config_v1_admin_config__key__patch"];
+        trace?: never;
+    };
+    "/v1/admin/cron-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Cron Status
+         * @description Return the pg_cron health snapshot.
+         *
+         *     Calls ``public.get_cron_health()`` (SECURITY DEFINER) via the backend's
+         *     service-role Supabase client. Response shape::
+         *
+         *         {
+         *             "queried_at": "2026-04-14T12:00:00+00:00",
+         *             "jobs": [
+         *                 {
+         *                     "jobname": "purge-old-bids",
+         *                     "schedule": "0 7 * * *",
+         *                     "active": true,
+         *                     "last_status": "succeeded",
+         *                     "last_run_at": "2026-04-14T07:00:04+00:00",
+         *                     "runs_24h": 1,
+         *                     "failures_24h": 0,
+         *                     "latency_avg_ms": 120,
+         *                     "last_return_message": null
+         *                 },
+         *                 ...
+         *             ],
+         *             "count": 6
+         *         }
+         *
+         *     On transient failure (Supabase CB open, RPC error) returns ``status=error``
+         *     with ``jobs=[]`` so that dashboards degrade gracefully instead of 500-ing.
+         */
+        get: operations["get_cron_status_v1_admin_cron_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/feature-flags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Feature Flags
+         * @description List all registered feature flags with current values and sources.
+         *
+         *     Returns each flag's effective value, where it comes from (redis override,
+         *     env var, or default), its description, and registry metadata.
+         *
+         *     Admin only.
+         */
+        get: operations["list_feature_flags_v1_admin_feature_flags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/feature-flags/reload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reload Flags Endpoint
+         * @description Reload all feature flags from environment variables (admin only).
+         *
+         *     This clears:
+         *     1. All Redis overrides (smartlic:ff:* keys)
+         *     2. All in-memory overrides
+         *     3. The feature flag TTL cache
+         *
+         *     After reload, flags return to their env var or registry default values.
+         *     Useful after updating env vars via Railway dashboard without restarting.
+         */
+        post: operations["reload_flags_endpoint_v1_admin_feature_flags_reload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/feature-flags/{flag_name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Feature Flag
+         * @description Update a feature flag value at runtime (admin only).
+         *
+         *     The new value is persisted to Redis (if available) and stored in-memory.
+         *     Takes effect immediately -- no container restart required.
+         *
+         *     The change persists across process restarts as long as Redis is available.
+         *     Use POST /admin/feature-flags/reload to clear all overrides.
+         */
+        patch: operations["update_feature_flag_v1_admin_feature_flags__flag_name__patch"];
+        trace?: never;
+    };
+    "/v1/admin/feedback/patterns": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Feedback Patterns
+         * @description AC6: Admin endpoint for feedback pattern analysis.
+         *
+         *     Requires admin role (via require_admin dependency).
+         */
+        get: operations["feedback_patterns_v1_admin_feedback_patterns_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/leads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Founding Leads
+         * @description List founding leads ordered by creation desc.
+         *
+         *     Optional ``status`` filter restricts to one of the checkout_status enum
+         *     values (pending|completed|abandoned|failed|cap_violated).
+         */
+        get: operations["list_founding_leads_v1_admin_founding_leads_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Pause Founding
+         * @description Soft-pause founding checkouts. Idempotent.
+         */
+        post: operations["pause_founding_v1_admin_founding_pause_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Founding Policy
+         * @description Snapshot of the canonical policy + live seat usage.
+         */
+        get: operations["get_founding_policy_v1_admin_founding_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/founding/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Founding
+         * @description Resume founding checkouts (clear paused_at + paused_by + paused_reason).
+         */
+        post: operations["resume_founding_v1_admin_founding_resume_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/llm-cost": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Admin Llm Cost
+         * @description Return LLM cost snapshot para o mês corrente (admin-only).
+         *
+         *     Response shape::
+         *
+         *         {
+         *             "month_to_date_usd": 42.1234,
+         *             "budget_usd": 100.0,
+         *             "pct_used": 42.12,
+         *             "projected_end_of_month_usd": 78.55,
+         *             "month": "llm_cost_month_2026_04",
+         *             "exceeded": false
+         *         }
+         *
+         *     Em caso de Redis indisponível, retorna zeros (graceful degradation).
+         */
+        get: operations["admin_llm_cost_v1_admin_llm_cost_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/memory-snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Memory Snapshot
+         * @description Return current process memory snapshot for leak investigation.
+         *
+         *     Master/admin only. Snapshots are NOT persisted (PII risk + size).
+         *     Caller is responsible for capturing 10× over 24h to build baseline.
+         */
+        get: operations["memory_snapshot_v1_admin_memory_snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/partners": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Partners Endpoint
+         * @description AC10: List all partners. Admin only.
+         */
+        get: operations["list_partners_endpoint_v1_admin_partners_get"];
+        put?: never;
+        /**
+         * Create Partner Endpoint
+         * @description AC11: Create a new partner. Admin only.
+         */
+        post: operations["create_partner_endpoint_v1_admin_partners_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/partners/{partner_id}/referrals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Partner Referrals Endpoint
+         * @description AC12: Get referrals for a specific partner. Admin only.
+         */
+        get: operations["get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/partners/{partner_id}/revenue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Partner Revenue Endpoint
+         * @description AC13: Get revenue share for a partner in a given month. Admin only.
+         */
+        get: operations["get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/billing-sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Billing Sync Rows
+         * @description Return every plan_billing_periods row enriched with drift_status.
+         */
+        get: operations["list_billing_sync_rows_v1_admin_plans_billing_sync_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/reconcile-now": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reconcile Now */
+        post: operations["reconcile_now_v1_admin_plans_reconcile_now_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/reconciliation-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Reconciliation Runs */
+        get: operations["list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/plans/{plan_billing_period_id}/sync-to-stripe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sync To Stripe
+         * @description AC8/AC9: Push DB price -> Stripe by creating a new Price + archiving old.
+         */
+        post: operations["sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -358,6 +970,187 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/revalidate-seo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Admin Revalidate Seo
+         * @description Manually trigger ISR revalidation for the given frontend paths.
+         *
+         *     Calls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).
+         *     Fire-and-forget — the HTTP call is made but result is not awaited for
+         *     user-facing errors.  Any failure is logged as a warning.
+         *
+         *     Requires admin role.  Raises HTTP 400 if ``paths`` is empty.
+         */
+        post: operations["admin_revalidate_seo_v1_admin_revalidate_seo_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/schema-contract-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Schema Contract Status
+         * @description STORY-414 AC4: Expose the last schema-contract validation result.
+         *
+         *     Returns the cached result from the startup check plus a ``stale``
+         *     flag that tells callers whether a fresh run is advisable (the cache
+         *     lives for ``schemas.contract.STATUS_CACHE_TTL`` seconds — 5 min by
+         *     default). Forcing a re-validation is out of scope here because it
+         *     would defeat the point of the cache on a polled dashboard.
+         */
+        get: operations["get_schema_contract_status_v1_admin_schema_contract_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/search-trace/{search_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Search Trace
+         * @description Reconstruct complete search journey from search_id.
+         *
+         *     Aggregates:
+         *     - Progress tracker state (if still active)
+         *     - Cache entries matching this search
+         *     - Job queue results (if ARQ available)
+         */
+        get: operations["get_search_trace_v1_admin_search_trace__search_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/seo-metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Seo Metrics
+         * @description Return SEO metrics for the last N days (legacy S14 daily rollup). Admin-only.
+         */
+        get: operations["get_seo_metrics_v1_admin_seo_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/seo/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Gsc Summary
+         * @description Return aggregated GSC analytics from gsc_metrics cache. Admin-only.
+         *
+         *     STORY-SEO-005 AC4. Populated weekly by backend/jobs/cron/gsc_sync.py.
+         */
+        get: operations["get_gsc_summary_v1_admin_seo_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/sitemap-cache/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Force-refresh sitemap combos cache (admin only)
+         * @description Clears the 24h in-memory sitemap cache and recomputes indexable combos immediately.
+         */
+        post: operations["refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/slo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Slo Dashboard
+         * @description AC7-AC9: SLO compliance data for admin dashboard.
+         *
+         *     Returns all SLO statuses, alert evaluations, and metadata.
+         */
+        get: operations["get_slo_dashboard_v1_admin_slo_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/slo/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Slo Alerts
+         * @description Return current alert evaluation results.
+         */
+        get: operations["get_slo_alerts_v1_admin_slo_alerts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/support-sla": {
         parameters: {
             query?: never;
@@ -375,6 +1168,86 @@ export interface paths {
          *         breached_count: Number of conversations exceeding 20 business hours
          */
         get: operations["get_support_sla_v1_admin_support_sla_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/survey/export-time-saved": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Export Surveys Aggregate
+         * @description Aggregated histogram + summary stats for the calibration dashboard.
+         */
+        get: operations["list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/trial-emails/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Preview Trial Emails
+         * @description AC15: Preview all 6 trial email templates.
+         */
+        get: operations["preview_trial_emails_v1_admin_trial_emails_preview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/trial-emails/test-send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test Send Trial Email
+         * @description AC14: Send a test trial email to the admin's own email.
+         */
+        post: operations["test_send_trial_email_v1_admin_trial_emails_test_send_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/trial-exit-surveys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Exit Surveys Admin
+         * @description STORY-369 AC6: Admin endpoint — exit survey counts grouped by reason.
+         */
+        get: operations["get_exit_surveys_admin_v1_admin_trial_exit_surveys_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -406,27 +1279,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/at-risk-trials": {
+    "/v1/admin/trigger-bids-backfill": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Get At Risk Trials
-         * @description Paginated list of trial users with risk categorization.
-         */
-        get: operations["get_at_risk_trials_v1_admin_at_risk_trials_get"];
+        get?: never;
         put?: never;
-        post?: never;
+        /**
+         * Trigger Bids Backfill
+         * @description Enqueue ingestion_backfill_job to ARQ Worker.
+         *
+         *     One-time historical crawl: fetches up to 365 days of PNCP bids
+         *     to capture all currently open opportunities.
+         *     Expected runtime: 4-8h. Safe to call multiple times (ARQ dedup).
+         */
+        post: operations["trigger_bids_backfill_v1_admin_trigger_bids_backfill_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/memory-snapshot": {
+    "/v1/admin/trigger-contracts-backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Contracts Backfill
+         * @description Enqueue contracts_full_crawl_job to ARQ Worker.
+         *
+         *     Runs on Railway Worker (better network for PNCP).
+         *     Safe to call multiple times — ARQ deduplicates by job name.
+         */
+        post: operations["trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users": {
         parameters: {
             query?: never;
             header?: never;
@@ -434,15 +1334,16 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Memory Snapshot
-         * @description Return current process memory snapshot for leak investigation.
-         *
-         *     Master/admin only. Snapshots are NOT persisted (PII risk + size).
-         *     Caller is responsible for capturing 10× over 24h to build baseline.
+         * List Users
+         * @description List all users with profiles and subscription info.
          */
-        get: operations["memory_snapshot_v1_admin_memory_snapshot_get"];
+        get: operations["list_users_v1_admin_users_get"];
         put?: never;
-        post?: never;
+        /**
+         * Create User
+         * @description Create a new user with optional plan assignment.
+         */
+        post: operations["create_user_v1_admin_users_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -476,7 +1377,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/update-billing-period": {
+    "/v1/admin/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update User
+         * @description Update user profile or plan.
+         */
+        put: operations["update_user_v1_admin_users__user_id__put"];
+        post?: never;
+        /**
+         * Delete User
+         * @description Delete a user and all their data.
+         */
+        delete: operations["delete_user_v1_admin_users__user_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{user_id}/assign-plan": {
         parameters: {
             query?: never;
             header?: never;
@@ -486,20 +1411,47 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Update Billing Period
-         * @description Update subscription billing period (monthly / semiannual / annual).
-         *
-         *     GTM-002: Simplified flow — Stripe handles proration automatically.
-         *     No deferral logic, no manual credit calculations.
+         * Assign Plan
+         * @description Manually assign a plan to a user (bypasses payment).
          */
-        post: operations["update_billing_period_v1_api_subscriptions_update_billing_period_post"];
+        post: operations["assign_plan_v1_admin_users__user_id__assign_plan_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/cancel": {
+    "/v1/admin/users/{user_id}/credits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update User Credits
+         * @description Manually adjust a user's credits (admin only).
+         *
+         *     Sets the credits_remaining value directly on the user's active subscription.
+         *     If no active subscription exists, creates one based on user's current plan.
+         *
+         *     Args:
+         *         user_id: UUID of the user
+         *         req.credits: New credit value (must be >= 0)
+         *
+         *     Returns:
+         *         Updated user info with new credit value
+         */
+        put: operations["update_user_credits_v1_admin_users__user_id__credits_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/users/{user_id}/reset-password": {
         parameters: {
             query?: never;
             header?: never;
@@ -509,43 +1461,17 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Cancel Subscription
-         * @description Cancel subscription at period end.
-         *
-         *     GTM-FIX-006: User-initiated cancellation flow.
-         *     UX-308: Accepts optional cancellation reason for retention analytics.
-         *     Sets cancel_at_period_end=True in Stripe, updates status to 'canceling'.
+         * Reset User Password
+         * @description Reset a user's password (admin only).
          */
-        post: operations["cancel_subscription_v1_api_subscriptions_cancel_post"];
+        post: operations["reset_user_password_v1_admin_users__user_id__reset_password_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/cancel-feedback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Submit Cancel Feedback
-         * @description Submit post-cancellation feedback (UX-308 AC6).
-         *
-         *     Logs feedback as a user action for analytics. Fire-and-forget — never blocks UX.
-         */
-        post: operations["submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/api/subscriptions/upgrade-to-lifetime/preview": {
+    "/v1/alertas/{setor_id}/uf/{uf}": {
         parameters: {
             query?: never;
             header?: never;
@@ -553,15 +1479,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Upgrade To Lifetime Preview
-         * @description Preview pro-rata math for the upgrade-to-lifetime modal (#1011).
-         *
-         *     Returns ``eligible=False`` with a structured ``reason`` whenever the user
-         *     is not allowed to upgrade (already founder, no active sub, cap reached,
-         *     feature flag off). Front-end uses this to render the right copy without
-         *     parsing free text.
+         * Get Alertas
+         * @description Return latest 20 bids for sector × UF from datalake (public, no auth).
          */
-        get: operations["upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get"];
+        get: operations["get_alertas_v1_alertas__setor_id__uf__uf__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -570,42 +1491,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/api/subscriptions/upgrade-to-lifetime": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Upgrade To Lifetime
-         * @description Upgrade Pro mensal -> Lifetime founder (#1011 / UPGRADE-PATH-013).
-         *
-         *     Flow:
-         *       1. Re-check founder cap via existing ``check_founding_availability()`` RPC
-         *          (race-guarded, atomic). Reject 410 if cap reached.
-         *       2. Reject 409 if ``profiles.is_founder`` is already TRUE (idempotent).
-         *       3. Cancel the active Stripe subscription with ``prorate=True``. Stripe
-         *          issues a credit balance to the customer automatically — no custom
-         *          prorata math.
-         *       4. Create a Stripe Checkout Session in ``mode='payment'`` for the
-         *          R$997 one-time founder price (``FOUNDING_ONE_TIME_PRICE_ID``).
-         *          Customer balance is consumed automatically by Stripe.
-         *       5. Return checkout URL. The existing webhook handler
-         *          (``webhooks/handlers/founding.py::_activate_lifetime_founder_entitlement``)
-         *          flips ``is_founder=TRUE`` once payment completes — DO NOT duplicate.
-         *       6. Audit log via ``audit_logger`` for billing.subscription_change.
-         */
-        post: operations["upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/api/features/me": {
+    "/v1/alerts": {
         parameters: {
             query?: never;
             header?: never;
@@ -613,77 +1499,28 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get My Features
-         * @description Get current user's enabled features.
+         * List Alerts
+         * @description List all alerts for the authenticated user, ordered by created_at desc.
          *
-         *     CACHING STRATEGY (STORY-217: unified pool):
-         *     - Redis cache with 5-minute TTL via shared pool
-         *     - Cache key: ``features:{user_id}``
-         *     - Cache miss: Fetch from Supabase (JOIN user_subscriptions + plan_features)
-         *     - Graceful degradation via InMemoryCache fallback
+         *     AC2: Includes sent_count (number of items sent for each alert).
          */
-        get: operations["get_my_features_v1_api_features_me_get"];
+        get: operations["list_alerts_v1_alerts_get"];
         put?: never;
-        post?: never;
+        /**
+         * Create Alert
+         * @description Create a new email alert for the authenticated user.
+         *
+         *     AC1: Persists alert definition with filter criteria.
+         *     Enforces a per-user limit to prevent abuse.
+         */
+        post: operations["create_alert_v1_alerts_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/api/messages/conversations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Conversations */
-        get: operations["list_conversations_v1_api_messages_conversations_get"];
-        put?: never;
-        /** Create Conversation */
-        post: operations["create_conversation_v1_api_messages_conversations_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/api/messages/conversations/{conversation_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Conversation */
-        get: operations["get_conversation_v1_api_messages_conversations__conversation_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/api/messages/conversations/{conversation_id}/reply": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Reply To Conversation */
-        post: operations["reply_to_conversation_v1_api_messages_conversations__conversation_id__reply_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/api/messages/conversations/{conversation_id}/status": {
+    "/v1/alerts/{alert_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -693,105 +1530,88 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update Conversation Status */
-        patch: operations["update_conversation_status_v1_api_messages_conversations__conversation_id__status_patch"];
-        trace?: never;
-    };
-    "/v1/api/messages/unread-count": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Unread Count */
-        get: operations["get_unread_count_v1_api_messages_unread_count_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
         /**
-         * Get Analytics Summary
-         * @description Get overall user analytics summary.
-         */
-        get: operations["get_analytics_summary_v1_analytics_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/searches-over-time": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Searches Over Time
-         * @description Get time-series search data grouped by period.
-         */
-        get: operations["get_searches_over_time_v1_analytics_searches_over_time_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/top-dimensions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Top Dimensions
-         * @description Get top UFs and sectors by search count.
-         */
-        get: operations["get_top_dimensions_v1_analytics_top_dimensions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/analytics/trial-value": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Trial Value
-         * @description Get value generated during trial period (GTM-010 AC1).
+         * Delete Alert
+         * @description Delete an alert and its sent-item history.
          *
-         *     Returns aggregated statistics of opportunities analyzed during the user's trial.
-         *     Used by TrialConversionScreen to show personalized conversion messaging.
+         *     AC4: Cascading delete removes associated alert_sent_items.
+         *     Validates that the alert belongs to the authenticated user.
          */
-        get: operations["get_trial_value_v1_analytics_trial_value_get"];
+        delete: operations["delete_alert_v1_alerts__alert_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Alert
+         * @description Update an existing alert (partial update).
+         *
+         *     AC3: Only name, filters, and active status can be updated.
+         *     Validates that the alert belongs to the authenticated user.
+         */
+        patch: operations["update_alert_v1_alerts__alert_id__patch"];
+        trace?: never;
+    };
+    "/v1/alerts/{alert_id}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Alert History
+         * @description Paginated history of items sent for this alert.
+         *
+         *     AC13: Returns alert_sent_items ordered by sent_at desc.
+         *     Only accessible if the alert belongs to the authenticated user.
+         */
+        get: operations["alert_history_v1_alerts__alert_id__history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/alerts/{alert_id}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Preview Alert
+         * @description Preview what opportunities an alert would match (dry-run).
+         *
+         *     STORY-315 AC12: Executes matching without sending email.
+         *     Returns opportunities that would be sent, useful for validating filters.
+         */
+        get: operations["preview_alert_v1_alerts__alert_id__preview_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/alerts/{alert_id}/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unsubscribe Alert
+         * @description One-click unsubscribe from an email alert (RFC 8058).
+         *
+         *     AC9: No authentication required — uses HMAC token verification.
+         *     Sets the alert's active flag to false.
+         *     Returns an HTML confirmation page.
+         */
+        get: operations["unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -825,6 +1645,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/analytics/searches-over-time": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Searches Over Time
+         * @description Get time-series search data grouped by period.
+         */
+        get: operations["get_searches_over_time_v1_analytics_searches_over_time_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/analytics/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Analytics Summary
+         * @description Get overall user analytics summary.
+         */
+        get: operations["get_analytics_summary_v1_analytics_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/analytics/top-dimensions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Top Dimensions
+         * @description Get top UFs and sectors by search count.
+         */
+        get: operations["get_top_dimensions_v1_analytics_top_dimensions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/analytics/track-cta": {
         parameters: {
             query?: never;
@@ -842,6 +1722,29 @@ export interface paths {
          *     Fire-and-forget — always returns 204.
          */
         post: operations["track_cta_event_v1_analytics_track_cta_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/analytics/trial-value": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Trial Value
+         * @description Get value generated during trial period (GTM-010 AC1).
+         *
+         *     Returns aggregated statistics of opportunities analyzed during the user's trial.
+         *     Used by TrialConversionScreen to show personalized conversion messaging.
+         */
+        get: operations["get_trial_value_v1_analytics_trial_value_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1047,7 +1950,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/buscar-progress/{search_id}": {
+    "/v1/api/features/me": {
         parameters: {
             query?: never;
             header?: never;
@@ -1055,26 +1958,16 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Buscar Progress Stream
-         * @description SSE endpoint for real-time search progress updates.
+         * Get My Features
+         * @description Get current user's enabled features.
          *
-         *     The client opens this connection simultaneously with POST /buscar,
-         *     using the same search_id to correlate progress events.
-         *
-         *     GTM-GO-002 AC6: Max 3 simultaneous SSE connections per user.
-         *
-         *     Events:
-         *         - connecting (5%): Initial setup
-         *         - fetching (10-55%): Per-UF progress with uf_index/uf_total
-         *         - filtering (60-70%): Filter application
-         *         - llm (75-90%): LLM summary generation
-         *         - excel (92-98%): Excel report generation
-         *         - complete (100%): Search finished
-         *         - partial_results: Non-terminal — intermediate results during background fetch (A-04)
-         *         - refresh_available (100%): Background fetch complete, new data available (A-04)
-         *         - error: Search failed
+         *     CACHING STRATEGY (STORY-217: unified pool):
+         *     - Redis cache with 5-minute TTL via shared pool
+         *     - Cache key: ``features:{user_id}``
+         *     - Cache miss: Fetch from Supabase (JOIN user_subscriptions + plan_features)
+         *     - Graceful degradation via InMemoryCache fallback
          */
-        get: operations["buscar_progress_stream_v1_buscar_progress__search_id__get"];
+        get: operations["get_my_features_v1_api_features_me_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1083,23 +1976,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/search/{search_id}/status": {
+    "/v1/api/messages/conversations": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Search Status Endpoint
-         * @description GTM-STAB-009 AC3: Enriched status response for polling.
-         *
-         *     LIGHTWEIGHT (<50ms): Reads from in-memory progress tracker + state machine.
-         *     Falls back to DB-based get_search_status only if in-memory state is unavailable.
-         *
-         *     Called by frontend when SSE disconnects (AC12) or for async polling.
-         */
-        get: operations["search_status_endpoint_v1_search__search_id__status_get"];
+        /** List Conversations */
+        get: operations["list_conversations_v1_api_messages_conversations_get"];
+        put?: never;
+        /** Create Conversation */
+        post: operations["create_conversation_v1_api_messages_conversations_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/api/messages/conversations/{conversation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Conversation */
+        get: operations["get_conversation_v1_api_messages_conversations__conversation_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1108,98 +2011,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/search/{search_id}/timeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Search Timeline Endpoint
-         * @description AC7: Return all state transitions for audit trail.
-         */
-        get: operations["search_timeline_endpoint_v1_search__search_id__timeline_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/buscar-results/{search_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Search Results
-         * @description Return results of a background fetch or async search.
-         *
-         *     A-04 AC5: Called by frontend when user clicks "Atualizar resultados" banner.
-         *     GTM-ARCH-001 AC3: Also serves results from ARQ Worker (via Redis).
-         *     Returns 404 if search_id not found or expired.
-         */
-        get: operations["get_search_results_v1_buscar_results__search_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/results": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Search Results V1
-         * @description GTM-STAB-009 AC4: Return results of async search.
-         *
-         *     - 200 with BuscaResponse when results are ready
-         *     - 202 with status when still processing
-         *     - 404 when search_id not found or expired
-         */
-        get: operations["get_search_results_v1_v1_search__search_id__results_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/zero-match": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Zero Match Results Endpoint
-         * @description Return items approved by background zero-match LLM classification.
-         *
-         *     - 200: Results ready (may be empty list if none approved)
-         *     - 404: Job not yet completed or results expired
-         */
-        get: operations["get_zero_match_results_endpoint_v1_search__search_id__zero_match_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/regenerate-excel": {
+    "/v1/api/messages/conversations/{conversation_id}/reply": {
         parameters: {
             query?: never;
             header?: never;
@@ -1208,21 +2020,15 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Regenerate Excel Endpoint
-         * @description STORY-364 AC7-AC8: Regenerate Excel from stored results without re-running search.
-         *
-         *     - 202: Excel generation job enqueued
-         *     - 404: Results not found or expired
-         */
-        post: operations["regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post"];
+        /** Reply To Conversation */
+        post: operations["reply_to_conversation_v1_api_messages_conversations__conversation_id__reply_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/search/{search_id}/retry": {
+    "/v1/api/messages/conversations/{conversation_id}/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -1231,493 +2037,23 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Retry Search
-         * @description CRIT-006 AC4-5: Retry search with only missing/failed UFs.
-         */
-        post: operations["retry_search_v1_search__search_id__retry_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/search/{search_id}/cancel": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Cancel Search
-         * @description CRIT-006 AC16-17: Cancel an in-progress search.
-         */
-        post: operations["cancel_search_v1_search__search_id__cancel_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/buscar": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Buscar Licitacoes
-         * @description Main search endpoint — thin wrapper that delegates to SearchPipeline.
-         *
-         *     GTM-RESILIENCE-A04: Cache-first progressive delivery.
-         *     When cache exists for this search, returns cached data immediately with
-         *     `live_fetch_in_progress=True` and dispatches background live fetch.
-         *     When no cache, runs synchronous pipeline as before (AC10).
-         *
-         *     The wrapper handles:
-         *     - Cache-first check and immediate response (A-04 AC1)
-         *     - Background task dispatch (A-04 AC2)
-         *     - SSE tracker lifecycle (create, cleanup on error)
-         *     - Exception mapping (PNCPRateLimitError → 503, PNCPAPIError → 502, etc.)
-         *     - Dependency injection (passing module-level names for test mock compatibility)
-         *
-         *     STORY-291 AC5: require_active_plan() moved INSIDE try block, AFTER tracker
-         *     creation. Previously, when it failed the frontend was left in limbo — POST
-         *     failed but SSE was waiting for a tracker that never existed.
-         */
-        post: operations["buscar_licitacoes_v1_buscar_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/change-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Change Password
-         * @description Change current user's password.
-         */
-        post: operations["change_password_v1_change_password_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/me": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile
-         * @description Get current user profile with plan capabilities and quota status.
-         *
-         *     Uses admin client (get_db) because it needs db.auth.admin.get_user_by_id()
-         *     to fetch the user's email from auth.users — an admin-only operation.
-         */
-        get: operations["get_profile_v1_me_get"];
-        put?: never;
-        post?: never;
-        /**
-         * Delete Account
-         * @description Delete entire user account and all associated data (LGPD Art. 18 VI).
-         *
-         *     Uses admin client (get_db) because it needs db.auth.admin.delete_user()
-         *     and must delete across multiple tables regardless of RLS.
-         *
-         *     Strategy:
-         *     1. Cancel active Stripe subscription (external side-effect, must be first)
-         *     2. Delete from profiles (CASCADE propagates to most child tables)
-         *     3. Delete from remaining tables that reference auth.users directly
-         *     4. Delete auth user via Supabase admin API
-         *     5. Log anonymized audit entry
-         *
-         *     If auth user deletion fails (step 4), we do NOT roll back the profile
-         *     deletion — the user's data is already gone and a dangling auth entry
-         *     is preferable to leaving personal data behind (LGPD Art. 18 VI).
-         */
-        delete: operations["delete_account_v1_me_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Trial Status
-         * @description Get detailed trial status for conversion flow (GTM-010 AC3).
-         *
-         *     Returns days remaining, usage stats, and expiration info.
-         */
-        get: operations["get_trial_status_v1_trial_status_get"];
-        put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Update Conversation Status */
+        patch: operations["update_conversation_status_v1_api_messages_conversations__conversation_id__status_patch"];
         trace?: never;
     };
-    "/v1/user/recommended-plan": {
+    "/v1/api/messages/unread-count": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Get Recommended Plan
-         * @description STORY-BIZ-002 AC2: return the upsell-eligible plan for the current user.
-         *
-         *     Detects consultancy profiles by CNAE primário (divisions 70.2 / 74.9 / 82.9)
-         *     and recommends the higher-ARPU Consultoria plan. Non-consultancies see the
-         *     default Pro recommendation. Cached in Redis for 24h keyed by user_id.
-         */
-        get: operations["get_recommended_plan_v1_user_recommended_plan_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/profile/context": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile Context
-         * @description Get business context from profile (STORY-247 AC3).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
-         *     ensures users can only read their own profile row.
-         */
-        get: operations["get_profile_context_v1_profile_context_get"];
-        /**
-         * Save Profile Context
-         * @description Save business context from onboarding wizard (STORY-247 AC2).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
-         *     ensures users can only update their own profile row.
-         *     Stores context_data as JSONB in profiles table.
-         */
-        put: operations["save_profile_context_v1_profile_context_put"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/profile/completeness": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Profile Completeness
-         * @description STORY-260 AC3: Calculate profile completeness and suggest next question.
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS ensures user can only
-         *     read their own profile.
-         */
-        get: operations["get_profile_completeness_v1_profile_completeness_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/profile/alert-preferences": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Alert Preferences
-         * @description Get user's alert preferences (STORY-278 AC6).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
-         *     ensures users can only read their own preferences.
-         */
-        get: operations["get_alert_preferences_v1_profile_alert_preferences_get"];
-        /**
-         * Update Alert Preferences
-         * @description Update user's alert preferences (STORY-278 AC6).
-         *
-         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
-         *     ensures users can only modify their own preferences.
-         */
-        put: operations["update_alert_preferences_v1_profile_alert_preferences_put"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/me/export": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Export User Data
-         * @description Export all user data as JSON file (LGPD Art. 18 V — data portability).
-         *
-         *     Uses admin client (get_db) because it queries across multiple tables
-         *     and needs unrestricted access to gather all user data for export.
-         *
-         *     Returns a downloadable JSON file containing:
-         *     - Profile information
-         *     - Search history (sessions)
-         *     - Subscription history
-         *     - Messages
-         */
-        get: operations["export_user_data_v1_me_export_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial/exit-survey": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Submit Exit Survey
-         * @description STORY-369 AC2: Submit exit survey when trial expires.
-         *     Returns 409 if user already submitted a survey.
-         */
-        post: operations["submit_exit_survey_v1_trial_exit_survey_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trial-exit-surveys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Exit Surveys Admin
-         * @description STORY-369 AC6: Admin endpoint — exit survey counts grouped by reason.
-         */
-        get: operations["get_exit_surveys_admin_v1_admin_trial_exit_surveys_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/plans": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Plans
-         * @description Get available subscription plans with billing period pricing.
-         *
-         *     STORY-360 AC1: Single source of truth — DB (synced from Stripe) is master.
-         *     Returns per-period pricing from plan_billing_periods table.
-         *     Stripe price IDs stripped from response (STORY-210 AC11).
-         */
-        get: operations["get_plans_v1_plans_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/checkout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Checkout
-         * @description Create Stripe Checkout session for a plan purchase.
-         */
-        post: operations["create_checkout_v1_checkout_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/billing-portal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Billing Portal Session
-         * @description Create Stripe Billing Portal session (GTM-FIX-007 AC6-AC7).
-         *
-         *     Allows users to update payment methods, view invoices, and manage subscriptions.
-         *
-         *     Returns:
-         *         dict: {"url": "https://billing.stripe.com/..."}
-         */
-        post: operations["create_billing_portal_session_v1_billing_portal_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/subscription/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Subscription Status
-         * @description Check subscription activation status (GTM-FIX-016).
-         *
-         *     Used by obrigado page to poll for webhook completion.
-         *     Returns current subscription state from DB, with Stripe API fallback.
-         */
-        get: operations["get_subscription_status_v1_subscription_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/billing/setup-intent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Setup Intent
-         * @description Create a Stripe SetupIntent for pre-signup card capture (CONV-003b AC2).
-         *
-         *     Anonymous endpoint: called before the Supabase user exists, so we cannot
-         *     attach a customer yet. The returned ``payment_method`` (from
-         *     ``stripe.confirmSetup()`` client-side) is forwarded to
-         *     ``POST /v1/auth/signup`` which then creates the Customer and attaches
-         *     the PM server-side via ``services.stripe_signup``.
-         *
-         *     Rate-limited via the same bucket as signup (3 req / 10 min per IP) to
-         *     block abuse. Returns the publishable key alongside the client secret so
-         *     the frontend does not need a second round-trip to ``/config`` (keeps
-         *     the signup flow to 2 network calls: setup-intent → signup).
-         */
-        post: operations["create_setup_intent_v1_billing_setup_intent_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sessions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Sessions
-         * @description Get user's search session history.
-         */
-        get: operations["get_sessions_v1_sessions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sessions/{search_id}/download": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Download Session Excel
-         * @description Download Excel for a previously completed search session.
-         *
-         *     Zero-Churn P2 §2.2: Allows downloads within DATA_RETENTION_DAYS even
-         *     after trial/subscription expires. Bypasses quota checks — only previously
-         *     generated data can be downloaded.
-         */
-        get: operations["download_session_excel_v1_sessions__search_id__download_get"];
+        /** Get Unread Count */
+        get: operations["get_unread_count_v1_api_messages_unread_count_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1756,7 +2092,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/emails/send-welcome": {
+    "/v1/api/subscriptions/cancel": {
         parameters: {
             query?: never;
             header?: never;
@@ -1766,144 +2102,21 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Send Welcome Email
-         * @description Send welcome email to authenticated user (idempotent).
+         * Cancel Subscription
+         * @description Cancel subscription at period end.
          *
-         *     AC7: Triggered after successful signup (both email and Google OAuth).
-         *     Frontend calls this after signup confirmation.
-         *     Idempotent: checks profiles.welcome_email_sent_at before sending.
+         *     GTM-FIX-006: User-initiated cancellation flow.
+         *     UX-308: Accepts optional cancellation reason for retention analytics.
+         *     Sets cancel_at_period_end=True in Stripe, updates status to 'canceling'.
          */
-        post: operations["send_welcome_email_v1_emails_send_welcome_post"];
+        post: operations["cancel_subscription_v1_api_subscriptions_cancel_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/emails/unsubscribe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Unsubscribe Email
-         * @description Unsubscribe from marketing emails.
-         *
-         *     AC15: Unsubscribe mechanism in all marketing emails (LGPD + CAN-SPAM).
-         *     AC16: Updates user preference in database.
-         *     AC17: Transactional emails exempt (payment, security).
-         */
-        get: operations["unsubscribe_email_v1_emails_unsubscribe_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/pipeline": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Pipeline Items
-         * @description List pipeline items for the authenticated user (AC3).
-         *
-         *     ISSUE-021 fix: Switched to admin client (get_supabase) — user-scoped client
-         *     (get_user_db) had fragile JWT header mutation that silently failed, causing
-         *     PostgREST to evaluate RLS as anonymous user and return 0 rows.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access,
-         *     consistent with POST/PATCH/DELETE handlers.
-         *
-         *     STORY-265 AC3: Trial expired can VIEW pipeline (read-only).
-         *     Supports filtering by stage and pagination via limit/offset.
-         */
-        get: operations["list_pipeline_items_v1_pipeline_get"];
-        put?: never;
-        /**
-         * Create Pipeline Item
-         * @description Add a procurement opportunity to the user's pipeline (AC2).
-         *
-         *     ISSUE-021 fix: Reverted to admin client (get_supabase) — user-scoped client
-         *     caused HTTP 500 due to fragile session header mutation in get_user_db.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
-         *     STORY-265 AC2: Trial expired cannot add items.
-         *     STORY-356: Enforce pipeline item limit (trial: 5 items max).
-         *     Returns 409 if the item already exists (UNIQUE constraint on user_id + pncp_id).
-         */
-        post: operations["create_pipeline_item_v1_pipeline_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/pipeline/{item_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Pipeline Item
-         * @description Remove an item from the pipeline (AC5).
-         *
-         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
-         *     STORY-265 AC2: Trial expired cannot delete items.
-         *     Returns 404 if item doesn't exist or doesn't belong to user.
-         */
-        delete: operations["delete_pipeline_item_v1_pipeline__item_id__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Pipeline Item
-         * @description Update stage and/or notes of a pipeline item (AC4).
-         *
-         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
-         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
-         *     STORY-265 AC2: Trial expired cannot modify items.
-         *     Validates that stage is a valid enum value.
-         *     Returns 404 if item doesn't exist or doesn't belong to user.
-         */
-        patch: operations["update_pipeline_item_v1_pipeline__item_id__patch"];
-        trace?: never;
-    };
-    "/v1/pipeline/alerts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Pipeline Alerts
-         * @description Get pipeline items with deadlines within 7 days (DEBT-127 AC1).
-         *
-         *     STORY-265 AC3: Trial expired can view alerts (read-only).
-         *     Returns items where data_encerramento < now() + 7 days
-         *     and stage is NOT in ('enviada', 'resultado').
-         */
-        get: operations["get_pipeline_alerts_v1_pipeline_alerts_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/first-analysis": {
+    "/v1/api/subscriptions/cancel-feedback": {
         parameters: {
             query?: never;
             header?: never;
@@ -1913,21 +2126,19 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * First Analysis
-         * @description Execute first automatic analysis based on onboarding profile.
+         * Submit Cancel Feedback
+         * @description Submit post-cancellation feedback (UX-308 AC6).
          *
-         *     STORY-265 AC5: Trial expired cannot initiate analysis.
-         *     GTM-004 AC1-4: Maps CNAE to sector, builds BuscaRequest automatically,
-         *     executes search in background, and returns search_id for SSE tracking.
+         *     Logs feedback as a user action for analytics. Fire-and-forget — never blocks UX.
          */
-        post: operations["first_analysis_v1_first_analysis_post"];
+        post: operations["submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/onboarding/tour-event": {
+    "/v1/api/subscriptions/update-billing-period": {
         parameters: {
             query?: never;
             header?: never;
@@ -1937,19 +2148,20 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Track Tour Event
-         * @description Persist onboarding tour completion/skip events (STORY-313 AC18).
+         * Update Billing Period
+         * @description Update subscription billing period (monthly / semiannual / annual).
          *
-         *     Fire-and-forget tracking — always returns 204 regardless of metric state.
+         *     GTM-002: Simplified flow — Stripe handles proration automatically.
+         *     No deferral logic, no manual credit calculations.
          */
-        post: operations["track_tour_event_v1_onboarding_tour_event_post"];
+        post: operations["update_billing_period_v1_api_subscriptions_update_billing_period_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/auth/validate-signup-email": {
+    "/v1/api/subscriptions/upgrade-to-lifetime": {
         parameters: {
             query?: never;
             header?: never;
@@ -1959,44 +2171,32 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Validate Signup Email
-         * @description STORY-258 AC3: Backend disposable email validation (defense-in-depth).
+         * Upgrade To Lifetime
+         * @description Upgrade Pro mensal -> Lifetime founder (#1011 / UPGRADE-PATH-013).
          *
-         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
-         *     Returns 422 if email domain is disposable.
+         *     Flow:
+         *       1. Re-check founder cap via existing ``check_founding_availability()`` RPC
+         *          (race-guarded, atomic). Reject 410 if cap reached.
+         *       2. Reject 409 if ``profiles.is_founder`` is already TRUE (idempotent).
+         *       3. Cancel the active Stripe subscription with ``prorate=True``. Stripe
+         *          issues a credit balance to the customer automatically — no custom
+         *          prorata math.
+         *       4. Create a Stripe Checkout Session in ``mode='payment'`` for the
+         *          R$997 one-time founder price (``FOUNDING_ONE_TIME_PRICE_ID``).
+         *          Customer balance is consumed automatically by Stripe.
+         *       5. Return checkout URL. The existing webhook handler
+         *          (``webhooks/handlers/founding.py::_activate_lifetime_founder_entitlement``)
+         *          flips ``is_founder=TRUE`` once payment completes — DO NOT duplicate.
+         *       6. Audit log via ``audit_logger`` for billing.subscription_change.
          */
-        post: operations["validate_signup_email_v1_auth_validate_signup_email_post"];
+        post: operations["upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/auth/resend-confirmation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Resend Confirmation
-         * @description Resend signup confirmation email with 60s rate limiting.
-         *
-         *     CONV-INST-003: Cooldown persisted in Supabase user_email_actions table.
-         *     In-memory _resend_timestamps used as fallback when DB is unavailable.
-         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
-         */
-        post: operations["resend_confirmation_v1_auth_resend_confirmation_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/status": {
+    "/v1/api/subscriptions/upgrade-to-lifetime/preview": {
         parameters: {
             query?: never;
             header?: never;
@@ -2004,321 +2204,15 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Auth Status
-         * @description Check if a signup email has been confirmed.
+         * Upgrade To Lifetime Preview
+         * @description Preview pro-rata math for the upgrade-to-lifetime modal (#1011).
          *
-         *     AC8: Returns { confirmed: boolean, user_id?: string }.
-         *     AC7/AC9: Frontend polls this every 5s for auto-redirect.
-         *     CONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side
-         *     on first confirmation (idempotent via user_email_actions table).
+         *     Returns ``eligible=False`` with a structured ``reason`` whenever the user
+         *     is not allowed to upgrade (already founder, no active sub, cap reached,
+         *     feature flag off). Front-end uses this to render the right copy without
+         *     parsing free text.
          */
-        get: operations["auth_status_v1_auth_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/signup": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Signup
-         * @description STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.
-         *
-         *     Returns 200 with `SignupResponse`. Error modes:
-         *
-         *     - 400: disposable email domain or weak password.
-         *     - 400: invalid `stripe_payment_method_id` shape (Pydantic regex).
-         *     - 409: email already registered (detected via Supabase error).
-         *     - 500: Supabase auth.create_user failed (NOT Stripe — Stripe fails open).
-         */
-        post: operations["signup_v1_auth_signup_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/auth/login-attempt": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Record Login Attempt
-         * @description MFA-EXT-001 AC5/AC6: track password attempts to drive MFA enforcement.
-         *
-         *     Frontend (``AuthProvider``) calls this endpoint immediately after a
-         *     Supabase ``signInWithPassword`` call to report the outcome:
-         *
-         *       * ``success=true``  -> reset counter to 0, set ``last_success_at``
-         *       * ``success=false`` -> increment counter; if it crosses
-         *         ``BRUTEFORCE_FAIL_THRESHOLD`` (3), set
-         *         ``profiles.force_mfa_enrollment_until = NOW() + 7d`` and email
-         *         the user.
-         *
-         *     Trust model: the endpoint is unauthenticated; an attacker can lie
-         *     about the outcome but gains nothing — self-reported success without
-         *     a real session never produces a forced MFA window. Documented in
-         *     ADR-MFA-EXT-001.
-         *
-         *     Always returns 200 (no user-existence oracle).
-         */
-        post: operations["record_login_attempt_v1_auth_login_attempt_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * System Health
-         * @description GTM-STAB-008 AC3: Comprehensive system health endpoint (AC4: internal, detailed).
-         *
-         *     Returns component-level statuses (Redis, Supabase, ARQ Worker, PNCP)
-         *     and overall health classification (healthy / degraded / unhealthy).
-         */
-        get: operations["system_health_v1_health_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Public Status
-         * @description STORY-316 AC3: Public status endpoint (no auth required).
-         *
-         *     Returns per-source status, component health, uptime percentages,
-         *     and last incident timestamp.
-         */
-        get: operations["public_status_v1_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/status/incidents": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Recent Incidents
-         * @description STORY-316 AC13: Recent incidents for status page.
-         */
-        get: operations["recent_incidents_v1_status_incidents_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/status/uptime-history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Uptime History
-         * @description STORY-316 AC12: Daily uptime data for status page chart.
-         */
-        get: operations["uptime_history_v1_status_uptime_history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/tasks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Background Tasks Health
-         * @description DEBT-014 SYS-006: Background task health via TaskRegistry.
-         */
-        get: operations["background_tasks_health_v1_health_tasks_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/sources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Sources Health
-         * @description UX-428 AC5: Health status for all configured procurement sources.
-         *
-         *     Returns enabled/disabled state and availability for each source.
-         *     Read-only — no side effects.
-         */
-        get: operations["sources_health_v1_health_sources_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/cache": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Cache Health
-         * @description AC7: Health check for all cache levels.
-         *
-         *     Returns status of Supabase, Redis/InMemory, and Local file caches
-         *     with latency measurements and error details.
-         *     B-03 AC9: Includes degraded_keys_count and avg_fail_streak from health metadata.
-         *     Note: warmup_coverage removed 2026-04-18 (STORY-CIG-BE-cache-warming-deprecate).
-         */
-        get: operations["cache_health_v1_health_cache_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/health/sitemap": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Sitemap Health
-         * @description SEO-SITEMAP-TELEMETRY-001: Health check for all sitemap materialized views.
-         *
-         *     Returns per-MV status (ok/empty/error) and overall status (ok/degraded).
-         *     Used by Sentry monitors and Railway probes to detect empty sitemap
-         *     responses before they reach GSC.
-         */
-        get: operations["sitemap_health_v1_health_sitemap_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feedback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Submit Feedback
-         * @description AC1: Submit classification feedback for a search result.
-         *
-         *     AC5: Upserts — if user already gave feedback for this search_id + bid_id, update it.
-         *     AC3: Captures context fields (setor_id, bid_objeto, etc.) from the request body.
-         */
-        post: operations["submit_feedback_v1_feedback_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feedback/{feedback_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Feedback
-         * @description AC9: Delete own feedback for LGPD compliance.
-         */
-        delete: operations["delete_feedback_v1_feedback__feedback_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/feedback/patterns": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Feedback Patterns
-         * @description AC6: Admin endpoint for feedback pattern analysis.
-         *
-         *     Requires admin role (via require_admin dependency).
-         */
-        get: operations["feedback_patterns_v1_admin_feedback_patterns_get"];
+        get: operations["upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2377,6 +2271,141 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/auth/login-attempt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record Login Attempt
+         * @description MFA-EXT-001 AC5/AC6: track password attempts to drive MFA enforcement.
+         *
+         *     Frontend (``AuthProvider``) calls this endpoint immediately after a
+         *     Supabase ``signInWithPassword`` call to report the outcome:
+         *
+         *       * ``success=true``  -> reset counter to 0, set ``last_success_at``
+         *       * ``success=false`` -> increment counter; if it crosses
+         *         ``BRUTEFORCE_FAIL_THRESHOLD`` (3), set
+         *         ``profiles.force_mfa_enrollment_until = NOW() + 7d`` and email
+         *         the user.
+         *
+         *     Trust model: the endpoint is unauthenticated; an attacker can lie
+         *     about the outcome but gains nothing — self-reported success without
+         *     a real session never produces a forced MFA window. Documented in
+         *     ADR-MFA-EXT-001.
+         *
+         *     Always returns 200 (no user-existence oracle).
+         */
+        post: operations["record_login_attempt_v1_auth_login_attempt_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/resend-confirmation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resend Confirmation
+         * @description Resend signup confirmation email with 60s rate limiting.
+         *
+         *     CONV-INST-003: Cooldown persisted in Supabase user_email_actions table.
+         *     In-memory _resend_timestamps used as fallback when DB is unavailable.
+         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
+         */
+        post: operations["resend_confirmation_v1_auth_resend_confirmation_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Signup
+         * @description STORY-CONV-003a AC1+AC2+AC3: Signup with optional Stripe trial.
+         *
+         *     Returns 200 with `SignupResponse`. Error modes:
+         *
+         *     - 400: disposable email domain or weak password.
+         *     - 400: invalid `stripe_payment_method_id` shape (Pydantic regex).
+         *     - 409: email already registered (detected via Supabase error).
+         *     - 500: Supabase auth.create_user failed (NOT Stripe — Stripe fails open).
+         */
+        post: operations["signup_v1_auth_signup_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Auth Status
+         * @description Check if a signup email has been confirmed.
+         *
+         *     AC8: Returns { confirmed: boolean, user_id?: string }.
+         *     AC7/AC9: Frontend polls this every 5s for auto-redirect.
+         *     CONV-INST-003 AC6: Emits Mixpanel email_verification_completed server-side
+         *     on first confirmation (idempotent via user_email_actions table).
+         */
+        get: operations["auth_status_v1_auth_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth/validate-signup-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Validate Signup Email
+         * @description STORY-258 AC3: Backend disposable email validation (defense-in-depth).
+         *
+         *     MED-SEC-001: Rate limited to 3 req/10min per IP to prevent trial multi-account abuse.
+         *     Returns 422 if email domain is disposable.
+         */
+        post: operations["validate_signup_email_v1_auth_validate_signup_email_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/bid-analysis/{bid_id}": {
         parameters: {
             query?: never;
@@ -2400,7 +2429,97 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts": {
+    "/v1/billing-portal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Billing Portal Session
+         * @description Create Stripe Billing Portal session (GTM-FIX-007 AC6-AC7).
+         *
+         *     Allows users to update payment methods, view invoices, and manage subscriptions.
+         *
+         *     Returns:
+         *         dict: {"url": "https://billing.stripe.com/..."}
+         */
+        post: operations["create_billing_portal_session_v1_billing_portal_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/setup-intent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Setup Intent
+         * @description Create a Stripe SetupIntent for pre-signup card capture (CONV-003b AC2).
+         *
+         *     Anonymous endpoint: called before the Supabase user exists, so we cannot
+         *     attach a customer yet. The returned ``payment_method`` (from
+         *     ``stripe.confirmSetup()`` client-side) is forwarded to
+         *     ``POST /v1/auth/signup`` which then creates the Customer and attaches
+         *     the PM server-side via ``services.stripe_signup``.
+         *
+         *     Rate-limited via the same bucket as signup (3 req / 10 min per IP) to
+         *     block abuse. Returns the publishable key alongside the client secret so
+         *     the frontend does not need a second round-trip to ``/config`` (keeps
+         *     the signup flow to 2 network calls: setup-intent → signup).
+         */
+        post: operations["create_setup_intent_v1_billing_setup_intent_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/daily/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest diario atual (publico) */
+        get: operations["daily_digest_latest_v1_blog_daily_latest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/daily/{date}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest diario para uma data especifica (publico) */
+        get: operations["daily_digest_by_date_v1_blog_daily__date__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/cidade/{cidade}": {
         parameters: {
             query?: never;
             header?: never;
@@ -2408,28 +2527,686 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Alerts
-         * @description List all alerts for the authenticated user, ordered by created_at desc.
+         * Get Cidade Stats
+         * @description City stats: count, frequent buying orgs, avg values.
          *
-         *     AC2: Includes sent_count (number of items sent for each alert).
+         *     Public (no auth). Cached 6h.
+         *     Uses the first sector with results to get city data.
          */
-        get: operations["list_alerts_v1_alerts_get"];
+        get: operations["get_cidade_stats_v1_blog_stats_cidade__cidade__get"];
         put?: never;
-        /**
-         * Create Alert
-         * @description Create a new email alert for the authenticated user.
-         *
-         *     AC1: Persists alert definition with filter criteria.
-         *     Enforces a per-user limit to prevent abuse.
-         */
-        post: operations["create_alert_v1_alerts_post"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts/{alert_id}": {
+    "/v1/blog/stats/cidade/{cidade}/setor/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Cidade Sector Stats
+         * @description City × Sector stats: cross-reference city with sector keywords.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_cidade_sector_stats_v1_blog_stats_cidade__cidade__setor__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/cidade/{cidade}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Cidade Stats
+         * @description City-level contract stats (all sectors) — fallback for blog cidade pages.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/cidade/{cidade}/setor/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Cidade Setor Stats
+         * @description City × Sector contract stats — fallback for blog cidade×setor pages.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Setor Stats
+         * @description National contract stats by sector from pncp_supplier_contracts.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_setor_stats_v1_blog_stats_contratos__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/contratos/{setor_id}/uf/{uf}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Contratos Setor Uf Stats
+         * @description Sector × UF contract stats — fallback for blog pages with zero open editais.
+         *
+         *     Queries pncp_supplier_contracts filtered by uf (idx_psc_uf_data) and sector
+         *     keywords. Public (no auth). Cached 6h.
+         */
+        get: operations["get_contratos_setor_uf_stats_v1_blog_stats_contratos__setor_id__uf__uf__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/panorama/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Panorama Stats
+         * @description National panorama: totals, seasonality, estimated YoY growth.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_panorama_stats_v1_blog_stats_panorama__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/setor/{setor_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sector Blog Stats
+         * @description Sector overview: count, value range, top modalities, top UFs, 90d trend.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_sector_blog_stats_v1_blog_stats_setor__setor_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/stats/setor/{setor_id}/uf/{uf}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sector Uf Stats
+         * @description Sector × UF detail: count, avg value, top 5 recent opportunities.
+         *
+         *     Public (no auth). Cached 6h.
+         */
+        get: operations["get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/weekly/latest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest semanal atual (público) */
+        get: operations["weekly_digest_latest_v1_blog_weekly_latest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/blog/weekly/{year}/{week}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Digest semanal para um período específico (público) */
+        get: operations["weekly_digest_by_week_v1_blog_weekly__year___week__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/buscar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Buscar Licitacoes
+         * @description Main search endpoint — thin wrapper that delegates to SearchPipeline.
+         *
+         *     GTM-RESILIENCE-A04: Cache-first progressive delivery.
+         *     When cache exists for this search, returns cached data immediately with
+         *     `live_fetch_in_progress=True` and dispatches background live fetch.
+         *     When no cache, runs synchronous pipeline as before (AC10).
+         *
+         *     The wrapper handles:
+         *     - Cache-first check and immediate response (A-04 AC1)
+         *     - Background task dispatch (A-04 AC2)
+         *     - SSE tracker lifecycle (create, cleanup on error)
+         *     - Exception mapping (PNCPRateLimitError → 503, PNCPAPIError → 502, etc.)
+         *     - Dependency injection (passing module-level names for test mock compatibility)
+         *
+         *     STORY-291 AC5: require_active_plan() moved INSIDE try block, AFTER tracker
+         *     creation. Previously, when it failed the frontend was left in limbo — POST
+         *     failed but SSE was waiting for a tracker that never existed.
+         */
+        post: operations["buscar_licitacoes_v1_buscar_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/buscar-progress/{search_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Buscar Progress Stream
+         * @description SSE endpoint for real-time search progress updates.
+         *
+         *     The client opens this connection simultaneously with POST /buscar,
+         *     using the same search_id to correlate progress events.
+         *
+         *     GTM-GO-002 AC6: Max 3 simultaneous SSE connections per user.
+         *
+         *     Events:
+         *         - connecting (5%): Initial setup
+         *         - fetching (10-55%): Per-UF progress with uf_index/uf_total
+         *         - filtering (60-70%): Filter application
+         *         - llm (75-90%): LLM summary generation
+         *         - excel (92-98%): Excel report generation
+         *         - complete (100%): Search finished
+         *         - partial_results: Non-terminal — intermediate results during background fetch (A-04)
+         *         - refresh_available (100%): Background fetch complete, new data available (A-04)
+         *         - error: Search failed
+         */
+        get: operations["buscar_progress_stream_v1_buscar_progress__search_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/buscar-results/{search_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Search Results
+         * @description Return results of a background fetch or async search.
+         *
+         *     A-04 AC5: Called by frontend when user clicks "Atualizar resultados" banner.
+         *     GTM-ARCH-001 AC3: Also serves results from ARQ Worker (via Redis).
+         *     Returns 404 if search_id not found or expired.
+         */
+        get: operations["get_search_results_v1_buscar_results__search_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/calculadora/dados": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Dados reais PNCP para a calculadora de oportunidades (público) */
+        get: operations["calculadora_dados_v1_calculadora_dados_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Change Password
+         * @description Change current user's password.
+         */
+        post: operations["change_password_v1_change_password_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Checkout
+         * @description Create Stripe Checkout session for a plan purchase.
+         */
+        post: operations["create_checkout_v1_checkout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/comparador/bids": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Bids By Ids
+         * @description Fetch specific bids by pncp_id from datalake (public, no auth).
+         */
+        get: operations["get_bids_by_ids_v1_comparador_bids_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/comparador/buscar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Buscar Editais
+         * @description Search bids by text query from datalake (public, no auth).
+         */
+        get: operations["buscar_editais_v1_comparador_buscar_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/compliance/{cnpj}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Perfil de due diligence B2G: CEIS + CNEP por CNPJ
+         * @description Agrega registros CEIS e CNEP do Portal da Transparencia para um CNPJ.
+         *
+         *     Publico, sem auth. Cache: 24h por CNPJ.
+         *     Em caso de falha do Portal da Transparencia, retorna dados parciais.
+         */
+        get: operations["compliance_profile_v1_compliance__cnpj__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/conta/cancelar-trial": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cancel Trial Info
+         * @description Return trial metadata for the confirmation UI.
+         *
+         *     Does NOT mutate state. Intended to be called by the frontend confirmation
+         *     page (STORY-CONV-003c frontend).
+         */
+        get: operations["cancel_trial_info_v1_conta_cancelar_trial_get"];
+        put?: never;
+        /**
+         * Cancel Trial Execute
+         * @description Cancel the user's active trial subscription.
+         *
+         *     Idempotent: if already cancelled, returns ``cancelled=true`` + ``already_cancelled=true``.
+         *     Fail-safe: Stripe errors are swallowed but profile is marked ``canceled_trial``
+         *     so the downgrade still happens if the Stripe-side cancel retries succeed out-of-band
+         *     via billing reconciliation (STORY-314).
+         */
+        post: operations["cancel_trial_execute_v1_conta_cancelar_trial_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contratos/orgao/{cnpj}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Perfil de contratos de um orgao publico (por CNPJ) */
+        get: operations["orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contratos/{setor}/{uf}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Estatisticas de contratos publicos por setor e UF */
+        get: operations["contratos_stats_v1_contratos__setor___uf__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/dados/agregados": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Dados agregados do PNCP para o painel público (sem autenticação) */
+        get: operations["dados_agregados_v1_dados_agregados_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/emails/send-welcome": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Send Welcome Email
+         * @description Send welcome email to authenticated user (idempotent).
+         *
+         *     AC7: Triggered after successful signup (both email and Google OAuth).
+         *     Frontend calls this after signup confirmation.
+         *     Idempotent: checks profiles.welcome_email_sent_at before sending.
+         */
+        post: operations["send_welcome_email_v1_emails_send_welcome_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/emails/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unsubscribe Email
+         * @description Unsubscribe from marketing emails.
+         *
+         *     AC15: Unsubscribe mechanism in all marketing emails (LGPD + CAN-SPAM).
+         *     AC16: Updates user preference in database.
+         *     AC17: Transactional emails exempt (payment, security).
+         */
+        get: operations["unsubscribe_email_v1_emails_unsubscribe_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/empresa/{cnpj}/perfil-b2g": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Perfil B2G público de uma empresa por CNPJ */
+        get: operations["perfil_b2g_v1_empresa__cnpj__perfil_b2g_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/export/pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Export Edital Pdf
+         * @description Generate and return a 1-page A4 PDF for a single bid.
+         *
+         *     Trial users get a watermark footer.
+         *     Synchronous generation wrapped in asyncio.to_thread with 10s timeout.
+         */
+        post: operations["export_edital_pdf_v1_export_pdf_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feature-flags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Public Feature Flags
+         * @description List all feature flags with current values (authenticated users).
+         *
+         *     DEBT-205 / DEBT-SYS-009: Public endpoint consumed by frontend via SWR.
+         *     Returns flag name, value, description, and category — no admin metadata.
+         */
+        get: operations["list_public_feature_flags_v1_feature_flags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feature-flags/experiments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Experiments
+         * @description Return active experiment variants for the authenticated user.
+         */
+        get: operations["get_experiments_v1_feature_flags_experiments_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feedback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Feedback
+         * @description AC1: Submit classification feedback for a search result.
+         *
+         *     AC5: Upserts — if user already gave feedback for this search_id + bid_id, update it.
+         *     AC3: Captures context fields (setor_id, bid_objeto, etc.) from the request body.
+         */
+        post: operations["submit_feedback_v1_feedback_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/feedback/{feedback_id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -2440,119 +3217,16 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Delete Alert
-         * @description Delete an alert and its sent-item history.
-         *
-         *     AC4: Cascading delete removes associated alert_sent_items.
-         *     Validates that the alert belongs to the authenticated user.
+         * Delete Feedback
+         * @description AC9: Delete own feedback for LGPD compliance.
          */
-        delete: operations["delete_alert_v1_alerts__alert_id__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Alert
-         * @description Update an existing alert (partial update).
-         *
-         *     AC3: Only name, filters, and active status can be updated.
-         *     Validates that the alert belongs to the authenticated user.
-         */
-        patch: operations["update_alert_v1_alerts__alert_id__patch"];
-        trace?: never;
-    };
-    "/v1/alerts/{alert_id}/unsubscribe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Unsubscribe Alert
-         * @description One-click unsubscribe from an email alert (RFC 8058).
-         *
-         *     AC9: No authentication required — uses HMAC token verification.
-         *     Sets the alert's active flag to false.
-         *     Returns an HTML confirmation page.
-         */
-        get: operations["unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
+        delete: operations["delete_feedback_v1_feedback__feedback_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/alerts/{alert_id}/preview": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Preview Alert
-         * @description Preview what opportunities an alert would match (dry-run).
-         *
-         *     STORY-315 AC12: Executes matching without sending email.
-         *     Returns opportunities that would be sent, useful for validating filters.
-         */
-        get: operations["preview_alert_v1_alerts__alert_id__preview_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/alerts/{alert_id}/history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Alert History
-         * @description Paginated history of items sent for this alert.
-         *
-         *     AC13: Returns alert_sent_items ordered by sent_at desc.
-         *     Only accessible if the alert belongs to the authenticated user.
-         */
-        get: operations["alert_history_v1_alerts__alert_id__history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial-emails/unsubscribe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Unsubscribe Trial Emails
-         * @description AC2/AC5: One-click unsubscribe from trial marketing emails.
-         *     Zero-churn P2 §1.2: Only disables marketing/promotional emails.
-         *     Critical conversion emails (Day 7/10/13/16) remain active unless
-         *     user explicitly opts out of those too.
-         */
-        get: operations["unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/trial-emails/webhook": {
+    "/v1/first-analysis": {
         parameters: {
             query?: never;
             header?: never;
@@ -2562,33 +3236,21 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Resend Webhook
-         * @description Handle Resend webhook events for email tracking.
+         * First Analysis
+         * @description Execute first automatic analysis based on onboarding profile.
          *
-         *     Security: Svix HMAC-SHA256 signature verified against `TRIAL_EMAILS_WEBHOOK_SECRET`
-         *     (or legacy alias `RESEND_WEBHOOK_SECRET`).
-         *     Replay protection: timestamp must be within 5 minutes of now.
-         *     Fail-closed — missing secret or invalid signature returns 401.
-         *
-         *     Accepts the full delivery lifecycle (sent → delivered → opened → clicked)
-         *     plus failure paths (bounced, complained, delivery_delayed, failed) so the
-         *     admin funnel dashboard can distinguish "email never arrived" from "email
-         *     arrived but wasn't engaged". Service handler
-         *     (`services.trial_email_sequence.handle_resend_webhook`) populates the
-         *     columns added in migration 20260424180000_trial_email_delivery_tracking.
-         *
-         *     Returns 200 for processed/ignored/skipped so Resend doesn't retry; 401 on
-         *     signature failure (Resend will retry — desired so legitimate events aren't
-         *     lost during transient secret rotation).
+         *     STORY-265 AC5: Trial expired cannot initiate analysis.
+         *     GTM-004 AC1-4: Maps CNAE to sector, builds BuscaRequest automatically,
+         *     executes search in background, and returns search_id for SSE tracking.
          */
-        post: operations["resend_webhook_v1_trial_emails_webhook_post"];
+        post: operations["first_analysis_v1_first_analysis_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/trial-emails/preview": {
+    "/v1/fornecedores/{cnpj}/profile": {
         parameters: {
             query?: never;
             header?: never;
@@ -2596,10 +3258,13 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Preview Trial Emails
-         * @description AC15: Preview all 6 trial email templates.
+         * Perfil completo de um fornecedor do governo (por CNPJ)
+         * @description Agrega historico de contratos do PNCP + dados cadastrais (BrasilAPI via
+         *     enriched_entities) para a pagina /fornecedores/{cnpj}.
+         *
+         *     Publico, sem auth. Cache: 24h TTL em memoria (5min em fallback partial).
          */
-        get: operations["preview_trial_emails_v1_admin_trial_emails_preview_get"];
+        get: operations["fornecedor_profile_v1_fornecedores__cnpj__profile_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2608,7 +3273,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/trial-emails/test-send": {
+    "/v1/fornecedores/{setor}/{uf}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ranking de fornecedores do governo por setor e UF */
+        get: operations["fornecedores_stats_v1_fornecedores__setor___uf__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/availability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Availability
+         * @description Public seat counter + countdown feed.
+         *
+         *     No auth — the landing page calls this anonymously to render the
+         *     countdown and the X/50 seat counter. Falls open with ``available=False``
+         *     on transient DB error so the CTA is disabled rather than over-selling.
+         */
+        get: operations["founding_availability_v1_founding_availability_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/checkout": {
         parameters: {
             query?: never;
             header?: never;
@@ -2618,10 +3324,651 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Test Send Trial Email
-         * @description AC14: Send a test trial email to the admin's own email.
+         * Founding Checkout
+         * @description Create a founding-customer Stripe Checkout Session (v2 one-time payment).
+         *
+         *     BIZ-FOUND-002 gate:
+         *     - Calls ``check_founding_availability()`` BEFORE creating the lead row.
+         *     - On ``available=false`` returns 410 Gone with structured ``error_code`` +
+         *       ``error_reason`` so the frontend can render the right copy.
+         *
+         *     #783 changes:
+         *     - Uses ``mode='payment'`` (one-time) with ``FOUNDING_ONE_TIME_PRICE_ID``.
+         *     - Accepts ``card`` and ``boleto`` payment methods.
+         *     - No coupon / discounts applied.
+         *     - Expanded metadata: ``offer_version``, ``offer_mode``, ``price_brl_cents``,
+         *       ``checkout_source`` (resolved from ``src`` or ``utm_source`` query param).
+         *
+         *     Side effects (when available):
+         *     - Inserts a ``founding_leads`` row with ``checkout_status='pending'``.
+         *     - Subsequent webhook events (``checkout.session.completed`` / ``expired``)
+         *       update it. The webhook also re-checks availability for race guard
+         *       (handled in webhooks.handlers.founding).
          */
-        post: operations["test_send_trial_email_v1_admin_trial_emails_test_send_post"];
+        post: operations["founding_checkout_v1_founding_checkout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/checkout/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Checkout Status
+         * @description Return Stripe checkout session status for the founding purchase confirmation page.
+         *
+         *     No auth required — Stripe ``cs_*`` session IDs are long random tokens that
+         *     are unguessable. Only ``status`` and ``payment_status`` are returned so no
+         *     PII is exposed. Used by ``/fundadores/obrigado`` to poll until payment is
+         *     confirmed (max 20 × 3 s = 60 s).
+         */
+        get: operations["founding_checkout_status_v1_founding_checkout_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/founding/session-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Founding Session Status
+         * @description Enriched session status for the /fundadores/obrigado confirmation page (#865).
+         *
+         *     No auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.
+         *     Returns masked email, ``has_account``, and ``invite_sent`` so the frontend
+         *     can render the right post-purchase CTA without polling Stripe directly.
+         *
+         *     Expiry guard: sessions with checkout_status != 'completed' that are older
+         *     than 24 h return ``status='pending'`` to prevent infinite polling.
+         */
+        get: operations["founding_session_status_v1_founding_session_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * System Health
+         * @description GTM-STAB-008 AC3: Comprehensive system health endpoint (AC4: internal, detailed).
+         *
+         *     Returns component-level statuses (Redis, Supabase, ARQ Worker, PNCP)
+         *     and overall health classification (healthy / degraded / unhealthy).
+         */
+        get: operations["system_health_v1_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/cache": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Cache Health
+         * @description AC7: Health check for all cache levels.
+         *
+         *     Returns status of Supabase, Redis/InMemory, and Local file caches
+         *     with latency measurements and error details.
+         *     B-03 AC9: Includes degraded_keys_count and avg_fail_streak from health metadata.
+         *     Note: warmup_coverage removed 2026-04-18 (STORY-CIG-BE-cache-warming-deprecate).
+         */
+        get: operations["cache_health_v1_health_cache_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/sitemap": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Sitemap Health
+         * @description SEO-SITEMAP-TELEMETRY-001: Health check for all sitemap materialized views.
+         *
+         *     Returns per-MV status (ok/empty/error) and overall status (ok/degraded).
+         *     Used by Sentry monitors and Railway probes to detect empty sitemap
+         *     responses before they reach GSC.
+         */
+        get: operations["sitemap_health_v1_health_sitemap_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Sources Health
+         * @description UX-428 AC5: Health status for all configured procurement sources.
+         *
+         *     Returns enabled/disabled state and availability for each source.
+         *     Read-only — no side effects.
+         */
+        get: operations["sources_health_v1_health_sources_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/health/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Background Tasks Health
+         * @description DEBT-014 SYS-006: Background task health via TaskRegistry.
+         */
+        get: operations["background_tasks_health_v1_health_tasks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/indice-municipal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ranking de transparência municipal em compras públicas (público)
+         * @description Ranking nacional ou por UF de transparência municipal. Dados do PNCP.
+         */
+        get: operations["get_ranking_v1_indice_municipal_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/indice-municipal/periodos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Períodos disponíveis no Índice Municipal (público)
+         * @description Lista trimestres com dados calculados no índice.
+         */
+        get: operations["get_periodos_v1_indice_municipal_periodos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/indice-municipal/{municipio_slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Índice de transparência de um município (público)
+         * @description Retorna índice de transparência de um município (slug: sao-paulo-sp).
+         */
+        get: operations["get_municipio_v1_indice_municipal__municipio_slug__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Intel Report Purchases
+         * @description List all Intel Report purchases for the authenticated user.
+         */
+        get: operations["list_intel_report_purchases_v1_intel_reports__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/checkout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Intel Report Checkout
+         * @description Create a Stripe Checkout session for an Intel Report one-time purchase.
+         *
+         *     product_type:
+         *         - "cnpj"       → R$197.00 — Company analysis report (INTEL-REPORT-001)
+         *         - "sector_uf"  → R$147.00 — Sector/UF market report (INTEL-REPORT-002)
+         *
+         *     entity_key:
+         *         - For cnpj:       the CNPJ string (e.g. "12345678000195")
+         *         - For sector_uf:  "sector:uf" (e.g. "limpeza:SP")
+         *
+         *     Returns checkout_url (redirect user) and session_id (for polling).
+         */
+        post: operations["create_intel_report_checkout_v1_intel_reports_checkout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/{purchase_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Intel Report Status
+         * @description Poll status of an Intel Report purchase.
+         *
+         *     Frontend uses this endpoint after being redirected back from Stripe
+         *     (/intel-reports/{CHECKOUT_SESSION_ID}?status=processing).
+         *     Poll until status is "ready" or "failed".
+         *
+         *     Returns:
+         *     - 404 if purchase does not exist
+         *     - 403 if purchase belongs to a different user
+         */
+        get: operations["get_intel_report_status_v1_intel_reports__purchase_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-reports/{purchase_id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download Intel Report
+         * @description Stream the Intel Report PDF.
+         *
+         *     Requires:
+         *     - Authentication
+         *     - Ownership: purchase must belong to the authenticated user
+         *     - Status: purchase must be "ready" (pdf_url present)
+         *
+         *     Returns:
+         *     - 401 if not authenticated
+         *     - 404 if purchase does not exist
+         *     - 403 if purchase belongs to a different user
+         *     - 400 if purchase status is not "ready"
+         *     - PDF stream if all checks pass
+         */
+        get: operations["download_intel_report_v1_intel_reports__purchase_id__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/itens/{catmat}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Benchmark de precos governamentais por codigo CATMAT
+         * @description Calcula P10/P50/P90 de contratos do PNCP datalake para um item CATMAT.
+         *
+         *     Publico, sem auth. Cache: 24h. Substitui o Painel de Precos do ComprasGov
+         *     (descontinuado jul/2025).
+         */
+        get: operations["item_profile_v1_itens__catmat__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/lead-capture": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Capture Lead
+         * @description Store a lead capture from a non-authenticated visitor.
+         *
+         *     - New sources (COPY-COP-006): stored in ``lead_captures`` table
+         *     - Old sources (backward compat): stored in ``leads`` table
+         *     - Rate limited to 3 requests/min per IP
+         *     - Fail-open: returns success even if DB storage fails
+         *     - Lead magnet PDF delivery enqueued for legacy sources (LEAD-MAGNET-001)
+         *
+         *     Returns 201 on success.
+         */
+        post: operations["capture_lead_v1_lead_capture_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/lead-magnet/{magnet_type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Lead Magnet
+         * @description Return a placeholder PDF for the requested lead magnet type.
+         *
+         *     This is a minimal/stub implementation — the real LLM-generated content
+         *     will replace the placeholder text in a future story.
+         */
+        get: operations["get_lead_magnet_v1_lead_magnet__magnet_type__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description Get current user profile with plan capabilities and quota status.
+         *
+         *     Uses admin client (get_db) because it needs db.auth.admin.get_user_by_id()
+         *     to fetch the user's email from auth.users — an admin-only operation.
+         */
+        get: operations["get_profile_v1_me_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Account
+         * @description Delete entire user account and all associated data (LGPD Art. 18 VI).
+         *
+         *     Uses admin client (get_db) because it needs db.auth.admin.delete_user()
+         *     and must delete across multiple tables regardless of RLS.
+         *
+         *     Strategy:
+         *     1. Cancel active Stripe subscription (external side-effect, must be first)
+         *     2. Delete from profiles (CASCADE propagates to most child tables)
+         *     3. Delete from remaining tables that reference auth.users directly
+         *     4. Delete auth user via Supabase admin API
+         *     5. Log anonymized audit entry
+         *
+         *     If auth user deletion fails (step 4), we do NOT roll back the profile
+         *     deletion — the user's data is already gone and a dangling auth entry
+         *     is preferable to leaving personal data behind (LGPD Art. 18 VI).
+         */
+        delete: operations["delete_account_v1_me_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/me/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export User Data
+         * @description Export all user data as JSON file (LGPD Art. 18 V — data portability).
+         *
+         *     Uses admin client (get_db) because it queries across multiple tables
+         *     and needs unrestricted access to gather all user data for export.
+         *
+         *     Returns a downloadable JSON file containing:
+         *     - Profile information
+         *     - Search history (sessions)
+         *     - Subscription history
+         *     - Messages
+         */
+        get: operations["export_user_data_v1_me_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/metrics/daily-volume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Daily Volume
+         * @description STORY-358 AC3: Return average bids processed per day.
+         *
+         *     Public endpoint (no authentication required). Used by InstitutionalSidebar
+         *     to display a verified bids/day count instead of a hardcoded number.
+         *
+         *     Queries search_sessions for the specified window and computes daily average
+         *     from total_raw (bids fetched before filtering).
+         */
+        get: operations["get_daily_volume_v1_metrics_daily_volume_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/metrics/discard-rate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Discard Rate
+         * @description Return the moving-average filter discard rate.
+         *
+         *     Public endpoint (no authentication required). Used by the landing page
+         *     to display a verified discard rate instead of a hardcoded number.
+         */
+        get: operations["get_discard_rate_v1_metrics_discard_rate_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/metrics/sse-fallback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Report Sse Fallback
+         * @description STORY-359 AC4: Frontend reports SSE fallback to simulated progress.
+         *
+         *     Lightweight fire-and-forget endpoint — no auth, no body, just increments counter.
+         */
+        post: operations["report_sse_fallback_v1_metrics_sse_fallback_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/mfa/enroll": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enroll Totp
+         * @description Issue #639 AC1: Enrol a TOTP MFA factor for the current user.
+         *
+         *     Returns the QR code URI (otpauth://...), the base32 secret, and 10 fresh
+         *     one-time backup codes. The user adds the URI/secret to an authenticator
+         *     app and then calls /verify-totp with a generated code to complete enrolment.
+         *
+         *     Backup codes are returned ONCE — the client must persist them.
+         */
+        post: operations["enroll_totp_v1_mfa_enroll_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/mfa/recovery-codes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Recovery Codes
+         * @description AC5: Generate 10 recovery codes after MFA enrollment.
+         *
+         *     This should be called immediately after successful MFA enrollment.
+         *     Stores bcrypt-hashed codes in the database, returns plaintext once.
+         */
+        post: operations["generate_recovery_codes_v1_mfa_recovery_codes_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/mfa/regenerate-recovery": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Regenerate Recovery Codes
+         * @description AC8: Regenerate recovery codes (requires aal2).
+         *
+         *     Invalidates all existing codes and generates a fresh set.
+         */
+        post: operations["regenerate_recovery_codes_v1_mfa_regenerate_recovery_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2652,29 +3999,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/mfa/recovery-codes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Generate Recovery Codes
-         * @description AC5: Generate 10 recovery codes after MFA enrollment.
-         *
-         *     This should be called immediately after successful MFA enrollment.
-         *     Stores bcrypt-hashed codes in the database, returns plaintext once.
-         */
-        post: operations["generate_recovery_codes_v1_mfa_recovery_codes_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/mfa/verify-recovery": {
         parameters: {
             query?: never;
@@ -2692,32 +4016,6 @@ export interface paths {
          *     On success: marks code as used, returns remaining count.
          */
         post: operations["verify_recovery_code_v1_mfa_verify_recovery_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/mfa/enroll": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enroll Totp
-         * @description Issue #639 AC1: Enrol a TOTP MFA factor for the current user.
-         *
-         *     Returns the QR code URI (otpauth://...), the base32 secret, and 10 fresh
-         *     one-time backup codes. The user adds the URI/secret to an authenticator
-         *     app and then calls /verify-totp with a generated code to complete enrolment.
-         *
-         *     Backup codes are returned ONCE — the client must persist them.
-         */
-        post: operations["enroll_totp_v1_mfa_enroll_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2751,7 +4049,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/mfa/regenerate-recovery": {
+    "/v1/municipios/{slug}/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Perfil de municipio com licitacoes abertas (por slug)
+         * @description Agrega licitacoes abertas do PNCP datalake + dados IBGE para a pagina
+         *     /municipios/{slug}. Publico, sem auth. Cache: 24h TTL em memoria.
+         */
+        get: operations["municipio_profile_v1_municipios__slug__profile_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/network-events/record": {
         parameters: {
             query?: never;
             header?: never;
@@ -2761,19 +4080,20 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Regenerate Recovery Codes
-         * @description AC8: Regenerate recovery codes (requires aal2).
+         * Record Network Event
+         * @description Record an anonymized network event.
          *
-         *     Invalidates all existing codes and generates a fresh set.
+         *     Only collects data if user has explicitly opted in
+         *     (profiles.allow_network_analytics = true). LGPD Art. 6, I.
          */
-        post: operations["regenerate_recovery_codes_v1_mfa_regenerate_recovery_post"];
+        post: operations["record_network_event_v1_network_events_record_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/organizations/me": {
+    "/v1/network-events/top": {
         parameters: {
             query?: never;
             header?: never;
@@ -2781,12 +4101,98 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get My Org
-         * @description Get the organization the current user belongs to.
+         * Get Top Network Events
+         * @description Get top dimension values for a given event type.
+         *
+         *     Public endpoint — returns only anonymized aggregated data.
          */
-        get: operations["get_my_org_v1_organizations_me_get"];
+        get: operations["get_top_network_events_v1_network_events_top_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/notifications/new-bids-count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get New Bids Count
+         * @description Return count of new bids available for the user since last check.
+         *
+         *     Returns 0 when no Redis key exists (cron not yet run, or badge was cleared).
+         */
+        get: operations["get_new_bids_count_v1_notifications_new_bids_count_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Clear New Bids Count
+         * @description Clear the new-bids badge for the user (called after they run a search).
+         *
+         *     Idempotent — safe to call even if the key does not exist.
+         */
+        delete: operations["clear_new_bids_count_v1_notifications_new_bids_count_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/observatorio/relatorio/{mes}/{ano}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Relatório mensal do Observatório de Licitações (público) */
+        get: operations["get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/observatorio/relatorio/{mes}/{ano}/csv": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download CSV do relatório mensal (público) */
+        get: operations["get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/onboarding/tour-event": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Track Tour Event
+         * @description Persist onboarding tour completion/skip events (STORY-313 AC18).
+         *
+         *     Fire-and-forget tracking — always returns 204 regardless of metric state.
+         */
+        post: operations["track_tour_event_v1_onboarding_tour_event_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2813,6 +4219,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get My Org
+         * @description Get the organization the current user belongs to.
+         */
+        get: operations["get_my_org_v1_organizations_me_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/{org_id}": {
         parameters: {
             query?: never;
@@ -2827,26 +4253,6 @@ export interface paths {
         get: operations["get_org_v1_organizations__org_id__get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/organizations/{org_id}/invite": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Invite Org Member
-         * @description Invite a member to the organization (owner/admin only).
-         */
-        post: operations["invite_org_member_v1_organizations__org_id__invite_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2873,26 +4279,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/organizations/{org_id}/members/{target_user_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Remove Org Member
-         * @description Remove a member from the organization (owner/admin only).
-         */
-        delete: operations["remove_org_member_v1_organizations__org_id__members__target_user_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/organizations/{org_id}/dashboard": {
         parameters: {
             query?: never;
@@ -2907,6 +4293,26 @@ export interface paths {
         get: operations["get_org_dashboard_endpoint_v1_organizations__org_id__dashboard_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/{org_id}/invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Invite Org Member
+         * @description Invite a member to the organization (owner/admin only).
+         */
+        post: operations["invite_org_member_v1_organizations__org_id__invite_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2936,6 +4342,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations/{org_id}/members/{target_user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove Org Member
+         * @description Remove a member from the organization (owner/admin only).
+         */
+        delete: operations["remove_org_member_v1_organizations__org_id__members__target_user_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/orgao/{cnpj}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Estatísticas públicas de um órgão comprador por CNPJ */
+        get: operations["orgao_stats_v1_orgao__cnpj__stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/partner/dashboard": {
         parameters: {
             query?: never;
@@ -2958,7 +4401,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/partners": {
+    "/v1/pipeline": {
         parameters: {
             query?: never;
             header?: never;
@@ -2966,23 +4409,39 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Partners Endpoint
-         * @description AC10: List all partners. Admin only.
+         * List Pipeline Items
+         * @description List pipeline items for the authenticated user (AC3).
+         *
+         *     ISSUE-021 fix: Switched to admin client (get_supabase) — user-scoped client
+         *     (get_user_db) had fragile JWT header mutation that silently failed, causing
+         *     PostgREST to evaluate RLS as anonymous user and return 0 rows.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access,
+         *     consistent with POST/PATCH/DELETE handlers.
+         *
+         *     STORY-265 AC3: Trial expired can VIEW pipeline (read-only).
+         *     Supports filtering by stage and pagination via limit/offset.
          */
-        get: operations["list_partners_endpoint_v1_admin_partners_get"];
+        get: operations["list_pipeline_items_v1_pipeline_get"];
         put?: never;
         /**
-         * Create Partner Endpoint
-         * @description AC11: Create a new partner. Admin only.
+         * Create Pipeline Item
+         * @description Add a procurement opportunity to the user's pipeline (AC2).
+         *
+         *     ISSUE-021 fix: Reverted to admin client (get_supabase) — user-scoped client
+         *     caused HTTP 500 due to fragile session header mutation in get_user_db.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
+         *     STORY-265 AC2: Trial expired cannot add items.
+         *     STORY-356: Enforce pipeline item limit (trial: 5 items max).
+         *     Returns 409 if the item already exists (UNIQUE constraint on user_id + pncp_id).
          */
-        post: operations["create_partner_endpoint_v1_admin_partners_post"];
+        post: operations["create_pipeline_item_v1_pipeline_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/partners/{partner_id}/referrals": {
+    "/v1/pipeline/alerts": {
         parameters: {
             query?: never;
             header?: never;
@@ -2990,10 +4449,14 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Partner Referrals Endpoint
-         * @description AC12: Get referrals for a specific partner. Admin only.
+         * Get Pipeline Alerts
+         * @description Get pipeline items with deadlines within 7 days (DEBT-127 AC1).
+         *
+         *     STORY-265 AC3: Trial expired can view alerts (read-only).
+         *     Returns items where data_encerramento < now() + 7 days
+         *     and stage is NOT in ('enviada', 'resultado').
          */
-        get: operations["get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get"];
+        get: operations["get_pipeline_alerts_v1_pipeline_alerts_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3002,7 +4465,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/admin/partners/{partner_id}/revenue": {
+    "/v1/pipeline/{item_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Pipeline Item
+         * @description Remove an item from the pipeline (AC5).
+         *
+         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
+         *     STORY-265 AC2: Trial expired cannot delete items.
+         *     Returns 404 if item doesn't exist or doesn't belong to user.
+         */
+        delete: operations["delete_pipeline_item_v1_pipeline__item_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Pipeline Item
+         * @description Update stage and/or notes of a pipeline item (AC4).
+         *
+         *     ISSUE-021 fix: Reverted to admin client — user-scoped client caused HTTP 500.
+         *     Defense-in-depth: .eq("user_id", user_id) prevents cross-user access.
+         *     STORY-265 AC2: Trial expired cannot modify items.
+         *     Validates that stage is a valid enum value.
+         *     Returns 404 if item doesn't exist or doesn't belong to user.
+         */
+        patch: operations["update_pipeline_item_v1_pipeline__item_id__patch"];
+        trace?: never;
+    };
+    "/v1/plans": {
         parameters: {
             query?: never;
             header?: never;
@@ -3010,10 +4508,475 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Partner Revenue Endpoint
-         * @description AC13: Get revenue share for a partner in a given month. Admin only.
+         * Get Plans
+         * @description Get available subscription plans with billing period pricing.
+         *
+         *     STORY-360 AC1: Single source of truth — DB (synced from Stripe) is master.
+         *     Returns per-period pricing from plan_billing_periods table.
+         *     Stripe price IDs stripped from response (STORY-210 AC11).
          */
-        get: operations["get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get"];
+        get: operations["get_plans_v1_plans_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/predict/seasonal-calendar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Calendario sazonal de compras por UF
+         * @description Retorna um calendario sazonal de 12 meses com base no historico de contratos e licitacoes da UF. Inclui volume medio, quantidade, setor dominante, orgaos principais, indice de sazonalidade, tendencia e variacao anual para cada mes.
+         */
+        get: operations["get_seasonal_calendar_v1_predict_seasonal_calendar_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/products": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Products
+         * @description List active digital products available for one-time purchase.
+         *
+         *     Public (no auth required). Results cached in Redis for 1 hour.
+         */
+        get: operations["list_products_v1_products_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/profile/alert-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Alert Preferences
+         * @description Get user's alert preferences (STORY-278 AC6).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
+         *     ensures users can only read their own preferences.
+         */
+        get: operations["get_alert_preferences_v1_profile_alert_preferences_get"];
+        /**
+         * Update Alert Preferences
+         * @description Update user's alert preferences (STORY-278 AC6).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS on alert_preferences
+         *     ensures users can only modify their own preferences.
+         */
+        put: operations["update_alert_preferences_v1_profile_alert_preferences_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/profile/completeness": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile Completeness
+         * @description STORY-260 AC3: Calculate profile completeness and suggest next question.
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS ensures user can only
+         *     read their own profile.
+         */
+        get: operations["get_profile_completeness_v1_profile_completeness_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/profile/context": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile Context
+         * @description Get business context from profile (STORY-247 AC3).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
+         *     ensures users can only read their own profile row.
+         */
+        get: operations["get_profile_context_v1_profile_context_get"];
+        /**
+         * Save Profile Context
+         * @description Save business context from onboarding wizard (STORY-247 AC2).
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS policy on profiles
+         *     ensures users can only update their own profile row.
+         *     Stores context_data as JSONB in profiles table.
+         */
+        put: operations["save_profile_context_v1_profile_context_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/pseo/recent-editais": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 5 últimos editais abertos no setor (público)
+         * @description Most recent open editais for sector+UF.
+         *
+         *     Returns orgao, objeto, valor_estimado, data_limite, link_interno.
+         *     link_interno = /licitacoes/{setor}?query={orgao}
+         *     Cache: 6h InMemory.
+         */
+        get: operations["get_recent_editais_v1_pseo_recent_editais_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/pseo/top-suppliers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Top 5 fornecedores por volume de contratos no setor (público)
+         * @description Top suppliers by contract volume in sector, last 12 months.
+         *
+         *     Returns cnpj, razao_social, contratos_count, valor_total.
+         *     If total contracts < 10, returns empty list (avoid weak social proof).
+         *     Cache: 6h InMemory.
+         */
+        get: operations["get_top_suppliers_v1_pseo_top_suppliers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/referral/code": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Referral Code
+         * @description Return the authenticated user's referral code (create if missing).
+         */
+        get: operations["get_referral_code_v1_referral_code_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/referral/redeem": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Redeem Referral
+         * @description Register a referral redemption during signup.
+         *
+         *     The authenticated user is the *referred* user. We look up the row
+         *     owned by the referrer (matched by code) and link the referred_user_id
+         *     while promoting status to 'signed_up'. If no such row exists we
+         *     silently succeed to avoid leaking code existence.
+         */
+        post: operations["redeem_referral_v1_referral_redeem_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/referral/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Referral Stats
+         * @description Aggregate stats for the authenticated user's referrals.
+         */
+        get: operations["get_referral_stats_v1_referral_stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/relatorio-2026-t1/request": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request Relatorio
+         * @description Capture a report lead and dispatch the delivery email.
+         *
+         *     Flow:
+         *       1. Upsert row into `report_leads` on (email, source).
+         *       2. Attempt to send the delivery email via Resend (best-effort).
+         *       3. Return the download URL + email_queued flag.
+         *
+         *     Persistence failure -> 500. Email failure -> 200 with email_queued=False.
+         */
+        post: operations["request_relatorio_v1_relatorio_2026_t1_request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/reports/diagnostico": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Diagnostico
+         * @description Generate a PDF diagnostico report for a completed search.
+         *
+         *     Fetches the results from a previous search (by search_id), applies
+         *     viability scoring if not already present, selects the top N opportunities,
+         *     and streams a styled PDF back to the caller as a file download.
+         *
+         *     Request Body:
+         *         {
+         *             "search_id": "uuid-of-completed-search",
+         *             "client_name": "Empresa ABC Ltda",  // optional
+         *             "max_items": 20                       // 1-50
+         *         }
+         *
+         *     Returns:
+         *         PDF file as a streaming attachment:
+         *         Content-Disposition: attachment; filename="diagnostico-<setor>-<date>.pdf"
+         *
+         *     Errors:
+         *         400 Bad Request: search_id is not a valid UUID
+         *         404 Not Found: search not found or expired
+         *         500 Internal Server Error: PDF generation failed
+         */
+        post: operations["generate_diagnostico_v1_reports_diagnostico_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Search
+         * @description CRIT-006 AC16-17: Cancel an in-progress search.
+         */
+        post: operations["cancel_search_v1_search__search_id__cancel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/regenerate-excel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Regenerate Excel Endpoint
+         * @description STORY-364 AC7-AC8: Regenerate Excel from stored results without re-running search.
+         *
+         *     - 202: Excel generation job enqueued
+         *     - 404: Results not found or expired
+         */
+        post: operations["regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Search Results V1
+         * @description GTM-STAB-009 AC4: Return results of async search.
+         *
+         *     - 200 with BuscaResponse when results are ready
+         *     - 202 with status when still processing
+         *     - 404 when search_id not found or expired
+         */
+        get: operations["get_search_results_v1_v1_search__search_id__results_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Retry Search
+         * @description CRIT-006 AC4-5: Retry search with only missing/failed UFs.
+         */
+        post: operations["retry_search_v1_search__search_id__retry_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search Status Endpoint
+         * @description GTM-STAB-009 AC3: Enriched status response for polling.
+         *
+         *     LIGHTWEIGHT (<50ms): Reads from in-memory progress tracker + state machine.
+         *     Falls back to DB-based get_search_status only if in-memory state is unavailable.
+         *
+         *     Called by frontend when SSE disconnects (AC12) or for async polling.
+         */
+        get: operations["search_status_endpoint_v1_search__search_id__status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/timeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search Timeline Endpoint
+         * @description AC7: Return all state transitions for audit trail.
+         */
+        get: operations["search_timeline_endpoint_v1_search__search_id__timeline_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/search/{search_id}/zero-match": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Zero Match Results Endpoint
+         * @description Return items approved by background zero-match LLM classification.
+         *
+         *     - 200: Results ready (may be empty list if none approved)
+         *     - 404: Job not yet completed or results expired
+         */
+        get: operations["get_zero_match_results_endpoint_v1_search__search_id__zero_match_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3087,7 +5050,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/reports/diagnostico": {
+    "/v1/segment/save": {
         parameters: {
             query?: never;
             header?: never;
@@ -3097,37 +5060,22 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Generate Diagnostico
-         * @description Generate a PDF diagnostico report for a completed search.
+         * Save Segment
+         * @description Save user segmentation data to profile context_data (CONV-018).
          *
-         *     Fetches the results from a previous search (by search_id), applies
-         *     viability scoring if not already present, selects the top N opportunities,
-         *     and streams a styled PDF back to the caller as a file download.
+         *     Merges the new fields into the existing ``context_data`` JSONB column
+         *     on the ``profiles`` table without overwriting other fields.
          *
-         *     Request Body:
-         *         {
-         *             "search_id": "uuid-of-completed-search",
-         *             "client_name": "Empresa ABC Ltda",  // optional
-         *             "max_items": 20                       // 1-50
-         *         }
-         *
-         *     Returns:
-         *         PDF file as a streaming attachment:
-         *         Content-Disposition: attachment; filename="diagnostico-<setor>-<date>.pdf"
-         *
-         *     Errors:
-         *         400 Bad Request: search_id is not a valid UUID
-         *         404 Not Found: search not found or expired
-         *         500 Internal Server Error: PDF generation failed
+         *     Returns the full updated context_data on success.
          */
-        post: operations["generate_diagnostico_v1_reports_diagnostico_post"];
+        post: operations["save_segment_v1_segment_save_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/blog/stats/setor/{setor_id}": {
+    "/v1/seo/coverage-manifest": {
         parameters: {
             query?: never;
             header?: never;
@@ -3135,12 +5083,14 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Sector Blog Stats
-         * @description Sector overview: count, value range, top modalities, top UFs, 90d trend.
+         * Per-slug coverage status for sitemap gate (SEO-COVERAGE-MANIFEST-001)
+         * @description Return the latest seo_coverage_manifest rows as a keyed dict.
          *
-         *     Public (no auth). Cached 6h.
+         *     AC1: <2s response time (served from 1h in-memory cache after first build).
+         *     AC7: historical_empty slugs are included — sitemap gate uses priority=0.3,
+         *          not excluded, so /observatorio/raio-x-marco-2026 stays accessible.
          */
-        get: operations["get_sector_blog_stats_v1_blog_stats_setor__setor_id__get"];
+        get: operations["get_coverage_manifest_v1_seo_coverage_manifest_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3149,7 +5099,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/blog/stats/setor/{setor_id}/uf/{uf}": {
+    "/v1/sessions": {
         parameters: {
             query?: never;
             header?: never;
@@ -3157,12 +5107,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Sector Uf Stats
-         * @description Sector × UF detail: count, avg value, top 5 recent opportunities.
-         *
-         *     Public (no auth). Cached 6h.
+         * Get Sessions
+         * @description Get user's search session history.
          */
-        get: operations["get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get"];
+        get: operations["get_sessions_v1_sessions_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3171,7 +5119,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/blog/stats/cidade/{cidade}": {
+    "/v1/sessions/{search_id}/download": {
         parameters: {
             query?: never;
             header?: never;
@@ -3179,13 +5127,14 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Cidade Stats
-         * @description City stats: count, frequent buying orgs, avg values.
+         * Download Session Excel
+         * @description Download Excel for a previously completed search session.
          *
-         *     Public (no auth). Cached 6h.
-         *     Uses the first sector with results to get city data.
+         *     Zero-Churn P2 §2.2: Allows downloads within DATA_RETENTION_DAYS even
+         *     after trial/subscription expires. Bypasses quota checks — only previously
+         *     generated data can be downloaded.
          */
-        get: operations["get_cidade_stats_v1_blog_stats_cidade__cidade__get"];
+        get: operations["download_session_excel_v1_sessions__search_id__download_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3194,7 +5143,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/blog/stats/cidade/{cidade}/setor/{setor_id}": {
+    "/v1/setores": {
         parameters: {
             query?: never;
             header?: never;
@@ -3202,350 +5151,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Cidade Sector Stats
-         * @description City × Sector stats: cross-reference city with sector keywords.
-         *
-         *     Public (no auth). Cached 6h.
+         * Listar Setores
+         * @description Return available procurement sectors for frontend dropdown.
          */
-        get: operations["get_cidade_sector_stats_v1_blog_stats_cidade__cidade__setor__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/panorama/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Panorama Stats
-         * @description National panorama: totals, seasonality, estimated YoY growth.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_panorama_stats_v1_blog_stats_panorama__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Setor Stats
-         * @description National contract stats by sector from pncp_supplier_contracts.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_setor_stats_v1_blog_stats_contratos__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/{setor_id}/uf/{uf}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Setor Uf Stats
-         * @description Sector × UF contract stats — fallback for blog pages with zero open editais.
-         *
-         *     Queries pncp_supplier_contracts filtered by uf (idx_psc_uf_data) and sector
-         *     keywords. Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_setor_uf_stats_v1_blog_stats_contratos__setor_id__uf__uf__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/cidade/{cidade}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Cidade Stats
-         * @description City-level contract stats (all sectors) — fallback for blog cidade pages.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/stats/contratos/cidade/{cidade}/setor/{setor_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Contratos Cidade Setor Stats
-         * @description City × Sector contract stats — fallback for blog cidade×setor pages.
-         *
-         *     Public (no auth). Cached 6h.
-         */
-        get: operations["get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/metrics/discard-rate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Discard Rate
-         * @description Return the moving-average filter discard rate.
-         *
-         *     Public endpoint (no authentication required). Used by the landing page
-         *     to display a verified discard rate instead of a hardcoded number.
-         */
-        get: operations["get_discard_rate_v1_metrics_discard_rate_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/metrics/daily-volume": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Daily Volume
-         * @description STORY-358 AC3: Return average bids processed per day.
-         *
-         *     Public endpoint (no authentication required). Used by InstitutionalSidebar
-         *     to display a verified bids/day count instead of a hardcoded number.
-         *
-         *     Queries search_sessions for the specified window and computes daily average
-         *     from total_raw (bids fetched before filtering).
-         */
-        get: operations["get_daily_volume_v1_metrics_daily_volume_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/metrics/sse-fallback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Report Sse Fallback
-         * @description STORY-359 AC4: Frontend reports SSE fallback to simulated progress.
-         *
-         *     Lightweight fire-and-forget endpoint — no auth, no body, just increments counter.
-         */
-        post: operations["report_sse_fallback_v1_metrics_sse_fallback_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/feature-flags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Feature Flags
-         * @description List all registered feature flags with current values and sources.
-         *
-         *     Returns each flag's effective value, where it comes from (redis override,
-         *     env var, or default), its description, and registry metadata.
-         *
-         *     Admin only.
-         */
-        get: operations["list_feature_flags_v1_admin_feature_flags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/feature-flags/{flag_name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Feature Flag
-         * @description Update a feature flag value at runtime (admin only).
-         *
-         *     The new value is persisted to Redis (if available) and stored in-memory.
-         *     Takes effect immediately -- no container restart required.
-         *
-         *     The change persists across process restarts as long as Redis is available.
-         *     Use POST /admin/feature-flags/reload to clear all overrides.
-         */
-        patch: operations["update_feature_flag_v1_admin_feature_flags__flag_name__patch"];
-        trace?: never;
-    };
-    "/v1/admin/feature-flags/reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reload Flags Endpoint
-         * @description Reload all feature flags from environment variables (admin only).
-         *
-         *     This clears:
-         *     1. All Redis overrides (smartlic:ff:* keys)
-         *     2. All in-memory overrides
-         *     3. The feature flag TTL cache
-         *
-         *     After reload, flags return to their env var or registry default values.
-         *     Useful after updating env vars via Railway dashboard without restarting.
-         */
-        post: operations["reload_flags_endpoint_v1_admin_feature_flags_reload_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feature-flags/experiments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Experiments
-         * @description Return active experiment variants for the authenticated user.
-         */
-        get: operations["get_experiments_v1_feature_flags_experiments_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/feature-flags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Public Feature Flags
-         * @description List all feature flags with current values (authenticated users).
-         *
-         *     DEBT-205 / DEBT-SYS-009: Public endpoint consumed by frontend via SWR.
-         *     Returns flag name, value, description, and category — no admin metadata.
-         */
-        get: operations["list_public_feature_flags_v1_feature_flags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/calculadora/dados": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Dados reais PNCP para a calculadora de oportunidades (público) */
-        get: operations["calculadora_dados_v1_calculadora_dados_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/empresa/{cnpj}/perfil-b2g": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Perfil B2G público de uma empresa por CNPJ */
-        get: operations["perfil_b2g_v1_empresa__cnpj__perfil_b2g_get"];
+        get: operations["listar_setores_v1_setores_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3594,18 +5203,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/referral/code": {
+    "/v1/sitemap/cnpjs": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Get Referral Code
-         * @description Return the authenticated user's referral code (create if missing).
-         */
-        get: operations["get_referral_code_v1_referral_code_get"];
+        /** CNPJs com ≥1 licitação no datalake (para sitemap) */
+        get: operations["sitemap_cnpjs_v1_sitemap_cnpjs_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3614,7 +5220,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/referral/stats": {
+    "/v1/sitemap/contratos-orgao-indexable": {
         parameters: {
             query?: never;
             header?: never;
@@ -3622,10 +5228,16 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Referral Stats
-         * @description Aggregate stats for the authenticated user's referrals.
+         * Órgãos compradores com contratos em pncp_supplier_contracts (para sitemap /contratos/orgao/)
+         * @description Retorna CNPJs de órgãos com ≥1 contrato ativo em pncp_supplier_contracts.
+         *
+         *     Diferente de /sitemap/orgaos (que usa mv_sitemap_orgaos/pncp_raw_bids), este
+         *     endpoint consulta pncp_supplier_contracts — a tabela que alimenta
+         *     /contratos/orgao/{cnpj}/stats. Garante que o sitemap só inclui URLs
+         *     que retornam 200, eliminando os 794 404s reportados no GSC.
+         *     Cache: 24h em memória.
          */
-        get: operations["get_referral_stats_v1_referral_stats_get"];
+        get: operations["sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3634,7 +5246,232 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/referral/redeem": {
+    "/v1/sitemap/fornecedores-cnpj": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Top CNPJs de fornecedores com contratos no datalake (para sitemap)
+         * @description Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.
+         *
+         *     SEO-SITEMAP-MV-001: agora usa mv_sitemap_fornecedores (MV pré-agregada).
+         *     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
+         *     Limite: 5.000 CNPJs por volume de contratos.
+         *     Cache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).
+         */
+        get: operations["sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/itens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Lista de codigos CATMAT para sitemap.xml */
+        get: operations["sitemap_itens_v1_sitemap_itens_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/licitacoes-do-dia-indexable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)
+         * @description Retorna apenas datas com bids suficientes para ter pagina renderizavel.
+         *
+         *     Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
+         */
+        get: operations["sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/licitacoes-indexable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Combos setor×UF indexáveis (público — sitemap)
+         * @description Retorna combos setor×UF com bids OR contracts suficientes.
+         */
+        get: operations["get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/municipios": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Lista de slugs de municipios para sitemap.xml
+         * @description Retorna slugs dos municipios pre-cadastrados para o sitemap.xml.
+         *     Cache: 24h em memoria.
+         */
+        get: operations["sitemap_municipios_v1_sitemap_municipios_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/sitemap/orgaos": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Órgãos compradores com ≥1 licitação no datalake (para sitemap) */
+        get: operations["sitemap_orgaos_v1_sitemap_orgaos_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/stats/public": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Estatísticas públicas agregadas do PNCP (sem auth) */
+        get: operations["stats_public_v1_stats_public_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Public Status
+         * @description STORY-316 AC3: Public status endpoint (no auth required).
+         *
+         *     Returns per-source status, component health, uptime percentages,
+         *     and last incident timestamp.
+         */
+        get: operations["public_status_v1_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/status/incidents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Recent Incidents
+         * @description STORY-316 AC13: Recent incidents for status page.
+         */
+        get: operations["recent_incidents_v1_status_incidents_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/status/uptime-history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Uptime History
+         * @description STORY-316 AC12: Daily uptime data for status page chart.
+         */
+        get: operations["uptime_history_v1_status_uptime_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/subscription/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Subscription Status
+         * @description Check subscription activation status (GTM-FIX-016).
+         *
+         *     Used by obrigado page to poll for webhook completion.
+         *     Returns current subscription state from DB, with Stripe API fallback.
+         */
+        get: operations["get_subscription_status_v1_subscription_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/survey/export-time-saved": {
         parameters: {
             query?: never;
             header?: never;
@@ -3644,22 +5481,44 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Redeem Referral
-         * @description Register a referral redemption during signup.
+         * Submit Export Time Saved Survey
+         * @description Persist one row in ``export_time_saved_survey``.
          *
-         *     The authenticated user is the *referred* user. We look up the row
-         *     owned by the referrer (matched by code) and link the referred_user_id
-         *     while promoting status to 'signed_up'. If no such row exists we
-         *     silently succeed to avoid leaking code existence.
+         *     Auth required. The row is owned by ``user.id`` (RLS: users only ever
+         *     see their own submissions). Returns 503 if the database is
+         *     unavailable so the frontend can retry on next export.
          */
-        post: operations["redeem_referral_v1_referral_redeem_post"];
+        post: operations["submit_export_time_saved_survey_v1_survey_export_time_saved_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/v1/relatorio-2026-t1/request": {
+    "/v1/trial-emails/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unsubscribe Trial Emails
+         * @description AC2/AC5: One-click unsubscribe from trial marketing emails.
+         *     Zero-churn P2 §1.2: Only disables marketing/promotional emails.
+         *     Critical conversion emails (Day 7/10/13/16) remain active unless
+         *     user explicitly opts out of those too.
+         */
+        get: operations["unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial-emails/webhook": {
         parameters: {
             query?: never;
             header?: never;
@@ -3669,17 +5528,69 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Request Relatorio
-         * @description Capture a report lead and dispatch the delivery email.
+         * Resend Webhook
+         * @description Handle Resend webhook events for email tracking.
          *
-         *     Flow:
-         *       1. Upsert row into `report_leads` on (email, source).
-         *       2. Attempt to send the delivery email via Resend (best-effort).
-         *       3. Return the download URL + email_queued flag.
+         *     Security: Svix HMAC-SHA256 signature verified against `TRIAL_EMAILS_WEBHOOK_SECRET`
+         *     (or legacy alias `RESEND_WEBHOOK_SECRET`).
+         *     Replay protection: timestamp must be within 5 minutes of now.
+         *     Fail-closed — missing secret or invalid signature returns 401.
          *
-         *     Persistence failure -> 500. Email failure -> 200 with email_queued=False.
+         *     Accepts the full delivery lifecycle (sent → delivered → opened → clicked)
+         *     plus failure paths (bounced, complained, delivery_delayed, failed) so the
+         *     admin funnel dashboard can distinguish "email never arrived" from "email
+         *     arrived but wasn't engaged". Service handler
+         *     (`services.trial_email_sequence.handle_resend_webhook`) populates the
+         *     columns added in migration 20260424180000_trial_email_delivery_tracking.
+         *
+         *     Returns 200 for processed/ignored/skipped so Resend doesn't retry; 401 on
+         *     signature failure (Resend will retry — desired so legitimate events aren't
+         *     lost during transient secret rotation).
          */
-        post: operations["request_relatorio_v1_relatorio_2026_t1_request_post"];
+        post: operations["resend_webhook_v1_trial_emails_webhook_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Trial Status
+         * @description Get detailed trial status for conversion flow (GTM-010 AC3).
+         *
+         *     Returns days remaining, usage stats, and expiration info.
+         */
+        get: operations["get_trial_status_v1_trial_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/trial/exit-survey": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Exit Survey
+         * @description STORY-369 AC2: Submit exit survey when trial expires.
+         *     Returns 409 if user already submitted a survey.
+         */
+        post: operations["submit_exit_survey_v1_trial_exit_survey_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3726,75 +5637,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/blog/weekly/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest semanal atual (público) */
-        get: operations["weekly_digest_latest_v1_blog_weekly_latest_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/weekly/{year}/{week}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest semanal para um período específico (público) */
-        get: operations["weekly_digest_by_week_v1_blog_weekly__year___week__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/stats/public": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Estatísticas públicas agregadas do PNCP (sem auth) */
-        get: operations["stats_public_v1_stats_public_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/dados/agregados": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Dados agregados do PNCP para o painel público (sem autenticação) */
-        get: operations["dados_agregados_v1_dados_agregados_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/alertas/{setor_id}/uf/{uf}": {
+    "/v1/user/recommended-plan": {
         parameters: {
             query?: never;
             header?: never;
@@ -3802,1771 +5645,16 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Alertas
-         * @description Return latest 20 bids for sector × UF from datalake (public, no auth).
-         */
-        get: operations["get_alertas_v1_alertas__setor_id__uf__uf__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/lead-capture": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Capture Lead
-         * @description Store a lead capture from a non-authenticated visitor.
+         * Get Recommended Plan
+         * @description STORY-BIZ-002 AC2: return the upsell-eligible plan for the current user.
          *
-         *     - New sources (COPY-COP-006): stored in ``lead_captures`` table
-         *     - Old sources (backward compat): stored in ``leads`` table
-         *     - Rate limited to 3 requests/min per IP
-         *     - Fail-open: returns success even if DB storage fails
-         *     - Lead magnet PDF delivery enqueued for legacy sources (LEAD-MAGNET-001)
-         *
-         *     Returns 201 on success.
+         *     Detects consultancy profiles by CNAE primário (divisions 70.2 / 74.9 / 82.9)
+         *     and recommends the higher-ARPU Consultoria plan. Non-consultancies see the
+         *     default Pro recommendation. Cached in Redis for 24h keyed by user_id.
          */
-        post: operations["capture_lead_v1_lead_capture_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/lead-magnet/{magnet_type}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Lead Magnet
-         * @description Return a placeholder PDF for the requested lead magnet type.
-         *
-         *     This is a minimal/stub implementation — the real LLM-generated content
-         *     will replace the placeholder text in a future story.
-         */
-        get: operations["get_lead_magnet_v1_lead_magnet__magnet_type__get"];
+        get: operations["get_recommended_plan_v1_user_recommended_plan_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/comparador/buscar": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Buscar Editais
-         * @description Search bids by text query from datalake (public, no auth).
-         */
-        get: operations["buscar_editais_v1_comparador_buscar_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/comparador/bids": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Bids By Ids
-         * @description Fetch specific bids by pncp_id from datalake (public, no auth).
-         */
-        get: operations["get_bids_by_ids_v1_comparador_bids_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/seo-metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Seo Metrics
-         * @description Return SEO metrics for the last N days (legacy S14 daily rollup). Admin-only.
-         */
-        get: operations["get_seo_metrics_v1_admin_seo_metrics_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/seo/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Gsc Summary
-         * @description Return aggregated GSC analytics from gsc_metrics cache. Admin-only.
-         *
-         *     STORY-SEO-005 AC4. Populated weekly by backend/jobs/cron/gsc_sync.py.
-         */
-        get: operations["get_gsc_summary_v1_admin_seo_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/revalidate-seo": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Admin Revalidate Seo
-         * @description Manually trigger ISR revalidation for the given frontend paths.
-         *
-         *     Calls the Next.js ``POST /api/revalidate`` endpoint (secret-gated).
-         *     Fire-and-forget — the HTTP call is made but result is not awaited for
-         *     user-facing errors.  Any failure is logged as a warning.
-         *
-         *     Requires admin role.  Raises HTTP 400 if ``paths`` is empty.
-         */
-        post: operations["admin_revalidate_seo_v1_admin_revalidate_seo_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/cnpjs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** CNPJs com ≥1 licitação no datalake (para sitemap) */
-        get: operations["sitemap_cnpjs_v1_sitemap_cnpjs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/fornecedores-cnpj": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Top CNPJs de fornecedores com contratos no datalake (para sitemap)
-         * @description Retorna os CNPJs de fornecedores com mais contratos em pncp_supplier_contracts.
-         *
-         *     SEO-SITEMAP-MV-001: agora usa mv_sitemap_fornecedores (MV pré-agregada).
-         *     Usado pelo frontend para gerar /fornecedores/{cnpj} no sitemap.xml.
-         *     Limite: 5.000 CNPJs por volume de contratos.
-         *     Cache: 24h em memoria sucesso, 5min em falha (negative cache PR #529 pattern).
-         */
-        get: operations["sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/orgaos": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Órgãos compradores com ≥1 licitação no datalake (para sitemap) */
-        get: operations["sitemap_orgaos_v1_sitemap_orgaos_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/contratos-orgao-indexable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Órgãos compradores com contratos em pncp_supplier_contracts (para sitemap /contratos/orgao/)
-         * @description Retorna CNPJs de órgãos com ≥1 contrato ativo em pncp_supplier_contracts.
-         *
-         *     Diferente de /sitemap/orgaos (que usa mv_sitemap_orgaos/pncp_raw_bids), este
-         *     endpoint consulta pncp_supplier_contracts — a tabela que alimenta
-         *     /contratos/orgao/{cnpj}/stats. Garante que o sitemap só inclui URLs
-         *     que retornam 200, eliminando os 794 404s reportados no GSC.
-         *     Cache: 24h em memória.
-         */
-        get: operations["sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/orgao/{cnpj}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Estatísticas públicas de um órgão comprador por CNPJ */
-        get: operations["orgao_stats_v1_orgao__cnpj__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/contratos/orgao/{cnpj}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Perfil de contratos de um orgao publico (por CNPJ) */
-        get: operations["orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/contratos/{setor}/{uf}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Estatisticas de contratos publicos por setor e UF */
-        get: operations["contratos_stats_v1_contratos__setor___uf__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/fornecedores/{setor}/{uf}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Ranking de fornecedores do governo por setor e UF */
-        get: operations["fornecedores_stats_v1_fornecedores__setor___uf__stats_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/fornecedores/{cnpj}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Perfil completo de um fornecedor do governo (por CNPJ)
-         * @description Agrega historico de contratos do PNCP + dados cadastrais (BrasilAPI via
-         *     enriched_entities) para a pagina /fornecedores/{cnpj}.
-         *
-         *     Publico, sem auth. Cache: 24h TTL em memoria (5min em fallback partial).
-         */
-        get: operations["fornecedor_profile_v1_fornecedores__cnpj__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/daily/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest diario atual (publico) */
-        get: operations["daily_digest_latest_v1_blog_daily_latest_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/blog/daily/{date}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Digest diario para uma data especifica (publico) */
-        get: operations["daily_digest_by_date_v1_blog_daily__date__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/municipios/{slug}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Perfil de municipio com licitacoes abertas (por slug)
-         * @description Agrega licitacoes abertas do PNCP datalake + dados IBGE para a pagina
-         *     /municipios/{slug}. Publico, sem auth. Cache: 24h TTL em memoria.
-         */
-        get: operations["municipio_profile_v1_municipios__slug__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/municipios": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Lista de slugs de municipios para sitemap.xml
-         * @description Retorna slugs dos municipios pre-cadastrados para o sitemap.xml.
-         *     Cache: 24h em memoria.
-         */
-        get: operations["sitemap_municipios_v1_sitemap_municipios_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/compliance/{cnpj}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Perfil de due diligence B2G: CEIS + CNEP por CNPJ
-         * @description Agrega registros CEIS e CNEP do Portal da Transparencia para um CNPJ.
-         *
-         *     Publico, sem auth. Cache: 24h por CNPJ.
-         *     Em caso de falha do Portal da Transparencia, retorna dados parciais.
-         */
-        get: operations["compliance_profile_v1_compliance__cnpj__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/itens/{catmat}/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Benchmark de precos governamentais por codigo CATMAT
-         * @description Calcula P10/P50/P90 de contratos do PNCP datalake para um item CATMAT.
-         *
-         *     Publico, sem auth. Cache: 24h. Substitui o Painel de Precos do ComprasGov
-         *     (descontinuado jul/2025).
-         */
-        get: operations["item_profile_v1_itens__catmat__profile_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/itens": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Lista de codigos CATMAT para sitemap.xml */
-        get: operations["sitemap_itens_v1_sitemap_itens_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/observatorio/relatorio/{mes}/{ano}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Relatório mensal do Observatório de Licitações (público) */
-        get: operations["get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/observatorio/relatorio/{mes}/{ano}/csv": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Download CSV do relatório mensal (público) */
-        get: operations["get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/licitacoes-indexable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Combos setor×UF indexáveis (público — sitemap)
-         * @description Retorna combos setor×UF com bids OR contracts suficientes.
-         */
-        get: operations["get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/sitemap-cache/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Force-refresh sitemap combos cache (admin only)
-         * @description Clears the 24h in-memory sitemap cache and recomputes indexable combos immediately.
-         */
-        post: operations["refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/sitemap/licitacoes-do-dia-indexable": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Datas dos ultimos 30d com >=5 bids ativos (sitemap /blog/licitacoes-do-dia/)
-         * @description Retorna apenas datas com bids suficientes para ter pagina renderizavel.
-         *
-         *     Elimina os 42 URLs 404 reportados no GSC sweep 2026-04-24.
-         */
-        get: operations["sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/indice-municipal/periodos": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Períodos disponíveis no Índice Municipal (público)
-         * @description Lista trimestres com dados calculados no índice.
-         */
-        get: operations["get_periodos_v1_indice_municipal_periodos_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/indice-municipal": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ranking de transparência municipal em compras públicas (público)
-         * @description Ranking nacional ou por UF de transparência municipal. Dados do PNCP.
-         */
-        get: operations["get_ranking_v1_indice_municipal_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/indice-municipal/{municipio_slug}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Índice de transparência de um município (público)
-         * @description Retorna índice de transparência de um município (slug: sao-paulo-sp).
-         */
-        get: operations["get_municipio_v1_indice_municipal__municipio_slug__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/notifications/new-bids-count": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get New Bids Count
-         * @description Return count of new bids available for the user since last check.
-         *
-         *     Returns 0 when no Redis key exists (cron not yet run, or badge was cleared).
-         */
-        get: operations["get_new_bids_count_v1_notifications_new_bids_count_get"];
-        put?: never;
-        post?: never;
-        /**
-         * Clear New Bids Count
-         * @description Clear the new-bids badge for the user (called after they run a search).
-         *
-         *     Idempotent — safe to call even if the key does not exist.
-         */
-        delete: operations["clear_new_bids_count_v1_notifications_new_bids_count_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/export/pdf": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Export Edital Pdf
-         * @description Generate and return a 1-page A4 PDF for a single bid.
-         *
-         *     Trial users get a watermark footer.
-         *     Synchronous generation wrapped in asyncio.to_thread with 10s timeout.
-         */
-        post: operations["export_edital_pdf_v1_export_pdf_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/availability": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founding Availability
-         * @description Public seat counter + countdown feed.
-         *
-         *     No auth — the landing page calls this anonymously to render the
-         *     countdown and the X/50 seat counter. Falls open with ``available=False``
-         *     on transient DB error so the CTA is disabled rather than over-selling.
-         */
-        get: operations["founding_availability_v1_founding_availability_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/checkout/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founding Checkout Status
-         * @description Return Stripe checkout session status for the founding purchase confirmation page.
-         *
-         *     No auth required — Stripe ``cs_*`` session IDs are long random tokens that
-         *     are unguessable. Only ``status`` and ``payment_status`` are returned so no
-         *     PII is exposed. Used by ``/fundadores/obrigado`` to poll until payment is
-         *     confirmed (max 20 × 3 s = 60 s).
-         */
-        get: operations["founding_checkout_status_v1_founding_checkout_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/session-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founding Session Status
-         * @description Enriched session status for the /fundadores/obrigado confirmation page (#865).
-         *
-         *     No auth required — Stripe ``cs_*`` session IDs are long random opaque tokens.
-         *     Returns masked email, ``has_account``, and ``invite_sent`` so the frontend
-         *     can render the right post-purchase CTA without polling Stripe directly.
-         *
-         *     Expiry guard: sessions with checkout_status != 'completed' that are older
-         *     than 24 h return ``status='pending'`` to prevent infinite polling.
-         */
-        get: operations["founding_session_status_v1_founding_session_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/founding/checkout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Founding Checkout
-         * @description Create a founding-customer Stripe Checkout Session (v2 one-time payment).
-         *
-         *     BIZ-FOUND-002 gate:
-         *     - Calls ``check_founding_availability()`` BEFORE creating the lead row.
-         *     - On ``available=false`` returns 410 Gone with structured ``error_code`` +
-         *       ``error_reason`` so the frontend can render the right copy.
-         *
-         *     #783 changes:
-         *     - Uses ``mode='payment'`` (one-time) with ``FOUNDING_ONE_TIME_PRICE_ID``.
-         *     - Accepts ``card`` and ``boleto`` payment methods.
-         *     - No coupon / discounts applied.
-         *     - Expanded metadata: ``offer_version``, ``offer_mode``, ``price_brl_cents``,
-         *       ``checkout_source`` (resolved from ``src`` or ``utm_source`` query param).
-         *
-         *     Side effects (when available):
-         *     - Inserts a ``founding_leads`` row with ``checkout_status='pending'``.
-         *     - Subsequent webhook events (``checkout.session.completed`` / ``expired``)
-         *       update it. The webhook also re-checks availability for race guard
-         *       (handled in webhooks.handlers.founding).
-         */
-        post: operations["founding_checkout_v1_founding_checkout_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/conta/cancelar-trial": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Cancel Trial Info
-         * @description Return trial metadata for the confirmation UI.
-         *
-         *     Does NOT mutate state. Intended to be called by the frontend confirmation
-         *     page (STORY-CONV-003c frontend).
-         */
-        get: operations["cancel_trial_info_v1_conta_cancelar_trial_get"];
-        put?: never;
-        /**
-         * Cancel Trial Execute
-         * @description Cancel the user's active trial subscription.
-         *
-         *     Idempotent: if already cancelled, returns ``cancelled=true`` + ``already_cancelled=true``.
-         *     Fail-safe: Stripe errors are swallowed but profile is marked ``canceled_trial``
-         *     so the downgrade still happens if the Stripe-side cancel retries succeed out-of-band
-         *     via billing reconciliation (STORY-314).
-         */
-        post: operations["cancel_trial_execute_v1_conta_cancelar_trial_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/survey/export-time-saved": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Submit Export Time Saved Survey
-         * @description Persist one row in ``export_time_saved_survey``.
-         *
-         *     Auth required. The row is owned by ``user.id`` (RLS: users only ever
-         *     see their own submissions). Returns 503 if the database is
-         *     unavailable so the frontend can retry on next export.
-         */
-        post: operations["submit_export_time_saved_survey_v1_survey_export_time_saved_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/checkout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Create Intel Report Checkout
-         * @description Create a Stripe Checkout session for an Intel Report one-time purchase.
-         *
-         *     product_type:
-         *         - "cnpj"       → R$197.00 — Company analysis report (INTEL-REPORT-001)
-         *         - "sector_uf"  → R$147.00 — Sector/UF market report (INTEL-REPORT-002)
-         *
-         *     entity_key:
-         *         - For cnpj:       the CNPJ string (e.g. "12345678000195")
-         *         - For sector_uf:  "sector:uf" (e.g. "limpeza:SP")
-         *
-         *     Returns checkout_url (redirect user) and session_id (for polling).
-         */
-        post: operations["create_intel_report_checkout_v1_intel_reports_checkout_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Intel Report Purchases
-         * @description List all Intel Report purchases for the authenticated user.
-         */
-        get: operations["list_intel_report_purchases_v1_intel_reports__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/{purchase_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Intel Report Status
-         * @description Poll status of an Intel Report purchase.
-         *
-         *     Frontend uses this endpoint after being redirected back from Stripe
-         *     (/intel-reports/{CHECKOUT_SESSION_ID}?status=processing).
-         *     Poll until status is "ready" or "failed".
-         *
-         *     Returns:
-         *     - 404 if purchase does not exist
-         *     - 403 if purchase belongs to a different user
-         */
-        get: operations["get_intel_report_status_v1_intel_reports__purchase_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/intel-reports/{purchase_id}/download": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Download Intel Report
-         * @description Stream the Intel Report PDF.
-         *
-         *     Requires:
-         *     - Authentication
-         *     - Ownership: purchase must belong to the authenticated user
-         *     - Status: purchase must be "ready" (pdf_url present)
-         *
-         *     Returns:
-         *     - 401 if not authenticated
-         *     - 404 if purchase does not exist
-         *     - 403 if purchase belongs to a different user
-         *     - 400 if purchase status is not "ready"
-         *     - PDF stream if all checks pass
-         */
-        get: operations["download_intel_report_v1_intel_reports__purchase_id__download_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/pseo/top-suppliers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Top 5 fornecedores por volume de contratos no setor (público)
-         * @description Top suppliers by contract volume in sector, last 12 months.
-         *
-         *     Returns cnpj, razao_social, contratos_count, valor_total.
-         *     If total contracts < 10, returns empty list (avoid weak social proof).
-         *     Cache: 6h InMemory.
-         */
-        get: operations["get_top_suppliers_v1_pseo_top_suppliers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/pseo/recent-editais": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 5 últimos editais abertos no setor (público)
-         * @description Most recent open editais for sector+UF.
-         *
-         *     Returns orgao, objeto, valor_estimado, data_limite, link_interno.
-         *     link_interno = /licitacoes/{setor}?query={orgao}
-         *     Cache: 6h InMemory.
-         */
-        get: operations["get_recent_editais_v1_pseo_recent_editais_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/seo/coverage-manifest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Per-slug coverage status for sitemap gate (SEO-COVERAGE-MANIFEST-001)
-         * @description Return the latest seo_coverage_manifest rows as a keyed dict.
-         *
-         *     AC1: <2s response time (served from 1h in-memory cache after first build).
-         *     AC7: historical_empty slugs are included — sitemap gate uses priority=0.3,
-         *          not excluded, so /observatorio/raio-x-marco-2026 stays accessible.
-         */
-        get: operations["get_coverage_manifest_v1_seo_coverage_manifest_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/products": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Products
-         * @description List active digital products available for one-time purchase.
-         *
-         *     Public (no auth required). Results cached in Redis for 1 hour.
-         */
-        get: operations["list_products_v1_products_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/predict/seasonal-calendar": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Calendario sazonal de compras por UF
-         * @description Retorna um calendario sazonal de 12 meses com base no historico de contratos e licitacoes da UF. Inclui volume medio, quantidade, setor dominante, orgaos principais, indice de sazonalidade, tendencia e variacao anual para cada mes.
-         */
-        get: operations["get_seasonal_calendar_v1_predict_seasonal_calendar_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/network-events/record": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Record Network Event
-         * @description Record an anonymized network event.
-         *
-         *     Only collects data if user has explicitly opted in
-         *     (profiles.allow_network_analytics = true). LGPD Art. 6, I.
-         */
-        post: operations["record_network_event_v1_network_events_record_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/network-events/top": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Top Network Events
-         * @description Get top dimension values for a given event type.
-         *
-         *     Public endpoint — returns only anonymized aggregated data.
-         */
-        get: operations["get_top_network_events_v1_network_events_top_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/segment/save": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Save Segment
-         * @description Save user segmentation data to profile context_data (CONV-018).
-         *
-         *     Merges the new fields into the existing ``context_data`` JSONB column
-         *     on the ``profiles`` table without overwriting other fields.
-         *
-         *     Returns the full updated context_data on success.
-         */
-        post: operations["save_segment_v1_segment_save_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trigger-contracts-backfill": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Trigger Contracts Backfill
-         * @description Enqueue contracts_full_crawl_job to ARQ Worker.
-         *
-         *     Runs on Railway Worker (better network for PNCP).
-         *     Safe to call multiple times — ARQ deduplicates by job name.
-         */
-        post: operations["trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/trigger-bids-backfill": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Trigger Bids Backfill
-         * @description Enqueue ingestion_backfill_job to ARQ Worker.
-         *
-         *     One-time historical crawl: fetches up to 365 days of PNCP bids
-         *     to capture all currently open opportunities.
-         *     Expected runtime: 4-8h. Safe to call multiple times (ARQ dedup).
-         */
-        post: operations["trigger_bids_backfill_v1_admin_trigger_bids_backfill_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/clear-contracts-checkpoints": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Clear Contracts Checkpoints
-         * @description Clear all Redis checkpoints for contracts crawler.
-         *
-         *     Use before re-triggering a full crawl when stale checkpoints
-         *     cause windows to be incorrectly skipped.
-         */
-        post: operations["clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/search-trace/{search_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Search Trace
-         * @description Reconstruct complete search journey from search_id.
-         *
-         *     Aggregates:
-         *     - Progress tracker state (if still active)
-         *     - Cache entries matching this search
-         *     - Job queue results (if ARQ available)
-         */
-        get: operations["get_search_trace_v1_admin_search_trace__search_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cb/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset Circuit Breakers
-         * @description STORY-416 AC5: Reset all segregated Supabase CBs to CLOSED.
-         *
-         *     Intended for on-call use after an upstream incident has been mitigated
-         *     and the CBs are still in OPEN/HALF_OPEN due to the cooldown. Returns
-         *     the previous state per category so the action is auditable in logs.
-         *     Admin only — never expose this without authentication.
-         */
-        post: operations["reset_circuit_breakers_v1_admin_cb_reset_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/schema-contract-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Schema Contract Status
-         * @description STORY-414 AC4: Expose the last schema-contract validation result.
-         *
-         *     Returns the cached result from the startup check plus a ``stale``
-         *     flag that tells callers whether a fresh run is advisable (the cache
-         *     lives for ``schemas.contract.STATUS_CACHE_TTL`` seconds — 5 min by
-         *     default). Forcing a re-validation is out of scope here because it
-         *     would defeat the point of the cache on a polled dashboard.
-         */
-        get: operations["get_schema_contract_status_v1_admin_schema_contract_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cron-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Cron Status
-         * @description Return the pg_cron health snapshot.
-         *
-         *     Calls ``public.get_cron_health()`` (SECURITY DEFINER) via the backend's
-         *     service-role Supabase client. Response shape::
-         *
-         *         {
-         *             "queried_at": "2026-04-14T12:00:00+00:00",
-         *             "jobs": [
-         *                 {
-         *                     "jobname": "purge-old-bids",
-         *                     "schedule": "0 7 * * *",
-         *                     "active": true,
-         *                     "last_status": "succeeded",
-         *                     "last_run_at": "2026-04-14T07:00:04+00:00",
-         *                     "runs_24h": 1,
-         *                     "failures_24h": 0,
-         *                     "latency_avg_ms": 120,
-         *                     "last_return_message": null
-         *                 },
-         *                 ...
-         *             ],
-         *             "count": 6
-         *         }
-         *
-         *     On transient failure (Supabase CB open, RPC error) returns ``status=error``
-         *     with ``jobs=[]`` so that dashboards degrade gracefully instead of 500-ing.
-         */
-        get: operations["get_cron_status_v1_admin_cron_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cnae-mapping": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Cnae Mappings
-         * @description List CNAE mappings, optionally filtered by ``setor``.
-         */
-        get: operations["list_cnae_mappings_v1_admin_cnae_mapping_get"];
-        put?: never;
-        /**
-         * Create Cnae Mapping
-         * @description Create a new CNAE -> setor mapping.
-         */
-        post: operations["create_cnae_mapping_v1_admin_cnae_mapping_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/cnae-mapping/{cnae_code}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Delete Cnae Mapping
-         * @description Soft delete: marks ``notes='deleted'`` so audit trail is preserved.
-         *
-         *     The DB lookup in ``utils.cnae_mapping._db_lookup`` skips rows with
-         *     ``notes = 'deleted'`` and the LRU cache is invalidated so the next
-         *     request falls back to the hardcoded dict (if present there).
-         */
-        delete: operations["delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete"];
-        options?: never;
-        head?: never;
-        /**
-         * Update Cnae Mapping
-         * @description Patch an existing mapping. Fields not present in the body are untouched.
-         */
-        patch: operations["update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch"];
-        trace?: never;
-    };
-    "/v1/admin/llm-cost": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Admin Llm Cost
-         * @description Return LLM cost snapshot para o mês corrente (admin-only).
-         *
-         *     Response shape::
-         *
-         *         {
-         *             "month_to_date_usd": 42.1234,
-         *             "budget_usd": 100.0,
-         *             "pct_used": 42.12,
-         *             "projected_end_of_month_usd": 78.55,
-         *             "month": "llm_cost_month_2026_04",
-         *             "exceeded": false
-         *         }
-         *
-         *     Em caso de Redis indisponível, retorna zeros (graceful degradation).
-         */
-        get: operations["admin_llm_cost_v1_admin_llm_cost_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/survey/export-time-saved": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Export Surveys Aggregate
-         * @description Aggregated histogram + summary stats for the calibration dashboard.
-         */
-        get: operations["list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/config/{key}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Patch App Config
-         * @description Update one row in ``app_config``. Whitelist enforced.
-         *
-         *     On success the in-process TTL cache for *key* is invalidated so
-         *     the new value becomes visible in this worker on the next read
-         *     (other workers see it after their TTL expires).
-         */
-        patch: operations["patch_app_config_v1_admin_config__key__patch"];
-        trace?: never;
-    };
-    "/v1/admin/calibration/recalibrate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Recalibrate
-         * @description Compute new ``hours_saved_per_search`` from survey distribution.
-         *
-         *     Eligibility rules (mirrors AC6 + risk R3):
-         *         * After IQR outlier removal there must be >= MIN_SAMPLE_SIZE rows.
-         *         * The new median must be in (0, 50].
-         *
-         *     When ``apply=true`` and eligible, persists the new value via
-         *     ``app_config`` and drops the cache.
-         */
-        post: operations["recalibrate_v1_admin_calibration_recalibrate_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/billing-sync": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Billing Sync Rows
-         * @description Return every plan_billing_periods row enriched with drift_status.
-         */
-        get: operations["list_billing_sync_rows_v1_admin_plans_billing_sync_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/reconciliation-runs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List Reconciliation Runs */
-        get: operations["list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/{plan_billing_period_id}/sync-to-stripe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Sync To Stripe
-         * @description AC8/AC9: Push DB price -> Stripe by creating a new Price + archiving old.
-         */
-        post: operations["sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/plans/reconcile-now": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Reconcile Now */
-        post: operations["reconcile_now_v1_admin_plans_reconcile_now_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/policy": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Founding Policy
-         * @description Snapshot of the canonical policy + live seat usage.
-         */
-        get: operations["get_founding_policy_v1_admin_founding_policy_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/leads": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Founding Leads
-         * @description List founding leads ordered by creation desc.
-         *
-         *     Optional ``status`` filter restricts to one of the checkout_status enum
-         *     values (pending|completed|abandoned|failed|cap_violated).
-         */
-        get: operations["list_founding_leads_v1_admin_founding_leads_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/pause": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Pause Founding
-         * @description Soft-pause founding checkouts. Idempotent.
-         */
-        post: operations["pause_founding_v1_admin_founding_pause_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/founding/resume": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Resume Founding
-         * @description Resume founding checkouts (clear paused_at + paused_by + paused_reason).
-         */
-        post: operations["resume_founding_v1_admin_founding_resume_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/slo": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Slo Dashboard
-         * @description AC7-AC9: SLO compliance data for admin dashboard.
-         *
-         *     Returns all SLO statuses, alert evaluations, and metadata.
-         */
-        get: operations["get_slo_dashboard_v1_admin_slo_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/admin/slo/alerts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Slo Alerts
-         * @description Return current alert evaluation results.
-         */
-        get: operations["get_slo_alerts_v1_admin_slo_alerts_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/founders/availability": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Founders Availability
-         * @description Public seat counter + countdown feed (issue #1002).
-         */
-        get: operations["founders_availability_api_founders_availability_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/founders/hall": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Hall Listing
-         * @description Public Hall of Founders listing (issue #1008).
-         *
-         *     Anonymous endpoint consumed by ``/fundadores/hall`` (ISR revalidate=300s).
-         *     Returns up to 100 founders that opted in via
-         *     ``founder_public_listing_consent=TRUE``.
-         */
-        get: operations["get_hall_listing_api_founders_hall_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/founders/hall/consent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Toggle Consent
-         * @description Authenticated opt-in / opt-out toggle (issue #1008).
-         *
-         *     Updates ``profiles.founder_public_listing_consent`` for the caller and,
-         *     on opt-in, also persists optional display name and logo URL. Logs an
-         *     LGPD audit event regardless of direction.
-         */
-        post: operations["toggle_consent_api_founders_hall_consent_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5616,66 +5704,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Root
-         * @description API root — navigation and version info.
-         */
-        get: operations["root__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/setores": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Listar Setores
-         * @description Return available procurement sectors for frontend dropdown.
-         */
-        get: operations["listar_setores_v1_setores_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug/pncp-test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Debug Pncp Test
-         * @description Diagnostic: test if PNCP API is reachable from this server. Admin only.
-         */
-        get: operations["debug_pncp_test_debug_pncp_test_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -5687,60 +5715,60 @@ export interface components {
         AdminAssignPlanResponse: {
             /** Assigned */
             assigned: boolean;
-            /** User Id */
-            user_id: string;
             /** Plan Id */
             plan_id: string;
+            /** User Id */
+            user_id: string;
         };
         /**
          * AdminCacheTraceState
          * @description ``cache`` field of the search-trace response.
          */
         AdminCacheTraceState: {
+            /** Error */
+            error?: string | null;
             /** Is Revalidating */
             is_revalidating?: boolean | null;
             /** Redis */
             redis?: string | null;
-            /** Error */
-            error?: string | null;
         };
         /**
          * AdminCircuitBreakerResetResponse
          * @description Response for POST /v1/admin/cb/reset (STORY-416 AC5).
          */
         AdminCircuitBreakerResetResponse: {
-            /** Status */
-            status: string;
             /** Previous States */
             previous_states: {
                 [key: string]: unknown;
             };
             /** Reset By */
             reset_by?: string | null;
+            /** Status */
+            status: string;
         };
         /**
          * AdminClearCheckpointsResponse
          * @description Response for POST /v1/admin/clear-contracts-checkpoints.
          */
         AdminClearCheckpointsResponse: {
-            /** Status */
-            status: string;
             /** Checkpoints Deleted */
             checkpoints_deleted?: number | null;
             /** Detail */
             detail?: string | null;
+            /** Status */
+            status: string;
         };
         /**
          * AdminCreateUserResponse
          * @description Response for POST /admin/users.
          */
         AdminCreateUserResponse: {
-            /** User Id */
-            user_id: string;
             /** Email */
             email: string;
             /** Plan Id */
             plan_id?: string | null;
+            /** User Id */
+            user_id: string;
         };
         /**
          * AdminCronStatusResponse
@@ -5751,16 +5779,16 @@ export interface components {
          *     gracefully instead of 500-ing.
          */
         AdminCronStatusResponse: {
-            /** Status */
-            status: string;
-            /** Queried At */
-            queried_at: string;
             /** Count */
             count: number;
-            /** Jobs */
-            jobs: components["schemas"]["CronJobHealthRow"][];
             /** Detail */
             detail?: string | null;
+            /** Jobs */
+            jobs: components["schemas"]["CronJobHealthRow"][];
+            /** Queried At */
+            queried_at: string;
+            /** Status */
+            status: string;
         };
         /**
          * AdminDeleteUserResponse
@@ -5781,12 +5809,12 @@ export interface components {
          *     when the lookup itself raised.
          */
         AdminJobTraceState: {
-            /** Llm Summary */
-            llm_summary?: string | null;
-            /** Excel Generation */
-            excel_generation?: string | null;
             /** Error */
             error?: string | null;
+            /** Excel Generation */
+            excel_generation?: string | null;
+            /** Llm Summary */
+            llm_summary?: string | null;
         };
         /**
          * AdminJobTriggerResponse
@@ -5797,14 +5825,14 @@ export interface components {
          *     ``detail`` carries the operator-facing reason string when non-OK.
          */
         AdminJobTriggerResponse: {
-            /** Status */
-            status: string;
-            /** Job Id */
-            job_id?: string | null;
-            /** Timeout S */
-            timeout_s?: number | null;
             /** Detail */
             detail?: string | null;
+            /** Job Id */
+            job_id?: string | null;
+            /** Status */
+            status: string;
+            /** Timeout S */
+            timeout_s?: number | null;
         };
         /**
          * AdminLlmCostResponse
@@ -5816,15 +5844,22 @@ export interface components {
          */
         AdminLlmCostResponse: {
             /**
-             * Month To Date Usd
-             * @default 0
-             */
-            month_to_date_usd: number;
-            /**
              * Budget Usd
              * @default 0
              */
             budget_usd: number;
+            /**
+             * Exceeded
+             * @default false
+             */
+            exceeded: boolean;
+            /** Month */
+            month: string;
+            /**
+             * Month To Date Usd
+             * @default 0
+             */
+            month_to_date_usd: number;
             /**
              * Pct Used
              * @default 0
@@ -5835,13 +5870,6 @@ export interface components {
              * @default 0
              */
             projected_end_of_month_usd: number;
-            /** Month */
-            month: string;
-            /**
-             * Exceeded
-             * @default false
-             */
-            exceeded: boolean;
         };
         /**
          * AdminProgressTraceState
@@ -5849,18 +5877,18 @@ export interface components {
          *     is still in memory. ``mode`` is ``"redis"`` or ``"in-memory"``.
          */
         AdminProgressTraceState: {
+            /** Created At */
+            created_at?: number | null;
+            /** Error */
+            error?: string | null;
+            /** Is Complete */
+            is_complete?: boolean | null;
+            /** Mode */
+            mode?: string | null;
             /** Uf Count */
             uf_count?: number | null;
             /** Ufs Completed */
             ufs_completed?: number | null;
-            /** Is Complete */
-            is_complete?: boolean | null;
-            /** Created At */
-            created_at?: number | null;
-            /** Mode */
-            mode?: string | null;
-            /** Error */
-            error?: string | null;
         };
         /**
          * AdminResetPasswordResponse
@@ -5877,28 +5905,28 @@ export interface components {
          * @description Response for GET /v1/admin/schema-contract-status (STORY-414 AC4).
          */
         AdminSchemaContractStatusResponse: {
-            /** Passed */
-            passed?: boolean | null;
-            /**
-             * Missing
-             * @default []
-             */
-            missing: string[];
-            /**
-             * Strict Mode
-             * @default false
-             */
-            strict_mode: boolean;
             /**
              * Checked At
              * @default 0
              */
             checked_at: number;
             /**
+             * Missing
+             * @default []
+             */
+            missing: string[];
+            /** Passed */
+            passed?: boolean | null;
+            /**
              * Stale
              * @default true
              */
             stale: boolean;
+            /**
+             * Strict Mode
+             * @default false
+             */
+            strict_mode: boolean;
         };
         /**
          * AdminSearchTraceResponse
@@ -5909,29 +5937,29 @@ export interface components {
          *     payload instead of failing the whole response.
          */
         AdminSearchTraceResponse: {
-            /** Search Id */
-            search_id: string;
-            /** Queried At */
-            queried_at: string;
-            progress?: components["schemas"]["AdminProgressTraceState"] | null;
             cache?: components["schemas"]["AdminCacheTraceState"] | null;
             jobs?: components["schemas"]["AdminJobTraceState"] | null;
+            progress?: components["schemas"]["AdminProgressTraceState"] | null;
+            /** Queried At */
+            queried_at: string;
+            /** Search Id */
+            search_id: string;
         };
         /**
          * AdminUpdateCreditsResponse
          * @description Response for PUT /admin/users/{user_id}/credits.
          */
         AdminUpdateCreditsResponse: {
-            /** Success */
-            success: boolean;
-            /** User Id */
-            user_id: string;
             /** Credits */
             credits: number;
             /** Previous Credits */
             previous_credits?: number | null;
             /** Subscription Created */
             subscription_created?: boolean | null;
+            /** Success */
+            success: boolean;
+            /** User Id */
+            user_id: string;
         };
         /**
          * AdminUpdateUserResponse
@@ -5948,22 +5976,27 @@ export interface components {
          * @description Response for GET /admin/users.
          */
         AdminUsersListResponse: {
-            /** Users */
-            users: {
-                [key: string]: unknown;
-            }[];
-            /** Total */
-            total: number;
             /** Limit */
             limit: number;
             /** Offset */
             offset: number;
+            /** Total */
+            total: number;
+            /** Users */
+            users: {
+                [key: string]: unknown;
+            }[];
         };
         /**
          * AlertFilters
          * @description Filter criteria that define which bids match this alert.
          */
         AlertFilters: {
+            /**
+             * Keywords
+             * @description Extra keyword filters
+             */
+            keywords?: string[] | null;
             /**
              * Setor
              * @description Sector ID from sectors_data.yaml
@@ -5975,27 +6008,22 @@ export interface components {
              */
             ufs?: string[] | null;
             /**
-             * Valor Min
-             * @description Minimum estimated value
-             */
-            valor_min?: number | null;
-            /**
              * Valor Max
              * @description Maximum estimated value
              */
             valor_max?: number | null;
             /**
-             * Keywords
-             * @description Extra keyword filters
+             * Valor Min
+             * @description Minimum estimated value
              */
-            keywords?: string[] | null;
+            valor_min?: number | null;
         };
         /** AlertHistoryItem */
         AlertHistoryItem: {
-            /** Id */
-            id: string;
             /** Alert Id */
             alert_id: string;
+            /** Id */
+            id: string;
             /** Item Id */
             item_id: string;
             /** Sent At */
@@ -6005,12 +6033,12 @@ export interface components {
         AlertHistoryResponse: {
             /** Items */
             items: components["schemas"]["AlertHistoryItem"][];
-            /** Total */
-            total: number;
             /** Limit */
             limit: number;
             /** Offset */
             offset: number;
+            /** Total */
+            total: number;
         };
         /** AlertListResponse */
         AlertListResponse: {
@@ -6022,22 +6050,22 @@ export interface components {
         /** AlertPreferencesRequest */
         AlertPreferencesRequest: {
             /**
-             * Frequency
-             * @default daily
-             */
-            frequency: string;
-            /**
              * Enabled
              * @default true
              */
             enabled: boolean;
+            /**
+             * Frequency
+             * @default daily
+             */
+            frequency: string;
         };
         /** AlertPreferencesResponse */
         AlertPreferencesResponse: {
-            /** Frequency */
-            frequency: string;
             /** Enabled */
             enabled: boolean;
+            /** Frequency */
+            frequency: string;
             /** Last Digest Sent At */
             last_digest_sent_at?: string | null;
         };
@@ -6045,30 +6073,30 @@ export interface components {
         AlertPreviewItem: {
             /** Id */
             id: string;
-            /** Titulo */
-            titulo: string;
+            /**
+             * Link Pncp
+             * @default
+             */
+            link_pncp: string;
+            /**
+             * Modalidade
+             * @default
+             */
+            modalidade: string;
             /** Orgao */
             orgao: string;
-            /**
-             * Valor Estimado
-             * @default 0
-             */
-            valor_estimado: number;
+            /** Titulo */
+            titulo: string;
             /**
              * Uf
              * @default
              */
             uf: string;
             /**
-             * Modalidade
-             * @default
+             * Valor Estimado
+             * @default 0
              */
-            modalidade: string;
-            /**
-             * Link Pncp
-             * @default
-             */
-            link_pncp: string;
+            valor_estimado: number;
             /** Viability Score */
             viability_score?: number | null;
         };
@@ -6080,84 +6108,84 @@ export interface components {
             alert_name: string;
             /** Items */
             items: components["schemas"]["AlertPreviewItem"][];
-            /** Total */
-            total: number;
             /** Message */
             message: string;
+            /** Total */
+            total: number;
         };
         /** AlertResponse */
         AlertResponse: {
-            /** Id */
-            id: string;
-            /** User Id */
-            user_id: string;
-            /** Name */
-            name: string;
+            /** Active */
+            active: boolean;
+            /** Created At */
+            created_at: string;
             /** Filters */
             filters: {
                 [key: string]: unknown;
             };
-            /** Active */
-            active: boolean;
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
             /**
              * Sent Count
              * @default 0
              */
             sent_count: number;
-            /** Created At */
-            created_at: string;
             /** Updated At */
             updated_at: string;
+            /** User Id */
+            user_id: string;
         };
         /** AlertaBid */
         AlertaBid: {
-            /** Titulo */
-            titulo: string;
-            /** Orgao */
-            orgao: string;
-            /** Valor */
-            valor?: number | null;
-            /** Uf */
-            uf: string;
-            /**
-             * Municipio
-             * @default
-             */
-            municipio: string;
-            /**
-             * Modalidade
-             * @default
-             */
-            modalidade: string;
-            /** Data Publicacao */
-            data_publicacao: string;
             /** Data Abertura */
             data_abertura?: string | null;
+            /** Data Publicacao */
+            data_publicacao: string;
             /**
              * Link Pncp
              * @default
              */
             link_pncp: string;
             /**
+             * Modalidade
+             * @default
+             */
+            modalidade: string;
+            /**
+             * Municipio
+             * @default
+             */
+            municipio: string;
+            /** Orgao */
+            orgao: string;
+            /**
              * Pncp Id
              * @default
              */
             pncp_id: string;
+            /** Titulo */
+            titulo: string;
+            /** Uf */
+            uf: string;
+            /** Valor */
+            valor?: number | null;
         };
         /** AlertasResponse */
         AlertasResponse: {
+            /** Bids */
+            bids: components["schemas"]["AlertaBid"][];
+            /** Last Updated */
+            last_updated: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Uf */
-            uf: string;
-            /** Bids */
-            bids: components["schemas"]["AlertaBid"][];
             /** Total */
             total: number;
-            /** Last Updated */
-            last_updated: string;
+            /** Uf */
+            uf: string;
         };
         /**
          * AppConfigPatchRequest
@@ -6165,28 +6193,28 @@ export interface components {
          */
         AppConfigPatchRequest: {
             /**
-             * Value
-             * @description New JSONB value (scalar/array/object)
-             */
-            value: unknown;
-            /**
              * Description
              * @description Optional updated description
              */
             description?: string | null;
+            /**
+             * Value
+             * @description New JSONB value (scalar/array/object)
+             */
+            value: unknown;
         };
         /** AppConfigRow */
         AppConfigRow: {
-            /** Key */
-            key: string;
-            /** Value */
-            value: unknown;
             /** Description */
             description?: string | null;
+            /** Key */
+            key: string;
             /** Updated At */
             updated_at?: string | null;
             /** Updated By */
             updated_by?: string | null;
+            /** Value */
+            value: unknown;
         };
         /**
          * AtividadeRecenteData
@@ -6206,11 +6234,8 @@ export interface components {
              * @default 0
              */
             contagem_90d: number;
-            /**
-             * Valor Total 30D
-             * @default 0
-             */
-            valor_total_30d: number;
+            /** Sazonalidade Mes Pico */
+            sazonalidade_mes_pico?: number | null;
             /**
              * Tendencia 12M
              * @default stable
@@ -6223,8 +6248,11 @@ export interface components {
             tendencia_percentual: number;
             /** Ultimo Evento Data */
             ultimo_evento_data?: string | null;
-            /** Sazonalidade Mes Pico */
-            sazonalidade_mes_pico?: number | null;
+            /**
+             * Valor Total 30D
+             * @default 0
+             */
+            valor_total_30d: number;
         };
         /** AuthStatusResponse */
         AuthStatusResponse: {
@@ -6272,38 +6300,38 @@ export interface components {
         };
         /** BillingSyncRow */
         BillingSyncRow: {
-            /** Id */
-            id: string;
-            /** Plan Id */
-            plan_id: string;
             /** Billing Period */
             billing_period: string;
-            /** Price Cents */
-            price_cents: number;
             /**
              * Discount Percent
              * @default 0
              */
             discount_percent: number;
-            /** Stripe Price Id */
-            stripe_price_id?: string | null;
-            /** Stripe Product Id */
-            stripe_product_id?: string | null;
-            /** Last Forward Synced At */
-            last_forward_synced_at?: string | null;
-            /** Last Reverse Synced At */
-            last_reverse_synced_at?: string | null;
-            /**
-             * Is Archived
-             * @default false
-             */
-            is_archived: boolean;
             /**
              * Drift Status
              * @description in_sync | drift_recent | drift_stale | unknown
              * @default unknown
              */
             drift_status: string;
+            /** Id */
+            id: string;
+            /**
+             * Is Archived
+             * @default false
+             */
+            is_archived: boolean;
+            /** Last Forward Synced At */
+            last_forward_synced_at?: string | null;
+            /** Last Reverse Synced At */
+            last_reverse_synced_at?: string | null;
+            /** Plan Id */
+            plan_id: string;
+            /** Price Cents */
+            price_cents: number;
+            /** Stripe Price Id */
+            stripe_price_id?: string | null;
+            /** Stripe Product Id */
+            stripe_product_id?: string | null;
         };
         /**
          * BuscaRequest
@@ -6361,20 +6389,11 @@ export interface components {
          */
         BuscaRequest: {
             /**
-             * Ufs
-             * @description List of Brazilian state codes (e.g., ['SP', 'RJ', 'MG'])
-             * @example [
-             *       "SP",
-             *       "RJ"
-             *     ]
+             * Check Sanctions
+             * @description When true, verify supplier CNPJs against CEIS/CNEP sanctions databases. Adds supplier_sanctions field to each result. Performance impact: ~1s per unique CNPJ.
+             * @default false
              */
-            ufs: string[];
-            /**
-             * Data Inicial
-             * @description Start date in YYYY-MM-DD format. The date range may span at most 30 days.
-             * @example 2025-01-01
-             */
-            data_inicial: string;
+            check_sanctions: boolean;
             /**
              * Data Final
              * @description End date in YYYY-MM-DD format. The date range may span at most 30 days.
@@ -6382,47 +6401,41 @@ export interface components {
              */
             data_final: string;
             /**
-             * Setor Id
-             * @description Sector ID for keyword filtering (e.g., 'vestuario', 'alimentos', 'informatica'). None when searching by 'Termos Específicos' (custom keywords only).
-             * @example vestuario
-             * @example null
+             * Data Inicial
+             * @description Start date in YYYY-MM-DD format. The date range may span at most 30 days.
+             * @example 2025-01-01
              */
-            setor_id?: string | null;
+            data_inicial: string;
             /**
-             * Termos Busca
-             * @description Custom search terms. Use commas to separate multi-word phrases (e.g., 'levantamento topográfico, terraplenagem, drenagem'). Without commas, spaces separate individual keywords (legacy mode).
-             * @example jaleco avental
-             * @example levantamento topográfico, terraplenagem, drenagem
+             * Esferas
+             * @description Lista de esferas governamentais ('F'=Federal, 'E'=Estadual, 'M'=Municipal). None = todas as esferas.
+             * @example [
+             *       "M",
+             *       "E"
+             *     ]
              */
-            termos_busca?: string | null;
-            /**
-             * Show All Matches
-             * @description When True, bypasses minimum match floor and returns all results with at least 1 keyword match (for 'show hidden results' feature).
-             * @default false
-             */
-            show_all_matches: boolean | null;
+            esferas?: components["schemas"]["EsferaGovernamental"][] | null;
             /**
              * Exclusion Terms
              * @description Custom exclusion terms. Overrides sector exclusions when provided.
              */
             exclusion_terms?: string[] | null;
             /**
-             * Modo Busca
-             * @description Modo de busca: 'abertas' (padrão) busca licitações com prazo aberto nos últimos 180 dias; 'publicacao' usa datas enviadas pelo frontend.
-             * @default abertas
-             * @example abertas
-             * @example publicacao
+             * Force Fresh
+             * @description When true, bypass result cache and always query primary sources. Cache write-through still happens on successful results.
+             * @default false
              */
-            modo_busca: string | null;
+            force_fresh: boolean;
             /**
-             * @description Status da licitação para filtrar. Padrão: 'todos' (sem filtro de status). IMPORTANTE: Filtro de status desabilitado por padrão devido a valores inconsistentes na API PNCP. Use 'todos' para máxima cobertura de resultados.
-             * @default todos
-             * @example todos
-             * @example recebendo_proposta
-             * @example em_julgamento
-             * @example encerrada
+             * Itens Por Pagina
+             * @description Quantidade de itens por página. Valores permitidos: 10, 20, 50, 100. Padrão: 20.
+             * @default 20
+             * @example 10
+             * @example 20
+             * @example 50
+             * @example 100
              */
-            status: components["schemas"]["StatusLicitacao"];
+            itens_por_pagina: number;
             /**
              * Modalidades
              * @description Lista de códigos de modalidade conforme API PNCP. Códigos válidos: 1 (Leilão Eletrônico), 2 (Diálogo Competitivo), 3 (Concurso), 4 (Concorrência Eletrônica), 5 (Concorrência Presencial), 6 (Pregão Eletrônico), 7 (Pregão Presencial), 8 (Dispensa), 10 (Manifestação de Interesse), 11 (Pré-qualificação), 12 (Credenciamento), 13 (Leilão Presencial), 15 (Chamada Pública). None = modalidades padrão [4, 5, 6, 7]. EXCLUÍDOS: 9 (Inexigibilidade) e 14 (Inaplicabilidade) — vencedor pré-definido.
@@ -6435,26 +6448,13 @@ export interface components {
              */
             modalidades?: number[] | null;
             /**
-             * Valor Minimo
-             * @description Valor mínimo estimado da licitação em BRL. None = sem limite inferior.
-             * @example 50000
+             * Modo Busca
+             * @description Modo de busca: 'abertas' (padrão) busca licitações com prazo aberto nos últimos 180 dias; 'publicacao' usa datas enviadas pelo frontend.
+             * @default abertas
+             * @example abertas
+             * @example publicacao
              */
-            valor_minimo?: number | null;
-            /**
-             * Valor Maximo
-             * @description Valor máximo estimado da licitação em BRL. None = sem limite superior. Ceiling: 1e15 (R$ 1 quatrilhão) — STORY-419 incident guard to match NUMERIC(18,2) on search_sessions.valor_total.
-             * @example 5000000
-             */
-            valor_maximo?: number | null;
-            /**
-             * Esferas
-             * @description Lista de esferas governamentais ('F'=Federal, 'E'=Estadual, 'M'=Municipal). None = todas as esferas.
-             * @example [
-             *       "M",
-             *       "E"
-             *     ]
-             */
-            esferas?: components["schemas"]["EsferaGovernamental"][] | null;
+            modo_busca: string | null;
             /**
              * Municipios
              * @description Lista de códigos IBGE de municípios para filtrar. None = todos os municípios das UFs selecionadas.
@@ -6492,32 +6492,60 @@ export interface components {
              */
             pagina: number;
             /**
-             * Itens Por Pagina
-             * @description Quantidade de itens por página. Valores permitidos: 10, 20, 50, 100. Padrão: 20.
-             * @default 20
-             * @example 10
-             * @example 20
-             * @example 50
-             * @example 100
-             */
-            itens_por_pagina: number;
-            /**
              * Search Id
              * @description Client-generated UUID for SSE progress tracking via /buscar-progress/{search_id}.
              */
             search_id?: string | null;
             /**
-             * Check Sanctions
-             * @description When true, verify supplier CNPJs against CEIS/CNEP sanctions databases. Adds supplier_sanctions field to each result. Performance impact: ~1s per unique CNPJ.
-             * @default false
+             * Setor Id
+             * @description Sector ID for keyword filtering (e.g., 'vestuario', 'alimentos', 'informatica'). None when searching by 'Termos Específicos' (custom keywords only).
+             * @example vestuario
+             * @example null
              */
-            check_sanctions: boolean;
+            setor_id?: string | null;
             /**
-             * Force Fresh
-             * @description When true, bypass result cache and always query primary sources. Cache write-through still happens on successful results.
+             * Show All Matches
+             * @description When True, bypasses minimum match floor and returns all results with at least 1 keyword match (for 'show hidden results' feature).
              * @default false
              */
-            force_fresh: boolean;
+            show_all_matches: boolean | null;
+            /**
+             * @description Status da licitação para filtrar. Padrão: 'todos' (sem filtro de status). IMPORTANTE: Filtro de status desabilitado por padrão devido a valores inconsistentes na API PNCP. Use 'todos' para máxima cobertura de resultados.
+             * @default todos
+             * @example todos
+             * @example recebendo_proposta
+             * @example em_julgamento
+             * @example encerrada
+             */
+            status: components["schemas"]["StatusLicitacao"];
+            /**
+             * Termos Busca
+             * @description Custom search terms. Use commas to separate multi-word phrases (e.g., 'levantamento topográfico, terraplenagem, drenagem'). Without commas, spaces separate individual keywords (legacy mode).
+             * @example jaleco avental
+             * @example levantamento topográfico, terraplenagem, drenagem
+             */
+            termos_busca?: string | null;
+            /**
+             * Ufs
+             * @description List of Brazilian state codes (e.g., ['SP', 'RJ', 'MG'])
+             * @example [
+             *       "SP",
+             *       "RJ"
+             *     ]
+             */
+            ufs: string[];
+            /**
+             * Valor Maximo
+             * @description Valor máximo estimado da licitação em BRL. None = sem limite superior. Ceiling: 1e15 (R$ 1 quatrilhão) — STORY-419 incident guard to match NUMERIC(18,2) on search_sessions.valor_total.
+             * @example 5000000
+             */
+            valor_maximo?: number | null;
+            /**
+             * Valor Minimo
+             * @description Valor mínimo estimado da licitação em BRL. None = sem limite inferior.
+             * @example 50000
+             */
+            valor_minimo?: number | null;
         };
         /**
          * BuscaResponse
@@ -6550,20 +6578,65 @@ export interface components {
          */
         BuscaResponse: {
             /**
-             * Resumo
-             * @description Strategic executive summary with actionable recommendations (AI-generated or fallback)
+             * Cache Date Range
+             * @description STORY-306 AC5: Date of the cached data when cache_fallback=True (e.g. '2026-02-20')
              */
-            resumo: components["schemas"]["ResumoEstrategico"] | components["schemas"]["ResumoLicitacoes"];
+            cache_date_range?: string | null;
             /**
-             * Licitacoes
-             * @description List of individual bids for display. FREE tier shows 5-10 fully, rest blurred.
+             * Cache Fallback
+             * @description STORY-306 AC5: True when serving cached data from a different date range than requested
+             * @default false
              */
-            licitacoes?: components["schemas"]["LicitacaoItem"][];
+            cache_fallback: boolean;
             /**
-             * Excel Base64
-             * @description Excel file encoded as base64 string (None if plan doesn't allow or storage used)
+             * Cache Level
+             * @description UX-303 AC2: Which cache level served the data — 'supabase', 'redis', or 'local'
              */
-            excel_base64?: string | null;
+            cache_level?: string | null;
+            /**
+             * Cache Status
+             * @description UX-303 AC5: Cache freshness status — 'fresh' (0-6h) or 'stale' (6-24h)
+             */
+            cache_status?: string | null;
+            /**
+             * Cached
+             * @description True when results are served from cache (STORY-257A AC9)
+             * @default false
+             */
+            cached: boolean;
+            /**
+             * Cached At
+             * @description ISO timestamp of when cached results were generated
+             */
+            cached_at?: string | null;
+            /**
+             * Cached Sources
+             * @description GTM-FIX-010 AC5r: Source codes that contributed to cached data (e.g. ['PNCP','PORTAL_COMPRAS'])
+             */
+            cached_sources?: string[] | null;
+            /** @description GTM-RESILIENCE-C03: Consolidated coverage metadata for frontend display */
+            coverage_metadata?: components["schemas"]["CoverageMetadata"] | null;
+            /**
+             * Coverage Pct
+             * @description GTM-RESILIENCE-A05 AC1: Coverage percentage (succeeded_ufs / total_ufs_requested * 100)
+             * @default 100
+             */
+            coverage_pct: number;
+            /**
+             * Data Sources
+             * @description Detailed status breakdown of each data source (None for backward compatibility)
+             */
+            data_sources?: components["schemas"]["DataSourceStatus"][] | null;
+            /**
+             * Degradation Guidance
+             * @description GTM-RESILIENCE-A01: User-facing guidance when response_state is 'empty_failure' or 'degraded'
+             */
+            degradation_guidance?: string | null;
+            /**
+             * Degradation Reason
+             * @description Human-readable explanation of partial results (e.g., 'PNCP indisponível, resultados de fontes alternativas')
+             */
+            degradation_reason?: string | null;
             /**
              * Download Url
              * @description Signed URL for direct Excel download (60min TTL, preferred over base64)
@@ -6575,47 +6648,127 @@ export interface components {
              */
             excel_available: boolean;
             /**
-             * Quota Used
-             * @description Monthly searches used after this request
+             * Excel Base64
+             * @description Excel file encoded as base64 string (None if plan doesn't allow or storage used)
              */
-            quota_used: number;
+            excel_base64?: string | null;
+            /**
+             * Excel Status
+             * @description Excel generation status: 'ready' (inline), 'processing' (background job running), 'skipped' (plan does not allow), 'failed' (job failed), None (legacy)
+             */
+            excel_status?: string | null;
+            /**
+             * Failed Ufs
+             * @description List of UF codes that failed during fetch (timeout or error)
+             */
+            failed_ufs?: string[] | null;
+            /**
+             * Filter Relaxed
+             * @description True if the minimum match filter was relaxed from strict to 1 due to zero results
+             */
+            filter_relaxed?: boolean | null;
+            /** @description Breakdown of filter rejection reasons */
+            filter_stats?: components["schemas"]["FilterStats"] | null;
+            /**
+             * Filter Summary
+             * @description GTM-STAB-005 AC3: Human-readable filter summary (e.g. '3 rejeitadas por UF, 12 por keyword')
+             */
+            filter_summary?: string | null;
+            /**
+             * From Cache
+             * @description GTM-INFRA-003 AC6: True when response came 100% from cache (quota was NOT consumed)
+             * @default false
+             */
+            from_cache: boolean;
+            /**
+             * Hidden By Min Match
+             * @description Number of bids that matched at least 1 term but were below the minimum match floor
+             */
+            hidden_by_min_match?: number | null;
+            /**
+             * Is Partial
+             * @description True when not all configured data sources responded successfully (some timed out/failed)
+             * @default false
+             */
+            is_partial: boolean;
+            /**
+             * Is Simplified
+             * @description GTM-STAB-003 AC4: True when time budget forced simplified (LLM/viability skipped)
+             * @default false
+             */
+            is_simplified: boolean;
+            /**
+             * Is Truncated
+             * @description True when at least one UF hit the max_pages limit (data may be incomplete)
+             * @default false
+             */
+            is_truncated: boolean;
+            /**
+             * Licitacoes
+             * @description List of individual bids for display. FREE tier shows 5-10 fully, rest blurred.
+             */
+            licitacoes?: components["schemas"]["LicitacaoItem"][];
+            /**
+             * Live Fetch In Progress
+             * @description A-04 AC1: True when cache-first response returned and live fetch is running in background
+             * @default false
+             */
+            live_fetch_in_progress: boolean;
+            /**
+             * Llm Source
+             * @description CRIT-005 AC13: Source of the summary — 'ai' (GPT-generated), 'fallback' (heuristic), 'processing' (in progress)
+             */
+            llm_source?: ("ai" | "fallback" | "processing") | null;
+            /**
+             * Llm Status
+             * @description LLM summary status: 'ready' (inline), 'processing' (background job running), None (legacy)
+             */
+            llm_status?: string | null;
+            /**
+             * Match Relaxed
+             * @description STORY-267 AC15: True when min_match_floor was relaxed, enabling 'expanded matching' badge in frontend
+             * @default false
+             */
+            match_relaxed: boolean;
+            /**
+             * Paywall Applied
+             * @description STORY-320 AC3: True when results were truncated due to trial paywall
+             * @default false
+             */
+            paywall_applied: boolean;
+            /**
+             * Pending Review Count
+             * @description STORY-354 AC2: Number of bids awaiting AI reclassification (LLM was temporarily unavailable)
+             * @default 0
+             */
+            pending_review_count: number;
             /**
              * Quota Remaining
              * @description Monthly searches remaining
              */
             quota_remaining: number;
             /**
-             * Total Raw
-             * @description Total records fetched from PNCP API (before filtering)
+             * Quota Used
+             * @description Monthly searches used after this request
              */
-            total_raw: number;
+            quota_used: number;
             /**
-             * Total Filtrado
-             * @description Records after applying filters (UF, value, keywords, deadline)
+             * Relaxation Level
+             * @description GTM-STAB-005 AC4: 0=normal, 1=no floor, 2=no density, 3=top by value
              */
-            total_filtrado: number;
-            /** @description Breakdown of filter rejection reasons */
-            filter_stats?: components["schemas"]["FilterStats"] | null;
+            relaxation_level?: number | null;
             /**
-             * Termos Utilizados
-             * @description Keywords effectively used for filtering (after stopword removal)
+             * Response State
+             * @description Semantic state of the response: 'live' (fresh data), 'cached' (stale cache served), 'degraded' (partial data), 'empty_failure' (all sources failed, no cache), 'degraded_expired' (all sources failed, expired cache >24h served as last resort)
+             * @default live
+             * @enum {string}
              */
-            termos_utilizados?: string[] | null;
+            response_state: "live" | "cached" | "degraded" | "empty_failure" | "degraded_expired";
             /**
-             * Stopwords Removidas
-             * @description Stopwords stripped from user input (for transparency)
+             * Resumo
+             * @description Strategic executive summary with actionable recommendations (AI-generated or fallback)
              */
-            stopwords_removidas?: string[] | null;
-            /**
-             * Upgrade Message
-             * @description Message shown when Excel is blocked, encouraging upgrade
-             */
-            upgrade_message?: string | null;
-            /**
-             * Sources Used
-             * @description List of source codes that returned data (e.g., ['PNCP', 'PORTAL_COMPRAS'])
-             */
-            sources_used?: string[] | null;
+            resumo: components["schemas"]["ResumoEstrategico"] | components["schemas"]["ResumoLicitacoes"];
             /**
              * Source Stats
              * @description Per-source fetch metrics when multi-source is active
@@ -6624,42 +6777,50 @@ export interface components {
                 [key: string]: unknown;
             }[] | null;
             /**
-             * Is Partial
-             * @description True when not all configured data sources responded successfully (some timed out/failed)
-             * @default false
-             */
-            is_partial: boolean;
-            /**
-             * Data Sources
-             * @description Detailed status breakdown of each data source (None for backward compatibility)
-             */
-            data_sources?: components["schemas"]["DataSourceStatus"][] | null;
-            /**
-             * Degradation Reason
-             * @description Human-readable explanation of partial results (e.g., 'PNCP indisponível, resultados de fontes alternativas')
-             */
-            degradation_reason?: string | null;
-            /**
              * Sources Degraded
              * @description CRIT-053: Source codes that are degraded (e.g., canary timeout). Not counted as succeeded.
              */
             sources_degraded?: string[] | null;
             /**
-             * Failed Ufs
-             * @description List of UF codes that failed during fetch (timeout or error)
+             * Sources Used
+             * @description List of source codes that returned data (e.g., ['PNCP', 'PORTAL_COMPRAS'])
              */
-            failed_ufs?: string[] | null;
+            sources_used?: string[] | null;
+            /**
+             * Stopwords Removidas
+             * @description Stopwords stripped from user input (for transparency)
+             */
+            stopwords_removidas?: string[] | null;
             /**
              * Succeeded Ufs
              * @description List of UF codes that returned data successfully
              */
             succeeded_ufs?: string[] | null;
             /**
-             * Is Truncated
-             * @description True when at least one UF hit the max_pages limit (data may be incomplete)
-             * @default false
+             * Termos Utilizados
+             * @description Keywords effectively used for filtering (after stopword removal)
              */
-            is_truncated: boolean;
+            termos_utilizados?: string[] | null;
+            /**
+             * Total Before Paywall
+             * @description STORY-320 AC3: Total results before paywall truncation (shown as 'See all N results')
+             */
+            total_before_paywall?: number | null;
+            /**
+             * Total Filtrado
+             * @description Records after applying filters (UF, value, keywords, deadline)
+             */
+            total_filtrado: number;
+            /**
+             * Total Raw
+             * @description Total records fetched from PNCP API (before filtering)
+             */
+            total_raw: number;
+            /**
+             * Total Ufs Requested
+             * @description Total number of UFs in the original request
+             */
+            total_ufs_requested?: number | null;
             /**
              * Truncated Ufs
              * @description UF codes where results were truncated due to max_pages limit
@@ -6673,147 +6834,20 @@ export interface components {
                 [key: string]: boolean;
             } | null;
             /**
-             * Total Ufs Requested
-             * @description Total number of UFs in the original request
-             */
-            total_ufs_requested?: number | null;
-            /**
-             * Cached
-             * @description True when results are served from cache (STORY-257A AC9)
-             * @default false
-             */
-            cached: boolean;
-            /**
-             * From Cache
-             * @description GTM-INFRA-003 AC6: True when response came 100% from cache (quota was NOT consumed)
-             * @default false
-             */
-            from_cache: boolean;
-            /**
-             * Cached At
-             * @description ISO timestamp of when cached results were generated
-             */
-            cached_at?: string | null;
-            /**
-             * Cached Sources
-             * @description GTM-FIX-010 AC5r: Source codes that contributed to cached data (e.g. ['PNCP','PORTAL_COMPRAS'])
-             */
-            cached_sources?: string[] | null;
-            /**
-             * Cache Status
-             * @description UX-303 AC5: Cache freshness status — 'fresh' (0-6h) or 'stale' (6-24h)
-             */
-            cache_status?: string | null;
-            /**
-             * Cache Level
-             * @description UX-303 AC2: Which cache level served the data — 'supabase', 'redis', or 'local'
-             */
-            cache_level?: string | null;
-            /**
-             * Cache Fallback
-             * @description STORY-306 AC5: True when serving cached data from a different date range than requested
-             * @default false
-             */
-            cache_fallback: boolean;
-            /**
-             * Cache Date Range
-             * @description STORY-306 AC5: Date of the cached data when cache_fallback=True (e.g. '2026-02-20')
-             */
-            cache_date_range?: string | null;
-            /**
-             * Response State
-             * @description Semantic state of the response: 'live' (fresh data), 'cached' (stale cache served), 'degraded' (partial data), 'empty_failure' (all sources failed, no cache), 'degraded_expired' (all sources failed, expired cache >24h served as last resort)
-             * @default live
-             * @enum {string}
-             */
-            response_state: "live" | "cached" | "degraded" | "empty_failure" | "degraded_expired";
-            /**
-             * Live Fetch In Progress
-             * @description A-04 AC1: True when cache-first response returned and live fetch is running in background
-             * @default false
-             */
-            live_fetch_in_progress: boolean;
-            /**
-             * Degradation Guidance
-             * @description GTM-RESILIENCE-A01: User-facing guidance when response_state is 'empty_failure' or 'degraded'
-             */
-            degradation_guidance?: string | null;
-            /**
-             * Coverage Pct
-             * @description GTM-RESILIENCE-A05 AC1: Coverage percentage (succeeded_ufs / total_ufs_requested * 100)
-             * @default 100
-             */
-            coverage_pct: number;
-            /**
              * Ufs Status Detail
              * @description GTM-RESILIENCE-A05 AC2: Per-UF status breakdown with results count
              */
             ufs_status_detail?: components["schemas"]["UfStatusDetail"][] | null;
-            /** @description GTM-RESILIENCE-C03: Consolidated coverage metadata for frontend display */
-            coverage_metadata?: components["schemas"]["CoverageMetadata"] | null;
-            /**
-             * Hidden By Min Match
-             * @description Number of bids that matched at least 1 term but were below the minimum match floor
-             */
-            hidden_by_min_match?: number | null;
-            /**
-             * Filter Relaxed
-             * @description True if the minimum match filter was relaxed from strict to 1 due to zero results
-             */
-            filter_relaxed?: boolean | null;
             /**
              * Ultima Atualizacao
              * @description ISO timestamp of when search results were generated
              */
             ultima_atualizacao?: string | null;
             /**
-             * Pending Review Count
-             * @description STORY-354 AC2: Number of bids awaiting AI reclassification (LLM was temporarily unavailable)
-             * @default 0
+             * Upgrade Message
+             * @description Message shown when Excel is blocked, encouraging upgrade
              */
-            pending_review_count: number;
-            /**
-             * Llm Status
-             * @description LLM summary status: 'ready' (inline), 'processing' (background job running), None (legacy)
-             */
-            llm_status?: string | null;
-            /**
-             * Excel Status
-             * @description Excel generation status: 'ready' (inline), 'processing' (background job running), 'skipped' (plan does not allow), 'failed' (job failed), None (legacy)
-             */
-            excel_status?: string | null;
-            /**
-             * Llm Source
-             * @description CRIT-005 AC13: Source of the summary — 'ai' (GPT-generated), 'fallback' (heuristic), 'processing' (in progress)
-             */
-            llm_source?: ("ai" | "fallback" | "processing") | null;
-            /**
-             * Match Relaxed
-             * @description STORY-267 AC15: True when min_match_floor was relaxed, enabling 'expanded matching' badge in frontend
-             * @default false
-             */
-            match_relaxed: boolean;
-            /**
-             * Filter Summary
-             * @description GTM-STAB-005 AC3: Human-readable filter summary (e.g. '3 rejeitadas por UF, 12 por keyword')
-             */
-            filter_summary?: string | null;
-            /**
-             * Is Simplified
-             * @description GTM-STAB-003 AC4: True when time budget forced simplified (LLM/viability skipped)
-             * @default false
-             */
-            is_simplified: boolean;
-            /**
-             * Relaxation Level
-             * @description GTM-STAB-005 AC4: 0=normal, 1=no floor, 2=no density, 3=top by value
-             */
-            relaxation_level?: number | null;
-            /**
-             * Zero Match Job Id
-             * @description CRIT-059 AC6: Job ID for background zero-match classification (None when sync or disabled)
-             */
-            zero_match_job_id?: string | null;
+            upgrade_message?: string | null;
             /**
              * Zero Match Candidates Count
              * @description CRIT-059 AC6: Number of zero-match candidates pending background classification
@@ -6821,16 +6855,10 @@ export interface components {
              */
             zero_match_candidates_count: number;
             /**
-             * Paywall Applied
-             * @description STORY-320 AC3: True when results were truncated due to trial paywall
-             * @default false
+             * Zero Match Job Id
+             * @description CRIT-059 AC6: Job ID for background zero-match classification (None when sync or disabled)
              */
-            paywall_applied: boolean;
-            /**
-             * Total Before Paywall
-             * @description STORY-320 AC3: Total results before paywall truncation (shown as 'See all N results')
-             */
-            total_before_paywall?: number | null;
+            zero_match_job_id?: string | null;
         };
         /** CTAEventRequest */
         CTAEventRequest: {
@@ -6844,18 +6872,18 @@ export interface components {
          * @description B-03/AC9 cache degradation aggregates.
          */
         CacheDegradationInfo: {
-            /** Degraded Keys Count */
-            degraded_keys_count?: number | null;
             /** Avg Fail Streak */
             avg_fail_streak?: number | null;
+            /** Degraded Keys Count */
+            degraded_keys_count?: number | null;
+            /** Error */
+            error?: string | null;
             /** Keys With Failures */
             keys_with_failures?: number | null;
             /** Priority Distribution */
             priority_distribution?: {
                 [key: string]: number;
             } | null;
-            /** Error */
-            error?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -6864,14 +6892,14 @@ export interface components {
          * @description UX-303 AC7: Cache health envelope across all levels.
          */
         CacheHealthResponse: {
-            /** Timestamp */
-            timestamp?: string | null;
+            degradation?: components["schemas"]["CacheDegradationInfo"] | null;
+            local?: components["schemas"]["CacheLevelHealth"] | null;
             /** Overall */
             overall?: string | null;
-            supabase?: components["schemas"]["CacheLevelHealth"] | null;
             redis?: components["schemas"]["CacheLevelHealth"] | null;
-            local?: components["schemas"]["CacheLevelHealth"] | null;
-            degradation?: components["schemas"]["CacheDegradationInfo"] | null;
+            supabase?: components["schemas"]["CacheLevelHealth"] | null;
+            /** Timestamp */
+            timestamp?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -6880,19 +6908,17 @@ export interface components {
          * @description Per-level cache health (supabase / redis / local).
          */
         CacheLevelHealth: {
-            /** Status */
-            status?: string | null;
-            /** Latency Ms */
-            latency_ms?: number | null;
             /** Last Error */
             last_error?: string | null;
+            /** Latency Ms */
+            latency_ms?: number | null;
+            /** Status */
+            status?: string | null;
         } & {
             [key: string]: unknown;
         };
         /** CalculadoraDadosResponse */
         CalculadoraDadosResponse: {
-            /** Total Editais Mes */
-            total_editais_mes: number;
             /** Avg Value */
             avg_value: number;
             /** P25 Value */
@@ -6901,6 +6927,8 @@ export interface components {
             p75_value: number;
             /** Setor Name */
             setor_name: string;
+            /** Total Editais Mes */
+            total_editais_mes: number;
             /** Uf */
             uf: string;
         };
@@ -6920,10 +6948,10 @@ export interface components {
          * @description Response for cancellation feedback.
          */
         CancelFeedbackResponse: {
-            /** Success */
-            success: boolean;
             /** Message */
             message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * CancelSubscriptionRequest
@@ -6941,20 +6969,23 @@ export interface components {
          * @description Response for subscription cancellation.
          */
         CancelSubscriptionResponse: {
-            /** Success */
-            success: boolean;
             /** Ends At */
             ends_at: string;
             /** Message */
             message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * CancelTrialInfoResponse
          * @description Returned by GET /cancelar-trial to populate the confirmation UI.
          */
         CancelTrialInfoResponse: {
-            /** User Id */
-            user_id: string;
+            /**
+             * Already Cancelled
+             * @default false
+             */
+            already_cancelled: boolean;
             /** Email */
             email: string;
             /** Plan Name */
@@ -6964,11 +6995,8 @@ export interface components {
              * @description Unix epoch seconds when trial ends
              */
             trial_end_ts?: number | null;
-            /**
-             * Already Cancelled
-             * @default false
-             */
-            already_cancelled: boolean;
+            /** User Id */
+            user_id: string;
         };
         /** CancelTrialRequest */
         CancelTrialRequest: {
@@ -6980,8 +7008,6 @@ export interface components {
         };
         /** CancelTrialResponse */
         CancelTrialResponse: {
-            /** Cancelled */
-            cancelled: boolean;
             /**
              * Access Until
              * @description Unix epoch seconds — trial access remains until this timestamp
@@ -6992,6 +7018,8 @@ export interface components {
              * @default false
              */
             already_cancelled: boolean;
+            /** Cancelled */
+            cancelled: boolean;
         };
         /**
          * CheckEmailResponse
@@ -7000,10 +7028,10 @@ export interface components {
         CheckEmailResponse: {
             /** Available */
             available: boolean;
-            /** Disposable */
-            disposable: boolean;
             /** Corporate */
             corporate: boolean;
+            /** Disposable */
+            disposable: boolean;
         } & {
             [key: string]: unknown;
         };
@@ -7018,8 +7046,23 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * CheckoutRequest
+         * @description Request body for POST /api/checkout/one-time.
+         */
+        CheckoutRequest: {
+            /**
+             * Context
+             * @default {}
+             */
+            context: {
+                [key: string]: unknown;
+            };
+            /** Sku */
+            sku: string;
+        };
+        /**
          * CheckoutResponse
-         * @description Response for POST /checkout.
+         * @description Response for a successful checkout session creation.
          */
         CheckoutResponse: {
             /** Checkout Url */
@@ -7027,43 +7070,10 @@ export interface components {
         };
         /** CidadeSectorStats */
         CidadeSectorStats: {
-            /** Cidade */
-            cidade: string;
-            /** Uf */
-            uf: string;
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Total Editais */
-            total_editais: number;
             /** Avg Value */
             avg_value: number;
-            /**
-             * Value Range Min
-             * @default 0
-             */
-            value_range_min: number;
-            /**
-             * Value Range Max
-             * @default 0
-             */
-            value_range_max: number;
-            /**
-             * Top Modalidades
-             * @default []
-             */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /**
-             * Orgaos Frequentes
-             * @default []
-             */
-            orgaos_frequentes: components["schemas"]["TopEntry"][];
-            /**
-             * Top Oportunidades
-             * @default []
-             */
-            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
+            /** Cidade */
+            cidade: string;
             /**
              * Has Sufficient Data
              * @default false
@@ -7071,21 +7081,54 @@ export interface components {
             has_sufficient_data: boolean;
             /** Last Updated */
             last_updated: string;
+            /**
+             * Orgaos Frequentes
+             * @default []
+             */
+            orgaos_frequentes: components["schemas"]["TopEntry"][];
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /**
+             * Top Modalidades
+             * @default []
+             */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /**
+             * Top Oportunidades
+             * @default []
+             */
+            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
+            /** Total Editais */
+            total_editais: number;
+            /** Uf */
+            uf: string;
+            /**
+             * Value Range Max
+             * @default 0
+             */
+            value_range_max: number;
+            /**
+             * Value Range Min
+             * @default 0
+             */
+            value_range_min: number;
         };
         /** CidadeStats */
         CidadeStats: {
-            /** Cidade */
-            cidade: string;
-            /** Uf */
-            uf: string;
-            /** Total Editais */
-            total_editais: number;
-            /** Orgaos Frequentes */
-            orgaos_frequentes: components["schemas"]["TopEntry"][];
             /** Avg Value */
             avg_value: number;
+            /** Cidade */
+            cidade: string;
             /** Last Updated */
             last_updated: string;
+            /** Orgaos Frequentes */
+            orgaos_frequentes: components["schemas"]["TopEntry"][];
+            /** Total Editais */
+            total_editais: number;
+            /** Uf */
+            uf: string;
         };
         /** ClearNewBidsCountResponse */
         ClearNewBidsCountResponse: {
@@ -7096,8 +7139,6 @@ export interface components {
         CnaeMappingCreate: {
             /** Cnae Code */
             cnae_code: string;
-            /** Setor Id */
-            setor_id: string;
             /**
              * Confidence
              * @default 1
@@ -7107,6 +7148,8 @@ export interface components {
             fallback_setor_id?: string | null;
             /** Notes */
             notes?: string | null;
+            /** Setor Id */
+            setor_id: string;
         };
         /** CnaeMappingListResponse */
         CnaeMappingListResponse: {
@@ -7119,16 +7162,16 @@ export interface components {
         CnaeMappingRow: {
             /** Cnae Code */
             cnae_code: string;
-            /** Setor Id */
-            setor_id: string;
             /** Confidence */
             confidence: number;
+            /** Created At */
+            created_at?: string | null;
             /** Fallback Setor Id */
             fallback_setor_id?: string | null;
             /** Notes */
             notes?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Setor Id */
+            setor_id: string;
             /** Updated At */
             updated_at?: string | null;
             /** Updated By */
@@ -7136,46 +7179,46 @@ export interface components {
         };
         /** CnaeMappingUpdate */
         CnaeMappingUpdate: {
-            /** Setor Id */
-            setor_id?: string | null;
             /** Confidence */
             confidence?: number | null;
             /** Fallback Setor Id */
             fallback_setor_id?: string | null;
             /** Notes */
             notes?: string | null;
+            /** Setor Id */
+            setor_id?: string | null;
         };
         /** ComparadorBid */
         ComparadorBid: {
-            /** Pncp Id */
-            pncp_id: string;
-            /** Titulo */
-            titulo: string;
-            /** Orgao */
-            orgao: string;
-            /** Valor */
-            valor?: number | null;
-            /** Uf */
-            uf: string;
-            /**
-             * Municipio
-             * @default
-             */
-            municipio: string;
-            /**
-             * Modalidade
-             * @default
-             */
-            modalidade: string;
-            /** Data Publicacao */
-            data_publicacao: string;
             /** Data Abertura */
             data_abertura?: string | null;
+            /** Data Publicacao */
+            data_publicacao: string;
             /**
              * Link Pncp
              * @default
              */
             link_pncp: string;
+            /**
+             * Modalidade
+             * @default
+             */
+            modalidade: string;
+            /**
+             * Municipio
+             * @default
+             */
+            municipio: string;
+            /** Orgao */
+            orgao: string;
+            /** Pncp Id */
+            pncp_id: string;
+            /** Titulo */
+            titulo: string;
+            /** Uf */
+            uf: string;
+            /** Valor */
+            valor?: number | null;
         };
         /** ComparadorBidsResponse */
         ComparadorBidsResponse: {
@@ -7186,192 +7229,192 @@ export interface components {
         };
         /** ComparadorSearchResponse */
         ComparadorSearchResponse: {
-            /** Query */
-            query: string;
-            /** Uf */
-            uf: string | null;
             /** Bids */
             bids: components["schemas"]["ComparadorBid"][];
+            /** Query */
+            query: string;
             /** Total */
             total: number;
+            /** Uf */
+            uf: string | null;
         };
         /** ComplianceProfileResponse */
         ComplianceProfileResponse: {
+            /** Aviso Legal */
+            aviso_legal: string;
             /** Cnpj */
             cnpj: string;
+            /** Fonte Dados */
+            fonte_dados: string;
+            /** Last Updated */
+            last_updated: string;
             /** Razao Social */
             razao_social: string;
+            /** Sancoes */
+            sancoes: components["schemas"]["SancaoEntry"][];
             /** Situacao Geral */
             situacao_geral: string;
             /** Total Sancoes Ceis */
             total_sancoes_ceis: number;
             /** Total Sancoes Cnep */
             total_sancoes_cnep: number;
-            /** Sancoes */
-            sancoes: components["schemas"]["SancaoEntry"][];
-            /** Fonte Dados */
-            fonte_dados: string;
-            /** Last Updated */
-            last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
         };
         /** ContratoPublico */
         ContratoPublico: {
-            /** Orgao */
-            orgao: string;
-            /** Orgao Cnpj */
-            orgao_cnpj?: string | null;
-            /** Valor */
-            valor?: number | null;
             /** Data Inicio */
             data_inicio?: string | null;
             /** Descricao */
             descricao: string;
             /** Esfera */
             esfera?: string | null;
+            /** Orgao */
+            orgao: string;
+            /** Orgao Cnpj */
+            orgao_cnpj?: string | null;
             /** Uf */
             uf?: string | null;
+            /** Valor */
+            valor?: number | null;
         };
         /** ContratoReferencia */
         ContratoReferencia: {
+            /** Data Assinatura */
+            data_assinatura: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
-            /** Valor */
-            valor: number;
-            /** Data Assinatura */
-            data_assinatura: string;
             /** Uf */
             uf: string;
+            /** Valor */
+            valor: number;
         };
         /**
          * ContratosCidadeSetorStats
          * @description City × Sector filtered contract stats for zero-editais cidade×setor pages.
          */
         ContratosCidadeSetorStats: {
-            /** Cidade */
-            cidade: string;
-            /** Uf */
-            uf: string;
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Total Contracts */
-            total_contracts: number;
-            /** Total Value */
-            total_value: number;
             /** Avg Value */
             avg_value: number;
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
+            /** Cidade */
+            cidade: string;
             /** Last Updated */
             last_updated: string;
-            /**
-             * N Unique Orgaos
-             * @default 0
-             */
-            n_unique_orgaos: number;
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
             /**
              * N Unique Fornecedores
              * @default 0
              */
             n_unique_fornecedores: number;
             /**
+             * N Unique Orgaos
+             * @default 0
+             */
+            n_unique_orgaos: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Value */
+            total_value: number;
+            /** Uf */
+            uf: string;
         };
         /**
          * ContratosCidadeStats
          * @description City-level contract stats (all sectors) for zero-editais cidade blog pages.
          */
         ContratosCidadeStats: {
-            /** Cidade */
-            cidade: string;
-            /** Uf */
-            uf: string;
-            /** Total Contracts */
-            total_contracts: number;
-            /** Total Value */
-            total_value: number;
             /** Avg Value */
             avg_value: number;
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
+            /** Cidade */
+            cidade: string;
             /** Last Updated */
             last_updated: string;
-            /**
-             * N Unique Orgaos
-             * @default 0
-             */
-            n_unique_orgaos: number;
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
             /**
              * N Unique Fornecedores
              * @default 0
              */
             n_unique_fornecedores: number;
             /**
+             * N Unique Orgaos
+             * @default 0
+             */
+            n_unique_orgaos: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
-        };
-        /** ContratosSetorStats */
-        ContratosSetorStats: {
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
             /** Total Contracts */
             total_contracts: number;
             /** Total Value */
             total_value: number;
+            /** Uf */
+            uf: string;
+        };
+        /** ContratosSetorStats */
+        ContratosSetorStats: {
             /** Avg Value */
             avg_value: number;
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
             /** By Uf */
             by_uf: components["schemas"]["ContratosSetorUfEntry"][];
             /** Last Updated */
             last_updated: string;
-            /**
-             * N Unique Orgaos
-             * @default 0
-             */
-            n_unique_orgaos: number;
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
             /**
              * N Unique Fornecedores
              * @default 0
              */
             n_unique_fornecedores: number;
             /**
+             * N Unique Orgaos
+             * @default 0
+             */
+            n_unique_orgaos: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Value */
+            total_value: number;
         };
         /** ContratosSetorTopEntry */
         ContratosSetorTopEntry: {
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
+            /** Nome */
+            nome: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -7379,19 +7422,19 @@ export interface components {
         };
         /** ContratosSetorTrend */
         ContratosSetorTrend: {
-            /** Month */
-            month: string;
             /** Count */
             count: number;
+            /** Month */
+            month: string;
             /** Value */
             value: number;
         };
         /** ContratosSetorUfEntry */
         ContratosSetorUfEntry: {
-            /** Uf */
-            uf: string;
             /** Total Contratos */
             total_contratos: number;
+            /** Uf */
+            uf: string;
             /** Valor Total */
             valor_total: number;
         };
@@ -7400,78 +7443,78 @@ export interface components {
          * @description Sector × UF filtered contract stats (fallback for zero-editais blog pages).
          */
         ContratosSetorUfStats: {
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Uf */
-            uf: string;
-            /** Total Contracts */
-            total_contracts: number;
-            /** Total Value */
-            total_value: number;
             /** Avg Value */
             avg_value: number;
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
             /** Last Updated */
             last_updated: string;
-            /**
-             * N Unique Orgaos
-             * @default 0
-             */
-            n_unique_orgaos: number;
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["ContratosSetorTrend"][];
             /**
              * N Unique Fornecedores
              * @default 0
              */
             n_unique_fornecedores: number;
             /**
+             * N Unique Orgaos
+             * @default 0
+             */
+            n_unique_orgaos: number;
+            /**
              * Sample Contracts
              * @default []
              */
             sample_contracts: components["schemas"]["routes__blog_stats__SampleContract"][];
-        };
-        /** ContratosStatsResponse */
-        ContratosStatsResponse: {
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Uf */
-            uf: string;
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["ContratosSetorTopEntry"][];
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["ContratosSetorTopEntry"][];
             /** Total Contracts */
             total_contracts: number;
             /** Total Value */
             total_value: number;
-            /** Avg Value */
-            avg_value: number;
-            /** Top Orgaos */
-            top_orgaos: components["schemas"]["OrgaoRank"][];
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["FornecedorRank"][];
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
-            /** Sample Contracts */
-            sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
-            /** Last Updated */
-            last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
+            /** Uf */
+            uf: string;
+        };
+        /** ContratosStatsResponse */
+        ContratosStatsResponse: {
             /**
              * @default {
              *       "contagem_30d": 0,
              *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
              *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
              *     }
              */
             atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Avg Value */
+            avg_value: number;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
+            /** Sample Contracts */
+            sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["FornecedorRank"][];
+            /** Top Orgaos */
+            top_orgaos: components["schemas"]["OrgaoRank"][];
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Value */
+            total_value: number;
+            /** Uf */
+            uf: string;
         };
         /**
          * ConversationCategory
@@ -7484,27 +7527,27 @@ export interface components {
          * @description Full conversation with messages thread.
          */
         ConversationDetail: {
-            /** Id */
-            id: string;
-            /** User Id */
-            user_id: string;
-            /** User Email */
-            user_email?: string | null;
-            /** Subject */
-            subject: string;
             /** Category */
             category: string;
-            /** Status */
-            status: string;
-            /** Last Message At */
-            last_message_at: string;
             /** Created At */
             created_at: string;
+            /** Id */
+            id: string;
+            /** Last Message At */
+            last_message_at: string;
             /**
              * Messages
              * @default []
              */
             messages: components["schemas"]["MessageResponse"][];
+            /** Status */
+            status: string;
+            /** Subject */
+            subject: string;
+            /** User Email */
+            user_email?: string | null;
+            /** User Id */
+            user_id: string;
         };
         /**
          * ConversationStatus
@@ -7517,27 +7560,27 @@ export interface components {
          * @description Summary of a conversation for list views.
          */
         ConversationSummary: {
-            /** Id */
-            id: string;
-            /** User Id */
-            user_id: string;
-            /** User Email */
-            user_email?: string | null;
-            /** Subject */
-            subject: string;
             /** Category */
             category: string;
-            /** Status */
-            status: string;
-            /** Last Message At */
-            last_message_at: string;
             /** Created At */
             created_at: string;
+            /** Id */
+            id: string;
+            /** Last Message At */
+            last_message_at: string;
+            /** Status */
+            status: string;
+            /** Subject */
+            subject: string;
             /**
              * Unread Count
              * @default 0
              */
             unread_count: number;
+            /** User Email */
+            user_email?: string | null;
+            /** User Id */
+            user_id: string;
         };
         /**
          * ConversationsListResponse
@@ -7551,24 +7594,24 @@ export interface components {
         };
         /** CoverageEntry */
         CoverageEntry: {
+            /** Bid Count */
+            bid_count: number;
             /**
              * Coverage Status
              * @enum {string}
              */
             coverage_status: "full" | "partial" | "empty" | "historical_empty";
-            /** Bid Count */
-            bid_count: number;
             /** Last Updated */
             last_updated: string;
         };
         /** CoverageManifestResponse */
         CoverageManifestResponse: {
+            /** Generated At */
+            generated_at: string;
             /** Manifest */
             manifest: {
                 [key: string]: components["schemas"]["CoverageEntry"];
             };
-            /** Generated At */
-            generated_at: string;
             /** Total Entities */
             total_entities: number;
         };
@@ -7577,33 +7620,6 @@ export interface components {
          * @description GTM-RESILIENCE-C03 AC1: Consolidated coverage metadata.
          */
         CoverageMetadata: {
-            /**
-             * Ufs Requested
-             * @description UFs solicitadas pelo usuario
-             */
-            ufs_requested: string[];
-            /**
-             * Ufs Processed
-             * @description UFs que retornaram dados com sucesso
-             */
-            ufs_processed: string[];
-            /**
-             * Ufs Failed
-             * @description UFs que falharam (timeout/erro)
-             */
-            ufs_failed?: string[];
-            /**
-             * Ufs Empty
-             * @description ISSUE-073: UFs processadas com 0 resultados pos-filtragem
-             */
-            ufs_empty?: string[];
-            /**
-             * Uf Result Counts
-             * @description ISSUE-073: contagem de resultados por UF
-             */
-            uf_result_counts?: {
-                [key: string]: number;
-            };
             /**
              * Coverage Pct
              * @description Porcentagem de cobertura (1 decimal)
@@ -7620,26 +7636,53 @@ export interface components {
              * @enum {string}
              */
             freshness: "live" | "cached_fresh" | "cached_stale";
+            /**
+             * Uf Result Counts
+             * @description ISSUE-073: contagem de resultados por UF
+             */
+            uf_result_counts?: {
+                [key: string]: number;
+            };
+            /**
+             * Ufs Empty
+             * @description ISSUE-073: UFs processadas com 0 resultados pos-filtragem
+             */
+            ufs_empty?: string[];
+            /**
+             * Ufs Failed
+             * @description UFs que falharam (timeout/erro)
+             */
+            ufs_failed?: string[];
+            /**
+             * Ufs Processed
+             * @description UFs que retornaram dados com sucesso
+             */
+            ufs_processed: string[];
+            /**
+             * Ufs Requested
+             * @description UFs solicitadas pelo usuario
+             */
+            ufs_requested: string[];
         };
         /** CreateAlertRequest */
         CreateAlertRequest: {
+            filters: components["schemas"]["AlertFilters"];
             /**
              * Name
              * @description Alert display name
              */
             name: string;
-            filters: components["schemas"]["AlertFilters"];
         };
         /**
          * CreateConversationRequest
          * @description Request to create a new conversation with first message.
          */
         CreateConversationRequest: {
-            /** Subject */
-            subject: string;
-            category: components["schemas"]["ConversationCategory"];
             /** Body */
             body: string;
+            category: components["schemas"]["ConversationCategory"];
+            /** Subject */
+            subject: string;
         };
         /**
          * CreateConversationResponse
@@ -7658,181 +7701,181 @@ export interface components {
         };
         /** CreatePartnerRequest */
         CreatePartnerRequest: {
-            /** Name */
-            name: string;
-            /** Slug */
-            slug: string;
             /** Contact Email */
             contact_email: string;
             /** Contact Name */
             contact_name?: string | null;
-            /** Stripe Coupon Id */
-            stripe_coupon_id?: string | null;
+            /** Name */
+            name: string;
             /**
              * Revenue Share Pct
              * @default 20
              */
             revenue_share_pct: number;
+            /** Slug */
+            slug: string;
+            /** Stripe Coupon Id */
+            stripe_coupon_id?: string | null;
         };
         /** CreateUserRequest */
         CreateUserRequest: {
+            /** Company */
+            company?: string | null;
             /**
              * Email
              * @description User email
              */
             email: string;
+            /** Full Name */
+            full_name?: string | null;
             /**
              * Password
              * @description User password (min 8 chars, 1 uppercase, 1 digit)
              */
             password: string;
-            /** Full Name */
-            full_name?: string | null;
             /**
              * Plan Id
              * @description Initial plan
              * @default free_trial
              */
             plan_id: string | null;
-            /** Company */
-            company?: string | null;
         };
         /**
          * CronJobHealthRow
          * @description One row of ``public.get_cron_health()`` (STORY-1.1).
          */
         CronJobHealthRow: {
-            /** Jobname */
-            jobname?: string | null;
-            /** Schedule */
-            schedule?: string | null;
             /** Active */
             active?: boolean | null;
-            /** Last Status */
-            last_status?: string | null;
-            /** Last Run At */
-            last_run_at?: string | null;
-            /**
-             * Runs 24H
-             * @default 0
-             */
-            runs_24h: number;
             /**
              * Failures 24H
              * @default 0
              */
             failures_24h: number;
-            /** Latency Avg Ms */
-            latency_avg_ms?: number | null;
+            /** Jobname */
+            jobname?: string | null;
             /** Last Return Message */
             last_return_message?: string | null;
+            /** Last Run At */
+            last_run_at?: string | null;
+            /** Last Status */
+            last_status?: string | null;
+            /** Latency Avg Ms */
+            latency_avg_ms?: number | null;
+            /**
+             * Runs 24H
+             * @default 0
+             */
+            runs_24h: number;
+            /** Schedule */
+            schedule?: string | null;
         };
         /** DadosAgregadosResponse */
         DadosAgregadosResponse: {
-            /** Updated At */
-            updated_at: string;
-            /** Period */
-            period: string;
-            /** Period Start */
-            period_start: string;
-            /** Period End */
-            period_end: string;
-            /** Total Bids */
-            total_bids: number;
-            /** Total Value */
-            total_value: number;
             /** Avg Value */
             avg_value: number;
+            /** By Modalidade */
+            by_modalidade: components["schemas"]["ModalidadeAggregate"][];
             /** By Sector */
             by_sector: components["schemas"]["SectorAggregate"][];
             /** By Uf */
             by_uf: components["schemas"]["UfAggregate"][];
-            /** By Modalidade */
-            by_modalidade: components["schemas"]["ModalidadeAggregate"][];
-            /** Trend 30D */
-            trend_30d: components["schemas"]["routes__dados_publicos__TrendPoint"][];
-        };
-        /** DailyDigestResponse */
-        DailyDigestResponse: {
-            /** Date */
-            date: string;
-            /** Title */
-            title: string;
+            /** Period */
+            period: string;
+            /** Period End */
+            period_end: string;
+            /** Period Start */
+            period_start: string;
             /** Total Bids */
             total_bids: number;
             /** Total Value */
             total_value: number;
+            /** Trend 30D */
+            trend_30d: components["schemas"]["routes__dados_publicos__TrendPoint"][];
+            /** Updated At */
+            updated_at: string;
+        };
+        /** DailyDigestResponse */
+        DailyDigestResponse: {
             /** Avg Value */
             avg_value: number;
+            /** By Modalidade */
+            by_modalidade: components["schemas"]["DailyModalidade"][];
             /** By Sector */
             by_sector: components["schemas"]["DailySector"][];
             /** By Uf */
             by_uf: components["schemas"]["DailyUf"][];
-            /** By Modalidade */
-            by_modalidade: components["schemas"]["DailyModalidade"][];
+            /** Date */
+            date: string;
             /** Highlights */
             highlights: components["schemas"]["DailyHighlight"][];
+            /** Title */
+            title: string;
             /** Top Sector */
             top_sector: string;
             /** Top Uf */
             top_uf: string;
+            /** Total Bids */
+            total_bids: number;
+            /** Total Value */
+            total_value: number;
             /** Updated At */
             updated_at: string;
         };
         /** DailyHighlight */
         DailyHighlight: {
-            /** Titulo */
-            titulo: string;
             /** Orgao */
             orgao: string;
-            /** Valor */
-            valor?: number | null;
-            /** Uf */
-            uf: string;
             /** Setor */
             setor: string;
+            /** Titulo */
+            titulo: string;
+            /** Uf */
+            uf: string;
+            /** Valor */
+            valor?: number | null;
         };
         /** DailyModalidade */
         DailyModalidade: {
-            /** Modalidade */
-            modalidade: string;
             /** Count */
             count: number;
+            /** Modalidade */
+            modalidade: string;
             /** Pct */
             pct: number;
         };
         /** DailySector */
         DailySector: {
-            /** Sector Name */
-            sector_name: string;
-            /** Sector Id */
-            sector_id: string;
-            /** Count */
-            count: number;
             /** Avg Value */
             avg_value: number;
+            /** Count */
+            count: number;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
         };
         /** DailyUf */
         DailyUf: {
-            /** Uf */
-            uf: string;
             /** Count */
             count: number;
             /** Total Value */
             total_value: number;
+            /** Uf */
+            uf: string;
         };
         /** DailyVolumeResponse */
         DailyVolumeResponse: {
             /** Avg Bids Per Day */
             avg_bids_per_day: number;
-            /** Total Bids 30D */
-            total_bids_30d: number;
-            /** Total Sessions 30D */
-            total_sessions_30d: number;
             /** Days With Data */
             days_with_data: number;
             /** Display Value */
             display_value: string;
+            /** Total Bids 30D */
+            total_bids_30d: number;
+            /** Total Sessions 30D */
+            total_sessions_30d: number;
         };
         /**
          * DataSourceStatus
@@ -7843,6 +7886,12 @@ export interface components {
          */
         DataSourceStatus: {
             /**
+             * Records
+             * @description Number of records successfully returned by this source
+             * @default 0
+             */
+            records: number;
+            /**
              * Source
              * @description Data source identifier (e.g., 'pncp', 'compras_gov', 'portal')
              */
@@ -7852,65 +7901,47 @@ export interface components {
              * @description Source status: 'ok' (success), 'timeout' (timed out), 'error' (failed), 'skipped' (not attempted)
              */
             status: string;
-            /**
-             * Records
-             * @description Number of records successfully returned by this source
-             * @default 0
-             */
-            records: number;
         };
         /**
          * DebugPNCPResponse
          * @description Response for GET /debug/pncp-test endpoint.
          */
         DebugPNCPResponse: {
-            /** Success */
-            success: boolean;
-            /** Total Registros */
-            total_registros?: number | null;
-            /** Items Returned */
-            items_returned?: number | null;
+            /** Elapsed Ms */
+            elapsed_ms: number;
             /** Error */
             error?: string | null;
             /** Error Type */
             error_type?: string | null;
-            /** Elapsed Ms */
-            elapsed_ms: number;
+            /** Items Returned */
+            items_returned?: number | null;
+            /** Success */
+            success: boolean;
+            /** Total Registros */
+            total_registros?: number | null;
         };
         /**
          * DeepAnalysisRequest
          * @description Request body for deep analysis.
          */
         DeepAnalysisRequest: {
-            /** Search Id */
-            search_id: string;
             /** Bid Data */
             bid_data?: {
                 [key: string]: unknown;
             } | null;
+            /** Search Id */
+            search_id: string;
         };
         /**
          * DeepBidAnalysis
          * @description Level 2: Deep on-demand analysis (STORY-259 AC8).
          */
         DeepBidAnalysis: {
-            /** Bid Id */
-            bid_id: string;
             /**
-             * Score
-             * @default 5
+             * Analise Competitividade
+             * @default
              */
-            score: number;
-            /**
-             * Decisao Sugerida
-             * @default AVALIAR COM CAUTELA
-             */
-            decisao_sugerida: string;
-            /**
-             * Compatibilidade Pct
-             * @default 50
-             */
-            compatibilidade_pct: number;
+            analise_competitividade: string;
             /**
              * Analise Prazo
              * @default
@@ -7918,40 +7949,50 @@ export interface components {
             analise_prazo: string;
             /** Analise Requisitos */
             analise_requisitos?: string[];
+            /** Bid Id */
+            bid_id: string;
             /**
-             * Analise Competitividade
-             * @default
+             * Compatibilidade Pct
+             * @default 50
              */
-            analise_competitividade: string;
-            /** Riscos */
-            riscos?: string[];
-            /** Justificativas Favoraveis */
-            justificativas_favoraveis?: string[];
+            compatibilidade_pct: number;
+            /**
+             * Decisao Sugerida
+             * @default AVALIAR COM CAUTELA
+             */
+            decisao_sugerida: string;
             /** Justificativas Contra */
             justificativas_contra?: string[];
+            /** Justificativas Favoraveis */
+            justificativas_favoraveis?: string[];
             /**
              * Recomendacao Final
              * @default
              */
             recomendacao_final: string;
+            /** Riscos */
+            riscos?: string[];
+            /**
+             * Score
+             * @default 5
+             */
+            score: number;
         };
         /**
          * DeleteAccountResponse
          * @description Response for DELETE /me.
          */
         DeleteAccountResponse: {
-            /** Success */
-            success: boolean;
             /** Message */
             message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * DiagnosticoRequest
          * @description Request body for PDF diagnostico report generation.
          */
         DiagnosticoRequest: {
-            /** Search Id */
-            search_id: string;
             /** Client Name */
             client_name?: string | null;
             /**
@@ -7959,27 +8000,14 @@ export interface components {
              * @default 20
              */
             max_items: number;
+            /** Search Id */
+            search_id: string;
         };
         /**
          * DigitalProductOut
          * @description Public representation of a digital product for checkout.
          */
         DigitalProductOut: {
-            /** Sku */
-            sku: string;
-            /** Name */
-            name: string;
-            /** Description */
-            description?: string | null;
-            /** Price Brl */
-            price_brl: number;
-            /**
-             * Preview Config
-             * @default {}
-             */
-            preview_config: {
-                [key: string]: unknown;
-            };
             /**
              * Delivery Config
              * @default {}
@@ -7987,13 +8015,28 @@ export interface components {
             delivery_config: {
                 [key: string]: unknown;
             };
+            /** Description */
+            description?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Preview Config
+             * @default {}
+             */
+            preview_config: {
+                [key: string]: unknown;
+            };
+            /** Price Brl */
+            price_brl: number;
+            /** Sku */
+            sku: string;
         };
         /** DimensionItem */
         DimensionItem: {
-            /** Name */
-            name: string;
             /** Count */
             count: number;
+            /** Name */
+            name: string;
             /** Value */
             value: number;
         };
@@ -8004,44 +8047,44 @@ export interface components {
         DiscardRateResponse: {
             /** Discard Rate */
             discard_rate?: number | null;
+            /** Discarded */
+            discarded?: number | null;
             /** Period Days */
             period_days?: number | null;
             /** Total Searches */
             total_searches?: number | null;
-            /** Discarded */
-            discarded?: number | null;
         } & {
             [key: string]: unknown;
         };
         /** EditaisAmostra */
         EditaisAmostra: {
-            /** Orgao */
-            orgao: string;
-            /** Descricao */
-            descricao: string;
-            /** Valor Estimado */
-            valor_estimado?: number | null;
             /** Data Encerramento */
             data_encerramento?: string | null;
-            /** Uf */
-            uf?: string | null;
+            /** Descricao */
+            descricao: string;
             /** Modalidade */
             modalidade?: string | null;
+            /** Orgao */
+            orgao: string;
+            /** Uf */
+            uf?: string | null;
+            /** Valor Estimado */
+            valor_estimado?: number | null;
         };
         /** EmpresaInfo */
         EmpresaInfo: {
-            /** Razao Social */
-            razao_social: string;
-            /** Cnpj */
-            cnpj: string;
             /** Cnae Principal */
             cnae_principal: string;
+            /** Cnpj */
+            cnpj: string;
             /** Porte */
             porte: string;
-            /** Uf */
-            uf: string;
+            /** Razao Social */
+            razao_social: string;
             /** Situacao */
             situacao: string;
+            /** Uf */
+            uf: string;
         };
         /**
          * EsferaGovernamental
@@ -8063,10 +8106,10 @@ export interface components {
         };
         /** ExitSurveyResponse */
         ExitSurveyResponse: {
-            /** Id */
-            id: string;
             /** Created At */
             created_at: string;
+            /** Id */
+            id: string;
         };
         /**
          * ExperienciaLicitacoes
@@ -8092,35 +8135,35 @@ export interface components {
          */
         ExportTimeSavedSurveyRequest: {
             /**
-             * Export Type
-             * @description excel | pdf | sheets
+             * Bid Count
+             * @description Number of bids included in the export
              */
-            export_type: string;
+            bid_count?: number | null;
             /**
              * Estimated Manual Hours
              * @description User-reported manual-equivalent hours (range [0.1, 50])
              */
             estimated_manual_hours: number;
             /**
-             * Search Id
-             * @description Search session id this export came from
-             */
-            search_id?: string | null;
-            /**
              * Export Id
              * @description Export job/download identifier
              */
             export_id?: string | null;
             /**
-             * Bid Count
-             * @description Number of bids included in the export
+             * Export Type
+             * @description excel | pdf | sheets
              */
-            bid_count?: number | null;
+            export_type: string;
             /**
              * Free Text
              * @description Optional free-text answer ('how would you have done this before?')
              */
             free_text?: string | null;
+            /**
+             * Search Id
+             * @description Search session id this export came from
+             */
+            search_id?: string | null;
         };
         /**
          * ExportTimeSavedSurveyResponse
@@ -8144,23 +8187,23 @@ export interface components {
         ExtendResponse: {
             /** Days Added */
             days_added: number;
-            /** Total Extended */
-            total_extended: number;
             /** New Expires At */
             new_expires_at?: string | null;
+            /** Total Extended */
+            total_extended: number;
         };
         /** ExtensionItem */
         ExtensionItem: {
-            /** Condition */
-            condition: string;
-            /** Label */
-            label: string;
-            /** Days */
-            days: number;
             /** Claimed */
             claimed: boolean;
+            /** Condition */
+            condition: string;
+            /** Days */
+            days: number;
             /** Eligible */
             eligible: boolean;
+            /** Label */
+            label: string;
         };
         /** ExtensionsStatusResponse */
         ExtensionsStatusResponse: {
@@ -8168,8 +8211,6 @@ export interface components {
             enabled: boolean;
             /** Extensions */
             extensions: components["schemas"]["ExtensionItem"][];
-            /** Total Extended */
-            total_extended: number;
             /** Max Extension */
             max_extension: number;
             /**
@@ -8177,43 +8218,36 @@ export interface components {
              * @default 0
              */
             remaining: number;
+            /** Total Extended */
+            total_extended: number;
         };
         /**
          * FPKeywordSuggestion
          * @description Keyword appearing frequently in false positives.
          */
         FPKeywordSuggestion: {
-            /** Keyword */
-            keyword: string;
             /** Count */
             count: number;
+            /** Keyword */
+            keyword: string;
             /** Suggestion */
             suggestion: string;
         };
         /** FaqItem */
         FaqItem: {
-            /** Question */
-            question: string;
             /** Answer */
             answer: string;
+            /** Question */
+            question: string;
         };
         /** FeatureFlagItem */
         FeatureFlagItem: {
             /**
-             * Name
-             * @description Flag name (e.g. LLM_ARBITER_ENABLED)
+             * Default
+             * @description Registry default value
+             * @default
              */
-            name: string;
-            /**
-             * Value
-             * @description Current effective value
-             */
-            value: boolean;
-            /**
-             * Source
-             * @description Value source: redis, memory, env, or default
-             */
-            source: string;
+            default: string;
             /**
              * Description
              * @description Human-readable description
@@ -8226,23 +8260,26 @@ export interface components {
              * @default
              */
             env_var: string;
-            /**
-             * Default
-             * @description Registry default value
-             * @default
-             */
-            default: string;
             /** @description Flag lifecycle metadata */
             lifecycle?: components["schemas"]["FeatureFlagLifecycle"] | null;
+            /**
+             * Name
+             * @description Flag name (e.g. LLM_ARBITER_ENABLED)
+             */
+            name: string;
+            /**
+             * Source
+             * @description Value source: redis, memory, env, or default
+             */
+            source: string;
+            /**
+             * Value
+             * @description Current effective value
+             */
+            value: boolean;
         };
         /** FeatureFlagLifecycle */
         FeatureFlagLifecycle: {
-            /**
-             * Owner
-             * @description Team/domain that owns this flag
-             * @default
-             */
-            owner: string;
             /**
              * Category
              * @description Flag category (llm, filter, source, cache, etc.)
@@ -8250,17 +8287,23 @@ export interface components {
              */
             category: string;
             /**
+             * Created
+             * @description Month created (YYYY-MM)
+             * @default
+             */
+            created: string;
+            /**
              * Lifecycle
              * @description permanent | experimental | ops-toggle | gate | deprecating
              * @default
              */
             lifecycle: string;
             /**
-             * Created
-             * @description Month created (YYYY-MM)
+             * Owner
+             * @description Team/domain that owns this flag
              * @default
              */
-            created: string;
+            owner: string;
             /**
              * Remove After
              * @description Planned removal date (YYYY-MM) if deprecating
@@ -8271,23 +8314,23 @@ export interface components {
         FeatureFlagListResponse: {
             /** Flags */
             flags: components["schemas"]["FeatureFlagItem"][];
-            /** Total */
-            total: number;
             /** Redis Available */
             redis_available: boolean;
+            /** Total */
+            total: number;
         };
         /** FeatureFlagReloadResponse */
         FeatureFlagReloadResponse: {
-            /** Success */
-            success: boolean;
             /** Flags */
             flags: {
                 [key: string]: boolean;
             };
-            /** Overrides Cleared */
-            overrides_cleared: number;
             /** Message */
             message: string;
+            /** Overrides Cleared */
+            overrides_cleared: number;
+            /** Success */
+            success: boolean;
         };
         /** FeatureFlagUpdateRequest */
         FeatureFlagUpdateRequest: {
@@ -8301,24 +8344,24 @@ export interface components {
         FeatureFlagUpdateResponse: {
             /** Name */
             name: string;
-            /** Value */
-            value: boolean;
-            /** Source */
-            source: string;
-            /** Previous Value */
-            previous_value: boolean;
             /** Previous Source */
             previous_source: string;
+            /** Previous Value */
+            previous_value: boolean;
+            /** Source */
+            source: string;
+            /** Value */
+            value: boolean;
         };
         /**
          * FeatureInfo
          * @description Single feature flag information.
          */
         FeatureInfo: {
-            /** Key */
-            key: string;
             /** Enabled */
             enabled: boolean;
+            /** Key */
+            key: string;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -8352,34 +8395,34 @@ export interface components {
              */
             correct: number;
             /**
-             * False Positive
-             * @default 0
-             */
-            false_positive: number;
-            /**
              * False Negative
              * @default 0
              */
             false_negative: number;
+            /**
+             * False Positive
+             * @default 0
+             */
+            false_positive: number;
         };
         /**
          * FeedbackPatternsResponse
          * @description GET /v1/admin/feedback/patterns response body.
          */
         FeedbackPatternsResponse: {
-            /** Total Feedbacks */
-            total_feedbacks: number;
             breakdown: components["schemas"]["FeedbackPatternBreakdown"];
-            /** Precision Estimate */
-            precision_estimate?: number | null;
             /** Fp Categories */
             fp_categories?: {
                 [key: string]: number;
             };
-            /** Top Fp Keywords */
-            top_fp_keywords?: components["schemas"]["FPKeywordSuggestion"][];
+            /** Precision Estimate */
+            precision_estimate?: number | null;
             /** Suggested Exclusions */
             suggested_exclusions?: string[];
+            /** Top Fp Keywords */
+            top_fp_keywords?: components["schemas"]["FPKeywordSuggestion"][];
+            /** Total Feedbacks */
+            total_feedbacks: number;
         };
         /**
          * FeedbackRequest
@@ -8387,34 +8430,34 @@ export interface components {
          */
         FeedbackRequest: {
             /**
-             * Search Id
-             * @description UUID of the search session
-             */
-            search_id: string;
-            /**
              * Bid Id
              * @description ID of the bid being rated
              */
             bid_id: string;
-            user_verdict: components["schemas"]["FeedbackVerdict"];
+            /** Bid Objeto */
+            bid_objeto?: string | null;
+            /** Bid Uf */
+            bid_uf?: string | null;
+            /** Bid Valor */
+            bid_valor?: number | null;
+            category?: components["schemas"]["FeedbackCategory"] | null;
+            /** Confidence Score */
+            confidence_score?: number | null;
             /**
              * Reason
              * @description Free-text reason (optional)
              */
             reason?: string | null;
-            category?: components["schemas"]["FeedbackCategory"] | null;
-            /** Setor Id */
-            setor_id?: string | null;
-            /** Bid Objeto */
-            bid_objeto?: string | null;
-            /** Bid Valor */
-            bid_valor?: number | null;
-            /** Bid Uf */
-            bid_uf?: string | null;
-            /** Confidence Score */
-            confidence_score?: number | null;
             /** Relevance Source */
             relevance_source?: string | null;
+            /**
+             * Search Id
+             * @description UUID of the search session
+             */
+            search_id: string;
+            /** Setor Id */
+            setor_id?: string | null;
+            user_verdict: components["schemas"]["FeedbackVerdict"];
         };
         /**
          * FeedbackResponse
@@ -8443,53 +8486,17 @@ export interface components {
          */
         FilterStats: {
             /**
-             * Rejeitadas Uf
-             * @description Rejected by UF filter
+             * Llm Zero Match Aprovadas
+             * @description Zero-match bids approved by LLM
              * @default 0
              */
-            rejeitadas_uf: number;
-            /**
-             * Rejeitadas Valor
-             * @description Rejected by value range
-             * @default 0
-             */
-            rejeitadas_valor: number;
-            /**
-             * Rejeitadas Keyword
-             * @description Rejected by keyword match (zero matches)
-             * @default 0
-             */
-            rejeitadas_keyword: number;
-            /**
-             * Rejeitadas Min Match
-             * @description Rejected by minimum match floor (had matches but below threshold)
-             * @default 0
-             */
-            rejeitadas_min_match: number;
-            /**
-             * Rejeitadas Prazo
-             * @description Rejected by deadline
-             * @default 0
-             */
-            rejeitadas_prazo: number;
-            /**
-             * Rejeitadas Outros
-             * @description Rejected by other reasons
-             * @default 0
-             */
-            rejeitadas_outros: number;
+            llm_zero_match_aprovadas: number;
             /**
              * Llm Zero Match Calls
              * @description Number of LLM calls for zero-keyword-match bids
              * @default 0
              */
             llm_zero_match_calls: number;
-            /**
-             * Llm Zero Match Aprovadas
-             * @description Zero-match bids approved by LLM
-             * @default 0
-             */
-            llm_zero_match_aprovadas: number;
             /**
              * Llm Zero Match Rejeitadas
              * @description Zero-match bids rejected by LLM
@@ -8503,23 +8510,59 @@ export interface components {
              */
             llm_zero_match_skipped_short: number;
             /**
+             * Rejeitadas Keyword
+             * @description Rejected by keyword match (zero matches)
+             * @default 0
+             */
+            rejeitadas_keyword: number;
+            /**
+             * Rejeitadas Min Match
+             * @description Rejected by minimum match floor (had matches but below threshold)
+             * @default 0
+             */
+            rejeitadas_min_match: number;
+            /**
+             * Rejeitadas Outros
+             * @description Rejected by other reasons
+             * @default 0
+             */
+            rejeitadas_outros: number;
+            /**
+             * Rejeitadas Prazo
+             * @description Rejected by deadline
+             * @default 0
+             */
+            rejeitadas_prazo: number;
+            /**
+             * Rejeitadas Uf
+             * @description Rejected by UF filter
+             * @default 0
+             */
+            rejeitadas_uf: number;
+            /**
+             * Rejeitadas Valor
+             * @description Rejected by value range
+             * @default 0
+             */
+            rejeitadas_valor: number;
+            /**
              * Zero Match Budget Exceeded
              * @description Zero-match bids deferred due to time budget
              * @default 0
              */
             zero_match_budget_exceeded: number;
             /**
-             * Zero Match Capped
-             * @description Whether zero-match pool was capped
-             * @default false
-             */
-            zero_match_capped: boolean;
-            /**
              * Zero Match Cap Value
              * @description Cap value applied to zero-match pool
              * @default 200
              */
             zero_match_cap_value: number;
+            /**
+             * Zero Match Capped
+             * @description Whether zero-match pool was capped
+             * @default false
+             */
+            zero_match_capped: boolean;
         };
         /**
          * FirstAnalysisRequest
@@ -8532,6 +8575,16 @@ export interface components {
              */
             cnae: string;
             /**
+             * Faixa Valor Max
+             * @description Max contract value in BRL (not cents)
+             */
+            faixa_valor_max?: number | null;
+            /**
+             * Faixa Valor Min
+             * @description Min contract value in BRL (not cents)
+             */
+            faixa_valor_min?: number | null;
+            /**
              * Objetivo Principal
              * @description User's primary objective
              * @default
@@ -8542,16 +8595,6 @@ export interface components {
              * @description States of operation
              */
             ufs: string[];
-            /**
-             * Faixa Valor Min
-             * @description Min contract value in BRL (not cents)
-             */
-            faixa_valor_min?: number | null;
-            /**
-             * Faixa Valor Max
-             * @description Max contract value in BRL (not cents)
-             */
-            faixa_valor_max?: number | null;
         };
         /**
          * FirstAnalysisResponse
@@ -8559,80 +8602,80 @@ export interface components {
          */
         FirstAnalysisResponse: {
             /**
-             * Search Id
-             * @description UUID for tracking search progress via SSE
-             */
-            search_id: string;
-            /**
-             * Status
-             * @description Search status
-             * @default in_progress
-             */
-            status: string;
-            /**
              * Message
              * @description User-facing status message
              * @default
              */
             message: string;
             /**
+             * Search Id
+             * @description UUID for tracking search progress via SSE
+             */
+            search_id: string;
+            /**
              * Setor Id
              * @description Resolved sector ID from CNAE mapping
              * @default vestuario
              */
             setor_id: string;
+            /**
+             * Status
+             * @description Search status
+             * @default in_progress
+             */
+            status: string;
         };
         /** FornecedorProfileResponse */
         FornecedorProfileResponse: {
-            /** Cnpj */
-            cnpj: string;
-            /** Razao Social */
-            razao_social: string;
-            /** Cnae Descricao */
-            cnae_descricao: string;
-            /** Municipio */
-            municipio: string;
-            /** Uf Sede */
-            uf_sede: string;
-            /** Simples Nacional */
-            simples_nacional: boolean;
-            /** Mei */
-            mei: boolean;
-            /** Total Contratos */
-            total_contratos: number;
-            /** Valor Total */
-            valor_total: number;
-            /** Ufs Atuantes */
-            ufs_atuantes: string[];
             /** Anos Atividade */
             anos_atividade: number[];
-            /** Top Compradores */
-            top_compradores: components["schemas"]["OrgaoRank"][];
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Aviso Legal */
+            aviso_legal: string;
+            /** Cnae Descricao */
+            cnae_descricao: string;
+            /** Cnpj */
+            cnpj: string;
             /** Contratos Recentes */
             contratos_recentes: components["schemas"]["RecentContract"][];
             /** Faq Items */
             faq_items: components["schemas"]["FaqItem"][];
             /** Last Updated */
             last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Mei */
+            mei: boolean;
+            /** Municipio */
+            municipio: string;
+            /** Razao Social */
+            razao_social: string;
+            /** Simples Nacional */
+            simples_nacional: boolean;
+            /** Top Compradores */
+            top_compradores: components["schemas"]["OrgaoRank"][];
+            /** Total Contratos */
+            total_contratos: number;
+            /** Uf Sede */
+            uf_sede: string;
+            /** Ufs Atuantes */
+            ufs_atuantes: string[];
+            /** Valor Total */
+            valor_total: number;
         };
         /** FornecedorRank */
         FornecedorRank: {
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
+            /** Nome */
+            nome: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -8640,10 +8683,10 @@ export interface components {
         };
         /** FornecedorTop */
         FornecedorTop: {
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
+            /** Nome */
+            nome: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -8651,32 +8694,32 @@ export interface components {
         };
         /** FornecedoresStatsResponse */
         FornecedoresStatsResponse: {
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Uf */
-            uf: string;
-            /** Total Suppliers */
-            total_suppliers: number;
-            /** Supplier Ranking */
-            supplier_ranking: components["schemas"]["SupplierEntry"][];
-            /** Top Orgaos Compradores */
-            top_orgaos_compradores: components["schemas"]["OrgaoRank"][];
-            /** Last Updated */
-            last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
             /**
              * @default {
              *       "contagem_30d": 0,
              *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
              *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
              *     }
              */
             atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Aviso Legal */
+            aviso_legal: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Supplier Ranking */
+            supplier_ranking: components["schemas"]["SupplierEntry"][];
+            /** Top Orgaos Compradores */
+            top_orgaos_compradores: components["schemas"]["OrgaoRank"][];
+            /** Total Suppliers */
+            total_suppliers: number;
+            /** Uf */
+            uf: string;
         };
         /**
          * FounderConsentRequest
@@ -8708,14 +8751,14 @@ export interface components {
             consent: boolean;
             /** Display Name */
             display_name?: string | null;
-            /** Logo Url */
-            logo_url?: string | null;
             /**
              * Is Founder
              * @description Reflects profiles.is_founder so the UI can show context.
              * @default false
              */
             is_founder: boolean;
+            /** Logo Url */
+            logo_url?: string | null;
         };
         /**
          * FounderHallEntry
@@ -8728,25 +8771,25 @@ export interface components {
              */
             display_name: string;
             /**
-             * Uf
-             * @description State code (2 letters).
+             * Founder Since
+             * @description ISO-8601 timestamp of when the user became a founder.
              */
-            uf?: string | null;
-            /**
-             * Setor
-             * @description Sector / category derived from CNAE (best-effort).
-             */
-            setor?: string | null;
+            founder_since?: string | null;
             /**
              * Logo Url
              * @description Optional logo URL.
              */
             logo_url?: string | null;
             /**
-             * Founder Since
-             * @description ISO-8601 timestamp of when the user became a founder.
+             * Setor
+             * @description Sector / category derived from CNAE (best-effort).
              */
-            founder_since?: string | null;
+            setor?: string | null;
+            /**
+             * Uf
+             * @description State code (2 letters).
+             */
+            uf?: string | null;
         };
         /**
          * FoundersAvailabilityResponse
@@ -8758,37 +8801,38 @@ export interface components {
          */
         FoundersAvailabilityResponse: {
             /**
-             * Vagasrestantes
-             * @description Seats still available (50 - taken). NULL when fallback=true.
+             * Deadline
+             * @description ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).
+             * @default 2026-06-30T23:59:59-03:00
              */
-            vagasRestantes?: number | null;
-            /**
-             * Vagastotal
-             * @description Hard cap (50).
-             * @default 50
-             */
-            vagasTotal: number;
-            /**
-             * Vagaspreenchidas
-             * @description Seats already taken (count of is_founder=TRUE profiles).
-             */
-            vagasPreenchidas?: number | null;
+            deadline: string;
             /**
              * Diasrestantes
              * @description Whole days until the deadline.
              */
             diasRestantes?: number | null;
             /**
+             * Fallback
+             * @description TRUE when DB or Redis is unavailable. Frontend should render the conservative copy without a number.
+             * @default false
+             */
+            fallback: boolean;
+            /**
              * Horasrestantes
              * @description Whole hours until the deadline.
              */
             horasRestantes?: number | null;
             /**
-             * Deadline
-             * @description ISO-8601 deadline (FOUNDERS_DEADLINE env var or default).
-             * @default 2026-06-30T23:59:59-03:00
+             * Message
+             * @description Conservative copy returned when fallback=true.
              */
-            deadline: string;
+            message?: string | null;
+            /**
+             * Sold Out
+             * @description TRUE when vagasPreenchidas >= cap (50).
+             * @default false
+             */
+            sold_out: boolean;
             /**
              * Ultimavagaem
              * @description ISO-8601 timestamp of the most recent founder_since.
@@ -8800,30 +8844,27 @@ export interface components {
              */
             ultimasVagasOptIn?: components["schemas"]["UltimaVagaOptIn"][];
             /**
-             * Sold Out
-             * @description TRUE when vagasPreenchidas >= cap (50).
-             * @default false
+             * Vagaspreenchidas
+             * @description Seats already taken (count of is_founder=TRUE profiles).
              */
-            sold_out: boolean;
+            vagasPreenchidas?: number | null;
             /**
-             * Fallback
-             * @description TRUE when DB or Redis is unavailable. Frontend should render the conservative copy without a number.
-             * @default false
+             * Vagasrestantes
+             * @description Seats still available (50 - taken). NULL when fallback=true.
              */
-            fallback: boolean;
+            vagasRestantes?: number | null;
             /**
-             * Message
-             * @description Conservative copy returned when fallback=true.
+             * Vagastotal
+             * @description Hard cap (50).
+             * @default 50
              */
-            message?: string | null;
+            vagasTotal: number;
         };
         /**
          * FoundersHallResponse
          * @description Response shape for ``GET /api/founders/hall``.
          */
         FoundersHallResponse: {
-            /** Founders */
-            founders?: components["schemas"]["FounderHallEntry"][];
             /**
              * Count
              * @description Number of opt-in founders.
@@ -8836,6 +8877,8 @@ export interface components {
              * @default false
              */
             fallback: boolean;
+            /** Founders */
+            founders?: components["schemas"]["FounderHallEntry"][];
         };
         /**
          * FoundingAvailabilityResponse
@@ -8844,20 +8887,10 @@ export interface components {
         FoundingAvailabilityResponse: {
             /** Available */
             available: boolean;
-            /** Seats Total */
-            seats_total: number;
-            /** Seats Remaining */
-            seats_remaining: number;
-            /** Seats Taken */
-            seats_taken: number;
-            /** Deadline At */
-            deadline_at: string | null;
-            /** Paused */
-            paused: boolean;
-            /** Reason */
-            reason: string;
             /** Coupon Code */
             coupon_code: string;
+            /** Deadline At */
+            deadline_at: string | null;
             /** Discount Pct */
             discount_pct: number;
             /**
@@ -8866,25 +8899,35 @@ export interface components {
              * @default lifetime
              */
             offer_mode: string;
+            /** Paused */
+            paused: boolean;
             /**
              * Price Brl Cents
              * @description Price in BRL cents
              * @default 99700
              */
             price_brl_cents: number;
+            /** Reason */
+            reason: string;
+            /** Seats Remaining */
+            seats_remaining: number;
+            /** Seats Taken */
+            seats_taken: number;
+            /** Seats Total */
+            seats_total: number;
         };
         /** FoundingCheckoutRequest */
         FoundingCheckoutRequest: {
-            /** Email */
-            email: string;
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
-            /** Razao Social */
-            razao_social?: string | null;
+            /** Email */
+            email: string;
             /** Motivo */
             motivo: string;
+            /** Nome */
+            nome: string;
+            /** Razao Social */
+            razao_social?: string | null;
         };
         /** FoundingCheckoutResponse */
         FoundingCheckoutResponse: {
@@ -8904,42 +8947,42 @@ export interface components {
          * @description Response model for GET /v1/founding/checkout/status.
          */
         FoundingCheckoutStatusResponse: {
-            /** Status */
-            status: string;
             /** Payment Status */
             payment_status: string;
+            /** Status */
+            status: string;
         };
         /** FoundingLeadEntry */
         FoundingLeadEntry: {
-            /** Id */
-            id: string;
-            /** Email */
-            email: string;
-            /** Nome */
-            nome: string;
-            /** Cnpj */
-            cnpj: string;
-            /** Razao Social */
-            razao_social?: string | null;
             /** Checkout Status */
             checkout_status: string;
-            /** Created At */
-            created_at: string;
+            /** Cnpj */
+            cnpj: string;
             /** Completed At */
             completed_at?: string | null;
+            /** Created At */
+            created_at: string;
+            /** Email */
+            email: string;
+            /** Id */
+            id: string;
+            /** Nome */
+            nome: string;
+            /** Razao Social */
+            razao_social?: string | null;
             /** Stripe Customer Id */
             stripe_customer_id?: string | null;
         };
         /** FoundingLeadsListResponse */
         FoundingLeadsListResponse: {
-            /** Count */
-            count: number;
             /** Completed Count */
             completed_count: number;
-            /** Pending Count */
-            pending_count: number;
+            /** Count */
+            count: number;
             /** Leads */
             leads: components["schemas"]["FoundingLeadEntry"][];
+            /** Pending Count */
+            pending_count: number;
         };
         /** FoundingPauseRequest */
         FoundingPauseRequest: {
@@ -8959,16 +9002,26 @@ export interface components {
         };
         /** FoundingPolicySnapshot */
         FoundingPolicySnapshot: {
-            /** Seat Limit */
-            seat_limit: number;
+            /** Active */
+            active: boolean;
+            /** Completion Pct */
+            completion_pct: number;
+            /**
+             * Consulting Discount Pct
+             * @default 50
+             */
+            consulting_discount_pct: number;
+            /** Coupon Code */
+            coupon_code: string;
             /** Deadline At */
             deadline_at: string;
             /** Discount Pct */
             discount_pct: number;
-            /** Coupon Code */
-            coupon_code: string;
-            /** Active */
-            active: boolean;
+            /**
+             * Offer Mode
+             * @default lifetime
+             */
+            offer_mode: string;
             /** Paused */
             paused: boolean;
             /** Paused At */
@@ -8977,27 +9030,17 @@ export interface components {
             paused_by: string | null;
             /** Paused Reason */
             paused_reason: string | null;
-            /** Seats Taken */
-            seats_taken: number;
-            /** Seats Remaining */
-            seats_remaining: number;
-            /** Completion Pct */
-            completion_pct: number;
-            /**
-             * Offer Mode
-             * @default lifetime
-             */
-            offer_mode: string;
             /**
              * Price Brl Cents
              * @default 99700
              */
             price_brl_cents: number;
-            /**
-             * Consulting Discount Pct
-             * @default 50
-             */
-            consulting_discount_pct: number;
+            /** Seat Limit */
+            seat_limit: number;
+            /** Seats Remaining */
+            seats_remaining: number;
+            /** Seats Taken */
+            seats_taken: number;
         };
         /**
          * FoundingSessionStatusResponse
@@ -9007,11 +9050,6 @@ export interface components {
          *     render the correct post-purchase CTA without exposing full PII.
          */
         FoundingSessionStatusResponse: {
-            /**
-             * Status
-             * @description 'completed' | 'pending' | 'not_found'
-             */
-            status: string;
             /**
              * Email
              * @description Masked email (2 chars before @ + **** + domain).
@@ -9027,58 +9065,63 @@ export interface components {
              * @description True if magic_link_sent_at IS NOT NULL.
              */
             invite_sent: boolean;
+            /**
+             * Status
+             * @description 'completed' | 'pending' | 'not_found'
+             */
+            status: string;
         };
         /** GSCLowCTROpportunity */
         GSCLowCTROpportunity: {
-            /** Page */
-            page: string;
-            /** Impressions */
-            impressions: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
+            /** Impressions */
+            impressions: number;
+            /** Page */
+            page: string;
         };
         /** GSCPageRow */
         GSCPageRow: {
-            /** Page */
-            page: string;
-            /** Impressions */
-            impressions: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
+            /** Impressions */
+            impressions: number;
+            /** Page */
+            page: string;
             /** Position */
             position: number;
         };
         /** GSCQueryRow */
         GSCQueryRow: {
-            /** Query */
-            query: string;
-            /** Impressions */
-            impressions: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
+            /** Impressions */
+            impressions: number;
             /** Position */
             position: number;
+            /** Query */
+            query: string;
         };
         /** GSCSummaryResponse */
         GSCSummaryResponse: {
-            /** Top Queries */
-            top_queries: components["schemas"]["GSCQueryRow"][];
-            /** Top Pages Ctr */
-            top_pages_ctr: components["schemas"]["GSCPageRow"][];
-            /** Low Ctr Opportunities */
-            low_ctr_opportunities: components["schemas"]["GSCLowCTROpportunity"][];
-            /** Last Sync At */
-            last_sync_at?: string | null;
             /** Days */
             days: number;
             /** Enabled */
             enabled: boolean;
+            /** Last Sync At */
+            last_sync_at?: string | null;
+            /** Low Ctr Opportunities */
+            low_ctr_opportunities: components["schemas"]["GSCLowCTROpportunity"][];
+            /** Top Pages Ctr */
+            top_pages_ctr: components["schemas"]["GSCPageRow"][];
+            /** Top Queries */
+            top_queries: components["schemas"]["GSCQueryRow"][];
         };
         /**
          * GoogleSheetsExportHistory
@@ -9086,10 +9129,22 @@ export interface components {
          */
         GoogleSheetsExportHistory: {
             /**
+             * Created At
+             * @description Creation timestamp (ISO 8601)
+             */
+            created_at: string;
+            /**
              * Id
              * @description Export record UUID
              */
             id: string;
+            /**
+             * Search Params
+             * @description Search parameters snapshot
+             */
+            search_params: {
+                [key: string]: unknown;
+            };
             /**
              * Spreadsheet Id
              * @description Google Sheets spreadsheet ID
@@ -9101,22 +9156,10 @@ export interface components {
              */
             spreadsheet_url: string;
             /**
-             * Search Params
-             * @description Search parameters snapshot
-             */
-            search_params: {
-                [key: string]: unknown;
-            };
-            /**
              * Total Rows
              * @description Number of rows exported
              */
             total_rows: number;
-            /**
-             * Created At
-             * @description Creation timestamp (ISO 8601)
-             */
-            created_at: string;
             /**
              * Updated At
              * @description Last update timestamp (ISO 8601)
@@ -9154,11 +9197,6 @@ export interface components {
                 [key: string]: unknown;
             }[];
             /**
-             * Title
-             * @description Spreadsheet title
-             */
-            title: string;
-            /**
              * Mode
              * @description 'create' for new spreadsheet, 'update' for existing
              * @default create
@@ -9169,18 +9207,17 @@ export interface components {
              * @description Google Sheets spreadsheet ID (required for mode='update')
              */
             spreadsheet_id?: string | null;
+            /**
+             * Title
+             * @description Spreadsheet title
+             */
+            title: string;
         };
         /**
          * GoogleSheetsExportResponse
          * @description Response schema for successful Google Sheets export.
          */
         GoogleSheetsExportResponse: {
-            /**
-             * Success
-             * @description Export success indicator
-             * @default true
-             */
-            success: boolean;
             /**
              * Spreadsheet Id
              * @description Google Sheets spreadsheet ID
@@ -9191,6 +9228,12 @@ export interface components {
              * @description Full shareable URL to the spreadsheet
              */
             spreadsheet_url: string;
+            /**
+             * Success
+             * @description Export success indicator
+             * @default true
+             */
+            success: boolean;
             /**
              * Total Rows
              * @description Number of contracts exported
@@ -9209,10 +9252,10 @@ export interface components {
         };
         /** HistogramBucket */
         HistogramBucket: {
-            /** Range Label */
-            range_label: string;
             /** Count */
             count: number;
+            /** Range Label */
+            range_label: string;
         };
         /**
          * IncidentEntry
@@ -9245,51 +9288,51 @@ export interface components {
         };
         /** IndiceResult */
         IndiceResult: {
+            /** Calculado Em */
+            calculado_em: string;
             /** Municipio Nome */
             municipio_nome: string;
             /** Municipio Slug */
             municipio_slug: string;
-            /** Uf */
-            uf: string;
-            /** Uf Nome */
-            uf_nome: string;
+            /** Percentil */
+            percentil?: number | null;
             /** Periodo */
             periodo: string;
-            /** Score Total */
-            score_total: number;
-            /** Score Volume Publicacao */
-            score_volume_publicacao: number;
-            /** Score Eficiencia Temporal */
-            score_eficiencia_temporal: number;
-            /** Score Diversidade Mercado */
-            score_diversidade_mercado: number;
-            /** Score Transparencia Digital */
-            score_transparencia_digital: number;
-            /** Score Consistencia */
-            score_consistencia: number;
-            /** Total Editais */
-            total_editais: number;
             /** Ranking Nacional */
             ranking_nacional?: number | null;
             /** Ranking Uf */
             ranking_uf?: number | null;
-            /** Percentil */
-            percentil?: number | null;
-            /** Calculado Em */
-            calculado_em: string;
+            /** Score Consistencia */
+            score_consistencia: number;
+            /** Score Diversidade Mercado */
+            score_diversidade_mercado: number;
+            /** Score Eficiencia Temporal */
+            score_eficiencia_temporal: number;
+            /** Score Total */
+            score_total: number;
+            /** Score Transparencia Digital */
+            score_transparencia_digital: number;
+            /** Score Volume Publicacao */
+            score_volume_publicacao: number;
+            /** Total Editais */
+            total_editais: number;
+            /** Uf */
+            uf: string;
+            /** Uf Nome */
+            uf_nome: string;
         };
         /**
          * IntelReportCheckoutRequest
          * @description Request body for POST /v1/intel-reports/checkout.
          */
         IntelReportCheckoutRequest: {
+            /** Entity Key */
+            entity_key: string;
             /**
              * Product Type
              * @enum {string}
              */
             product_type: "cnpj" | "sector_uf";
-            /** Entity Key */
-            entity_key: string;
         };
         /**
          * IntelReportCheckoutResponse
@@ -9306,34 +9349,34 @@ export interface components {
          * @description Represents a row in intel_report_purchases table.
          */
         IntelReportPurchase: {
-            /** Id */
-            id: string;
-            /** User Id */
-            user_id: string;
-            /** Product Type */
-            product_type: string;
-            /** Entity Key */
-            entity_key: string;
-            /** Status */
-            status: string;
-            /** Pdf Url */
-            pdf_url?: string | null;
             /** Created At */
             created_at: string;
+            /** Entity Key */
+            entity_key: string;
             /** Expires At */
             expires_at?: string | null;
+            /** Id */
+            id: string;
+            /** Pdf Url */
+            pdf_url?: string | null;
+            /** Product Type */
+            product_type: string;
+            /** Status */
+            status: string;
+            /** User Id */
+            user_id: string;
         };
         /**
          * IntelReportStatusResponse
          * @description Response for GET /v1/intel-reports/{purchase_id}.
          */
         IntelReportStatusResponse: {
-            /** Status */
-            status: string;
-            /** Pdf Url */
-            pdf_url?: string | null;
             /** Expires At */
             expires_at?: string | null;
+            /** Pdf Url */
+            pdf_url?: string | null;
+            /** Status */
+            status: string;
         };
         /** InviteMemberRequest */
         InviteMemberRequest: {
@@ -9342,34 +9385,34 @@ export interface components {
         };
         /** ItemProfileResponse */
         ItemProfileResponse: {
-            /** Catmat */
-            catmat: string;
-            /** Nome Item */
-            nome_item: string;
+            /** Aviso Legal */
+            aviso_legal: string;
             /** Categoria */
             categoria: string;
+            /** Catmat */
+            catmat: string;
+            /** Contratos Referencia */
+            contratos_referencia: components["schemas"]["ContratoReferencia"][];
+            /** Faq Items */
+            faq_items: components["schemas"]["FaqItem"][];
+            /** Last Updated */
+            last_updated: string;
+            /** Nome Item */
+            nome_item: string;
+            /** Periodo Referencia */
+            periodo_referencia: string;
             /** Total Contratos */
             total_contratos: number;
+            /** Unidade Referencia */
+            unidade_referencia: string;
+            /** Valor Medio */
+            valor_medio?: number | null;
             /** Valor P10 */
             valor_p10?: number | null;
             /** Valor P50 */
             valor_p50?: number | null;
             /** Valor P90 */
             valor_p90?: number | null;
-            /** Valor Medio */
-            valor_medio?: number | null;
-            /** Unidade Referencia */
-            unidade_referencia: string;
-            /** Contratos Referencia */
-            contratos_referencia: components["schemas"]["ContratoReferencia"][];
-            /** Faq Items */
-            faq_items: components["schemas"]["FaqItem"][];
-            /** Periodo Referencia */
-            periodo_referencia: string;
-            /** Last Updated */
-            last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
         };
         /**
          * LeadCaptureRequest
@@ -9378,46 +9421,46 @@ export interface components {
          *     Supports both old (backward compat) and new (COPY-COP-006) sources.
          */
         LeadCaptureRequest: {
-            /** Email */
-            email: string;
-            /** Source */
-            source: string;
-            /** Sector */
-            sector?: string | null;
-            /** Origin Url */
-            origin_url?: string | null;
-            /** Uf */
-            uf?: string | null;
             /** Captured At */
             captured_at?: string | null;
-            /** Nome */
-            nome?: string | null;
-            /** Empresa */
-            empresa?: string | null;
             /** Cnpj */
             cnpj?: string | null;
-            /** Telefone */
-            telefone?: string | null;
-            /** Modalidade Interesse */
-            modalidade_interesse?: ("radar" | "report" | "intel" | "nao_sei") | null;
+            /** Email */
+            email: string;
+            /** Empresa */
+            empresa?: string | null;
             /** Mensagem */
             mensagem?: string | null;
-            /** Utm Source */
-            utm_source?: string | null;
-            /** Utm Campaign */
-            utm_campaign?: string | null;
+            /** Modalidade Interesse */
+            modalidade_interesse?: ("radar" | "report" | "intel" | "nao_sei") | null;
+            /** Nome */
+            nome?: string | null;
+            /** Origin Url */
+            origin_url?: string | null;
             /** Referer Path */
             referer_path?: string | null;
+            /** Sector */
+            sector?: string | null;
+            /** Source */
+            source: string;
+            /** Telefone */
+            telefone?: string | null;
+            /** Uf */
+            uf?: string | null;
+            /** Utm Campaign */
+            utm_campaign?: string | null;
+            /** Utm Source */
+            utm_source?: string | null;
         };
         /**
          * LeadCaptureResponse
          * @description Body for POST /v1/lead-capture (201).
          */
         LeadCaptureResponse: {
-            /** Success */
-            success: boolean;
             /** Id */
             id?: string | null;
+            /** Success */
+            success: boolean;
         };
         /**
          * LicitacaoItem
@@ -9440,45 +9483,30 @@ export interface components {
          */
         LicitacaoItem: {
             /**
-             * Pncp Id
-             * @description Unique PNCP identifier
+             * Source
+             * @description Source that provided this record
              */
-            pncp_id: string;
+            _source?: string | null;
             /**
-             * Objeto
-             * @description Procurement object description
+             * Value Source
+             * @description Whether the bid's estimated value was reported ('estimated') or missing ('missing')
              */
-            objeto: string;
+            _value_source?: ("estimated" | "missing") | null;
             /**
-             * Orgao
-             * @description Government agency name
+             * Cnpj Orgao
+             * @description CNPJ of the issuing government agency. UX-400 AC6.
              */
-            orgao: string;
+            cnpj_orgao?: string | null;
             /**
-             * Uf
-             * @description State code (e.g., 'SP')
+             * Confidence
+             * @description Confidence level derived from relevance_source: keyword=high, llm_standard=medium, llm_conservative/llm_zero_match=low
              */
-            uf: string;
+            confidence?: ("high" | "medium" | "low") | null;
             /**
-             * Municipio
-             * @description Municipality name
+             * Confidence Score
+             * @description Classification confidence 0-100%. keyword=95, llm=varies, item_inspection=85, zero_match<=70
              */
-            municipio?: string | null;
-            /**
-             * Valor
-             * @description Estimated total value in BRL. Null when source does not provide value data (e.g., PCP v2).
-             */
-            valor?: number | null;
-            /**
-             * Modalidade
-             * @description Procurement modality
-             */
-            modalidade?: string | null;
-            /**
-             * Data Publicacao
-             * @description Publication date
-             */
-            data_publicacao?: string | null;
+            confidence_score?: number | null;
             /**
              * Data Abertura
              * @description Proposal opening date
@@ -9490,77 +9518,87 @@ export interface components {
              */
             data_encerramento?: string | null;
             /**
+             * Data Publicacao
+             * @description Publication date
+             */
+            data_publicacao?: string | null;
+            /**
              * Dias Restantes
              * @description Days remaining until proposal deadline (negative if past)
              */
             dias_restantes?: number | null;
-            /**
-             * Urgencia
-             * @description Urgency level: critica (<7d), alta (7-14d), media (14-30d), baixa (>30d), encerrada (past)
-             */
-            urgencia?: string | null;
             /**
              * Link
              * @description Direct link to bid source (priority: linkSistemaOrigem > constructed PNCP URL). Null when no link available (UX-400 AC2).
              */
             link?: string | null;
             /**
+             * Llm Evidence
+             * @description Literal text excerpts from procurement description that support the classification (max 3)
+             */
+            llm_evidence?: string[] | null;
+            /**
+             * Matched Terms
+             * @description List of search terms that matched this bid
+             */
+            matched_terms?: string[] | null;
+            /**
+             * Modalidade
+             * @description Procurement modality
+             */
+            modalidade?: string | null;
+            /**
+             * Municipio
+             * @description Municipality name
+             */
+            municipio?: string | null;
+            /**
              * Numero Compra
              * @description Procurement number (e.g., edital number). UX-400 AC5.
              */
             numero_compra?: string | null;
             /**
-             * Cnpj Orgao
-             * @description CNPJ of the issuing government agency. UX-400 AC6.
+             * Objeto
+             * @description Procurement object description
              */
-            cnpj_orgao?: string | null;
+            objeto: string;
             /**
-             * Source
-             * @description Source that provided this record
+             * Orgao
+             * @description Government agency name
              */
-            _source?: string | null;
+            orgao: string;
+            /**
+             * Pncp Id
+             * @description Unique PNCP identifier
+             */
+            pncp_id: string;
             /**
              * Relevance Score
              * @description Relevance score 0.0-1.0 (only when custom terms active)
              */
             relevance_score?: number | null;
             /**
-             * Matched Terms
-             * @description List of search terms that matched this bid
-             */
-            matched_terms?: string[] | null;
-            /** @description Sanctions check result (only when check_sanctions=true in request) */
-            supplier_sanctions?: components["schemas"]["SanctionsSummarySchema"] | null;
-            /**
              * Relevance Source
              * @description How relevance was determined: 'keyword' (density >5%), 'llm_standard' (2-5%), 'llm_conservative' (1-2%), 'llm_zero_match' (0% keyword match, LLM classified)
              */
             relevance_source?: string | null;
+            /** @description Sanctions check result (only when check_sanctions=true in request) */
+            supplier_sanctions?: components["schemas"]["SanctionsSummarySchema"] | null;
             /**
-             * Confidence Score
-             * @description Classification confidence 0-100%. keyword=95, llm=varies, item_inspection=85, zero_match<=70
+             * Uf
+             * @description State code (e.g., 'SP')
              */
-            confidence_score?: number | null;
+            uf: string;
             /**
-             * Llm Evidence
-             * @description Literal text excerpts from procurement description that support the classification (max 3)
+             * Urgencia
+             * @description Urgency level: critica (<7d), alta (7-14d), media (14-30d), baixa (>30d), encerrada (past)
              */
-            llm_evidence?: string[] | null;
+            urgencia?: string | null;
             /**
-             * Confidence
-             * @description Confidence level derived from relevance_source: keyword=high, llm_standard=medium, llm_conservative/llm_zero_match=low
+             * Valor
+             * @description Estimated total value in BRL. Null when source does not provide value data (e.g., PCP v2).
              */
-            confidence?: ("high" | "medium" | "low") | null;
-            /**
-             * Viability Score
-             * @description Viability score 0-100 based on modalidade, timeline, value fit, and geography
-             */
-            viability_score?: number | null;
-            /**
-             * Viability Level
-             * @description Viability level: alta (>70), media (40-70), baixa (<40)
-             */
-            viability_level?: ("alta" | "media" | "baixa") | null;
+            valor?: number | null;
             /**
              * Viability Factors
              * @description Breakdown of viability factors: modalidade, timeline, value_fit, geography (each 0-100 with label)
@@ -9569,10 +9607,15 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /**
-             * Value Source
-             * @description Whether the bid's estimated value was reported ('estimated') or missing ('missing')
+             * Viability Level
+             * @description Viability level: alta (>70), media (40-70), baixa (<40)
              */
-            _value_source?: ("estimated" | "missing") | null;
+            viability_level?: ("alta" | "media" | "baixa") | null;
+            /**
+             * Viability Score
+             * @description Viability score 0-100 based on modalidade, timeline, value fit, and geography
+             */
+            viability_score?: number | null;
         };
         /** LicitacoesIndexableResponse */
         LicitacoesIndexableResponse: {
@@ -9580,10 +9623,10 @@ export interface components {
             combos: {
                 [key: string]: unknown;
             }[];
-            /** Total */
-            total: number;
             /** Threshold */
             threshold: number;
+            /** Total */
+            total: number;
             /** Updated At */
             updated_at: string;
         };
@@ -9613,15 +9656,15 @@ export interface components {
          */
         LoginAttemptResponse: {
             /**
-             * Ok
-             * @default true
-             */
-            ok: boolean;
-            /**
              * Force Mfa Triggered
              * @default false
              */
             force_mfa_triggered: boolean;
+            /**
+             * Ok
+             * @default true
+             */
+            ok: boolean;
         };
         /**
          * MFAEnrollResponse
@@ -9632,6 +9675,11 @@ export interface components {
          *     one-time backup codes for recovery if the device is lost.
          */
         MFAEnrollResponse: {
+            /**
+             * Backup Codes
+             * @description 10 one-time recovery codes (XXXX-XXXX format). Shown ONCE — user must save them. Used as MFA bypass via /v1/mfa/verify-recovery.
+             */
+            backup_codes?: string[];
             /**
              * Factor Id
              * @description Supabase mfa_factors.id (UUID)
@@ -9647,11 +9695,6 @@ export interface components {
              * @description Base32-encoded TOTP shared secret. Provided so the user can manually enter it when the QR code cannot be scanned.
              */
             secret: string;
-            /**
-             * Backup Codes
-             * @description 10 one-time recovery codes (XXXX-XXXX format). Shown ONCE — user must save them. Used as MFA bypass via /v1/mfa/verify-recovery.
-             */
-            backup_codes?: string[];
         };
         /**
          * MFAVerifyRequest
@@ -9670,11 +9713,6 @@ export interface components {
          */
         MFAVerifyResponse: {
             /**
-             * Success
-             * @description True when the code matched and AAL was elevated to aal2
-             */
-            success: boolean;
-            /**
              * Aal Level
              * @description Authenticator Assurance Level after verification
              * @default aal2
@@ -9691,12 +9729,29 @@ export interface components {
              * @default
              */
             message: string;
+            /**
+             * Success
+             * @description True when the code matched and AAL was elevated to aal2
+             */
+            success: boolean;
         };
         /**
          * MemorySnapshot
          * @description Response for GET /admin/memory-snapshot (SEN-BE-010 AC0).
          */
         MemorySnapshot: {
+            /**
+             * Asyncio Tasks Pending
+             * @default 0
+             */
+            asyncio_tasks_pending: number;
+            /**
+             * Gc Objects Count
+             * @default 0
+             */
+            gc_objects_count: number;
+            /** Redis Pool Size */
+            redis_pool_size?: number | null;
             /** Rss Bytes */
             rss_bytes?: number | null;
             /** Rss Mb */
@@ -9711,18 +9766,6 @@ export interface components {
              * @default []
              */
             tracemalloc_top_25: components["schemas"]["TraceMallocEntry"][];
-            /**
-             * Asyncio Tasks Pending
-             * @default 0
-             */
-            asyncio_tasks_pending: number;
-            /**
-             * Gc Objects Count
-             * @default 0
-             */
-            gc_objects_count: number;
-            /** Redis Pool Size */
-            redis_pool_size?: number | null;
         };
         /**
          * MesCalendario
@@ -9730,15 +9773,20 @@ export interface components {
          */
         MesCalendario: {
             /**
+             * Indice Sazonalidade
+             * @description Seasonality index: 0 = at average, >0 = detectable seasonality
+             */
+            indice_sazonalidade: number;
+            /**
              * Mes
              * @description Month number (1-12)
              */
             mes: number;
             /**
-             * Volume Medio
-             * @description Average total contract value for this month
+             * Orgaos Principais
+             * @description Top 5 public buyers in this month
              */
-            volume_medio: number;
+            orgaos_principais: string[];
             /**
              * Quantidade Media
              * @description Average number of contracts/opportunities for this month
@@ -9750,16 +9798,6 @@ export interface components {
              */
             setor_dominante: string;
             /**
-             * Orgaos Principais
-             * @description Top 5 public buyers in this month
-             */
-            orgaos_principais: string[];
-            /**
-             * Indice Sazonalidade
-             * @description Seasonality index: 0 = at average, >0 = detectable seasonality
-             */
-            indice_sazonalidade: number;
-            /**
              * Tendencia
              * @description Trend direction: crescimento | estabilidade | declinio
              */
@@ -9769,101 +9807,106 @@ export interface components {
              * @description Year-over-year relative change in average volume
              */
             variacao_anual: number;
+            /**
+             * Volume Medio
+             * @description Average total contract value for this month
+             */
+            volume_medio: number;
         };
         /**
          * MessageResponse
          * @description Single message in a conversation thread.
          */
         MessageResponse: {
-            /** Id */
-            id: string;
-            /** Sender Id */
-            sender_id: string;
-            /** Sender Email */
-            sender_email?: string | null;
             /** Body */
             body: string;
-            /** Is Admin Reply */
-            is_admin_reply: boolean;
-            /** Read By User */
-            read_by_user: boolean;
-            /** Read By Admin */
-            read_by_admin: boolean;
             /** Created At */
             created_at: string;
+            /** Id */
+            id: string;
+            /** Is Admin Reply */
+            is_admin_reply: boolean;
+            /** Read By Admin */
+            read_by_admin: boolean;
+            /** Read By User */
+            read_by_user: boolean;
+            /** Sender Email */
+            sender_email?: string | null;
+            /** Sender Id */
+            sender_id: string;
         };
         /** MfaStatusResponse */
         MfaStatusResponse: {
-            /** Mfa Enabled */
-            mfa_enabled: boolean;
-            /** Factors */
-            factors?: {
-                [key: string]: unknown;
-            }[];
             /**
              * Aal Level
              * @default aal1
              */
             aal_level: string;
+            /** Enforce Reason */
+            enforce_reason?: string | null;
+            /** Factors */
+            factors?: {
+                [key: string]: unknown;
+            }[];
+            /** Force Mfa Enrollment Until */
+            force_mfa_enrollment_until?: string | null;
+            /** Grace Days Remaining */
+            grace_days_remaining?: number | null;
+            /** Mfa Enabled */
+            mfa_enabled: boolean;
             /**
              * Mfa Required
              * @default false
              */
             mfa_required: boolean;
-            /** Enforce Reason */
-            enforce_reason?: string | null;
-            /** Force Mfa Enrollment Until */
-            force_mfa_enrollment_until?: string | null;
-            /** Grace Days Remaining */
-            grace_days_remaining?: number | null;
         };
         /** ModalidadeAggregate */
         ModalidadeAggregate: {
             /** Code */
             code: number;
-            /** Name */
-            name: string;
             /** Count */
             count: number;
+            /** Name */
+            name: string;
             /** Pct */
             pct: number;
         };
         /** MunicipioProfileResponse */
         MunicipioProfileResponse: {
-            /** Slug */
-            slug: string;
-            /** Nome */
-            nome: string;
-            /** Uf */
-            uf: string;
-            /** Ibge Code */
-            ibge_code: string;
-            /** Populacao */
-            populacao: number;
-            /** Pib Per Capita */
-            pib_per_capita?: number | null;
-            /** Total Licitacoes Abertas */
-            total_licitacoes_abertas: number;
-            /** Valor Total Licitacoes */
-            valor_total_licitacoes: number;
-            /** Licitacoes Recentes */
-            licitacoes_recentes: components["schemas"]["routes__municipios_publicos__LicitacaoRecente"][];
-            /** Faq Items */
-            faq_items: components["schemas"]["FaqItem"][];
-            /** Last Updated */
-            last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
             /**
              * @default {
              *       "contagem_30d": 0,
              *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
              *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
              *     }
              */
             atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Aviso Legal */
+            aviso_legal: string;
+            /** Faq Items */
+            faq_items: components["schemas"]["FaqItem"][];
+            /** Ibge Code */
+            ibge_code: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Licitacoes Recentes */
+            licitacoes_recentes: components["schemas"]["routes__municipios_publicos__LicitacaoRecente"][];
+            /** Nome */
+            nome: string;
+            /** Pib Per Capita */
+            pib_per_capita?: number | null;
+            /** Populacao */
+            populacao: number;
+            /** Slug */
+            slug: string;
+            /** Total Licitacoes Abertas */
+            total_licitacoes_abertas: number;
+            /** Uf */
+            uf: string;
+            /** Valor Total Licitacoes */
+            valor_total_licitacoes: number;
         };
         /** NewBidsCountResponse */
         NewBidsCountResponse: {
@@ -9877,14 +9920,14 @@ export interface components {
         NewOpportunitiesResponse: {
             /** Count */
             count: number;
-            /** Has Previous Search */
-            has_previous_search: boolean;
-            /** Last Search At */
-            last_search_at?: string | null;
             /** Days Since Last Search */
             days_since_last_search?: number | null;
+            /** Has Previous Search */
+            has_previous_search: boolean;
             /** Label */
             label?: string | null;
+            /** Last Search At */
+            last_search_at?: string | null;
         };
         /**
          * ObjetivoTipo
@@ -9911,16 +9954,16 @@ export interface components {
          * @description Aggregated dashboard for an org (extends over time).
          */
         OrganizationDashboardResponse: {
-            /** Organization Id */
-            organization_id?: string | null;
             /** Members Count */
             members_count?: number | null;
-            /** Seats Used */
-            seats_used?: number | null;
+            /** Organization Id */
+            organization_id?: string | null;
             /** Pipeline Count */
             pipeline_count?: number | null;
             /** Searches 30D */
             searches_30d?: number | null;
+            /** Seats Used */
+            seats_used?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -9929,14 +9972,14 @@ export interface components {
          * @description POST /organizations/{org_id}/invite response.
          */
         OrganizationInviteResponse: {
+            /** Expires At */
+            expires_at?: string | null;
             /** Invite Id */
             invite_id?: string | null;
             /** Invite Token */
             invite_token?: string | null;
             /** Invite Url */
             invite_url?: string | null;
-            /** Expires At */
-            expires_at?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -9945,10 +9988,10 @@ export interface components {
          * @description PUT /organizations/{org_id}/logo response.
          */
         OrganizationLogoUpdatedResponse: {
-            /** Success */
-            success?: boolean | null;
             /** Logo Url */
             logo_url?: string | null;
+            /** Success */
+            success?: boolean | null;
         } & {
             [key: string]: unknown;
         };
@@ -9957,10 +10000,10 @@ export interface components {
          * @description DELETE /organizations/{org_id}/members/{user_id} response.
          */
         OrganizationMemberRemovedResponse: {
-            /** Success */
-            success?: boolean | null;
             /** Removed User Id */
             removed_user_id?: string | null;
+            /** Success */
+            success?: boolean | null;
         } & {
             [key: string]: unknown;
         };
@@ -9969,11 +10012,11 @@ export interface components {
          * @description `/organizations/me` returns membership + org info.
          */
         OrganizationMembershipResponse: {
+            organization?: components["schemas"]["OrganizationResponse"] | null;
             /** Organization Id */
             organization_id?: string | null;
             /** Role */
             role?: string | null;
-            organization?: components["schemas"]["OrganizationResponse"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -9982,6 +10025,8 @@ export interface components {
          * @description One organization row + denormalized fields the API may add.
          */
         OrganizationResponse: {
+            /** Created At */
+            created_at?: string | null;
             /** Id */
             id?: string | null;
             /** Name */
@@ -9992,50 +10037,48 @@ export interface components {
             plan_id?: string | null;
             /** Seats Used */
             seats_used?: number | null;
-            /** Created At */
-            created_at?: string | null;
         } & {
             [key: string]: unknown;
         };
         /** OrgaoContratosStatsResponse */
         OrgaoContratosStatsResponse: {
-            /** Orgao Nome */
-            orgao_nome: string;
-            /** Orgao Cnpj */
-            orgao_cnpj: string;
-            /** Total Contracts */
-            total_contracts: number;
-            /** Total Value */
-            total_value: number;
-            /** Avg Value */
-            avg_value: number;
-            /** Top Fornecedores */
-            top_fornecedores: components["schemas"]["FornecedorRank"][];
-            /** Monthly Trend */
-            monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
-            /** Sample Contracts */
-            sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
-            /** Last Updated */
-            last_updated: string;
-            /** Aviso Legal */
-            aviso_legal: string;
             /**
              * @default {
              *       "contagem_30d": 0,
              *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
              *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
              *     }
              */
             atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Avg Value */
+            avg_value: number;
+            /** Aviso Legal */
+            aviso_legal: string;
+            /** Last Updated */
+            last_updated: string;
+            /** Monthly Trend */
+            monthly_trend: components["schemas"]["routes__contratos_publicos__MonthlyTrend"][];
+            /** Orgao Cnpj */
+            orgao_cnpj: string;
+            /** Orgao Nome */
+            orgao_nome: string;
+            /** Sample Contracts */
+            sample_contracts: components["schemas"]["routes__contratos_publicos__SampleContract"][];
+            /** Top Fornecedores */
+            top_fornecedores: components["schemas"]["FornecedorRank"][];
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Value */
+            total_value: number;
         };
         /** OrgaoRank */
         OrgaoRank: {
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
+            /** Nome */
+            nome: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -10043,84 +10086,84 @@ export interface components {
         };
         /** OrgaoStatsResponse */
         OrgaoStatsResponse: {
-            /** Nome */
-            nome: string;
+            /**
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
+             */
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Aviso Legal */
+            aviso_legal: string;
             /** Cnpj */
             cnpj: string;
             /** Esfera */
             esfera: string;
-            /** Uf */
-            uf: string;
-            /** Municipio */
-            municipio: string;
-            /** Total Licitacoes */
-            total_licitacoes: number;
             /** Licitacoes 30D */
             licitacoes_30d: number;
-            /** Licitacoes 90D */
-            licitacoes_90d: number;
             /** Licitacoes 365D */
             licitacoes_365d: number;
-            /** Valor Medio Estimado */
-            valor_medio_estimado: number;
-            /** Valor Total Estimado */
-            valor_total_estimado: number;
-            /** Top Modalidades */
-            top_modalidades: components["schemas"]["routes__orgao_publico__ModalidadeCount"][];
-            /** Top Setores */
-            top_setores: string[];
-            /** Ultimas Licitacoes */
-            ultimas_licitacoes: components["schemas"]["routes__orgao_publico__LicitacaoRecente"][];
+            /** Licitacoes 90D */
+            licitacoes_90d: number;
+            /** Municipio */
+            municipio: string;
+            /** Nome */
+            nome: string;
             /**
              * Top Fornecedores
              * @default []
              */
             top_fornecedores: components["schemas"]["FornecedorTop"][];
+            /** Top Modalidades */
+            top_modalidades: components["schemas"]["routes__orgao_publico__ModalidadeCount"][];
+            /** Top Setores */
+            top_setores: string[];
             /**
              * Total Contratos 24M
              * @default 0
              */
             total_contratos_24m: number;
+            /** Total Licitacoes */
+            total_licitacoes: number;
+            /** Uf */
+            uf: string;
+            /** Ultimas Licitacoes */
+            ultimas_licitacoes: components["schemas"]["routes__orgao_publico__LicitacaoRecente"][];
+            /** Valor Medio Estimado */
+            valor_medio_estimado: number;
             /**
              * Valor Total Contratos 24M
              * @default 0
              */
             valor_total_contratos_24m: number;
-            /** Aviso Legal */
-            aviso_legal: string;
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Valor Total Estimado */
+            valor_total_estimado: number;
         };
         /** PanoramaStats */
         PanoramaStats: {
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Total Nacional */
-            total_nacional: number;
-            /** Total Value */
-            total_value: number;
             /** Avg Value */
             avg_value: number;
-            /** Top Ufs */
-            top_ufs: components["schemas"]["TopEntry"][];
-            /** Top Modalidades */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /** Sazonalidade */
-            sazonalidade: components["schemas"]["routes__blog_stats__TrendPoint"][];
             /** Crescimento Estimado Pct */
             crescimento_estimado_pct: number;
             /** Last Updated */
             last_updated: string;
+            /** Sazonalidade */
+            sazonalidade: components["schemas"]["routes__blog_stats__TrendPoint"][];
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Top Modalidades */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /** Top Ufs */
+            top_ufs: components["schemas"]["TopEntry"][];
+            /** Total Nacional */
+            total_nacional: number;
+            /** Total Value */
+            total_value: number;
         };
         /**
          * PartnerCreateResponse
@@ -10143,12 +10186,10 @@ export interface components {
          * @description AC14: Partner self-service dashboard payload.
          */
         PartnerDashboardResponse: {
-            /** Partner Id */
-            partner_id?: string | null;
             /** Name */
             name?: string | null;
-            /** Status */
-            status?: string | null;
+            /** Partner Id */
+            partner_id?: string | null;
             /** Referrals */
             referrals?: {
                 [key: string]: unknown;
@@ -10157,6 +10198,8 @@ export interface components {
             revenue?: {
                 [key: string]: unknown;
             } | null;
+            /** Status */
+            status?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -10165,18 +10208,18 @@ export interface components {
          * @description One partner referral record.
          */
         PartnerReferralEntry: {
-            /** Id */
-            id?: string | null;
-            /** User Id */
-            user_id?: string | null;
-            /** Converted At */
-            converted_at?: string | null;
             /** Churned At */
             churned_at?: string | null;
+            /** Converted At */
+            converted_at?: string | null;
+            /** Id */
+            id?: string | null;
             /** Monthly Revenue */
             monthly_revenue?: number | null;
             /** Revenue Share Amount */
             revenue_share_amount?: number | null;
+            /** User Id */
+            user_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -10198,16 +10241,16 @@ export interface components {
          * @description AC13: Partner revenue share for a given month.
          */
         PartnerRevenueResponse: {
-            /** Partner Id */
-            partner_id?: string | null;
-            /** Year */
-            year?: number | null;
             /** Month */
             month?: number | null;
-            /** Total Revenue */
-            total_revenue?: number | null;
+            /** Partner Id */
+            partner_id?: string | null;
             /** Revenue Share Amount */
             revenue_share_amount?: number | null;
+            /** Total Revenue */
+            total_revenue?: number | null;
+            /** Year */
+            year?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -10216,24 +10259,24 @@ export interface components {
          * @description One partner row in the admin list.
          */
         PartnerSummary: {
+            /** Contact Email */
+            contact_email?: string | null;
             /** Id */
             id?: string | null;
+            /** Monthly Share */
+            monthly_share?: number | null;
             /** Name */
             name?: string | null;
+            /** Referrals Active */
+            referrals_active?: number | null;
+            /** Referrals Total */
+            referrals_total?: number | null;
+            /** Revenue Share Pct */
+            revenue_share_pct?: number | null;
             /** Slug */
             slug?: string | null;
             /** Status */
             status?: string | null;
-            /** Contact Email */
-            contact_email?: string | null;
-            /** Revenue Share Pct */
-            revenue_share_pct?: number | null;
-            /** Referrals Total */
-            referrals_total?: number | null;
-            /** Referrals Active */
-            referrals_active?: number | null;
-            /** Monthly Share */
-            monthly_share?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -10252,65 +10295,53 @@ export interface components {
         };
         /** PdfEditalRequest */
         PdfEditalRequest: {
-            /** Objeto */
-            objeto: string;
-            /** Orgao */
-            orgao: string;
-            /** Uf */
-            uf: string;
-            /** Municipio */
-            municipio?: string | null;
-            /** Valor */
-            valor?: number | null;
             /** Data Encerramento */
             data_encerramento?: string | null;
             /** Data Publicacao */
             data_publicacao?: string | null;
-            /** Modalidade */
-            modalidade?: string | null;
             /** Link */
             link?: string | null;
+            /** Modalidade */
+            modalidade?: string | null;
+            /** Municipio */
+            municipio?: string | null;
             /** Numero Compra */
             numero_compra?: string | null;
+            /** Objeto */
+            objeto: string;
+            /** Orgao */
+            orgao: string;
             /** Pncp Id */
             pncp_id?: string | null;
-            /** Viability Level */
-            viability_level?: string | null;
-            /** Viability Score */
-            viability_score?: number | null;
+            /** Recomendacao */
+            recomendacao?: string | null;
+            /** Resumo Executivo */
+            resumo_executivo?: string | null;
+            /** Uf */
+            uf: string;
+            /** Valor */
+            valor?: number | null;
             /** Viability Factors */
             viability_factors?: {
                 [key: string]: unknown;
             } | null;
-            /** Resumo Executivo */
-            resumo_executivo?: string | null;
-            /** Recomendacao */
-            recomendacao?: string | null;
+            /** Viability Level */
+            viability_level?: string | null;
+            /** Viability Score */
+            viability_score?: number | null;
         };
         /** PerfilB2GResponse */
         PerfilB2GResponse: {
-            empresa: components["schemas"]["EmpresaInfo"];
-            /** Contratos */
-            contratos: components["schemas"]["ContratoPublico"][];
-            /** Score */
-            score: string;
-            /** Setor Detectado */
-            setor_detectado: string;
-            /** Setor Nome */
-            setor_nome: string;
-            /** Editais Abertos Setor */
-            editais_abertos_setor: number;
             /**
-             * Editais Amostra
-             * @default []
+             * @default {
+             *       "contagem_30d": 0,
+             *       "contagem_90d": 0,
+             *       "tendencia_12m": "stable",
+             *       "tendencia_percentual": 0,
+             *       "valor_total_30d": 0
+             *     }
              */
-            editais_amostra: components["schemas"]["EditaisAmostra"][];
-            /** Total Contratos 24M */
-            total_contratos_24m: number;
-            /** Valor Total 24M */
-            valor_total_24m: number;
-            /** Ufs Atuacao */
-            ufs_atuacao: string[];
+            atividade_recente: components["schemas"]["AtividadeRecenteData"];
             /** Aviso Legal */
             aviso_legal: string;
             /**
@@ -10318,21 +10349,33 @@ export interface components {
              * @default ok
              */
             brasilapi_status: string;
+            /** Contratos */
+            contratos: components["schemas"]["ContratoPublico"][];
+            /** Editais Abertos Setor */
+            editais_abertos_setor: number;
+            /**
+             * Editais Amostra
+             * @default []
+             */
+            editais_amostra: components["schemas"]["EditaisAmostra"][];
+            empresa: components["schemas"]["EmpresaInfo"];
             /**
              * Partial
              * @default false
              */
             partial: boolean;
-            /**
-             * @default {
-             *       "contagem_30d": 0,
-             *       "contagem_90d": 0,
-             *       "valor_total_30d": 0,
-             *       "tendencia_12m": "stable",
-             *       "tendencia_percentual": 0
-             *     }
-             */
-            atividade_recente: components["schemas"]["AtividadeRecenteData"];
+            /** Score */
+            score: string;
+            /** Setor Detectado */
+            setor_detectado: string;
+            /** Setor Nome */
+            setor_nome: string;
+            /** Total Contratos 24M */
+            total_contratos_24m: number;
+            /** Ufs Atuacao */
+            ufs_atuacao: string[];
+            /** Valor Total 24M */
+            valor_total_24m: number;
         };
         /**
          * PerfilContexto
@@ -10342,61 +10385,6 @@ export interface components {
          *     Stored as JSONB in profiles.context_data.
          */
         PerfilContexto: {
-            /**
-             * Ufs Atuacao
-             * @description States where the company operates (e.g., ['SP', 'RJ', 'MG'])
-             * @example [
-             *       "SP",
-             *       "RJ"
-             *     ]
-             */
-            ufs_atuacao: string[];
-            /** @description Company size: ME, EPP, MEDIO, GRANDE */
-            porte_empresa: components["schemas"]["PorteEmpresa"];
-            /** @description Procurement experience level */
-            experiencia_licitacoes: components["schemas"]["ExperienciaLicitacoes"];
-            /**
-             * Faixa Valor Min
-             * @description Minimum contract value of interest (BRL)
-             */
-            faixa_valor_min?: number | null;
-            /**
-             * Faixa Valor Max
-             * @description Maximum contract value of interest (BRL)
-             */
-            faixa_valor_max?: number | null;
-            /**
-             * Modalidades Interesse
-             * @description Preferred procurement modality codes (PNCP API codes)
-             */
-            modalidades_interesse?: number[] | null;
-            /**
-             * Palavras Chave
-             * @description Business-specific keywords for relevance boosting
-             */
-            palavras_chave?: string[] | null;
-            /**
-             * Cnae
-             * @description CNAE code or business segment (e.g., '4781-4/00')
-             */
-            cnae?: string | null;
-            /**
-             * Objetivo Principal
-             * @description User's primary objective in free text
-             */
-            objetivo_principal?: string | null;
-            /**
-             * Segmento Principal
-             * @description Primary business sector ID for personalization (CONV-018)
-             */
-            segmento_principal?: number | null;
-            /** @description User's primary objective for journey routing (CONV-018) */
-            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
-            /**
-             * Ticket Medio Desejado
-             * @description Desired average ticket in BRL cents
-             */
-            ticket_medio_desejado?: number | null;
             /**
              * Atestados
              * @description Certifications held (e.g., ['crea', 'iso_9001'])
@@ -10408,10 +10396,65 @@ export interface components {
              */
             capacidade_funcionarios?: number | null;
             /**
+             * Cnae
+             * @description CNAE code or business segment (e.g., '4781-4/00')
+             */
+            cnae?: string | null;
+            /** @description Procurement experience level */
+            experiencia_licitacoes: components["schemas"]["ExperienciaLicitacoes"];
+            /**
+             * Faixa Valor Max
+             * @description Maximum contract value of interest (BRL)
+             */
+            faixa_valor_max?: number | null;
+            /**
+             * Faixa Valor Min
+             * @description Minimum contract value of interest (BRL)
+             */
+            faixa_valor_min?: number | null;
+            /**
              * Faturamento Anual
              * @description Annual revenue in BRL
              */
             faturamento_anual?: number | null;
+            /**
+             * Modalidades Interesse
+             * @description Preferred procurement modality codes (PNCP API codes)
+             */
+            modalidades_interesse?: number[] | null;
+            /**
+             * Objetivo Principal
+             * @description User's primary objective in free text
+             */
+            objetivo_principal?: string | null;
+            /** @description User's primary objective for journey routing (CONV-018) */
+            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
+            /**
+             * Palavras Chave
+             * @description Business-specific keywords for relevance boosting
+             */
+            palavras_chave?: string[] | null;
+            /** @description Company size: ME, EPP, MEDIO, GRANDE */
+            porte_empresa: components["schemas"]["PorteEmpresa"];
+            /**
+             * Segmento Principal
+             * @description Primary business sector ID for personalization (CONV-018)
+             */
+            segmento_principal?: number | null;
+            /**
+             * Ticket Medio Desejado
+             * @description Desired average ticket in BRL cents
+             */
+            ticket_medio_desejado?: number | null;
+            /**
+             * Ufs Atuacao
+             * @description States where the company operates (e.g., ['SP', 'RJ', 'MG'])
+             * @example [
+             *       "SP",
+             *       "RJ"
+             *     ]
+             */
+            ufs_atuacao: string[];
         };
         /**
          * PerfilContextoResponse
@@ -10419,18 +10462,18 @@ export interface components {
          */
         PerfilContextoResponse: {
             /**
+             * Completed
+             * @description Whether onboarding wizard has been completed
+             * @default false
+             */
+            completed: boolean;
+            /**
              * Context Data
              * @description Business context data from onboarding
              */
             context_data?: {
                 [key: string]: unknown;
             };
-            /**
-             * Completed
-             * @description Whether onboarding wizard has been completed
-             * @default false
-             */
-            completed: boolean;
         };
         /** PeriodosResponse */
         PeriodosResponse: {
@@ -10453,10 +10496,20 @@ export interface components {
          */
         PipelineItemCreate: {
             /**
-             * Pncp Id
-             * @description PNCP unique identifier
+             * Data Encerramento
+             * @description Deadline ISO timestamp
              */
-            pncp_id: string;
+            data_encerramento?: string | null;
+            /**
+             * Link Pncp
+             * @description Direct PNCP link
+             */
+            link_pncp?: string | null;
+            /**
+             * Notes
+             * @description User notes
+             */
+            notes?: string | null;
             /**
              * Objeto
              * @description Procurement object description
@@ -10468,6 +10521,22 @@ export interface components {
              */
             orgao?: string | null;
             /**
+             * Pncp Id
+             * @description PNCP unique identifier
+             */
+            pncp_id: string;
+            /**
+             * Search Id
+             * @description Search session that discovered this item (DEBT-120)
+             */
+            search_id?: string | null;
+            /**
+             * Stage
+             * @description Initial pipeline stage
+             * @default descoberta
+             */
+            stage: string | null;
+            /**
              * Uf
              * @description State code
              */
@@ -10477,66 +10546,40 @@ export interface components {
              * @description Estimated value in BRL
              */
             valor_estimado?: number | null;
-            /**
-             * Data Encerramento
-             * @description Deadline ISO timestamp
-             */
-            data_encerramento?: string | null;
-            /**
-             * Link Pncp
-             * @description Direct PNCP link
-             */
-            link_pncp?: string | null;
-            /**
-             * Stage
-             * @description Initial pipeline stage
-             * @default descoberta
-             */
-            stage: string | null;
-            /**
-             * Notes
-             * @description User notes
-             */
-            notes?: string | null;
-            /**
-             * Search Id
-             * @description Search session that discovered this item (DEBT-120)
-             */
-            search_id?: string | null;
         };
         /**
          * PipelineItemResponse
          * @description Single pipeline item response.
          */
         PipelineItemResponse: {
+            /** Created At */
+            created_at: string;
+            /** Data Encerramento */
+            data_encerramento?: string | null;
             /** Id */
             id: string;
-            /** User Id */
-            user_id: string;
-            /** Pncp Id */
-            pncp_id: string;
+            /** Link Pncp */
+            link_pncp?: string | null;
+            /** Notes */
+            notes?: string | null;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao?: string | null;
-            /** Uf */
-            uf?: string | null;
-            /** Valor Estimado */
-            valor_estimado?: number | null;
-            /** Data Encerramento */
-            data_encerramento?: string | null;
-            /** Link Pncp */
-            link_pncp?: string | null;
-            /** Stage */
-            stage: string;
-            /** Notes */
-            notes?: string | null;
+            /** Pncp Id */
+            pncp_id: string;
             /** Search Id */
             search_id?: string | null;
-            /** Created At */
-            created_at: string;
+            /** Stage */
+            stage: string;
+            /** Uf */
+            uf?: string | null;
             /** Updated At */
             updated_at: string;
+            /** User Id */
+            user_id: string;
+            /** Valor Estimado */
+            valor_estimado?: number | null;
             /**
              * Version
              * @default 1
@@ -10549,15 +10592,15 @@ export interface components {
          */
         PipelineItemUpdate: {
             /**
-             * Stage
-             * @description New pipeline stage
-             */
-            stage?: string | null;
-            /**
              * Notes
              * @description Updated notes
              */
             notes?: string | null;
+            /**
+             * Stage
+             * @description New pipeline stage
+             */
+            stage?: string | null;
             /**
              * Version
              * @description Current version for optimistic locking (STORY-307)
@@ -10571,12 +10614,12 @@ export interface components {
         PipelineListResponse: {
             /** Items */
             items: components["schemas"]["PipelineItemResponse"][];
-            /** Total */
-            total: number;
             /** Limit */
             limit: number;
             /** Offset */
             offset: number;
+            /** Total */
+            total: number;
         };
         /**
          * PlanDetails
@@ -10586,24 +10629,24 @@ export interface components {
          *     to prevent enumeration attacks on pricing infrastructure.
          */
         PlanDetails: {
-            /** Id */
-            id: string;
-            /** Name */
-            name: string;
-            /** Description */
-            description: string;
-            /** Price Brl */
-            price_brl: number;
-            /** Duration Days */
-            duration_days: number;
-            /** Max Searches */
-            max_searches: number;
             /** Capabilities */
             capabilities: {
                 [key: string]: unknown;
             };
+            /** Description */
+            description: string;
+            /** Duration Days */
+            duration_days: number;
+            /** Id */
+            id: string;
             /** Is Active */
             is_active: boolean;
+            /** Max Searches */
+            max_searches: number;
+            /** Name */
+            name: string;
+            /** Price Brl */
+            price_brl: number;
         };
         /**
          * PlansResponse
@@ -10633,22 +10676,34 @@ export interface components {
         ProfileCompletenessResponse: {
             /** Completeness Pct */
             completeness_pct: number;
-            /** Total Fields */
-            total_fields: number;
             /** Filled Fields */
             filled_fields: number;
-            /** Missing Fields */
-            missing_fields?: string[];
-            /** Next Question */
-            next_question?: string | null;
             /**
              * Is Complete
              * @default false
              */
             is_complete: boolean;
+            /** Missing Fields */
+            missing_fields?: string[];
+            /** Next Question */
+            next_question?: string | null;
+            /** Total Fields */
+            total_fields: number;
         };
         /** PublicFeatureFlagItem */
         PublicFeatureFlagItem: {
+            /**
+             * Category
+             * @description Flag category
+             * @default
+             */
+            category: string;
+            /**
+             * Description
+             * @description Human-readable description
+             * @default
+             */
+            description: string;
             /**
              * Name
              * @description Flag name
@@ -10659,18 +10714,6 @@ export interface components {
              * @description Current effective value
              */
             value: boolean;
-            /**
-             * Description
-             * @description Human-readable description
-             * @default
-             */
-            description: string;
-            /**
-             * Category
-             * @description Flag category
-             * @default
-             */
-            category: string;
         };
         /** PublicFeatureFlagListResponse */
         PublicFeatureFlagListResponse: {
@@ -10693,28 +10736,30 @@ export interface components {
         };
         /** RankingResponse */
         RankingResponse: {
-            /** Periodo */
-            periodo: string;
-            /** Total */
-            total: number;
-            /** Resultados */
-            resultados: components["schemas"]["IndiceResult"][];
             /** Fonte */
             fonte: string;
             /** License */
             license: string;
+            /** Periodo */
+            periodo: string;
+            /** Resultados */
+            resultados: components["schemas"]["IndiceResult"][];
+            /** Total */
+            total: number;
         };
         /**
          * ReadinessResponse
          * @description Response for GET /health/ready endpoint (Issue #640).
          */
         ReadinessResponse: {
-            /** Ready */
-            ready: boolean;
             /** Checks */
             checks: {
                 [key: string]: unknown;
             };
+            /** Ready */
+            ready: boolean;
+            /** Shutting Down */
+            shutting_down?: boolean | null;
             /** Uptime Seconds */
             uptime_seconds: number;
             /**
@@ -10723,8 +10768,6 @@ export interface components {
              * @default unknown
              */
             wedge_risk: string;
-            /** Shutting Down */
-            shutting_down?: boolean | null;
         };
         /**
          * RecalibrateRequest
@@ -10732,86 +10775,86 @@ export interface components {
          */
         RecalibrateRequest: {
             /**
-             * Range Days
-             * @default 90
-             */
-            range_days: number;
-            /**
              * Apply
              * @description When true, writes the new median to app_config.
              * @default false
              */
             apply: boolean;
+            /**
+             * Range Days
+             * @default 90
+             */
+            range_days: number;
         };
         /** RecalibrateResponse */
         RecalibrateResponse: {
-            /** Range Days */
-            range_days: number;
-            /** Sample Size */
-            sample_size: number;
             /** After Outlier Removal */
             after_outlier_removal: number;
-            /** Eligible */
-            eligible: boolean;
-            /** Reason */
-            reason?: string | null;
-            /** Old Value */
-            old_value: number;
-            /** New Value */
-            new_value?: number | null;
-            /** Diff Pct */
-            diff_pct?: number | null;
             /** Applied */
             applied: boolean;
-            /** Median Per Bid */
-            median_per_bid?: number | null;
+            /** Diff Pct */
+            diff_pct?: number | null;
+            /** Eligible */
+            eligible: boolean;
             /** Median Bid Count */
             median_bid_count?: number | null;
+            /** Median Per Bid */
+            median_per_bid?: number | null;
+            /** New Value */
+            new_value?: number | null;
+            /** Old Value */
+            old_value: number;
+            /** Range Days */
+            range_days: number;
+            /** Reason */
+            reason?: string | null;
+            /** Sample Size */
+            sample_size: number;
         };
         /** RecentContract */
         RecentContract: {
+            /** Data Assinatura */
+            data_assinatura: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
             /** Orgao Cnpj */
             orgao_cnpj?: string | null;
-            /** Valor */
-            valor?: number | null;
-            /** Data Assinatura */
-            data_assinatura: string;
             /** Uf */
             uf: string;
+            /** Valor */
+            valor?: number | null;
         };
         /** RecentEditaisResponse */
         RecentEditaisResponse: {
-            /** Setor */
-            setor: string;
-            /** Uf */
-            uf?: string | null;
-            /** Municipio */
-            municipio?: string | null;
             /** Items */
             items: components["schemas"]["RecentEditalItem"][];
-            /** Total */
-            total: number;
             /** Last Updated */
             last_updated: string;
+            /** Municipio */
+            municipio?: string | null;
+            /** Setor */
+            setor: string;
+            /** Total */
+            total: number;
+            /** Uf */
+            uf?: string | null;
         };
         /** RecentEditalItem */
         RecentEditalItem: {
-            /** Orgao */
-            orgao: string;
-            /** Objeto */
-            objeto: string;
-            /** Valor Estimado */
-            valor_estimado?: number | null;
             /** Data Limite */
             data_limite?: string | null;
             /** Data Publicacao */
             data_publicacao?: string | null;
             /** Link Interno */
             link_interno: string;
+            /** Objeto */
+            objeto: string;
+            /** Orgao */
+            orgao: string;
+            /** Valor Estimado */
+            valor_estimado?: number | null;
         };
         /**
          * Recomendacao
@@ -10821,23 +10864,6 @@ export interface components {
          *     Each recommendation includes a concrete action and justification.
          */
         Recomendacao: {
-            /**
-             * Oportunidade
-             * @description Opportunity name (agency/object)
-             * @example Prefeitura de Porto Alegre - Uniformes Escolares
-             */
-            oportunidade: string;
-            /**
-             * Valor
-             * @description Estimated value in BRL
-             */
-            valor: number;
-            /**
-             * Urgencia
-             * @description Urgency level: alta (<3 days), media (3-7 days), baixa (>7 days)
-             * @enum {string}
-             */
-            urgencia: "alta" | "media" | "baixa";
             /**
              * Acao Sugerida
              * @description Concrete suggested action
@@ -10850,6 +10876,23 @@ export interface components {
              * @example Valor compatível com seu porte, órgão federal com bom histórico de pagamento.
              */
             justificativa: string;
+            /**
+             * Oportunidade
+             * @description Opportunity name (agency/object)
+             * @example Prefeitura de Porto Alegre - Uniformes Escolares
+             */
+            oportunidade: string;
+            /**
+             * Urgencia
+             * @description Urgency level: alta (<3 days), media (3-7 days), baixa (>7 days)
+             * @enum {string}
+             */
+            urgencia: "alta" | "media" | "baixa";
+            /**
+             * Valor
+             * @description Estimated value in BRL
+             */
+            valor: number;
         };
         /** RecommendedPlanResponse */
         RecommendedPlanResponse: {
@@ -10860,10 +10903,6 @@ export interface components {
         };
         /** ReconcileNowResponse */
         ReconcileNowResponse: {
-            /** Status */
-            status: string;
-            /** Dry Run */
-            dry_run: boolean;
             /**
              * Drifts Detected
              * @default 0
@@ -10879,51 +10918,55 @@ export interface components {
              * @default 0
              */
             drifts_manual: number;
+            /** Dry Run */
+            dry_run: boolean;
             /** Run Id */
             run_id?: string | null;
+            /** Status */
+            status: string;
         };
         /** ReconciliationRun */
         ReconciliationRun: {
-            /** Id */
-            id: string;
+            /** Drift Report */
+            drift_report?: unknown;
             /**
-             * Started At
-             * Format: date-time
+             * Drifts Detected
+             * @default 0
              */
-            started_at: string;
-            /** Finished At */
-            finished_at?: string | null;
-            /** Status */
-            status: string;
+            drifts_detected: number;
+            /**
+             * Drifts Fixed
+             * @default 0
+             */
+            drifts_fixed: number;
+            /**
+             * Drifts Manual
+             * @default 0
+             */
+            drifts_manual: number;
             /**
              * Dry Run
              * @default false
              */
             dry_run: boolean;
+            /** Error Message */
+            error_message?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Id */
+            id: string;
             /**
              * Rows Checked
              * @default 0
              */
             rows_checked: number;
             /**
-             * Drifts Detected
-             * @default 0
+             * Started At
+             * Format: date-time
              */
-            drifts_detected: number;
-            /**
-             * Drifts Fixed
-             * @default 0
-             */
-            drifts_fixed: number;
-            /**
-             * Drifts Manual
-             * @default 0
-             */
-            drifts_manual: number;
-            /** Drift Report */
-            drift_report?: unknown;
-            /** Error Message */
-            error_message?: string | null;
+            started_at: string;
+            /** Status */
+            status: string;
         };
         /** ReconciliationRunsResponse */
         ReconciliationRunsResponse: {
@@ -10932,11 +10975,6 @@ export interface components {
         };
         /** RecordEventRequest */
         RecordEventRequest: {
-            /**
-             * Evento Tipo
-             * @description Tipo do evento: search_query, sector_view, org_view, cnpj_lookup
-             */
-            evento_tipo: string;
             /**
              * Dimensao Tipo
              * @description Tipo da dimensao: setor, uf, modalidade, orgao
@@ -10948,6 +10986,11 @@ export interface components {
              */
             dimensao_valor: string;
             /**
+             * Evento Tipo
+             * @description Tipo do evento: search_query, sector_view, org_view, cnpj_lookup
+             */
+            evento_tipo: string;
+            /**
              * Metadados
              * @description Metadados adicionais (setores, ufs, modalidades). NUNCA PII.
              */
@@ -10958,15 +11001,15 @@ export interface components {
         /** RecordEventResponse */
         RecordEventResponse: {
             /**
-             * Success
-             * @default true
-             */
-            success: boolean;
-            /**
              * Message
              * @default Evento registrado com sucesso
              */
             message: string;
+            /**
+             * Success
+             * @default true
+             */
+            success: boolean;
         };
         /** RecoveryCodesResponse */
         RecoveryCodesResponse: {
@@ -11000,30 +11043,30 @@ export interface components {
         };
         /** ReferralRedeemResponse */
         ReferralRedeemResponse: {
-            /** Status */
-            status: string;
             /** Code */
             code?: string | null;
+            /** Status */
+            status: string;
         };
         /** ReferralStatsResponse */
         ReferralStatsResponse: {
             /** Code */
             code: string;
             /**
-             * Total Signups
+             * Credits Earned Months
              * @default 0
              */
-            total_signups: number;
+            credits_earned_months: number;
             /**
              * Total Converted
              * @default 0
              */
             total_converted: number;
             /**
-             * Credits Earned Months
+             * Total Signups
              * @default 0
              */
-            credits_earned_months: number;
+            total_signups: number;
         };
         /** RegenerateRecoveryResponse */
         RegenerateRecoveryResponse: {
@@ -11037,48 +11080,53 @@ export interface components {
         };
         /** RelatorioMensal */
         RelatorioMensal: {
-            /** Mes */
-            mes: number;
             /** Ano */
             ano: number;
-            /** Mes Nome */
-            mes_nome: string;
-            /** Periodo */
-            periodo: string;
-            /** Total Editais */
-            total_editais: number;
-            /** Valor Total */
-            valor_total: number;
-            /** Valor Medio */
-            valor_medio: number;
-            /** Top Ufs */
-            top_ufs: components["schemas"]["UfCount"][];
-            /** Modalidades */
-            modalidades: components["schemas"]["routes__observatorio__ModalidadeCount"][];
-            /** Tendencia Semanal */
-            tendencia_semanal: components["schemas"]["routes__observatorio__MonthlyTrend"][];
-            /** Setores Em Alta */
-            setores_em_alta: components["schemas"]["SetorHighlight"][];
-            /** Gerado Em */
-            gerado_em: string;
+            /** Coverage Window */
+            coverage_window?: {
+                [key: string]: unknown;
+            } | null;
             /** Fonte */
             fonte: string;
-            /** License */
-            license: string;
+            /** Gerado Em */
+            gerado_em: string;
             /**
              * Is Empty Period
              * @default false
              */
             is_empty_period: boolean;
+            /** License */
+            license: string;
+            /** Mes */
+            mes: number;
+            /** Mes Nome */
+            mes_nome: string;
+            /** Modalidades */
+            modalidades: components["schemas"]["routes__observatorio__ModalidadeCount"][];
             /** Period Label */
             period_label?: string | null;
-            /** Coverage Window */
-            coverage_window?: {
-                [key: string]: unknown;
-            } | null;
+            /** Periodo */
+            periodo: string;
+            /** Setores Em Alta */
+            setores_em_alta: components["schemas"]["SetorHighlight"][];
+            /** Tendencia Semanal */
+            tendencia_semanal: components["schemas"]["routes__observatorio__MonthlyTrend"][];
+            /** Top Ufs */
+            top_ufs: components["schemas"]["UfCount"][];
+            /** Total Editais */
+            total_editais: number;
+            /** Valor Medio */
+            valor_medio: number;
+            /** Valor Total */
+            valor_total: number;
         };
         /** RelatorioRequest */
         RelatorioRequest: {
+            /**
+             * Cargo
+             * @enum {string}
+             */
+            cargo: "diretor" | "gerente" | "analista" | "consultor" | "outro";
             /**
              * Email
              * Format: email
@@ -11086,11 +11134,6 @@ export interface components {
             email: string;
             /** Empresa */
             empresa: string;
-            /**
-             * Cargo
-             * @enum {string}
-             */
-            cargo: "diretor" | "gerente" | "analista" | "consultor" | "outro";
             /**
              * Newsletter Opt In
              * @default false
@@ -11130,10 +11173,10 @@ export interface components {
         };
         /** ResendResponse */
         ResendResponse: {
-            /** Success */
-            success: boolean;
             /** Message */
             message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * ResumoEstrategico
@@ -11174,6 +11217,48 @@ export interface components {
          */
         ResumoEstrategico: {
             /**
+             * Alerta Urgencia
+             * @description Optional urgency alert for time-sensitive opportunities
+             * @example ⚠️ 5 licitações encerram em 24 horas
+             */
+            alerta_urgencia?: string | null;
+            /**
+             * Alertas Urgencia
+             * @description Multiple urgency alerts for time-sensitive opportunities
+             * @example [
+             *       "⚠️ 2 licitações encerram em 48h",
+             *       "📋 3 editais exigem certidão atualizada"
+             *     ]
+             */
+            alertas_urgencia?: string[];
+            /**
+             * Destaques
+             * @description Key highlights (2-5 bullet points)
+             * @example [
+             *       "3 licitações com prazo até 48h",
+             *       "Maior valor: R$ 500k em SP"
+             *     ]
+             */
+            destaques?: string[];
+            /**
+             * Insight Setorial
+             * @description Sector-level market context and trend insight
+             * @default
+             * @example Este mês há 20% mais oportunidades de vestuário que o mês anterior no RS.
+             */
+            insight_setorial: string;
+            /**
+             * Outlier Count
+             * @description Number of outlier values excluded from valor_total computation
+             * @default 0
+             */
+            outlier_count: number;
+            /**
+             * Recomendacoes
+             * @description Prioritized list of recommended opportunities with concrete actions
+             */
+            recomendacoes?: components["schemas"]["Recomendacao"][];
+            /**
              * Resumo Executivo
              * @description 1-2 sentence executive summary
              * @example Encontradas 15 licitações de uniformes em SP e RJ, totalizando R$ 2.3M.
@@ -11185,58 +11270,16 @@ export interface components {
              */
             total_oportunidades: number;
             /**
-             * Valor Total
-             * @description Total value of all opportunities in BRL
-             */
-            valor_total: number;
-            /**
-             * Destaques
-             * @description Key highlights (2-5 bullet points)
-             * @example [
-             *       "3 licitações com prazo até 48h",
-             *       "Maior valor: R$ 500k em SP"
-             *     ]
-             */
-            destaques?: string[];
-            /**
-             * Alerta Urgencia
-             * @description Optional urgency alert for time-sensitive opportunities
-             * @example ⚠️ 5 licitações encerram em 24 horas
-             */
-            alerta_urgencia?: string | null;
-            /**
-             * Outlier Count
-             * @description Number of outlier values excluded from valor_total computation
-             * @default 0
-             */
-            outlier_count: number;
-            /**
              * Valor Sanitizado
              * @description Whether outlier-robust sanitization was applied to valor_total
              * @default false
              */
             valor_sanitizado: boolean;
             /**
-             * Recomendacoes
-             * @description Prioritized list of recommended opportunities with concrete actions
+             * Valor Total
+             * @description Total value of all opportunities in BRL
              */
-            recomendacoes?: components["schemas"]["Recomendacao"][];
-            /**
-             * Alertas Urgencia
-             * @description Multiple urgency alerts for time-sensitive opportunities
-             * @example [
-             *       "⚠️ 2 licitações encerram em 48h",
-             *       "📋 3 editais exigem certidão atualizada"
-             *     ]
-             */
-            alertas_urgencia?: string[];
-            /**
-             * Insight Setorial
-             * @description Sector-level market context and trend insight
-             * @default
-             * @example Este mês há 20% mais oportunidades de vestuário que o mês anterior no RS.
-             */
-            insight_setorial: string;
+            valor_total: number;
         };
         /**
          * ResumoLicitacoes
@@ -11267,6 +11310,27 @@ export interface components {
          */
         ResumoLicitacoes: {
             /**
+             * Alerta Urgencia
+             * @description Optional urgency alert for time-sensitive opportunities
+             * @example ⚠️ 5 licitações encerram em 24 horas
+             */
+            alerta_urgencia?: string | null;
+            /**
+             * Destaques
+             * @description Key highlights (2-5 bullet points)
+             * @example [
+             *       "3 licitações com prazo até 48h",
+             *       "Maior valor: R$ 500k em SP"
+             *     ]
+             */
+            destaques?: string[];
+            /**
+             * Outlier Count
+             * @description Number of outlier values excluded from valor_total computation
+             * @default 0
+             */
+            outlier_count: number;
+            /**
              * Resumo Executivo
              * @description 1-2 sentence executive summary
              * @example Encontradas 15 licitações de uniformes em SP e RJ, totalizando R$ 2.3M.
@@ -11278,37 +11342,16 @@ export interface components {
              */
             total_oportunidades: number;
             /**
-             * Valor Total
-             * @description Total value of all opportunities in BRL
-             */
-            valor_total: number;
-            /**
-             * Destaques
-             * @description Key highlights (2-5 bullet points)
-             * @example [
-             *       "3 licitações com prazo até 48h",
-             *       "Maior valor: R$ 500k em SP"
-             *     ]
-             */
-            destaques?: string[];
-            /**
-             * Alerta Urgencia
-             * @description Optional urgency alert for time-sensitive opportunities
-             * @example ⚠️ 5 licitações encerram em 24 horas
-             */
-            alerta_urgencia?: string | null;
-            /**
-             * Outlier Count
-             * @description Number of outlier values excluded from valor_total computation
-             * @default 0
-             */
-            outlier_count: number;
-            /**
              * Valor Sanitizado
              * @description Whether outlier-robust sanitization was applied to valor_total
              * @default false
              */
             valor_sanitizado: boolean;
+            /**
+             * Valor Total
+             * @description Total value of all opportunities in BRL
+             */
+            valor_total: number;
         };
         /** RevalidateSEORequest */
         RevalidateSEORequest: {
@@ -11317,10 +11360,10 @@ export interface components {
         };
         /** RevalidateSEOResponse */
         RevalidateSEOResponse: {
-            /** Status */
-            status: string;
             /** Paths */
             paths: string[];
+            /** Status */
+            status: string;
         };
         /** ReverseSyncRequest */
         ReverseSyncRequest: {
@@ -11335,38 +11378,34 @@ export interface components {
         };
         /** ReverseSyncResponse */
         ReverseSyncResponse: {
-            /** Status */
-            status: string;
-            /** Plan Billing Period Id */
-            plan_billing_period_id: string;
-            /** Old Stripe Price Id */
-            old_stripe_price_id?: string | null;
-            /** New Stripe Price Id */
-            new_stripe_price_id?: string | null;
-            /** Skipped Reason */
-            skipped_reason?: string | null;
             /** Audit Log Id */
             audit_log_id?: string | null;
+            /** New Stripe Price Id */
+            new_stripe_price_id?: string | null;
+            /** Old Stripe Price Id */
+            old_stripe_price_id?: string | null;
+            /** Plan Billing Period Id */
+            plan_billing_period_id: string;
+            /** Skipped Reason */
+            skipped_reason?: string | null;
+            /** Status */
+            status: string;
         };
         /**
          * RevokeResponse
          * @description Response for revoke endpoint.
          */
         RevokeResponse: {
-            /** Success */
-            success: boolean;
             /** Message */
             message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * RootResponse
          * @description Response for GET / root endpoint.
          */
         RootResponse: {
-            /** Name */
-            name: string;
-            /** Version */
-            version: string;
             /** Api Version */
             api_version: string;
             /** Description */
@@ -11375,53 +11414,57 @@ export interface components {
             endpoints: {
                 [key: string]: string;
             };
+            /** Name */
+            name: string;
+            /** Status */
+            status: string;
+            /** Version */
+            version: string;
             /** Versioning */
             versioning: {
                 [key: string]: unknown;
             };
-            /** Status */
-            status: string;
         };
         /** SEOMetricRow */
         SEOMetricRow: {
-            /** Date */
-            date: string;
-            /** Impressions */
-            impressions: number;
+            /** Avg Position */
+            avg_position: number;
             /** Clicks */
             clicks: number;
             /** Ctr */
             ctr: number;
-            /** Avg Position */
-            avg_position: number;
+            /** Date */
+            date: string;
+            /** Impressions */
+            impressions: number;
             /** Pages Indexed */
             pages_indexed: number;
-            /** Top Queries */
-            top_queries: unknown[];
             /** Top Pages */
             top_pages: unknown[];
+            /** Top Queries */
+            top_queries: unknown[];
         };
         /** SEOMetricsResponse */
         SEOMetricsResponse: {
+            /** Latest Date */
+            latest_date?: string | null;
             /** Metrics */
             metrics: components["schemas"]["SEOMetricRow"][];
             /** Total */
             total: number;
-            /** Latest Date */
-            latest_date?: string | null;
         };
         /** SancaoEntry */
         SancaoEntry: {
-            /** Tipo */
-            tipo: string;
-            /** Orgao Sancionador */
-            orgao_sancionador: string;
-            /** Data Inicio */
-            data_inicio: string;
             /** Data Fim */
             data_fim?: string | null;
+            /** Data Inicio */
+            data_inicio: string;
             /** Motivo */
             motivo: string;
+            /** Orgao Sancionador */
+            orgao_sancionador: string;
+            /** Tipo */
+            tipo: string;
             /** Valor Multa */
             valor_multa?: number | null;
         };
@@ -11433,39 +11476,39 @@ export interface components {
          */
         SanctionsSummarySchema: {
             /**
-             * Is Clean
-             * @description True if no active sanctions found
-             */
-            is_clean: boolean;
-            /**
              * Active Sanctions Count
              * @description Number of active sanctions
              * @default 0
              */
             active_sanctions_count: number;
             /**
-             * Sanction Types
-             * @description e.g. ['CEIS: Impedimento', 'CNEP: Multa']
-             */
-            sanction_types?: string[];
-            /**
              * Checked At
              * @description ISO timestamp of check
              */
             checked_at?: string | null;
+            /**
+             * Is Clean
+             * @description True if no active sanctions found
+             */
+            is_clean: boolean;
+            /**
+             * Sanction Types
+             * @description e.g. ['CEIS: Impedimento', 'CNEP: Multa']
+             */
+            sanction_types?: string[];
         };
         /**
          * SaveSegmentRequest
          * @description Request body for POST /v1/segment/save (CONV-018).
          */
         SaveSegmentRequest: {
+            /** @description User's primary objective: vencer_licitacao, subcontratar, monitorar */
+            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
             /**
              * Segmento Principal
              * @description Primary business sector ID from sectors list
              */
             segmento_principal?: number | null;
-            /** @description User's primary objective: vencer_licitacao, subcontratar, monitorar */
-            objetivo_tipo?: components["schemas"]["ObjetivoTipo"] | null;
         };
         /**
          * SaveSegmentResponse
@@ -11473,29 +11516,29 @@ export interface components {
          */
         SaveSegmentResponse: {
             /**
-             * Status
-             * @description Operation status, always 'ok' on success
-             */
-            status: string;
-            /**
              * Context Data
              * @description Full merged context_data after save
              */
             context_data: {
                 [key: string]: unknown;
             };
+            /**
+             * Status
+             * @description Operation status, always 'ok' on success
+             */
+            status: string;
         };
         /**
          * SearchActionResponse
          * @description Generic ack for `regenerate-excel`, `retry`, `cancel`.
          */
         SearchActionResponse: {
+            /** Message */
+            message?: string | null;
             /** Search Id */
             search_id?: string | null;
             /** Status */
             status?: string | null;
-            /** Message */
-            message?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -11504,8 +11547,6 @@ export interface components {
          * @description `GET /buscar-results/{id}` and `/search/{id}/results` — full envelope.
          */
         SearchResultsResponse: {
-            /** Search Id */
-            search_id?: string | null;
             /** Licitacoes */
             licitacoes?: {
                 [key: string]: unknown;
@@ -11514,6 +11555,8 @@ export interface components {
             resumo?: {
                 [key: string]: unknown;
             } | null;
+            /** Search Id */
+            search_id?: string | null;
             /** Total */
             total?: number | null;
         } & {
@@ -11530,31 +11573,32 @@ export interface components {
          */
         SearchStatusResponse: {
             /**
-             * Search Id
-             * @description UUID of the search
+             * Created At
+             * @description ISO timestamp when search was created
              */
-            search_id: string;
+            created_at?: string | null;
             /**
-             * Status
-             * @description running, completed, failed, or timeout
+             * Elapsed S
+             * @description Seconds since search started
+             * @default 0
              */
-            status: string;
+            elapsed_s: number;
+            /**
+             * Excel Status
+             * @description Excel generation status: processing, ready, failed, skipped
+             */
+            excel_status?: string | null;
+            /**
+             * Excel Url
+             * @description Signed URL for Excel download (set when ready)
+             */
+            excel_url?: string | null;
             /**
              * Progress Pct
              * @description Overall progress 0-100
              * @default 0
              */
             progress_pct: number;
-            /**
-             * Ufs Completed
-             * @description UFs that finished fetching
-             */
-            ufs_completed?: string[];
-            /**
-             * Ufs Pending
-             * @description UFs still being fetched
-             */
-            ufs_pending?: string[];
             /**
              * Results Count
              * @description Number of filtered results so far
@@ -11567,38 +11611,37 @@ export interface components {
              */
             results_url?: string | null;
             /**
-             * Elapsed S
-             * @description Seconds since search started
-             * @default 0
+             * Search Id
+             * @description UUID of the search
              */
-            elapsed_s: number;
+            search_id: string;
             /**
-             * Created At
-             * @description ISO timestamp when search was created
+             * Status
+             * @description running, completed, failed, or timeout
              */
-            created_at?: string | null;
+            status: string;
             /**
-             * Excel Url
-             * @description Signed URL for Excel download (set when ready)
+             * Ufs Completed
+             * @description UFs that finished fetching
              */
-            excel_url?: string | null;
+            ufs_completed?: string[];
             /**
-             * Excel Status
-             * @description Excel generation status: processing, ready, failed, skipped
+             * Ufs Pending
+             * @description UFs still being fetched
              */
-            excel_status?: string | null;
+            ufs_pending?: string[];
         };
         /**
          * SearchTimelineResponse
          * @description `GET /search/{id}/timeline` — list of progress events.
          */
         SearchTimelineResponse: {
-            /** Search Id */
-            search_id?: string | null;
             /** Events */
             events?: {
                 [key: string]: unknown;
             }[] | null;
+            /** Search Id */
+            search_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -11618,10 +11661,10 @@ export interface components {
         };
         /** SearchesOverTimeResponse */
         SearchesOverTimeResponse: {
-            /** Period */
-            period: string;
             /** Data */
             data: components["schemas"]["TimeSeriesDataPoint"][];
+            /** Period */
+            period: string;
         };
         /**
          * SeasonalCalendarResponse
@@ -11642,20 +11685,10 @@ export interface components {
          */
         SeasonalCalendarStats: {
             /**
-             * Uf
-             * @description UF code (uppercase)
-             */
-            uf: string;
-            /**
              * Anos Analisados
              * @description Number of years analyzed
              */
             anos_analisados: number;
-            /**
-             * Total Contratos Base
-             * @description Total number of contracts/bids in the analysis base
-             */
-            total_contratos_base: number;
             /**
              * Mes Pico
              * @description Month with highest average volume
@@ -11666,113 +11699,93 @@ export interface components {
              * @description Month with lowest average volume
              */
             mes_vale?: number | null;
+            /**
+             * Total Contratos Base
+             * @description Total number of contracts/bids in the analysis base
+             */
+            total_contratos_base: number;
+            /**
+             * Uf
+             * @description UF code (uppercase)
+             */
+            uf: string;
         };
         /** SectorAggregate */
         SectorAggregate: {
+            /** Avg Value */
+            avg_value: number;
+            /** Count */
+            count: number;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Count */
-            count: number;
             /** Total Value */
             total_value: number;
-            /** Avg Value */
-            avg_value: number;
         };
         /** SectorBlogStats */
         SectorBlogStats: {
+            /** Avg Value */
+            avg_value: number;
+            /** Last Updated */
+            last_updated: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Total Editais */
-            total_editais: number;
-            /** Value Range Min */
-            value_range_min: number;
-            /** Value Range Max */
-            value_range_max: number;
-            /** Avg Value */
-            avg_value: number;
             /** Top Modalidades */
             top_modalidades: components["schemas"]["TopEntry"][];
             /** Top Ufs */
             top_ufs: components["schemas"]["TopEntry"][];
+            /** Total Editais */
+            total_editais: number;
             /** Trend 90D */
             trend_90d: components["schemas"]["routes__blog_stats__TrendPoint"][];
-            /** Last Updated */
-            last_updated: string;
+            /** Value Range Max */
+            value_range_max: number;
+            /** Value Range Min */
+            value_range_min: number;
         };
         /** SectorListItem */
         SectorListItem: {
-            /** Id */
-            id: string;
-            /** Slug */
-            slug: string;
-            /** Name */
-            name: string;
             /** Description */
             description: string;
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
         };
         /** SectorStatsResponse */
         SectorStatsResponse: {
+            /** Avg Value */
+            avg_value: number;
+            /** Last Updated */
+            last_updated: string;
+            /** Sample Items */
+            sample_items: components["schemas"]["routes__sectors_public__SampleItem"][];
+            /** Sector Description */
+            sector_description: string;
             /** Sector Id */
             sector_id: string;
             /** Sector Name */
             sector_name: string;
-            /** Sector Description */
-            sector_description: string;
             /** Slug */
             slug: string;
+            /** Top Modalidades */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /** Top Ufs */
+            top_ufs: components["schemas"]["TopEntry"][];
             /** Total Open */
             total_open: number;
             /** Total Value */
             total_value: number;
-            /** Avg Value */
-            avg_value: number;
-            /** Top Ufs */
-            top_ufs: components["schemas"]["TopEntry"][];
-            /** Top Modalidades */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /** Sample Items */
-            sample_items: components["schemas"]["routes__sectors_public__SampleItem"][];
-            /** Last Updated */
-            last_updated: string;
         };
         /** SectorUfStats */
         SectorUfStats: {
-            /** Sector Id */
-            sector_id: string;
-            /** Sector Name */
-            sector_name: string;
-            /** Uf */
-            uf: string;
-            /** Total Editais */
-            total_editais: number;
             /** Avg Value */
             avg_value: number;
-            /**
-             * Value Range Min
-             * @default 0
-             */
-            value_range_min: number;
-            /**
-             * Value Range Max
-             * @default 0
-             */
-            value_range_max: number;
-            /**
-             * Top Modalidades
-             * @default []
-             */
-            top_modalidades: components["schemas"]["TopEntry"][];
-            /**
-             * Trend 90D
-             * @default []
-             */
-            trend_90d: components["schemas"]["routes__blog_stats__TrendPoint"][];
-            /** Top Oportunidades */
-            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
             /** Last Updated */
             last_updated: string;
             /** Most Recent Bid Date */
@@ -11782,29 +11795,59 @@ export interface components {
              * @default 0
              */
             municipios_ativos: number;
-            /** Vs Media Nacional Pct */
-            vs_media_nacional_pct?: number | null;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
             /**
              * Top Compradores
              * @default []
              */
             top_compradores: components["schemas"]["TopComprador"][];
+            /**
+             * Top Modalidades
+             * @default []
+             */
+            top_modalidades: components["schemas"]["TopEntry"][];
+            /** Top Oportunidades */
+            top_oportunidades: components["schemas"]["routes__blog_stats__SampleItem"][];
+            /** Total Editais */
+            total_editais: number;
+            /**
+             * Trend 90D
+             * @default []
+             */
+            trend_90d: components["schemas"]["routes__blog_stats__TrendPoint"][];
+            /** Uf */
+            uf: string;
+            /**
+             * Value Range Max
+             * @default 0
+             */
+            value_range_max: number;
+            /**
+             * Value Range Min
+             * @default 0
+             */
+            value_range_min: number;
+            /** Vs Media Nacional Pct */
+            vs_media_nacional_pct?: number | null;
         };
         /**
          * SessionsListResponse
          * @description Response for GET /sessions.
          */
         SessionsListResponse: {
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
             /** Sessions */
             sessions: {
                 [key: string]: unknown;
             }[];
             /** Total */
             total: number;
-            /** Limit */
-            limit: number;
-            /** Offset */
-            offset: number;
         };
         /** SetorHighlight */
         SetorHighlight: {
@@ -11812,10 +11855,10 @@ export interface components {
             setor_id: string;
             /** Setor Name */
             setor_name: string;
-            /** Total Atual */
-            total_atual: number;
             /** Total Anterior */
             total_anterior: number;
+            /** Total Atual */
+            total_atual: number;
             /** Variacao Pct */
             variacao_pct: number;
         };
@@ -11851,69 +11894,69 @@ export interface components {
         ShareAnaliseRequest: {
             /** Bid Id */
             bid_id: string;
-            /** Bid Title */
-            bid_title: string;
+            /** Bid Modalidade */
+            bid_modalidade?: string | null;
             /** Bid Orgao */
             bid_orgao?: string | null;
+            /** Bid Title */
+            bid_title: string;
             /** Bid Uf */
             bid_uf?: string | null;
             /** Bid Valor */
             bid_valor?: number | null;
-            /** Bid Modalidade */
-            bid_modalidade?: string | null;
-            /** Viability Score */
-            viability_score: number;
-            /** Viability Level */
-            viability_level: string;
             /** Viability Factors */
             viability_factors?: {
                 [key: string]: unknown;
             };
+            /** Viability Level */
+            viability_level: string;
+            /** Viability Score */
+            viability_score: number;
         };
         /**
          * ShareAnaliseResponse
          * @description Response with the shareable URL.
          */
         ShareAnaliseResponse: {
-            /** Url */
-            url: string;
             /** Hash */
             hash: string;
+            /** Url */
+            url: string;
         };
         /**
          * SharedAnalisePublic
          * @description Public view of a shared analysis (no user_id exposed).
          */
         SharedAnalisePublic: {
-            /** Hash */
-            hash: string;
             /** Bid Id */
             bid_id: string;
-            /** Bid Title */
-            bid_title: string;
+            /** Bid Modalidade */
+            bid_modalidade?: string | null;
             /** Bid Orgao */
             bid_orgao?: string | null;
+            /** Bid Title */
+            bid_title: string;
             /** Bid Uf */
             bid_uf?: string | null;
             /** Bid Valor */
             bid_valor?: number | null;
-            /** Bid Modalidade */
-            bid_modalidade?: string | null;
-            /** Viability Score */
-            viability_score: number;
-            /** Viability Level */
-            viability_level: string;
+            /** Created At */
+            created_at: string;
+            /** Hash */
+            hash: string;
             /** Viability Factors */
             viability_factors: {
                 [key: string]: unknown;
             };
+            /** Viability Level */
+            viability_level: string;
+            /** Viability Score */
+            viability_score: number;
             /**
              * View Count
              * @default 0
              */
             view_count: number;
-            /** Created At */
-            created_at: string;
         };
         /**
          * SignupRequest
@@ -11926,41 +11969,41 @@ export interface components {
          */
         SignupRequest: {
             /**
+             * Company
+             * @description Optional company name, stored in profiles.company
+             */
+            company?: string | null;
+            /**
              * Email
              * Format: email
              * @description User email (must be valid format, max 320 chars)
              */
             email: string;
             /**
-             * Password
-             * @description Password (min 8 chars — Supabase enforces complexity)
-             */
-            password: string;
-            /**
-             * Stripe Payment Method Id
-             * @description Stripe PaymentMethod ID (pm_...) from frontend PaymentElement
-             */
-            stripe_payment_method_id?: string | null;
-            /**
              * Full Name
              * @description Optional display name, propagated to profiles.full_name
              */
             full_name?: string | null;
             /**
-             * Company
-             * @description Optional company name, stored in profiles.company
+             * Password
+             * @description Password (min 8 chars — Supabase enforces complexity)
              */
-            company?: string | null;
+            password: string;
+            /**
+             * Ref
+             * @description Attribution ref slug (e.g. 'municipios-sao-paulo-sp')
+             */
+            ref?: string | null;
             /**
              * Source
              * @description Attribution source (e.g. 'municipio-page', 'orgao-page')
              */
             source?: string | null;
             /**
-             * Ref
-             * @description Attribution ref slug (e.g. 'municipios-sao-paulo-sp')
+             * Stripe Payment Method Id
+             * @description Stripe PaymentMethod ID (pm_...) from frontend PaymentElement
              */
-            ref?: string | null;
+            stripe_payment_method_id?: string | null;
         };
         /**
          * SignupResponse
@@ -11968,21 +12011,17 @@ export interface components {
          */
         SignupResponse: {
             /**
-             * User Id
-             * @description Supabase auth.users.id UUID
-             */
-            user_id: string;
-            /**
              * Email
              * Format: email
              * @description Confirmed user email
              */
             email: string;
             /**
-             * Trial End Ts
-             * @description Unix epoch seconds when trial ends. Sourced from Stripe when subscription created; otherwise computed locally (now + 14d).
+             * Requires Email Confirmation
+             * @description Whether Supabase requires email confirmation before login
+             * @default true
              */
-            trial_end_ts?: number | null;
+            requires_email_confirmation: boolean;
             /**
              * Stripe Customer Id
              * @description Stripe Customer ID (cus_...) if card was attached
@@ -12000,11 +12039,15 @@ export interface components {
              */
             subscription_status: string;
             /**
-             * Requires Email Confirmation
-             * @description Whether Supabase requires email confirmation before login
-             * @default true
+             * Trial End Ts
+             * @description Unix epoch seconds when trial ends. Sourced from Stripe when subscription created; otherwise computed locally (now + 14d).
              */
-            requires_email_confirmation: boolean;
+            trial_end_ts?: number | null;
+            /**
+             * User Id
+             * @description Supabase auth.users.id UUID
+             */
+            user_id: string;
         };
         /**
          * SitemapCacheRefreshResponse
@@ -12013,10 +12056,10 @@ export interface components {
         SitemapCacheRefreshResponse: {
             /** Status */
             status?: string | null;
-            /** Total Combos */
-            total_combos?: number | null;
             /** Threshold */
             threshold?: number | null;
+            /** Total Combos */
+            total_combos?: number | null;
         } & {
             [key: string]: unknown;
         };
@@ -12055,14 +12098,14 @@ export interface components {
          *     HTTP 200 when all MVs are ok; HTTP 503 when any MV is empty or errored.
          */
         SitemapHealthResponse: {
-            /** Status */
-            status?: string | null;
-            /** Timestamp */
-            timestamp?: string | null;
             /** Checks */
             checks?: {
                 [key: string]: components["schemas"]["SitemapMvCheck"];
             } | null;
+            /** Status */
+            status?: string | null;
+            /** Timestamp */
+            timestamp?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -12098,12 +12141,12 @@ export interface components {
          * @description Per-MV status entry for the sitemap health endpoint.
          */
         SitemapMvCheck: {
-            /** Status */
-            status?: string | null;
             /** Count */
             count?: number | null;
             /** Error */
             error?: string | null;
+            /** Status */
+            status?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -12135,26 +12178,26 @@ export interface components {
          * @description STORY-299 AC7-AC9: SLO compliance + alerts + definitions.
          */
         SloDashboardResponse: {
-            /** Compliance */
-            compliance?: string | null;
-            /** Slos */
-            slos?: {
-                [key: string]: unknown;
-            } | null;
             /** Alerts */
             alerts?: {
                 [key: string]: unknown;
             }[] | null;
+            /** Compliance */
+            compliance?: string | null;
             /** Firing Count */
             firing_count?: number | null;
-            /** Slo Definitions */
-            slo_definitions?: {
-                [key: string]: unknown;
-            } | null;
             /** Recording Rules */
             recording_rules?: unknown | null;
             /** Sentry Alerts */
             sentry_alerts?: unknown | null;
+            /** Slo Definitions */
+            slo_definitions?: {
+                [key: string]: unknown;
+            } | null;
+            /** Slos */
+            slos?: {
+                [key: string]: unknown;
+            } | null;
         } & {
             [key: string]: unknown;
         };
@@ -12163,12 +12206,12 @@ export interface components {
          * @description Per-source health state.
          */
         SourceHealthEntry: {
+            /** Available */
+            available?: boolean | null;
             /** Enabled */
             enabled?: boolean | null;
             /** Status */
             status?: string | null;
-            /** Available */
-            available?: boolean | null;
         } & {
             [key: string]: unknown;
         };
@@ -12179,16 +12222,16 @@ export interface components {
         SourceInfo: {
             /** Code */
             code: string;
-            /** Name */
-            name: string;
             /** Enabled */
             enabled: boolean;
+            /** Name */
+            name: string;
             /** Priority */
             priority: number;
-            /** Status */
-            status?: string | null;
             /** Response Ms */
             response_ms?: number | null;
+            /** Status */
+            status?: string | null;
         };
         /**
          * SourcesHealthMapResponse
@@ -12210,16 +12253,16 @@ export interface components {
          * @description Response for GET /sources/health endpoint.
          */
         SourcesHealthResponse: {
-            /** Sources */
-            sources: components["schemas"]["SourceInfo"][];
-            /** Multi Source Enabled */
-            multi_source_enabled: boolean;
-            /** Total Enabled */
-            total_enabled: number;
-            /** Total Available */
-            total_available: number;
             /** Checked At */
             checked_at: string;
+            /** Multi Source Enabled */
+            multi_source_enabled: boolean;
+            /** Sources */
+            sources: components["schemas"]["SourceInfo"][];
+            /** Total Available */
+            total_available: number;
+            /** Total Enabled */
+            total_enabled: number;
         };
         /**
          * StatusLicitacao
@@ -12246,16 +12289,16 @@ export interface components {
          * @description GET /subscription/status — current plan + period info.
          */
         SubscriptionStatusResponse: {
-            /** Status */
-            status?: string | null;
-            /** Plan Id */
-            plan_id?: string | null;
             /** Activated At */
             activated_at?: string | null;
-            /** Current Period End */
-            current_period_end?: string | null;
             /** Cancel At Period End */
             cancel_at_period_end?: boolean | null;
+            /** Current Period End */
+            current_period_end?: string | null;
+            /** Plan Id */
+            plan_id?: string | null;
+            /** Status */
+            status?: string | null;
             /** Trial End */
             trial_end?: string | null;
         } & {
@@ -12266,10 +12309,10 @@ export interface components {
          * @description Success response with message.
          */
         SuccessMessageResponse: {
-            /** Success */
-            success: boolean;
             /** Message */
             message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * SuccessResponse
@@ -12281,29 +12324,29 @@ export interface components {
         };
         /** SummaryResponse */
         SummaryResponse: {
-            /** Total Searches */
-            total_searches: number;
+            /** Avg Results Per Search */
+            avg_results_per_search: number;
+            /** Estimated Hours Saved */
+            estimated_hours_saved: number;
+            /** Member Since */
+            member_since: string;
+            /** Success Rate */
+            success_rate: number;
             /** Total Downloads */
             total_downloads: number;
             /** Total Opportunities */
             total_opportunities: number;
+            /** Total Searches */
+            total_searches: number;
             /** Total Value Discovered */
             total_value_discovered: number;
-            /** Estimated Hours Saved */
-            estimated_hours_saved: number;
-            /** Avg Results Per Search */
-            avg_results_per_search: number;
-            /** Success Rate */
-            success_rate: number;
-            /** Member Since */
-            member_since: string;
         };
         /** SupplierEntry */
         SupplierEntry: {
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
+            /** Nome */
+            nome: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -12314,32 +12357,32 @@ export interface components {
          * @description GET /v1/admin/survey/export-time-saved response.
          */
         SurveyAggregateResponse: {
-            /** Range Days */
-            range_days: number;
-            /** Sample Size */
-            sample_size: number;
             /** After Outlier Removal */
             after_outlier_removal: number;
-            /** Median Hours */
-            median_hours?: number | null;
-            /** Mean Hours */
-            mean_hours?: number | null;
+            /** Current Constant */
+            current_constant: number;
+            /** Histogram */
+            histogram: components["schemas"]["HistogramBucket"][];
+            /** Iqr Lower Bound */
+            iqr_lower_bound?: number | null;
             /** Iqr Q1 */
             iqr_q1?: number | null;
             /** Iqr Q3 */
             iqr_q3?: number | null;
-            /** Iqr Lower Bound */
-            iqr_lower_bound?: number | null;
             /** Iqr Upper Bound */
             iqr_upper_bound?: number | null;
-            /** Median Per Bid */
-            median_per_bid?: number | null;
+            /** Mean Hours */
+            mean_hours?: number | null;
             /** Median Bid Count */
             median_bid_count?: number | null;
-            /** Histogram */
-            histogram: components["schemas"]["HistogramBucket"][];
-            /** Current Constant */
-            current_constant: number;
+            /** Median Hours */
+            median_hours?: number | null;
+            /** Median Per Bid */
+            median_per_bid?: number | null;
+            /** Range Days */
+            range_days: number;
+            /** Sample Size */
+            sample_size: number;
         };
         /**
          * SystemHealthResponse
@@ -12350,10 +12393,10 @@ export interface components {
          *     just see additional keys.
          */
         SystemHealthResponse: {
-            /** Status */
-            status?: string | null;
             /** Overall */
             overall?: string | null;
+            /** Status */
+            status?: string | null;
             /** Timestamp */
             timestamp?: string | null;
         } & {
@@ -12363,19 +12406,19 @@ export interface components {
         TimeSeriesDataPoint: {
             /** Label */
             label: string;
-            /** Searches */
-            searches: number;
             /** Opportunities */
             opportunities: number;
+            /** Searches */
+            searches: number;
             /** Value */
             value: number;
         };
         /** TopComprador */
         TopComprador: {
-            /** Nome */
-            nome: string;
             /** Cnpj */
             cnpj: string;
+            /** Nome */
+            nome: string;
             /** Total Contratos */
             total_contratos: number;
             /** Valor Total */
@@ -12383,93 +12426,88 @@ export interface components {
         };
         /** TopDimensionsResponse */
         TopDimensionsResponse: {
-            /** Top Ufs */
-            top_ufs: components["schemas"]["DimensionItem"][];
             /** Top Sectors */
             top_sectors: components["schemas"]["DimensionItem"][];
+            /** Top Ufs */
+            top_ufs: components["schemas"]["DimensionItem"][];
         };
         /** TopEntry */
         TopEntry: {
-            /** Name */
-            name: string;
             /** Count */
             count: number;
+            /** Name */
+            name: string;
         };
         /** TopItem */
         TopItem: {
-            /** Dimensao Valor */
-            dimensao_valor: string;
             /** Contagem */
             contagem: number;
+            /** Dimensao Valor */
+            dimensao_valor: string;
         };
         /** TopOpportunity */
         TopOpportunity: {
-            /** Title */
-            title: string;
-            /** Value */
-            value: number;
-            /** Objeto */
-            objeto?: string | null;
-            /** Orgao Nome */
-            orgao_nome?: string | null;
-            /** Numero Controle */
-            numero_controle?: string | null;
             /** Data Encerramento */
             data_encerramento?: string | null;
             /** Dias Ate Encerramento */
             dias_ate_encerramento?: number | null;
-            /** Setor */
-            setor?: string | null;
             /** Modalidade */
             modalidade?: string | null;
+            /** Numero Controle */
+            numero_controle?: string | null;
+            /** Objeto */
+            objeto?: string | null;
+            /** Orgao Nome */
+            orgao_nome?: string | null;
+            /** Setor */
+            setor?: string | null;
+            /** Title */
+            title: string;
+            /** Value */
+            value: number;
         };
         /** TopResponse */
         TopResponse: {
             /** Evento Tipo */
             evento_tipo: string;
-            /** Periodo Inicio */
-            periodo_inicio: string;
-            /** Periodo Fim */
-            periodo_fim: string;
             /** Items */
             items: components["schemas"]["TopItem"][];
+            /** Periodo Fim */
+            periodo_fim: string;
+            /** Periodo Inicio */
+            periodo_inicio: string;
         };
         /** TopSupplierItem */
         TopSupplierItem: {
-            /** Razao Social */
-            razao_social: string;
             /** Cnpj */
             cnpj: string;
             /** Contratos Count */
             contratos_count: number;
+            /** Razao Social */
+            razao_social: string;
             /** Valor Total */
             valor_total: number;
         };
         /** TopSuppliersResponse */
         TopSuppliersResponse: {
-            /** Setor */
-            setor: string;
-            /** Uf */
-            uf?: string | null;
-            /** Municipio */
-            municipio?: string | null;
             /** Items */
             items: components["schemas"]["TopSupplierItem"][];
-            /** Total Contracts In Scope */
-            total_contracts_in_scope: number;
             /** Last Updated */
             last_updated: string;
+            /** Municipio */
+            municipio?: string | null;
+            /** Setor */
+            setor: string;
+            /** Total Contracts In Scope */
+            total_contracts_in_scope: number;
+            /** Uf */
+            uf?: string | null;
         };
         /**
          * TourEventRequest
          * @description Request for onboarding tour event tracking (STORY-313 AC18).
          */
         TourEventRequest: {
-            /**
-             * Tour Id
-             * @description Tour identifier (search, results, pipeline)
-             */
-            tour_id: string;
             /**
              * Event
              * @description Event type: completed or skipped
@@ -12480,45 +12518,50 @@ export interface components {
              * @description Number of steps the user saw before event
              */
             steps_seen: number;
+            /**
+             * Tour Id
+             * @description Tour identifier (search, results, pipeline)
+             */
+            tour_id: string;
         };
         /**
          * TraceMallocEntry
          * @description Single tracemalloc allocation entry.
          */
         TraceMallocEntry: {
+            /** Count */
+            count: number;
             /** Filename */
             filename: string;
             /** Lineno */
             lineno: number;
             /** Size Kb */
             size_kb: number;
-            /** Count */
-            count: number;
         };
         /** TrendingSector */
         TrendingSector: {
-            /** Slug */
-            slug: string;
-            /** Name */
-            name: string;
             /** Count This Week */
             count_this_week: number;
+            /** Name */
+            name: string;
+            /** Slug */
+            slug: string;
         };
         /**
          * TrialExitSurveyEntry
          * @description One trial exit survey response row.
          */
         TrialExitSurveyEntry: {
-            /** Id */
-            id?: string | null;
-            /** User Id */
-            user_id?: string | null;
-            /** Reason */
-            reason?: string | null;
-            /** Feedback */
-            feedback?: string | null;
             /** Created At */
             created_at?: string | null;
+            /** Feedback */
+            feedback?: string | null;
+            /** Id */
+            id?: string | null;
+            /** Reason */
+            reason?: string | null;
+            /** User Id */
+            user_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -12527,10 +12570,10 @@ export interface components {
          * @description One {reason, count} aggregation row.
          */
         TrialExitSurveysReasonCount: {
-            /** Reason */
-            reason?: string | null;
             /** Count */
             count?: number | null;
+            /** Reason */
+            reason?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -12539,76 +12582,76 @@ export interface components {
          * @description GET /admin/trial-exit-surveys: aggregated reason counts.
          */
         TrialExitSurveysResponse: {
-            /** Total */
-            total?: number | null;
             /** By Reason */
             by_reason?: components["schemas"]["TrialExitSurveysReasonCount"][] | null;
             /** Surveys */
             surveys?: components["schemas"]["TrialExitSurveyEntry"][] | null;
+            /** Total */
+            total?: number | null;
         } & {
             [key: string]: unknown;
         };
         /** TrialStatusResponse */
         TrialStatusResponse: {
-            /** Plan */
-            plan: string;
             /** Days Remaining */
             days_remaining: number;
-            /** Searches Used */
-            searches_used: number;
-            /** Searches Limit */
-            searches_limit: number;
             /** Expires At */
             expires_at?: string | null;
             /** Is Expired */
             is_expired: boolean;
+            /** Plan */
+            plan: string;
             /**
              * Plan Features
              * @default []
              */
             plan_features: string[];
-            /**
-             * Trial Phase
-             * @default full_access
-             */
-            trial_phase: string;
+            /** Searches Limit */
+            searches_limit: number;
+            /** Searches Used */
+            searches_used: number;
             /**
              * Trial Day
              * @default 0
              */
             trial_day: number;
+            /**
+             * Trial Phase
+             * @default full_access
+             */
+            trial_phase: string;
         };
         /** TrialValueResponse */
         TrialValueResponse: {
+            /** Avg Opportunity Value */
+            avg_opportunity_value: number;
+            /** Searches Executed */
+            searches_executed: number;
+            top_opportunity?: components["schemas"]["TopOpportunity"] | null;
             /** Total Opportunities */
             total_opportunities: number;
             /** Total Value */
             total_value: number;
-            /** Searches Executed */
-            searches_executed: number;
-            /** Avg Opportunity Value */
-            avg_opportunity_value: number;
-            top_opportunity?: components["schemas"]["TopOpportunity"] | null;
         };
         /** UfAggregate */
         UfAggregate: {
-            /** Uf */
-            uf: string;
             /** Count */
             count: number;
             /** Total Value */
             total_value: number;
+            /** Uf */
+            uf: string;
         };
         /** UfCount */
         UfCount: {
+            /** Pct */
+            pct: number;
+            /** Total */
+            total: number;
             /** Uf */
             uf: string;
             /** Uf Name */
             uf_name: string;
-            /** Total */
-            total: number;
-            /** Pct */
-            pct: number;
         };
         /**
          * UfStatusDetail
@@ -12616,10 +12659,11 @@ export interface components {
          */
         UfStatusDetail: {
             /**
-             * Uf
-             * @description State code (e.g., 'SP')
+             * Results Count
+             * @description Number of results from this UF
+             * @default 0
              */
-            uf: string;
+            results_count: number;
             /**
              * Status
              * @description UF fetch status
@@ -12627,11 +12671,10 @@ export interface components {
              */
             status: "ok" | "timeout" | "error" | "skipped";
             /**
-             * Results Count
-             * @description Number of results from this UF
-             * @default 0
+             * Uf
+             * @description State code (e.g., 'SP')
              */
-            results_count: number;
+            uf: string;
         };
         /**
          * UltimaVagaOptIn
@@ -12644,15 +12687,15 @@ export interface components {
              */
             empresa: string;
             /**
-             * Uf
-             * @description State code, 2 letters.
-             */
-            uf: string;
-            /**
              * Preenchidaem
              * @description ISO-8601 timestamp.
              */
             preenchidaEm: string;
+            /**
+             * Uf
+             * @description State code, 2 letters.
+             */
+            uf: string;
         };
         /**
          * UnreadCountResponse
@@ -12667,11 +12710,11 @@ export interface components {
          * @description Partial update — all fields optional.
          */
         UpdateAlertRequest: {
-            /** Name */
-            name?: string | null;
-            filters?: components["schemas"]["AlertFilters"] | null;
             /** Active */
             active?: boolean | null;
+            filters?: components["schemas"]["AlertFilters"] | null;
+            /** Name */
+            name?: string | null;
         };
         /**
          * UpdateBillingPeriodRequest
@@ -12690,14 +12733,14 @@ export interface components {
          * @description Response for billing period update.
          */
         UpdateBillingPeriodResponse: {
-            /** Success */
-            success: boolean;
+            /** Message */
+            message: string;
             /** New Billing Period */
             new_billing_period: string;
             /** Next Billing Date */
             next_billing_date: string;
-            /** Message */
-            message: string;
+            /** Success */
+            success: boolean;
         };
         /**
          * UpdateConversationStatusRequest
@@ -12724,10 +12767,10 @@ export interface components {
         };
         /** UpdateUserRequest */
         UpdateUserRequest: {
-            /** Full Name */
-            full_name?: string | null;
             /** Company */
             company?: string | null;
+            /** Full Name */
+            full_name?: string | null;
             /** Plan Id */
             plan_id?: string | null;
         };
@@ -12743,33 +12786,11 @@ export interface components {
         UpgradeToLifetimePreviewResponse: {
             /** Eligible */
             eligible: boolean;
-            /** Reason */
-            reason: string;
-            /**
-             * Lifetime Price Brl Cents
-             * @default 99700
-             */
-            lifetime_price_brl_cents: number;
-            /**
-             * Seats Remaining
-             * @default 0
-             */
-            seats_remaining: number;
-            /**
-             * Seats Total
-             * @default 0
-             */
-            seats_total: number;
             /**
              * Estimated Credit Brl Cents
              * @default 0
              */
             estimated_credit_brl_cents: number;
-            /**
-             * Net Charge Brl Cents
-             * @default 99700
-             */
-            net_charge_brl_cents: number;
             /**
              * Has Active Subscription
              * @default false
@@ -12780,6 +12801,28 @@ export interface components {
              * @default false
              */
             is_already_founder: boolean;
+            /**
+             * Lifetime Price Brl Cents
+             * @default 99700
+             */
+            lifetime_price_brl_cents: number;
+            /**
+             * Net Charge Brl Cents
+             * @default 99700
+             */
+            net_charge_brl_cents: number;
+            /** Reason */
+            reason: string;
+            /**
+             * Seats Remaining
+             * @default 0
+             */
+            seats_remaining: number;
+            /**
+             * Seats Total
+             * @default 0
+             */
+            seats_total: number;
         };
         /**
          * UpgradeToLifetimeRequest
@@ -12797,8 +12840,6 @@ export interface components {
         UpgradeToLifetimeResponse: {
             /** Checkout Url */
             checkout_url: string;
-            /** Session Id */
-            session_id: string;
             /**
              * Estimated Credit Brl Cents
              * @default 0
@@ -12809,6 +12850,8 @@ export interface components {
              * @default 99700
              */
             net_charge_brl_cents: number;
+            /** Session Id */
+            session_id: string;
         };
         /**
          * UptimeHistoryEntry
@@ -12840,14 +12883,14 @@ export interface components {
          * @description Response containing user's enabled features.
          */
         UserFeaturesResponse: {
-            /** Features */
-            features: components["schemas"]["FeatureInfo"][];
-            /** Plan Id */
-            plan_id: string;
             /** Billing Period */
             billing_period: string;
             /** Cached At */
             cached_at?: string | null;
+            /** Features */
+            features: components["schemas"]["FeatureInfo"][];
+            /** Plan Id */
+            plan_id: string;
         };
         /**
          * UserProfileResponse
@@ -12857,10 +12900,58 @@ export interface components {
          *     necessary plan information for UI rendering.
          */
         UserProfileResponse: {
-            /** User Id */
-            user_id: string;
+            /**
+             * Capabilities
+             * @description Plan capabilities (max_history_days, allow_excel, etc.)
+             */
+            capabilities: {
+                [key: string]: unknown;
+            };
+            /**
+             * Consulting Discount Pct
+             * @description Consultoria discount % granted to this founder (default 50 for v2_lifetime). NULL = no consulting discount.
+             */
+            consulting_discount_pct?: number | null;
+            /**
+             * Days Since Failure
+             * @description STORY-309: Days since first payment failure (null if no failure)
+             */
+            days_since_failure?: number | null;
+            /**
+             * Dunning Phase
+             * @description STORY-309: Dunning phase — healthy, active_retries, grace_period, blocked
+             * @default healthy
+             */
+            dunning_phase: string;
             /** Email */
             email: string;
+            /**
+             * Founder Checkout Source
+             * @description utm_source or checkout source param from founding checkout metadata.
+             */
+            founder_checkout_source?: string | null;
+            /**
+             * Founder Offer Version
+             * @description Offer version string from checkout metadata (e.g. 'v2_lifetime').
+             */
+            founder_offer_version?: string | null;
+            /**
+             * Founder Since
+             * @description Timestamp of checkout.session.completed for the lifetime purchase.
+             */
+            founder_since?: string | null;
+            /**
+             * Is Admin
+             * @description Whether user has admin privileges
+             * @default false
+             */
+            is_admin: boolean;
+            /**
+             * Is Founder
+             * @description TRUE if user purchased the v2 lifetime Plano Fundadores (R$997). NOT set for v1 subscription founders (-50% monthly).
+             * @default false
+             */
+            is_founder: boolean;
             /**
              * Plan Id
              * @description Plan ID (e.g., 'consultor_agil')
@@ -12872,18 +12963,6 @@ export interface components {
              */
             plan_name: string;
             /**
-             * Capabilities
-             * @description Plan capabilities (max_history_days, allow_excel, etc.)
-             */
-            capabilities: {
-                [key: string]: unknown;
-            };
-            /**
-             * Quota Used
-             * @description Searches used this month
-             */
-            quota_used: number;
-            /**
              * Quota Remaining
              * @description Searches remaining this month
              */
@@ -12894,63 +12973,27 @@ export interface components {
              */
             quota_reset_date: string;
             /**
-             * Trial Expires At
-             * @description ISO 8601 timestamp when trial expires (if applicable)
+             * Quota Used
+             * @description Searches used this month
              */
-            trial_expires_at?: string | null;
-            /**
-             * Subscription Status
-             * @description Status: 'trial', 'active', 'expired', or 'past_due'
-             */
-            subscription_status: string;
-            /**
-             * Is Admin
-             * @description Whether user has admin privileges
-             * @default false
-             */
-            is_admin: boolean;
-            /**
-             * Dunning Phase
-             * @description STORY-309: Dunning phase — healthy, active_retries, grace_period, blocked
-             * @default healthy
-             */
-            dunning_phase: string;
-            /**
-             * Days Since Failure
-             * @description STORY-309: Days since first payment failure (null if no failure)
-             */
-            days_since_failure?: number | null;
+            quota_used: number;
             /**
              * Subscription End Date
              * @description ISO 8601 — data real de renovação Stripe (current_period_end), null para trial/admin
              */
             subscription_end_date?: string | null;
             /**
-             * Is Founder
-             * @description TRUE if user purchased the v2 lifetime Plano Fundadores (R$997). NOT set for v1 subscription founders (-50% monthly).
-             * @default false
+             * Subscription Status
+             * @description Status: 'trial', 'active', 'expired', or 'past_due'
              */
-            is_founder: boolean;
+            subscription_status: string;
             /**
-             * Founder Since
-             * @description Timestamp of checkout.session.completed for the lifetime purchase.
+             * Trial Expires At
+             * @description ISO 8601 timestamp when trial expires (if applicable)
              */
-            founder_since?: string | null;
-            /**
-             * Founder Offer Version
-             * @description Offer version string from checkout metadata (e.g. 'v2_lifetime').
-             */
-            founder_offer_version?: string | null;
-            /**
-             * Founder Checkout Source
-             * @description utm_source or checkout source param from founding checkout metadata.
-             */
-            founder_checkout_source?: string | null;
-            /**
-             * Consulting Discount Pct
-             * @description Consultoria discount % granted to this founder (default 50 for v2_lifetime). NULL = no consulting discount.
-             */
-            consulting_discount_pct?: number | null;
+            trial_expires_at?: string | null;
+            /** User Id */
+            user_id: string;
         };
         /**
          * UserSegmentsResponse
@@ -12961,45 +13004,45 @@ export interface components {
             count_by_state: {
                 [key: string]: unknown;
             };
-            /** Total Users */
-            total_users: number;
-            /** Transitions Last Week */
-            transitions_last_week: unknown[];
             /** Power Users */
             power_users: unknown[];
             /** Queried At */
             queried_at: string;
+            /** Total Users */
+            total_users: number;
+            /** Transitions Last Week */
+            transitions_last_week: unknown[];
         };
         /**
          * ValidateSignupEmailResponse
          * @description POST /validate-signup-email response.
          */
         ValidateSignupEmailResponse: {
-            /** Valid */
-            valid?: boolean | null;
             /** Available */
             available?: boolean | null;
-            /** Disposable */
-            disposable?: boolean | null;
             /** Corporate */
             corporate?: boolean | null;
+            /** Disposable */
+            disposable?: boolean | null;
             /** Reason */
             reason?: string | null;
+            /** Valid */
+            valid?: boolean | null;
         } & {
             [key: string]: unknown;
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
         };
         /** VerifyRecoveryRequest */
         VerifyRecoveryRequest: {
@@ -13008,89 +13051,89 @@ export interface components {
         };
         /** VerifyRecoveryResponse */
         VerifyRecoveryResponse: {
-            /** Success */
-            success: boolean;
-            /**
-             * Remaining Codes
-             * @default 0
-             */
-            remaining_codes: number;
             /**
              * Message
              * @default
              */
             message: string;
+            /**
+             * Remaining Codes
+             * @default 0
+             */
+            remaining_codes: number;
+            /** Success */
+            success: boolean;
         };
         /** WeeklyDigestResponse */
         WeeklyDigestResponse: {
-            /** Year */
-            year: number;
-            /** Week */
-            week: number;
-            /** Slug */
-            slug: string;
-            /** Title */
-            title: string;
-            /** Period Start */
-            period_start: string;
-            /** Period End */
-            period_end: string;
-            /** Total Bids */
-            total_bids: number;
-            /** Total Value */
-            total_value: number;
             /** Avg Value */
             avg_value: number;
+            /** By Modalidade */
+            by_modalidade: components["schemas"]["WeeklyModalidadeStat"][];
             /** By Sector */
             by_sector: components["schemas"]["WeeklyHighlight"][];
             /** By Uf */
             by_uf: components["schemas"]["WeeklyUfStat"][];
-            /** By Modalidade */
-            by_modalidade: components["schemas"]["WeeklyModalidadeStat"][];
+            /** Period End */
+            period_end: string;
+            /** Period Start */
+            period_start: string;
+            /** Slug */
+            slug: string;
+            /** Title */
+            title: string;
             /** Top Sector */
             top_sector: string;
             /** Top Uf */
             top_uf: string;
+            /** Total Bids */
+            total_bids: number;
+            /** Total Value */
+            total_value: number;
             /** Updated At */
             updated_at: string;
+            /** Week */
+            week: number;
+            /** Year */
+            year: number;
         };
         /** WeeklyHighlight */
         WeeklyHighlight: {
-            /** Sector Name */
-            sector_name: string;
-            /** Sector Id */
-            sector_id: string;
-            /** Count */
-            count: number;
             /** Avg Value */
             avg_value: number;
+            /** Count */
+            count: number;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
             /** Trend */
             trend: string;
         };
         /** WeeklyModalidadeStat */
         WeeklyModalidadeStat: {
-            /** Modalidade */
-            modalidade: string;
             /** Count */
             count: number;
+            /** Modalidade */
+            modalidade: string;
             /** Pct */
             pct: number;
         };
         /** WeeklyUfStat */
         WeeklyUfStat: {
-            /** Uf */
-            uf: string;
             /** Count */
             count: number;
             /** Total Value */
             total_value: number;
+            /** Uf */
+            uf: string;
         };
         /** WelcomeEmailResponse */
         WelcomeEmailResponse: {
-            /** Sent */
-            sent: boolean;
             /** Message */
             message: string;
+            /** Sent */
+            sent: boolean;
         };
         /**
          * _LivenessResponse
@@ -13103,6 +13146,11 @@ export interface components {
              */
             live: boolean;
             /**
+             * Process Uptime Seconds
+             * @default 0
+             */
+            process_uptime_seconds: number;
+            /**
              * Ready
              * @default false
              */
@@ -13112,94 +13160,89 @@ export interface components {
              * @default 0
              */
             uptime_seconds: number;
-            /**
-             * Process Uptime Seconds
-             * @default 0
-             */
-            process_uptime_seconds: number;
         } & {
             [key: string]: unknown;
         };
         /** SampleContract */
         routes__blog_stats__SampleContract: {
+            /** Data Assinatura */
+            data_assinatura: string;
+            /** Fornecedor */
+            fornecedor: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
-            /** Fornecedor */
-            fornecedor: string;
             /** Valor */
             valor: number | null;
-            /** Data Assinatura */
-            data_assinatura: string;
         };
         /** SampleItem */
         routes__blog_stats__SampleItem: {
-            /** Titulo */
-            titulo: string;
+            /** Data */
+            data: string;
             /** Orgao */
             orgao: string;
             /** Orgao Cnpj */
             orgao_cnpj?: string | null;
-            /** Valor */
-            valor?: number | null;
+            /** Titulo */
+            titulo: string;
             /** Uf */
             uf: string;
-            /** Data */
-            data: string;
+            /** Valor */
+            valor?: number | null;
         };
         /** TrendPoint */
         routes__blog_stats__TrendPoint: {
-            /** Period */
-            period: string;
-            /** Count */
-            count: number;
             /** Avg Value */
             avg_value: number;
+            /** Count */
+            count: number;
+            /** Period */
+            period: string;
         };
         /** MonthlyTrend */
         routes__contratos_publicos__MonthlyTrend: {
-            /** Month */
-            month: string;
             /** Count */
             count: number;
+            /** Month */
+            month: string;
             /** Value */
             value: number;
         };
         /** SampleContract */
         routes__contratos_publicos__SampleContract: {
+            /** Data Assinatura */
+            data_assinatura: string;
+            /** Fornecedor */
+            fornecedor: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
-            /** Fornecedor */
-            fornecedor: string;
             /** Valor */
             valor?: number | null;
-            /** Data Assinatura */
-            data_assinatura: string;
         };
         /** TrendPoint */
         routes__dados_publicos__TrendPoint: {
-            /** Date */
-            date: string;
             /** Count */
             count: number;
+            /** Date */
+            date: string;
             /** Value */
             value: number;
         };
         /** LicitacaoRecente */
         routes__municipios_publicos__LicitacaoRecente: {
+            /** Data Publicacao */
+            data_publicacao: string;
+            /** Modalidade */
+            modalidade: string;
             /** Objeto */
             objeto: string;
             /** Orgao */
             orgao: string;
             /** Valor */
             valor?: number | null;
-            /** Data Publicacao */
-            data_publicacao: string;
-            /** Modalidade */
-            modalidade: string;
         };
         /** ModalidadeCount */
         routes__observatorio__ModalidadeCount: {
@@ -13207,10 +13250,10 @@ export interface components {
             modalidade_id: number;
             /** Modalidade Name */
             modalidade_name: string;
-            /** Total */
-            total: number;
             /** Pct */
             pct: number;
+            /** Total */
+            total: number;
         };
         /** MonthlyTrend */
         routes__observatorio__MonthlyTrend: {
@@ -13221,36 +13264,36 @@ export interface components {
         };
         /** LicitacaoRecente */
         routes__orgao_publico__LicitacaoRecente: {
-            /** Objeto Compra */
-            objeto_compra: string;
-            /** Modalidade Nome */
-            modalidade_nome: string;
-            /** Valor Total Estimado */
-            valor_total_estimado?: number | null;
             /** Data Publicacao */
             data_publicacao: string;
+            /** Modalidade Nome */
+            modalidade_nome: string;
+            /** Objeto Compra */
+            objeto_compra: string;
             /** Uf */
             uf: string;
+            /** Valor Total Estimado */
+            valor_total_estimado?: number | null;
         };
         /** ModalidadeCount */
         routes__orgao_publico__ModalidadeCount: {
-            /** Nome */
-            nome: string;
             /** Count */
             count: number;
+            /** Nome */
+            nome: string;
         };
         /** SampleItem */
         routes__sectors_public__SampleItem: {
-            /** Titulo */
-            titulo: string;
-            /** Orgao */
-            orgao: string;
-            /** Valor */
-            valor?: number | null;
-            /** Uf */
-            uf: string;
             /** Data */
             data: string;
+            /** Orgao */
+            orgao: string;
+            /** Titulo */
+            titulo: string;
+            /** Uf */
+            uf: string;
+            /** Valor */
+            valor?: number | null;
         };
     };
     responses: never;
@@ -13261,6 +13304,172 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    root__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RootResponse"];
+                };
+            };
+        };
+    };
+    create_one_time_checkout_api_checkout_one_time_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founders_availability_api_founders_availability_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundersAvailabilityResponse"];
+                };
+            };
+        };
+    };
+    get_hall_listing_api_founders_hall_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundersHallResponse"];
+                };
+            };
+        };
+    };
+    toggle_consent_api_founders_hall_consent_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FounderConsentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FounderConsentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    debug_pncp_test_debug_pncp_test_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DebugPNCPResponse"];
+                };
+            };
+        };
+    };
+    health_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemHealthResponse"];
+                };
+            };
+        };
+    };
     health_live_health_live_get: {
         parameters: {
             query?: never;
@@ -13301,26 +13510,6 @@ export interface operations {
             };
         };
     };
-    health_health_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SystemHealthResponse"];
-                };
-            };
-        };
-    };
     sources_health_sources_health_get: {
         parameters: {
             query?: never;
@@ -13337,243 +13526,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SourcesHealthResponse"];
-                };
-            };
-        };
-    };
-    list_users_v1_admin_users_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                search?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminUsersListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_user_v1_admin_users_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateUserRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminCreateUserResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_user_v1_admin_users__user_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description User UUID to update */
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateUserRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminUpdateUserResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_user_v1_admin_users__user_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description User UUID to delete */
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminDeleteUserResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    reset_user_password_v1_admin_users__user_id__reset_password_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description User UUID to reset password for */
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminResetPasswordResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    assign_plan_v1_admin_users__user_id__assign_plan_post: {
-        parameters: {
-            query: {
-                /** @description Plan ID to assign */
-                plan_id: string;
-            };
-            header?: never;
-            path: {
-                /** @description User UUID to assign plan to */
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminAssignPlanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_user_credits_v1_admin_users__user_id__credits_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description User UUID to update credits for */
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateCreditsRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminUpdateCreditsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -13606,6 +13558,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_at_risk_trials_v1_admin_at_risk_trials_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                limit?: number;
+                risk_category?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_all_cache_endpoint_v1_admin_cache_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };
@@ -13694,7 +13699,40 @@ export interface operations {
             };
         };
     };
-    delete_all_cache_endpoint_v1_admin_cache_delete: {
+    recalibrate_v1_admin_calibration_recalibrate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RecalibrateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecalibrateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_circuit_breakers_v1_admin_cb_reset_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -13709,7 +13747,717 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["AdminCircuitBreakerResetResponse"];
+                };
+            };
+        };
+    };
+    clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminClearCheckpointsResponse"];
+                };
+            };
+        };
+    };
+    list_cnae_mappings_v1_admin_cnae_mapping_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by setor_id */
+                setor?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_cnae_mapping_v1_admin_cnae_mapping_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CnaeMappingCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnae_code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnae_code: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CnaeMappingUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CnaeMappingRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    patch_app_config_v1_admin_config__key__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AppConfigPatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppConfigRow"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cron_status_v1_admin_cron_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminCronStatusResponse"];
+                };
+            };
+        };
+    };
+    list_feature_flags_v1_admin_feature_flags_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeatureFlagListResponse"];
+                };
+            };
+        };
+    };
+    reload_flags_endpoint_v1_admin_feature_flags_reload_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeatureFlagReloadResponse"];
+                };
+            };
+        };
+    };
+    update_feature_flag_v1_admin_feature_flags__flag_name__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Feature flag name from the registry */
+                flag_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FeatureFlagUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeatureFlagUpdateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    feedback_patterns_v1_admin_feedback_patterns_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by sector ID */
+                setor_id?: string | null;
+                /** @description Look-back period in days */
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackPatternsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_founding_leads_v1_admin_founding_leads_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingLeadsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    pause_founding_v1_admin_founding_pause_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["FoundingPauseRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_founding_policy_v1_admin_founding_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingPolicySnapshot"];
+                };
+            };
+        };
+    };
+    resume_founding_v1_admin_founding_resume_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
+                };
+            };
+        };
+    };
+    admin_llm_cost_v1_admin_llm_cost_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminLlmCostResponse"];
+                };
+            };
+        };
+    };
+    memory_snapshot_v1_admin_memory_snapshot_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MemorySnapshot"];
+                };
+            };
+        };
+    };
+    list_partners_endpoint_v1_admin_partners_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by status: active, inactive, pending */
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnersListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_partner_endpoint_v1_admin_partners_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePartnerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerCreateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                partner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerReferralsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get: {
+        parameters: {
+            query?: {
+                /** @description Year (default: current) */
+                year?: number;
+                /** @description Month 1-12 (default: current) */
+                month?: number;
+            };
+            header?: never;
+            path: {
+                partner_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerRevenueResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_billing_sync_rows_v1_admin_plans_billing_sync_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingSyncListResponse"];
+                };
+            };
+        };
+    };
+    reconcile_now_v1_admin_plans_reconcile_now_post: {
+        parameters: {
+            query?: {
+                dry_run?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReconcileNowResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReconciliationRunsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plan_billing_period_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReverseSyncRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReverseSyncResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -13765,6 +14513,212 @@ export interface operations {
             };
         };
     };
+    admin_revalidate_seo_v1_admin_revalidate_seo_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RevalidateSEORequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RevalidateSEOResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_schema_contract_status_v1_admin_schema_contract_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSchemaContractStatusResponse"];
+                };
+            };
+        };
+    };
+    get_search_trace_v1_admin_search_trace__search_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminSearchTraceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_seo_metrics_v1_admin_seo_metrics_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SEOMetricsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gsc_summary_v1_admin_seo_summary_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GSCSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapCacheRefreshResponse"];
+                };
+            };
+        };
+    };
+    get_slo_dashboard_v1_admin_slo_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SloDashboardResponse"];
+                };
+            };
+        };
+    };
+    get_slo_alerts_v1_admin_slo_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SloAlertsResponse"];
+                };
+            };
+        };
+    };
     get_support_sla_v1_admin_support_sla_get: {
         parameters: {
             query?: never;
@@ -13781,6 +14735,97 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get: {
+        parameters: {
+            query?: {
+                range_days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SurveyAggregateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_trial_emails_v1_admin_trial_emails_preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    test_send_trial_email_v1_admin_trial_emails_test_send_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_exit_surveys_admin_v1_admin_trial_exit_surveys_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrialExitSurveysResponse"];
                 };
             };
         };
@@ -13805,12 +14850,714 @@ export interface operations {
             };
         };
     };
-    get_at_risk_trials_v1_admin_at_risk_trials_get: {
+    trigger_bids_backfill_v1_admin_trigger_bids_backfill_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
+                };
+            };
+        };
+    };
+    trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
+                };
+            };
+        };
+    };
+    list_users_v1_admin_users_get: {
         parameters: {
             query?: {
-                page?: number;
                 limit?: number;
-                risk_category?: string | null;
+                offset?: number;
+                search?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUsersListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_user_v1_admin_users_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateUserRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminCreateUserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_user_segments_v1_admin_users_segments_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserSegmentsResponse"];
+                };
+            };
+        };
+    };
+    update_user_v1_admin_users__user_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID to update */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateUserRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUpdateUserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_user_v1_admin_users__user_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID to delete */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminDeleteUserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    assign_plan_v1_admin_users__user_id__assign_plan_post: {
+        parameters: {
+            query: {
+                /** @description Plan ID to assign */
+                plan_id: string;
+            };
+            header?: never;
+            path: {
+                /** @description User UUID to assign plan to */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminAssignPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_user_credits_v1_admin_users__user_id__credits_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID to update credits for */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateCreditsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUpdateCreditsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_user_password_v1_admin_users__user_id__reset_password_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description User UUID to reset password for */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminResetPasswordResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_alertas_v1_alertas__setor_id__uf__uf__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor_id: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertasResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_alerts_v1_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertListResponse"];
+                };
+            };
+        };
+    };
+    create_alert_v1_alerts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAlertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_alert_v1_alerts__alert_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_alert_v1_alerts__alert_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateAlertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    alert_history_v1_alerts__alert_id__history_get: {
+        parameters: {
+            query?: {
+                /** @description Items per page */
+                limit?: number;
+                /** @description Offset for pagination */
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_alert_v1_alerts__alert_id__preview_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertPreviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get: {
+        parameters: {
+            query: {
+                /** @description HMAC verification token */
+                token: string;
+            };
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_new_opportunities_v1_analytics_new_opportunities_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NewOpportunitiesResponse"];
+                };
+            };
+        };
+    };
+    get_searches_over_time_v1_analytics_searches_over_time_get: {
+        parameters: {
+            query?: {
+                period?: string;
+                range_days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchesOverTimeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_analytics_summary_v1_analytics_summary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SummaryResponse"];
+                };
+            };
+        };
+    };
+    get_top_dimensions_v1_analytics_top_dimensions_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopDimensionsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    track_cta_event_v1_analytics_track_cta_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CTAEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_trial_value_v1_analytics_trial_value_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrialValueResponse"];
+                };
+            };
+        };
+    };
+    google_oauth_initiate_v1_api_auth_google_get: {
+        parameters: {
+            query?: {
+                /** @description Page to return to after auth */
+                redirect?: string;
             };
             header?: never;
             path?: never;
@@ -13838,7 +15585,7 @@ export interface operations {
             };
         };
     };
-    memory_snapshot_v1_admin_memory_snapshot_get: {
+    google_oauth_revoke_v1_api_auth_google_delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -13853,14 +15600,21 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MemorySnapshot"];
+                    "application/json": components["schemas"]["RevokeResponse"];
                 };
             };
         };
     };
-    get_user_segments_v1_admin_users_segments_get: {
+    google_oauth_callback_v1_api_auth_google_callback_get: {
         parameters: {
-            query?: never;
+            query: {
+                /** @description Authorization code from Google */
+                code?: string | null;
+                /** @description CSRF state token */
+                state: string;
+                /** @description OAuth error (if any) */
+                error?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -13873,12 +15627,21 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserSegmentsResponse"];
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
-    update_billing_period_v1_api_subscriptions_update_billing_period_post: {
+    export_to_google_sheets_v1_api_export_google_sheets_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -13887,7 +15650,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UpdateBillingPeriodRequest"];
+                "application/json": components["schemas"]["GoogleSheetsExportRequest"];
             };
         };
         responses: {
@@ -13897,7 +15660,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UpdateBillingPeriodResponse"];
+                    "application/json": components["schemas"]["GoogleSheetsExportResponse"];
                 };
             };
             /** @description Validation Error */
@@ -13911,75 +15674,11 @@ export interface operations {
             };
         };
     };
-    cancel_subscription_v1_api_subscriptions_cancel_post: {
+    get_export_history_v1_api_export_google_sheets_history_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["CancelSubscriptionRequest"] | null;
+            query?: {
+                limit?: number;
             };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelSubscriptionResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CancelFeedbackRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelFeedbackResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get: {
-        parameters: {
-            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -13992,31 +15691,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UpgradeToLifetimePreviewResponse"];
-                };
-            };
-        };
-    };
-    upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpgradeToLifetimeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UpgradeToLifetimeResponse"];
+                    "application/json": components["schemas"]["GoogleSheetsExportHistoryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -14237,1103 +15912,6 @@ export interface operations {
             };
         };
     };
-    get_analytics_summary_v1_analytics_summary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SummaryResponse"];
-                };
-            };
-        };
-    };
-    get_searches_over_time_v1_analytics_searches_over_time_get: {
-        parameters: {
-            query?: {
-                period?: string;
-                range_days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchesOverTimeResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_top_dimensions_v1_analytics_top_dimensions_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopDimensionsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_trial_value_v1_analytics_trial_value_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrialValueResponse"];
-                };
-            };
-        };
-    };
-    get_new_opportunities_v1_analytics_new_opportunities_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NewOpportunitiesResponse"];
-                };
-            };
-        };
-    };
-    track_cta_event_v1_analytics_track_cta_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CTAEventRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    google_oauth_initiate_v1_api_auth_google_get: {
-        parameters: {
-            query?: {
-                /** @description Page to return to after auth */
-                redirect?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    google_oauth_revoke_v1_api_auth_google_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RevokeResponse"];
-                };
-            };
-        };
-    };
-    google_oauth_callback_v1_api_auth_google_callback_get: {
-        parameters: {
-            query: {
-                /** @description Authorization code from Google */
-                code?: string | null;
-                /** @description CSRF state token */
-                state: string;
-                /** @description OAuth error (if any) */
-                error?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    export_to_google_sheets_v1_api_export_google_sheets_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GoogleSheetsExportRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoogleSheetsExportResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_export_history_v1_api_export_google_sheets_history_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoogleSheetsExportHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    buscar_progress_stream_v1_buscar_progress__search_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    search_status_endpoint_v1_search__search_id__status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    search_timeline_endpoint_v1_search__search_id__timeline_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchTimelineResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_search_results_v1_buscar_results__search_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchResultsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_search_results_v1_v1_search__search_id__results_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_zero_match_results_endpoint_v1_search__search_id__zero_match_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchZeroMatchResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    retry_search_v1_search__search_id__retry_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchActionResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_search_v1_search__search_id__cancel_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SearchActionResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    buscar_licitacoes_v1_buscar_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BuscaRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BuscaResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    change_password_v1_change_password_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SuccessResponse"];
-                };
-            };
-        };
-    };
-    get_profile_v1_me_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UserProfileResponse"];
-                };
-            };
-        };
-    };
-    delete_account_v1_me_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeleteAccountResponse"];
-                };
-            };
-        };
-    };
-    get_trial_status_v1_trial_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrialStatusResponse"];
-                };
-            };
-        };
-    };
-    get_recommended_plan_v1_user_recommended_plan_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecommendedPlanResponse"];
-                };
-            };
-        };
-    };
-    get_profile_context_v1_profile_context_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PerfilContextoResponse"];
-                };
-            };
-        };
-    };
-    save_profile_context_v1_profile_context_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PerfilContexto"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PerfilContextoResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_profile_completeness_v1_profile_completeness_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProfileCompletenessResponse"];
-                };
-            };
-        };
-    };
-    get_alert_preferences_v1_profile_alert_preferences_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertPreferencesResponse"];
-                };
-            };
-        };
-    };
-    update_alert_preferences_v1_profile_alert_preferences_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AlertPreferencesRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertPreferencesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    export_user_data_v1_me_export_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    submit_exit_survey_v1_trial_exit_survey_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ExitSurveyRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExitSurveyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_exit_surveys_admin_v1_admin_trial_exit_surveys_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrialExitSurveysResponse"];
-                };
-            };
-        };
-    };
-    get_plans_v1_plans_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BillingPlansResponse"];
-                };
-            };
-        };
-    };
-    create_checkout_v1_checkout_post: {
-        parameters: {
-            query: {
-                plan_id: string;
-                billing_period?: string;
-                coupon?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_billing_portal_session_v1_billing_portal_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BillingPortalResponse"];
-                };
-            };
-        };
-    };
-    get_subscription_status_v1_subscription_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SubscriptionStatusResponse"];
-                };
-            };
-        };
-    };
-    create_setup_intent_v1_billing_setup_intent_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SetupIntentResponse"];
-                };
-            };
-        };
-    };
-    get_sessions_v1_sessions_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                /** @description Filter by session status (completed, failed, timed_out) */
-                status?: string | null;
-                /** @description UX-433 AC3: hide failed/timed_out entries older than 7 days from default listing */
-                hide_old_failures?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SessionsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    download_session_excel_v1_sessions__search_id__download_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                search_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_plans_with_capabilities_v1_api_plans_get: {
         parameters: {
             query?: never;
@@ -15354,14 +15932,18 @@ export interface operations {
             };
         };
     };
-    send_welcome_email_v1_emails_send_welcome_post: {
+    cancel_subscription_v1_api_subscriptions_cancel_post: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["CancelSubscriptionRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -15369,32 +15951,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WelcomeEmailResponse"];
-                };
-            };
-        };
-    };
-    unsubscribe_email_v1_emails_unsubscribe_get: {
-        parameters: {
-            query: {
-                /** @description User ID */
-                user_id: string;
-                /** @description Verification token */
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/html": string;
+                    "application/json": components["schemas"]["CancelSubscriptionResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15408,43 +15965,7 @@ export interface operations {
             };
         };
     };
-    list_pipeline_items_v1_pipeline_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by stage */
-                stage?: string | null;
-                /** @description Items per page */
-                limit?: number;
-                /** @description Offset for pagination */
-                offset?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_pipeline_item_v1_pipeline_post: {
+    submit_cancel_feedback_v1_api_subscriptions_cancel_feedback_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -15453,17 +15974,17 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["PipelineItemCreate"];
+                "application/json": components["schemas"]["CancelFeedbackRequest"];
             };
         };
         responses: {
             /** @description Successful Response */
-            201: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PipelineItemResponse"];
+                    "application/json": components["schemas"]["CancelFeedbackResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15477,93 +15998,7 @@ export interface operations {
             };
         };
     };
-    delete_pipeline_item_v1_pipeline__item_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                item_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SuccessMessageResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_pipeline_item_v1_pipeline__item_id__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                item_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PipelineItemUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineItemResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_pipeline_alerts_v1_pipeline_alerts_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PipelineAlertsResponse"];
-                };
-            };
-        };
-    };
-    first_analysis_v1_first_analysis_post: {
+    update_billing_period_v1_api_subscriptions_update_billing_period_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -15572,7 +16007,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["FirstAnalysisRequest"];
+                "application/json": components["schemas"]["UpdateBillingPeriodRequest"];
             };
         };
         responses: {
@@ -15582,7 +16017,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FirstAnalysisResponse"];
+                    "application/json": components["schemas"]["UpdateBillingPeriodResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15596,7 +16031,7 @@ export interface operations {
             };
         };
     };
-    track_tour_event_v1_onboarding_tour_event_post: {
+    upgrade_to_lifetime_v1_api_subscriptions_upgrade_to_lifetime_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -15605,38 +16040,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["TourEventRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    validate_signup_email_v1_auth_validate_signup_email_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ResendRequest"];
+                "application/json": components["schemas"]["UpgradeToLifetimeRequest"];
             };
         };
         responses: {
@@ -15646,7 +16050,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ValidateSignupEmailResponse"];
+                    "application/json": components["schemas"]["UpgradeToLifetimeResponse"];
                 };
             };
             /** @description Validation Error */
@@ -15660,138 +16064,7 @@ export interface operations {
             };
         };
     };
-    resend_confirmation_v1_auth_resend_confirmation_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ResendRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResendResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    auth_status_v1_auth_status_get: {
-        parameters: {
-            query: {
-                /** @description Email to check */
-                email: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    signup_v1_auth_signup_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SignupRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SignupResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    record_login_attempt_v1_auth_login_attempt_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LoginAttemptRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LoginAttemptResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    system_health_v1_health_get: {
+    upgrade_to_lifetime_preview_v1_api_subscriptions_upgrade_to_lifetime_preview_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -15806,245 +16079,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SystemHealthResponse"];
-                };
-            };
-        };
-    };
-    public_status_v1_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PublicStatusResponse"];
-                };
-            };
-        };
-    };
-    recent_incidents_v1_status_incidents_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IncidentsResponse"];
-                };
-            };
-        };
-    };
-    uptime_history_v1_status_uptime_history_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UptimeHistoryResponse"];
-                };
-            };
-        };
-    };
-    background_tasks_health_v1_health_tasks_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BackgroundTasksHealthResponse"];
-                };
-            };
-        };
-    };
-    sources_health_v1_health_sources_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SourcesHealthMapResponse"];
-                };
-            };
-        };
-    };
-    cache_health_v1_health_cache_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CacheHealthResponse"];
-                };
-            };
-        };
-    };
-    sitemap_health_v1_health_sitemap_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapHealthResponse"];
-                };
-            };
-        };
-    };
-    submit_feedback_v1_feedback_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FeedbackRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeedbackResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_feedback_v1_feedback__feedback_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                feedback_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeedbackDeleteResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    feedback_patterns_v1_admin_feedback_patterns_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by sector ID */
-                setor_id?: string | null;
-                /** @description Look-back period in days */
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeedbackPatternsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["UpgradeToLifetimePreviewResponse"];
                 };
             };
         };
@@ -16112,6 +16147,170 @@ export interface operations {
             };
         };
     };
+    record_login_attempt_v1_auth_login_attempt_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginAttemptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LoginAttemptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resend_confirmation_v1_auth_resend_confirmation_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResendResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    signup_v1_auth_signup_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignupRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    auth_status_v1_auth_status_get: {
+        parameters: {
+            query: {
+                /** @description Email to check */
+                email: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    validate_signup_email_v1_auth_validate_signup_email_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResendRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidateSignupEmailResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     analyze_bid_v1_bid_analysis__bid_id__post: {
         parameters: {
             query?: never;
@@ -16147,7 +16346,7 @@ export interface operations {
             };
         };
     };
-    list_alerts_v1_alerts_get: {
+    create_billing_portal_session_v1_billing_portal_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -16162,50 +16361,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AlertListResponse"];
+                    "application/json": components["schemas"]["BillingPortalResponse"];
                 };
             };
         };
     };
-    create_alert_v1_alerts_post: {
+    create_setup_intent_v1_billing_setup_intent_post: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateAlertRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
-            201: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AlertResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["SetupIntentResponse"];
                 };
             };
         };
     };
-    delete_alert_v1_alerts__alert_id__delete: {
+    daily_digest_latest_v1_blog_daily_latest_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DailyDigestResponse"];
+                };
+            };
+        };
+    };
+    daily_digest_by_date_v1_blog_daily__date__get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                alert_id: string;
+                date: string;
             };
             cookie?: never;
         };
@@ -16217,963 +16423,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SuccessMessageResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_alert_v1_alerts__alert_id__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateAlertRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unsubscribe_alert_v1_alerts__alert_id__unsubscribe_get: {
-        parameters: {
-            query: {
-                /** @description HMAC verification token */
-                token: string;
-            };
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/html": string;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    preview_alert_v1_alerts__alert_id__preview_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertPreviewResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    alert_history_v1_alerts__alert_id__history_get: {
-        parameters: {
-            query?: {
-                /** @description Items per page */
-                limit?: number;
-                /** @description Offset for pagination */
-                offset?: number;
-            };
-            header?: never;
-            path: {
-                alert_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AlertHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get: {
-        parameters: {
-            query: {
-                /** @description User ID */
-                user_id: string;
-                /** @description HMAC unsubscribe token */
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    resend_webhook_v1_trial_emails_webhook_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "svix-id"?: string | null;
-                "svix-timestamp"?: string | null;
-                "svix-signature"?: string | null;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    preview_trial_emails_v1_admin_trial_emails_preview_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    test_send_trial_email_v1_admin_trial_emails_test_send_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_mfa_status_v1_mfa_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MfaStatusResponse"];
-                };
-            };
-        };
-    };
-    generate_recovery_codes_v1_mfa_recovery_codes_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecoveryCodesResponse"];
-                };
-            };
-        };
-    };
-    verify_recovery_code_v1_mfa_verify_recovery_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["VerifyRecoveryRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VerifyRecoveryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enroll_totp_v1_mfa_enroll_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MFAEnrollResponse"];
-                };
-            };
-        };
-    };
-    verify_totp_v1_mfa_verify_totp_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["MFAVerifyRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["MFAVerifyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    regenerate_recovery_codes_v1_mfa_regenerate_recovery_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RegenerateRecoveryResponse"];
-                };
-            };
-        };
-    };
-    get_my_org_v1_organizations_me_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationMembershipResponse"];
-                };
-            };
-        };
-    };
-    create_org_v1_organizations_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateOrgRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_org_v1_organizations__org_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invite_org_member_v1_organizations__org_id__invite_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InviteMemberRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationInviteResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    accept_org_invite_v1_organizations__org_id__accept_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationAcceptResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    remove_org_member_v1_organizations__org_id__members__target_user_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-                target_user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationMemberRemovedResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_org_dashboard_endpoint_v1_organizations__org_id__dashboard_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationDashboardResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    upload_org_logo_v1_organizations__org_id__logo_put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                org_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateLogoRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrganizationLogoUpdatedResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    partner_dashboard_v1_partner_dashboard_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerDashboardResponse"];
-                };
-            };
-        };
-    };
-    list_partners_endpoint_v1_admin_partners_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by status: active, inactive, pending */
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnersListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_partner_endpoint_v1_admin_partners_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreatePartnerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerCreateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_partner_referrals_endpoint_v1_admin_partners__partner_id__referrals_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                partner_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerReferralsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_partner_revenue_endpoint_v1_admin_partners__partner_id__revenue_get: {
-        parameters: {
-            query?: {
-                /** @description Year (default: current) */
-                year?: number;
-                /** @description Month 1-12 (default: current) */
-                month?: number;
-            };
-            header?: never;
-            path: {
-                partner_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PartnerRevenueResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_all_sectors_v1_sectors_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SectorListItem"][];
-                };
-            };
-        };
-    };
-    get_trending_sectors_v1_sectors_trending_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TrendingSector"][];
-                };
-            };
-        };
-    };
-    get_sector_stats_v1_sectors__slug__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                slug: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SectorStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    generate_diagnostico_v1_reports_diagnostico_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DiagnosticoRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_sector_blog_stats_v1_blog_stats_setor__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SectorBlogStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor_id: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SectorUfStats"];
+                    "application/json": components["schemas"]["DailyDigestResponse"];
                 };
             };
             /** @description Validation Error */
@@ -17250,11 +16500,43 @@ export interface operations {
             };
         };
     };
-    get_panorama_stats_v1_blog_stats_panorama__setor_id__get: {
+    get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
+                cidade: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosCidadeStats"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cidade: string;
                 setor_id: string;
             };
             cookie?: never;
@@ -17267,7 +16549,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PanoramaStats"];
+                    "application/json": components["schemas"]["ContratosCidadeSetorStats"];
                 };
             };
             /** @description Validation Error */
@@ -17344,43 +16626,11 @@ export interface operations {
             };
         };
     };
-    get_contratos_cidade_stats_v1_blog_stats_contratos_cidade__cidade__get: {
+    get_panorama_stats_v1_blog_stats_panorama__setor_id__get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                cidade: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosCidadeStats"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_contratos_cidade_setor_stats_v1_blog_stats_contratos_cidade__cidade__setor__setor_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cidade: string;
                 setor_id: string;
             };
             cookie?: never;
@@ -17393,7 +16643,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ContratosCidadeSetorStats"];
+                    "application/json": components["schemas"]["PanoramaStats"];
                 };
             };
             /** @description Validation Error */
@@ -17407,121 +16657,16 @@ export interface operations {
             };
         };
     };
-    get_discard_rate_v1_metrics_discard_rate_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DiscardRateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_daily_volume_v1_metrics_daily_volume_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DailyVolumeResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    report_sse_fallback_v1_metrics_sse_fallback_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    list_feature_flags_v1_admin_feature_flags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeatureFlagListResponse"];
-                };
-            };
-        };
-    };
-    update_feature_flag_v1_admin_feature_flags__flag_name__patch: {
+    get_sector_blog_stats_v1_blog_stats_setor__setor_id__get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                /** @description Feature flag name from the registry */
-                flag_name: string;
+                setor_id: string;
             };
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FeatureFlagUpdateRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -17529,7 +16674,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FeatureFlagUpdateResponse"];
+                    "application/json": components["schemas"]["SectorBlogStats"];
                 };
             };
             /** @description Validation Error */
@@ -17543,76 +16688,14 @@ export interface operations {
             };
         };
     };
-    reload_flags_endpoint_v1_admin_feature_flags_reload_post: {
+    get_sector_uf_stats_v1_blog_stats_setor__setor_id__uf__uf__get: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FeatureFlagReloadResponse"];
-                };
-            };
-        };
-    };
-    get_experiments_v1_feature_flags_experiments_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExperimentsListResponse"];
-                };
-            };
-        };
-    };
-    list_public_feature_flags_v1_feature_flags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PublicFeatureFlagListResponse"];
-                };
-            };
-        };
-    };
-    calculadora_dados_v1_calculadora_dados_get: {
-        parameters: {
-            query: {
-                /** @description Sector ID (e.g. 'saude') */
-                setor: string;
-                /** @description UF sigla (e.g. 'SP') */
+            path: {
+                setor_id: string;
                 uf: string;
             };
-            header?: never;
-            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -17623,7 +16706,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CalculadoraDadosResponse"];
+                    "application/json": components["schemas"]["SectorUfStats"];
                 };
             };
             /** @description Validation Error */
@@ -17633,260 +16716,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    perfil_b2g_v1_empresa__cnpj__perfil_b2g_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PerfilB2GResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_shared_analysis_v1_share_analise_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ShareAnaliseRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShareAnaliseResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_shared_analysis_v1_share_analise__hash__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                hash: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SharedAnalisePublic"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_referral_code_v1_referral_code_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReferralCodeResponse"];
-                };
-            };
-        };
-    };
-    get_referral_stats_v1_referral_stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReferralStatsResponse"];
-                };
-            };
-        };
-    };
-    redeem_referral_v1_referral_redeem_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReferralRedeemRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReferralRedeemResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    request_relatorio_v1_relatorio_2026_t1_request_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RelatorioRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RelatorioResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    extend_trial_endpoint_v1_trial_extend_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ExtendRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExtendResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_extensions_status_v1_trial_extensions_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExtensionsStatusResponse"];
                 };
             };
         };
@@ -17943,11 +16772,108 @@ export interface operations {
             };
         };
     };
-    stats_public_v1_stats_public_get: {
+    buscar_licitacoes_v1_buscar_post: {
         parameters: {
-            query?: {
-                /** @description json | embed | badge */
-                format?: string;
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BuscaRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuscaResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    buscar_progress_stream_v1_buscar_progress__search_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_search_results_v1_buscar_results__search_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchResultsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    calculadora_dados_v1_calculadora_dados_get: {
+        parameters: {
+            query: {
+                /** @description Sector ID (e.g. 'saude') */
+                setor: string;
+                /** @description UF sigla (e.g. 'SP') */
+                uf: string;
             };
             header?: never;
             path?: never;
@@ -17961,7 +16887,284 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["CalculadoraDadosResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    change_password_v1_change_password_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessResponse"];
+                };
+            };
+        };
+    };
+    create_checkout_v1_checkout_post: {
+        parameters: {
+            query: {
+                plan_id: string;
+                billing_period?: string;
+                coupon?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_bids_by_ids_v1_comparador_bids_get: {
+        parameters: {
+            query: {
+                /** @description Comma-separated pncp_ids (max 5) */
+                ids: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComparadorBidsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    buscar_editais_v1_comparador_buscar_get: {
+        parameters: {
+            query: {
+                /** @description Termo de busca (mínimo 3 caracteres) */
+                q: string;
+                /** @description Filtrar por UF (ex: SP, RJ) */
+                uf?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComparadorSearchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    compliance_profile_v1_compliance__cnpj__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComplianceProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_trial_info_v1_conta_cancelar_trial_get: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelTrialInfoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_trial_execute_v1_conta_cancelar_trial_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CancelTrialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelTrialResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgaoContratosStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    contratos_stats_v1_contratos__setor___uf__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor: string;
+                uf: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContratosStatsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -17995,12 +17198,298 @@ export interface operations {
             };
         };
     };
-    get_alertas_v1_alertas__setor_id__uf__uf__get: {
+    send_welcome_email_v1_emails_send_welcome_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WelcomeEmailResponse"];
+                };
+            };
+        };
+    };
+    unsubscribe_email_v1_emails_unsubscribe_get: {
+        parameters: {
+            query: {
+                /** @description User ID */
+                user_id: string;
+                /** @description Verification token */
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/html": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    perfil_b2g_v1_empresa__cnpj__perfil_b2g_get: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                setor_id: string;
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerfilB2GResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_edital_pdf_v1_export_pdf_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PdfEditalRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_public_feature_flags_v1_feature_flags_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicFeatureFlagListResponse"];
+                };
+            };
+        };
+    };
+    get_experiments_v1_feature_flags_experiments_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExperimentsListResponse"];
+                };
+            };
+        };
+    };
+    submit_feedback_v1_feedback_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FeedbackRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_feedback_v1_feedback__feedback_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                feedback_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeedbackDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    first_analysis_v1_first_analysis_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FirstAnalysisRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FirstAnalysisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fornecedor_profile_v1_fornecedores__cnpj__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FornecedorProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fornecedores_stats_v1_fornecedores__setor___uf__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor: string;
                 uf: string;
             };
             cookie?: never;
@@ -18013,7 +17502,458 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AlertasResponse"];
+                    "application/json": components["schemas"]["FornecedoresStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_availability_v1_founding_availability_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingAvailabilityResponse"];
+                };
+            };
+        };
+    };
+    founding_checkout_v1_founding_checkout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FoundingCheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingCheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_checkout_status_v1_founding_checkout_status_get: {
+        parameters: {
+            query: {
+                session_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingCheckoutStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    founding_session_status_v1_founding_session_status_get: {
+        parameters: {
+            query: {
+                session_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FoundingSessionStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    system_health_v1_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemHealthResponse"];
+                };
+            };
+        };
+    };
+    cache_health_v1_health_cache_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CacheHealthResponse"];
+                };
+            };
+        };
+    };
+    sitemap_health_v1_health_sitemap_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapHealthResponse"];
+                };
+            };
+        };
+    };
+    sources_health_v1_health_sources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SourcesHealthMapResponse"];
+                };
+            };
+        };
+    };
+    background_tasks_health_v1_health_tasks_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackgroundTasksHealthResponse"];
+                };
+            };
+        };
+    };
+    get_ranking_v1_indice_municipal_get: {
+        parameters: {
+            query?: {
+                /** @description Período trimestral (ex: 2026-Q1) */
+                periodo?: string;
+                /** @description Filtrar por UF */
+                uf?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RankingResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_periodos_v1_indice_municipal_periodos_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PeriodosResponse"];
+                };
+            };
+        };
+    };
+    get_municipio_v1_indice_municipal__municipio_slug__get: {
+        parameters: {
+            query?: {
+                /** @description Período trimestral (ex: 2026-Q1) */
+                periodo?: string;
+            };
+            header?: never;
+            path: {
+                municipio_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IndiceResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_intel_report_purchases_v1_intel_reports__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelReportPurchase"][];
+                };
+            };
+        };
+    };
+    create_intel_report_checkout_v1_intel_reports_checkout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IntelReportCheckoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelReportCheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_intel_report_status_v1_intel_reports__purchase_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                purchase_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelReportStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_intel_report_v1_intel_reports__purchase_id__download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                purchase_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    item_profile_v1_itens__catmat__profile_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                catmat: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ItemProfileResponse"];
                 };
             };
             /** @description Validation Error */
@@ -18092,14 +18032,9 @@ export interface operations {
             };
         };
     };
-    buscar_editais_v1_comparador_buscar_get: {
+    get_profile_v1_me_get: {
         parameters: {
-            query: {
-                /** @description Termo de busca (mínimo 3 caracteres) */
-                q: string;
-                /** @description Filtrar por UF (ex: SP, RJ) */
-                uf?: string | null;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -18112,26 +18047,14 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ComparadorSearchResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["UserProfileResponse"];
                 };
             };
         };
     };
-    get_bids_by_ids_v1_comparador_bids_get: {
+    delete_account_v1_me_delete: {
         parameters: {
-            query: {
-                /** @description Comma-separated pncp_ids (max 5) */
-                ids: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -18144,21 +18067,32 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ComparadorBidsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["DeleteAccountResponse"];
                 };
             };
         };
     };
-    get_seo_metrics_v1_admin_seo_metrics_get: {
+    export_user_data_v1_me_export_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_daily_volume_v1_metrics_daily_volume_get: {
         parameters: {
             query?: {
                 days?: number;
@@ -18175,7 +18109,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SEOMetricsResponse"];
+                    "application/json": components["schemas"]["DailyVolumeResponse"];
                 };
             };
             /** @description Validation Error */
@@ -18189,7 +18123,7 @@ export interface operations {
             };
         };
     };
-    get_gsc_summary_v1_admin_seo_summary_get: {
+    get_discard_rate_v1_metrics_discard_rate_get: {
         parameters: {
             query?: {
                 days?: number;
@@ -18206,7 +18140,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GSCSummaryResponse"];
+                    "application/json": components["schemas"]["DiscardRateResponse"];
                 };
             };
             /** @description Validation Error */
@@ -18220,7 +18154,105 @@ export interface operations {
             };
         };
     };
-    admin_revalidate_seo_v1_admin_revalidate_seo_post: {
+    report_sse_fallback_v1_metrics_sse_fallback_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    enroll_totp_v1_mfa_enroll_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MFAEnrollResponse"];
+                };
+            };
+        };
+    };
+    generate_recovery_codes_v1_mfa_recovery_codes_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryCodesResponse"];
+                };
+            };
+        };
+    };
+    regenerate_recovery_codes_v1_mfa_regenerate_recovery_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegenerateRecoveryResponse"];
+                };
+            };
+        };
+    };
+    get_mfa_status_v1_mfa_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MfaStatusResponse"];
+                };
+            };
+        };
+    };
+    verify_recovery_code_v1_mfa_verify_recovery_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -18229,7 +18261,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["RevalidateSEORequest"];
+                "application/json": components["schemas"]["VerifyRecoveryRequest"];
             };
         };
         responses: {
@@ -18239,7 +18271,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RevalidateSEOResponse"];
+                    "application/json": components["schemas"]["VerifyRecoveryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -18253,14 +18285,18 @@ export interface operations {
             };
         };
     };
-    sitemap_cnpjs_v1_sitemap_cnpjs_get: {
+    verify_totp_v1_mfa_verify_totp_post: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MFAVerifyRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -18268,266 +18304,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SitemapCnpjsResponse"];
-                };
-            };
-        };
-    };
-    sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapFornecedoresCnpjResponse"];
-                };
-            };
-        };
-    };
-    sitemap_orgaos_v1_sitemap_orgaos_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapOrgaosResponse"];
-                };
-            };
-        };
-    };
-    sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapContratosOrgaoResponse"];
-                };
-            };
-        };
-    };
-    orgao_stats_v1_orgao__cnpj__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrgaoStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    orgao_contratos_stats_v1_contratos_orgao__cnpj__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OrgaoContratosStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    contratos_stats_v1_contratos__setor___uf__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContratosStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    fornecedores_stats_v1_fornecedores__setor___uf__stats_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                setor: string;
-                uf: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FornecedoresStatsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    fornecedor_profile_v1_fornecedores__cnpj__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FornecedorProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    daily_digest_latest_v1_blog_daily_latest_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DailyDigestResponse"];
-                };
-            };
-        };
-    };
-    daily_digest_by_date_v1_blog_daily__date__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                date: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DailyDigestResponse"];
+                    "application/json": components["schemas"]["MFAVerifyResponse"];
                 };
             };
             /** @description Validation Error */
@@ -18559,868 +18336,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MunicipioProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    sitemap_municipios_v1_sitemap_municipios_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapMunicipiosResponse"];
-                };
-            };
-        };
-    };
-    compliance_profile_v1_compliance__cnpj__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnpj: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ComplianceProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    item_profile_v1_itens__catmat__profile_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                catmat: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ItemProfileResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    sitemap_itens_v1_sitemap_itens_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapItensResponse"];
-                };
-            };
-        };
-    };
-    get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Mês (1-12) */
-                mes: number;
-                /** @description Ano */
-                ano: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RelatorioMensal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                mes: number;
-                ano: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LicitacoesIndexableResponse"];
-                };
-            };
-        };
-    };
-    refresh_sitemap_cache_v1_admin_sitemap_cache_refresh_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapCacheRefreshResponse"];
-                };
-            };
-        };
-    };
-    sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SitemapLicitacoesDoDiaResponse"];
-                };
-            };
-        };
-    };
-    get_periodos_v1_indice_municipal_periodos_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PeriodosResponse"];
-                };
-            };
-        };
-    };
-    get_ranking_v1_indice_municipal_get: {
-        parameters: {
-            query?: {
-                /** @description Período trimestral (ex: 2026-Q1) */
-                periodo?: string;
-                /** @description Filtrar por UF */
-                uf?: string | null;
-                limit?: number;
-                offset?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RankingResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_municipio_v1_indice_municipal__municipio_slug__get: {
-        parameters: {
-            query?: {
-                /** @description Período trimestral (ex: 2026-Q1) */
-                periodo?: string;
-            };
-            header?: never;
-            path: {
-                municipio_slug: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IndiceResult"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_new_bids_count_v1_notifications_new_bids_count_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NewBidsCountResponse"];
-                };
-            };
-        };
-    };
-    clear_new_bids_count_v1_notifications_new_bids_count_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ClearNewBidsCountResponse"];
-                };
-            };
-        };
-    };
-    export_edital_pdf_v1_export_pdf_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PdfEditalRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founding_availability_v1_founding_availability_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingAvailabilityResponse"];
-                };
-            };
-        };
-    };
-    founding_checkout_status_v1_founding_checkout_status_get: {
-        parameters: {
-            query: {
-                session_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingCheckoutStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founding_session_status_v1_founding_session_status_get: {
-        parameters: {
-            query: {
-                session_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingSessionStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    founding_checkout_v1_founding_checkout_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FoundingCheckoutRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingCheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_trial_info_v1_conta_cancelar_trial_get: {
-        parameters: {
-            query: {
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelTrialInfoResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_trial_execute_v1_conta_cancelar_trial_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CancelTrialRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelTrialResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    submit_export_time_saved_survey_v1_survey_export_time_saved_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ExportTimeSavedSurveyRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExportTimeSavedSurveyResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_intel_report_checkout_v1_intel_reports_checkout_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IntelReportCheckoutRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IntelReportCheckoutResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_intel_report_purchases_v1_intel_reports__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IntelReportPurchase"][];
-                };
-            };
-        };
-    };
-    get_intel_report_status_v1_intel_reports__purchase_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                purchase_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IntelReportStatusResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    download_intel_report_v1_intel_reports__purchase_id__download_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                purchase_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_top_suppliers_v1_pseo_top_suppliers_get: {
-        parameters: {
-            query: {
-                setor: string;
-                uf?: string | null;
-                municipio?: string | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TopSuppliersResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_recent_editais_v1_pseo_recent_editais_get: {
-        parameters: {
-            query: {
-                setor: string;
-                uf?: string | null;
-                municipio?: string | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecentEditaisResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_coverage_manifest_v1_seo_coverage_manifest_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CoverageManifestResponse"];
-                };
-            };
-        };
-    };
-    list_products_v1_products_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProductsResponse"];
-                };
-            };
-        };
-    };
-    get_seasonal_calendar_v1_predict_seasonal_calendar_get: {
-        parameters: {
-            query: {
-                /** @description UF (ex: SP, RJ, SC) */
-                uf: string;
-                /** @description Optional filter by sector slugs (e.g. engenharia, saude) */
-                setores?: string[] | null;
-                /** @description Number of historical years to analyze (1-20) */
-                anos_historico?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SeasonalCalendarResponse"];
                 };
             };
             /** @description Validation Error */
@@ -19505,6 +18420,1294 @@ export interface operations {
             };
         };
     };
+    get_new_bids_count_v1_notifications_new_bids_count_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NewBidsCountResponse"];
+                };
+            };
+        };
+    };
+    clear_new_bids_count_v1_notifications_new_bids_count_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ClearNewBidsCountResponse"];
+                };
+            };
+        };
+    };
+    get_relatorio_mensal_v1_observatorio_relatorio__mes___ano__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Mês (1-12) */
+                mes: number;
+                /** @description Ano */
+                ano: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RelatorioMensal"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_relatorio_csv_v1_observatorio_relatorio__mes___ano__csv_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                mes: number;
+                ano: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    track_tour_event_v1_onboarding_tour_event_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TourEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_org_v1_organizations_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateOrgRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_my_org_v1_organizations_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationMembershipResponse"];
+                };
+            };
+        };
+    };
+    get_org_v1_organizations__org_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    accept_org_invite_v1_organizations__org_id__accept_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationAcceptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_org_dashboard_endpoint_v1_organizations__org_id__dashboard_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationDashboardResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    invite_org_member_v1_organizations__org_id__invite_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteMemberRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationInviteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_org_logo_v1_organizations__org_id__logo_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateLogoRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationLogoUpdatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_org_member_v1_organizations__org_id__members__target_user_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                org_id: string;
+                target_user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationMemberRemovedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    orgao_stats_v1_orgao__cnpj__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgaoStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    partner_dashboard_v1_partner_dashboard_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PartnerDashboardResponse"];
+                };
+            };
+        };
+    };
+    list_pipeline_items_v1_pipeline_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by stage */
+                stage?: string | null;
+                /** @description Items per page */
+                limit?: number;
+                /** @description Offset for pagination */
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_pipeline_item_v1_pipeline_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PipelineItemCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineItemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_pipeline_alerts_v1_pipeline_alerts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineAlertsResponse"];
+                };
+            };
+        };
+    };
+    delete_pipeline_item_v1_pipeline__item_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_pipeline_item_v1_pipeline__item_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PipelineItemUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PipelineItemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_plans_v1_plans_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingPlansResponse"];
+                };
+            };
+        };
+    };
+    get_seasonal_calendar_v1_predict_seasonal_calendar_get: {
+        parameters: {
+            query: {
+                /** @description UF (ex: SP, RJ, SC) */
+                uf: string;
+                /** @description Optional filter by sector slugs (e.g. engenharia, saude) */
+                setores?: string[] | null;
+                /** @description Number of historical years to analyze (1-20) */
+                anos_historico?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeasonalCalendarResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_products_v1_products_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductsResponse"];
+                };
+            };
+        };
+    };
+    get_alert_preferences_v1_profile_alert_preferences_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertPreferencesResponse"];
+                };
+            };
+        };
+    };
+    update_alert_preferences_v1_profile_alert_preferences_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AlertPreferencesRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertPreferencesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_completeness_v1_profile_completeness_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileCompletenessResponse"];
+                };
+            };
+        };
+    };
+    get_profile_context_v1_profile_context_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerfilContextoResponse"];
+                };
+            };
+        };
+    };
+    save_profile_context_v1_profile_context_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PerfilContexto"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PerfilContextoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_recent_editais_v1_pseo_recent_editais_get: {
+        parameters: {
+            query: {
+                setor: string;
+                uf?: string | null;
+                municipio?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecentEditaisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_top_suppliers_v1_pseo_top_suppliers_get: {
+        parameters: {
+            query: {
+                setor: string;
+                uf?: string | null;
+                municipio?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopSuppliersResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_referral_code_v1_referral_code_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReferralCodeResponse"];
+                };
+            };
+        };
+    };
+    redeem_referral_v1_referral_redeem_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReferralRedeemRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReferralRedeemResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_referral_stats_v1_referral_stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReferralStatsResponse"];
+                };
+            };
+        };
+    };
+    request_relatorio_v1_relatorio_2026_t1_request_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RelatorioRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RelatorioResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_diagnostico_v1_reports_diagnostico_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DiagnosticoRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_search_v1_search__search_id__cancel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchActionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    regenerate_excel_endpoint_v1_search__search_id__regenerate_excel_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_search_results_v1_v1_search__search_id__results_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    retry_search_v1_search__search_id__retry_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchActionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_status_endpoint_v1_search__search_id__status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    search_timeline_endpoint_v1_search__search_id__timeline_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchTimelineResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_zero_match_results_endpoint_v1_search__search_id__zero_match_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                search_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchZeroMatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_all_sectors_v1_sectors_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorListItem"][];
+                };
+            };
+        };
+    };
+    get_trending_sectors_v1_sectors_trending_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrendingSector"][];
+                };
+            };
+        };
+    };
+    get_sector_stats_v1_sectors__slug__stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorStatsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     save_segment_v1_segment_save_post: {
         parameters: {
             query?: never;
@@ -19538,7 +19741,7 @@ export interface operations {
             };
         };
     };
-    trigger_contracts_backfill_v1_admin_trigger_contracts_backfill_post: {
+    get_coverage_manifest_v1_seo_coverage_manifest_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -19553,14 +19756,21 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
+                    "application/json": components["schemas"]["CoverageManifestResponse"];
                 };
             };
         };
     };
-    trigger_bids_backfill_v1_admin_trigger_bids_backfill_post: {
+    get_sessions_v1_sessions_get: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                offset?: number;
+                /** @description Filter by session status (completed, failed, timed_out) */
+                status?: string | null;
+                /** @description UX-433 AC3: hide failed/timed_out entries older than 7 days from default listing */
+                hide_old_failures?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -19573,32 +19783,21 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AdminJobTriggerResponse"];
+                    "application/json": components["schemas"]["SessionsListResponse"];
                 };
             };
-        };
-    };
-    clear_contracts_checkpoints_v1_admin_clear_contracts_checkpoints_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
+            /** @description Validation Error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AdminClearCheckpointsResponse"];
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
-    get_search_trace_v1_admin_search_trace__search_id__get: {
+    download_session_excel_v1_sessions__search_id__download_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -19615,701 +19814,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AdminSearchTraceResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    reset_circuit_breakers_v1_admin_cb_reset_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminCircuitBreakerResetResponse"];
-                };
-            };
-        };
-    };
-    get_schema_contract_status_v1_admin_schema_contract_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminSchemaContractStatusResponse"];
-                };
-            };
-        };
-    };
-    get_cron_status_v1_admin_cron_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminCronStatusResponse"];
-                };
-            };
-        };
-    };
-    list_cnae_mappings_v1_admin_cnae_mapping_get: {
-        parameters: {
-            query?: {
-                /** @description Filter by setor_id */
-                setor?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_cnae_mapping_v1_admin_cnae_mapping_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CnaeMappingCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_cnae_mapping_v1_admin_cnae_mapping__cnae_code__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnae_code: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_cnae_mapping_v1_admin_cnae_mapping__cnae_code__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                cnae_code: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CnaeMappingUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CnaeMappingRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    admin_llm_cost_v1_admin_llm_cost_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminLlmCostResponse"];
-                };
-            };
-        };
-    };
-    list_export_surveys_aggregate_v1_admin_survey_export_time_saved_get: {
-        parameters: {
-            query?: {
-                range_days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SurveyAggregateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    patch_app_config_v1_admin_config__key__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                key: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["AppConfigPatchRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AppConfigRow"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    recalibrate_v1_admin_calibration_recalibrate_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RecalibrateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RecalibrateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_billing_sync_rows_v1_admin_plans_billing_sync_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BillingSyncListResponse"];
-                };
-            };
-        };
-    };
-    list_reconciliation_runs_v1_admin_plans_reconciliation_runs_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReconciliationRunsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    sync_to_stripe_v1_admin_plans__plan_billing_period_id__sync_to_stripe_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plan_billing_period_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ReverseSyncRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReverseSyncResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    reconcile_now_v1_admin_plans_reconcile_now_post: {
-        parameters: {
-            query?: {
-                dry_run?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReconcileNowResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_founding_policy_v1_admin_founding_policy_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingPolicySnapshot"];
-                };
-            };
-        };
-    };
-    list_founding_leads_v1_admin_founding_leads_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingLeadsListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    pause_founding_v1_admin_founding_pause_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["FoundingPauseRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    resume_founding_v1_admin_founding_resume_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundingPolicyMutationResponse"];
-                };
-            };
-        };
-    };
-    get_slo_dashboard_v1_admin_slo_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SloDashboardResponse"];
-                };
-            };
-        };
-    };
-    get_slo_alerts_v1_admin_slo_alerts_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SloAlertsResponse"];
-                };
-            };
-        };
-    };
-    founders_availability_api_founders_availability_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundersAvailabilityResponse"];
-                };
-            };
-        };
-    };
-    get_hall_listing_api_founders_hall_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoundersHallResponse"];
-                };
-            };
-        };
-    };
-    toggle_consent_api_founders_hall_consent_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FounderConsentRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FounderConsentResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    stripe_webhook_webhooks_stripe_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
                     "application/json": unknown;
                 };
             };
-        };
-    };
-    root__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
+            /** @description Validation Error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RootResponse"];
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -20334,7 +19848,71 @@ export interface operations {
             };
         };
     };
-    debug_pncp_test_debug_pncp_test_get: {
+    create_shared_analysis_v1_share_analise_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ShareAnaliseRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShareAnaliseResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_shared_analysis_v1_share_analise__hash__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                hash: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SharedAnalisePublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sitemap_cnpjs_v1_sitemap_cnpjs_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -20349,7 +19927,505 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DebugPNCPResponse"];
+                    "application/json": components["schemas"]["SitemapCnpjsResponse"];
+                };
+            };
+        };
+    };
+    sitemap_contratos_orgao_indexable_v1_sitemap_contratos_orgao_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapContratosOrgaoResponse"];
+                };
+            };
+        };
+    };
+    sitemap_fornecedores_cnpj_v1_sitemap_fornecedores_cnpj_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapFornecedoresCnpjResponse"];
+                };
+            };
+        };
+    };
+    sitemap_itens_v1_sitemap_itens_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapItensResponse"];
+                };
+            };
+        };
+    };
+    sitemap_licitacoes_do_dia_indexable_v1_sitemap_licitacoes_do_dia_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapLicitacoesDoDiaResponse"];
+                };
+            };
+        };
+    };
+    get_licitacoes_indexable_v1_sitemap_licitacoes_indexable_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LicitacoesIndexableResponse"];
+                };
+            };
+        };
+    };
+    sitemap_municipios_v1_sitemap_municipios_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapMunicipiosResponse"];
+                };
+            };
+        };
+    };
+    sitemap_orgaos_v1_sitemap_orgaos_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SitemapOrgaosResponse"];
+                };
+            };
+        };
+    };
+    stats_public_v1_stats_public_get: {
+        parameters: {
+            query?: {
+                /** @description json | embed | badge */
+                format?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    public_status_v1_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicStatusResponse"];
+                };
+            };
+        };
+    };
+    recent_incidents_v1_status_incidents_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IncidentsResponse"];
+                };
+            };
+        };
+    };
+    uptime_history_v1_status_uptime_history_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UptimeHistoryResponse"];
+                };
+            };
+        };
+    };
+    get_subscription_status_v1_subscription_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionStatusResponse"];
+                };
+            };
+        };
+    };
+    submit_export_time_saved_survey_v1_survey_export_time_saved_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExportTimeSavedSurveyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExportTimeSavedSurveyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unsubscribe_trial_emails_v1_trial_emails_unsubscribe_get: {
+        parameters: {
+            query: {
+                /** @description User ID */
+                user_id: string;
+                /** @description HMAC unsubscribe token */
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resend_webhook_v1_trial_emails_webhook_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "svix-id"?: string | null;
+                "svix-timestamp"?: string | null;
+                "svix-signature"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_trial_status_v1_trial_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrialStatusResponse"];
+                };
+            };
+        };
+    };
+    submit_exit_survey_v1_trial_exit_survey_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExitSurveyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExitSurveyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    extend_trial_endpoint_v1_trial_extend_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExtendRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExtendResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_extensions_status_v1_trial_extensions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExtensionsStatusResponse"];
+                };
+            };
+        };
+    };
+    get_recommended_plan_v1_user_recommended_plan_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecommendedPlanResponse"];
+                };
+            };
+        };
+    };
+    stripe_webhook_webhooks_stripe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };

--- a/supabase/migrations/20260604170000_user_lifecycle.down.sql
+++ b/supabase/migrations/20260604170000_user_lifecycle.down.sql
@@ -1,0 +1,15 @@
+-- LIFECYCLE-003 (#1428): Rollback user lifecycle migration
+--
+-- Reverses in opposite order:
+--   1. Drop functions
+--   2. Drop tables
+--   3. Drop enum type
+
+drop function if exists public.get_user_lifecycles;
+drop function if exists public.compute_all_user_lifecycles;
+drop function if exists public.compute_user_lifecycle;
+
+drop table if exists public.user_lifecycle_events;
+drop table if exists public.user_lifecycle;
+
+drop type if exists public.user_lifecycle_state;

--- a/supabase/migrations/20260604170000_user_lifecycle.sql
+++ b/supabase/migrations/20260604170000_user_lifecycle.sql
@@ -1,0 +1,311 @@
+-- LIFECYCLE-003 (#1428): User lifecycle classification
+--
+-- Creates:
+--   1. user_lifecycle_state enum type (10 states)
+--   2. compute_user_lifecycle(user_id UUID) function
+--   3. user_lifecycle_cache + user_lifecycle_events tables
+--   4. compute_all_user_lifecycles() batch function
+--
+-- Performance: CTE-based, <200ms for all users with proper indexes
+
+-- ============================================================
+-- 1. Create enum type for lifecycle states
+-- ============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_lifecycle_state') THEN
+    CREATE TYPE public.user_lifecycle_state AS ENUM (
+      'anonymous', 'lead', 'trial_active', 'trial_limited', 'trial_expired',
+      'paid_active', 'paid_past_due', 'canceled', 'churned', 'power_user'
+    );
+  END IF;
+END
+$$;
+
+-- ============================================================
+-- 2. Create user_lifecycle cache table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.user_lifecycle (
+  user_id UUID PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+  lifecycle public.user_lifecycle_state NOT NULL,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_lifecycle_state
+  ON public.user_lifecycle(lifecycle);
+
+-- ============================================================
+-- 3. Create user_lifecycle_events table (transition tracking)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.user_lifecycle_events (
+  id UUID PRIMARY KEY DEFAULT GEN_RANDOM_UUID(),
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  previous_lifecycle public.user_lifecycle_state,
+  new_lifecycle public.user_lifecycle_state NOT NULL,
+  changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lifecycle_events_user_time
+  ON public.user_lifecycle_events(user_id, changed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_lifecycle_events_changed_at
+  ON public.user_lifecycle_events(changed_at DESC);
+
+-- ============================================================
+-- 4. RLS (service_role only -- admin endpoint uses service_role client)
+-- ============================================================
+ALTER TABLE public.user_lifecycle ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_lifecycle_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_all_lifecycle" ON public.user_lifecycle;
+CREATE POLICY "service_all_lifecycle" ON public.user_lifecycle
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "service_all_lifecycle_events" ON public.user_lifecycle_events;
+CREATE POLICY "service_all_lifecycle_events" ON public.user_lifecycle_events
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ============================================================
+-- 5. compute_user_lifecycle(p_user_id UUID) -- single user
+--    Returns the classified lifecycle state for the given user.
+--    Idempotent: stores result in user_lifecycle and logs
+--    transitions to user_lifecycle_events when state changes.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.compute_user_lifecycle(p_user_id UUID)
+RETURNS public.user_lifecycle_state
+LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  v_state public.user_lifecycle_state;
+  v_prev_state public.user_lifecycle_state;
+  v_plan_type TEXT;
+  v_sub_status TEXT;
+  v_trial_expires_at TIMESTAMPTZ;
+  v_last_login_at TIMESTAMPTZ;
+  v_logins_14d INT;
+  v_pipeline_count INT;
+  v_alert_count INT;
+  v_search_count INT;
+  v_paid_subs INT;
+BEGIN
+  -- Fetch user profile data
+  SELECT
+    p.plan_type,
+    p.subscription_status,
+    p.trial_expires_at,
+    p.last_login_at
+  INTO v_plan_type, v_sub_status, v_trial_expires_at, v_last_login_at
+  FROM public.profiles p
+  WHERE p.id = p_user_id;
+
+  -- No profile found -> anonymous
+  IF NOT FOUND THEN
+    RETURN 'anonymous'::public.user_lifecycle_state;
+  END IF;
+
+  -- Aggregate counts in parallel subqueries (efficient with indexes)
+  SELECT
+    COALESCE((SELECT COUNT(*) FROM public.login_activity la
+              WHERE la.user_id = p_user_id AND la.login_date >= CURRENT_DATE - 14), 0),
+    COALESCE((SELECT COUNT(*) FROM public.pipeline_items pi
+              WHERE pi.user_id = p_user_id), 0),
+    COALESCE((SELECT COUNT(*) FROM public.alerts a
+              WHERE a.user_id = p_user_id AND a.active = true), 0),
+    COALESCE((SELECT COUNT(*) FROM public.search_sessions ss
+              WHERE ss.user_id = p_user_id), 0),
+    COALESCE((SELECT COUNT(*) FROM public.user_subscriptions us
+              WHERE us.user_id = p_user_id
+                AND us.is_active = true
+                AND us.plan_id NOT IN ('free_trial', 'free')
+                AND us.subscription_status = 'active'), 0)
+  INTO v_logins_14d, v_pipeline_count, v_alert_count, v_search_count, v_paid_subs;
+
+  -- Get previously cached state (if any)
+  SELECT lifecycle INTO v_prev_state
+  FROM public.user_lifecycle
+  WHERE user_id = p_user_id;
+
+  -- === Classification (highest specificity first) ===
+
+  -- Power user: overrides all other states
+  IF v_logins_14d >= 5 AND v_pipeline_count >= 3 AND v_alert_count >= 1 THEN
+    v_state := 'power_user';
+
+  -- Churned: canceled + no login for 30 days
+  ELSIF v_sub_status IN ('canceling', 'expired')
+    AND (v_last_login_at IS NULL OR v_last_login_at < NOW() - INTERVAL '30 days') THEN
+    v_state := 'churned';
+
+  -- Canceled
+  ELSIF v_sub_status IN ('canceling', 'expired') THEN
+    v_state := 'canceled';
+
+  -- Paid past due
+  ELSIF v_sub_status = 'past_due' AND v_paid_subs > 0 THEN
+    v_state := 'paid_past_due';
+
+  -- Paid active
+  ELSIF v_paid_subs > 0 THEN
+    v_state := 'paid_active';
+
+  -- Trial expired
+  ELSIF v_plan_type = 'free_trial'
+    AND v_trial_expires_at IS NOT NULL
+    AND v_trial_expires_at < NOW() THEN
+    v_state := 'trial_expired';
+
+  -- Trial limited (quota exhaustion -- >= 3 searches used on free_trial)
+  ELSIF v_plan_type = 'free_trial'
+    AND (v_trial_expires_at IS NULL OR v_trial_expires_at > NOW())
+    AND v_search_count >= 3 THEN
+    v_state := 'trial_limited';
+
+  -- Trial active
+  ELSIF v_plan_type = 'free_trial'
+    AND (v_trial_expires_at IS NULL OR v_trial_expires_at > NOW()) THEN
+    v_state := 'trial_active';
+
+  -- Lead: has profile but never started trial or paid
+  ELSIF (v_plan_type IS NULL OR v_plan_type IN ('free', 'free_trial'))
+    AND v_trial_expires_at IS NULL THEN
+    v_state := 'lead';
+
+  ELSE
+    v_state := 'anonymous';
+  END IF;
+
+  -- === Track transition ===
+  IF v_prev_state IS DISTINCT FROM v_state THEN
+    INSERT INTO public.user_lifecycle_events (user_id, previous_lifecycle, new_lifecycle)
+    VALUES (p_user_id, v_prev_state, v_state);
+  END IF;
+
+  -- === Upsert cache ===
+  INSERT INTO public.user_lifecycle (user_id, lifecycle, computed_at)
+  VALUES (p_user_id, v_state, NOW())
+  ON CONFLICT (user_id) DO UPDATE SET
+    lifecycle = v_state,
+    computed_at = NOW();
+
+  RETURN v_state;
+END;
+$$;
+
+-- ============================================================
+-- 6. compute_all_user_lifecycles() -- batch compute for all users
+--    Returns table of (user_id, lifecycle) for every profile.
+--    Uses a single CTE pass for performance (<200ms target).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.compute_all_user_lifecycles()
+RETURNS TABLE(user_id UUID, lifecycle public.user_lifecycle_state)
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH stats AS (
+    SELECT
+      p.id,
+      p.plan_type,
+      p.subscription_status,
+      p.trial_expires_at,
+      p.last_login_at,
+      COALESCE(la.logins_14d, 0) AS logins_14d,
+      COALESCE(pi.pipeline_count, 0) AS pipeline_count,
+      COALESCE(al.alert_count, 0) AS alert_count,
+      COALESCE(ss.search_count, 0) AS search_count,
+      COALESCE(ps.paid_subs, 0) AS paid_subs
+    FROM public.profiles p
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS logins_14d
+      FROM public.login_activity
+      WHERE user_id = p.id AND login_date >= CURRENT_DATE - 14
+    ) la ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS pipeline_count
+      FROM public.pipeline_items
+      WHERE user_id = p.id
+    ) pi ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS alert_count
+      FROM public.alerts
+      WHERE user_id = p.id AND active = true
+    ) al ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS search_count
+      FROM public.search_sessions
+      WHERE user_id = p.id
+    ) ss ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*) AS paid_subs
+      FROM public.user_subscriptions
+      WHERE user_id = p.id
+        AND is_active = true
+        AND plan_id NOT IN ('free_trial', 'free')
+        AND subscription_status = 'active'
+    ) ps ON true
+  ),
+  classified AS (
+    SELECT
+      s.id,
+      CASE
+        -- Power user
+        WHEN s.logins_14d >= 5 AND s.pipeline_count >= 3 AND s.alert_count >= 1
+          THEN 'power_user'::public.user_lifecycle_state
+        -- Churned
+        WHEN s.subscription_status IN ('canceling', 'expired')
+          AND (s.last_login_at IS NULL OR s.last_login_at < NOW() - INTERVAL '30 days')
+          THEN 'churned'::public.user_lifecycle_state
+        -- Canceled
+        WHEN s.subscription_status IN ('canceling', 'expired')
+          THEN 'canceled'::public.user_lifecycle_state
+        -- Paid past due
+        WHEN s.subscription_status = 'past_due' AND s.paid_subs > 0
+          THEN 'paid_past_due'::public.user_lifecycle_state
+        -- Paid active
+        WHEN s.paid_subs > 0
+          THEN 'paid_active'::public.user_lifecycle_state
+        -- Trial expired
+        WHEN s.plan_type = 'free_trial'
+          AND s.trial_expires_at IS NOT NULL
+          AND s.trial_expires_at < NOW()
+          THEN 'trial_expired'::public.user_lifecycle_state
+        -- Trial limited
+        WHEN s.plan_type = 'free_trial'
+          AND (s.trial_expires_at IS NULL OR s.trial_expires_at > NOW())
+          AND s.search_count >= 3
+          THEN 'trial_limited'::public.user_lifecycle_state
+        -- Trial active
+        WHEN s.plan_type = 'free_trial'
+          AND (s.trial_expires_at IS NULL OR s.trial_expires_at > NOW())
+          THEN 'trial_active'::public.user_lifecycle_state
+        -- Lead
+        WHEN (s.plan_type IS NULL OR s.plan_type IN ('free', 'free_trial'))
+          AND s.trial_expires_at IS NULL
+          THEN 'lead'::public.user_lifecycle_state
+        ELSE 'anonymous'::public.user_lifecycle_state
+      END AS lifecycle
+    FROM stats s
+  )
+  SELECT c.id, c.lifecycle
+  FROM classified c;
+END;
+$$;
+
+-- ============================================================
+-- 7. Helper: get_user_lifecycles() -- read current cached states
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_user_lifecycles()
+RETURNS TABLE(
+  user_id UUID,
+  lifecycle public.user_lifecycle_state,
+  computed_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT ul.user_id, ul.lifecycle, ul.computed_at
+  FROM public.user_lifecycle ul
+  ORDER BY ul.lifecycle, ul.user_id;
+END;
+$$;


### PR DESCRIPTION
## Summary

Implementa LIFECYCLE-003: sistema de classificacao de ciclo de vida de usuarios com 10 estados e endpoint admin de segmentos.

## Context

Feature de lifecycle classification para o admin dashboard. Permite visualizar distribuicao de usuarios por estado de ciclo de vida, transicoes recentes e power users.

### SQL Migration
- New `user_lifecycle_state` enum with 10 states
- `compute_user_lifecycle(user_id UUID)` single-user function
- `compute_all_user_lifecycles()` batch CTE function (<200ms)
- `user_lifecycle` + `user_lifecycle_events` tables
- Paired `.down.sql` rollback

### Backend
- `GET /v1/admin/users/segments` — count_by_state, transitions_last_week, power_users
- Redis cache 5-min TTL
- Admin-only (is_admin / ADMIN_USER_IDS)
- Pydantic schemas: UserSegmentsResponse, PowerUserDetail, UserLifecycleTransition

### Tests: 12/12 passing

Closes #1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-only user segmentation endpoint providing lifecycle state analytics, including user counts by lifecycle stage, power user profiles, and transition history from the past 7 days.
  * Implemented database-level user lifecycle classification system that tracks user states and transitions over time.
  * Results are cached for 5 minutes to optimize performance.

* **Tests**
  * Comprehensive test coverage for endpoint access control, data aggregation, caching behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->