### PR TITLE
feat(frontend): add Follow button on orgaos and CNPJ pages (#1446)

### DIFF
--- a/frontend/__tests__/api-alerts-route.test.ts
+++ b/frontend/__tests__/api-alerts-route.test.ts
@@ -1,17 +1,46 @@
 /**
  * @jest-environment node
  *
- * UX-434: /api/alerts is now a stub returning 200 (never proxying to backend).
- * Previous proxy tests (STORY-301) replaced — stub eliminates 404 console errors.
+ * ENTITY-003 / UX-434: /api/alerts proxy route tests.
+ * Now uses createProxyRoute (real proxy to backend), not a stub.
  */
 import { GET, POST } from "../app/api/alerts/route";
 import { NextRequest } from "next/server";
 
+// Mock fetch globally
+global.fetch = jest.fn();
+
 const AUTH = "Bearer test-token-123";
 
+// Set BACKEND_URL for all tests
+process.env.BACKEND_URL = "http://test-backend:8000";
+
+/** Helper: create a mock fetch response */
+function mockResponse(status: number, body: unknown) {
+  const bodyStr = JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => bodyStr,
+    headers: {
+      get: (h: string) =>
+        h.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  };
+}
+
 describe("/api/alerts route handlers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("GET /api/alerts", () => {
-    it("returns 200 with empty array when authenticated", async () => {
+    it("returns 200 with backend data when authenticated", async () => {
+      const backendData = [{ id: "1", name: "Teste" }];
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockResponse(200, backendData)
+      );
+
       const req = new NextRequest("http://localhost:3000/api/alerts", {
         headers: { Authorization: AUTH },
       });
@@ -19,7 +48,15 @@ describe("/api/alerts route handlers", () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(Array.isArray(data)).toBe(true);
-      expect(data).toHaveLength(0);
+      expect(data).toEqual(backendData);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/alerts"),
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({ Authorization: AUTH }),
+        })
+      );
     });
 
     it("returns 401 when no authorization header", async () => {
@@ -28,26 +65,49 @@ describe("/api/alerts route handlers", () => {
       const data = await res.json();
       expect(res.status).toBe(401);
       expect(data.message).toBeDefined();
+      // Auth check happens before fetch
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("never returns 404 (AC3/AC4 — stub eliminates ghost 404s)", async () => {
+    it("proxies backend status (no hardcoded 404 handling)", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockResponse(404, { message: "Not found" })
+      );
+
       const req = new NextRequest("http://localhost:3000/api/alerts", {
         headers: { Authorization: AUTH },
       });
       const res = await GET(req);
-      expect(res.status).not.toBe(404);
+      expect(res.status).toBe(404); // Proxy forwards backend status
     });
   });
 
   describe("POST /api/alerts", () => {
-    it("returns 200 when authenticated", async () => {
+    it("returns backend status when authenticated", async () => {
+      const backendResponse = { id: "new-1", name: "Alerta Teste" };
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockResponse(201, backendResponse)
+      );
+
       const req = new NextRequest("http://localhost:3000/api/alerts", {
         method: "POST",
         headers: { Authorization: AUTH },
         body: JSON.stringify({ name: "Alerta Teste" }),
       });
       const res = await POST(req);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/alerts"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Authorization": AUTH,
+            "Content-Type": "application/json",
+          }),
+          body: JSON.stringify({ name: "Alerta Teste" }),
+        })
+      );
     });
 
     it("returns 401 for POST without auth header", async () => {
@@ -59,16 +119,21 @@ describe("/api/alerts route handlers", () => {
       const data = await res.json();
       expect(res.status).toBe(401);
       expect(data.message).toBeDefined();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("never returns 404", async () => {
+    it("proxies backend status for POST", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce(
+        mockResponse(404, { message: "Not found" })
+      );
+
       const req = new NextRequest("http://localhost:3000/api/alerts", {
         method: "POST",
         headers: { Authorization: AUTH },
         body: JSON.stringify({}),
       });
       const res = await POST(req);
-      expect(res.status).not.toBe(404);
+      expect(res.status).toBe(404); // Proxy forwards backend status
     });
   });
 });

--- a/frontend/__tests__/api/alerts-stub.test.ts
+++ b/frontend/__tests__/api/alerts-stub.test.ts
@@ -1,22 +1,80 @@
 /**
  * @jest-environment node
  *
- * UX-434: Stub for /api/alerts must return 200 (never 404) to eliminate
- * console errors during authenticated navigation.
+ * UX-434 / ENTITY-003: /api/alerts proxy route tests.
+ * Now a proxy (createProxyRoute) instead of a stub — tests validate
+ * auth gating, backend forwarding, and error handling.
  */
 import { GET, POST } from "@/app/api/alerts/route";
 import { NextRequest } from "next/server";
 
+// Mock fetch globally
+global.fetch = jest.fn();
+
 const AUTH_HEADER = "Bearer test-token-ux434";
 
-describe("GET /api/alerts (UX-434 stub)", () => {
+// Set BACKEND_URL for all tests
+process.env.BACKEND_URL = "http://test-backend:8000";
+
+/** Helper: create a mock fetch response */
+function mockResponse(status: number, body: unknown) {
+  const bodyStr = JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => bodyStr,
+    headers: {
+      get: (h: string) =>
+        h.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  };
+}
+
+describe("GET /api/alerts (proxy)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns 401 when Authorization header is missing", async () => {
     const req = new NextRequest("http://localhost:3000/api/alerts");
     const res = await GET(req);
     expect(res.status).toBe(401);
+    // Auth check happens before fetch — fetch should never be called
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("returns 200 with empty array when authenticated", async () => {
+  it("returns 200 with backend data when authenticated", async () => {
+    const backendData = [{ id: "1", name: "Alerta Teste" }];
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockResponse(200, backendData)
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/alerts", {
+      headers: { Authorization: AUTH_HEADER },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toEqual(backendData);
+
+    // Verify backend was called with auth header
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/alerts"),
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: AUTH_HEADER,
+        }),
+      })
+    );
+  });
+
+  it("returns 200 with empty array when backend returns empty", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockResponse(200, [])
+    );
+
     const req = new NextRequest("http://localhost:3000/api/alerts", {
       headers: { Authorization: AUTH_HEADER },
     });
@@ -27,16 +85,38 @@ describe("GET /api/alerts (UX-434 stub)", () => {
     expect(body).toHaveLength(0);
   });
 
-  it("never returns 404", async () => {
+  it("proxies backend 404 status", async () => {
+    // Proxy forwards backend response including 404 (unlike old stub)
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockResponse(404, { message: "Not found" })
+    );
+
     const req = new NextRequest("http://localhost:3000/api/alerts", {
       headers: { Authorization: AUTH_HEADER },
     });
     const res = await GET(req);
-    expect(res.status).not.toBe(404);
+    expect(res.status).toBe(404); // Proxy forwards backend status
+  });
+
+  it("returns 503 on network error", async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(
+      new Error("connect ECONNREFUSED")
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/alerts", {
+      headers: { Authorization: AUTH_HEADER },
+    });
+    const res = await GET(req);
+    // Network errors are sanitized to 503
+    expect(res.status).toBe(503);
   });
 });
 
-describe("POST /api/alerts (UX-434 stub)", () => {
+describe("POST /api/alerts (proxy)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns 401 when Authorization header is missing", async () => {
     const req = new NextRequest("http://localhost:3000/api/alerts", {
       method: "POST",
@@ -44,25 +124,63 @@ describe("POST /api/alerts (UX-434 stub)", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(401);
+    // Auth check happens before fetch
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("returns 200 when authenticated", async () => {
+  it("returns 200 when authenticated and backend responds", async () => {
+    const backendResponse = { id: "new-1", name: "Alerta Teste" };
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockResponse(201, backendResponse)
+    );
+
     const req = new NextRequest("http://localhost:3000/api/alerts", {
       method: "POST",
       headers: { Authorization: AUTH_HEADER },
       body: JSON.stringify({ name: "Alerta Teste" }),
     });
     const res = await POST(req);
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
+
+    // Verify backend was called with correct method and body
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/alerts"),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Authorization": AUTH_HEADER,
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ name: "Alerta Teste" }),
+      })
+    );
   });
 
-  it("never returns 404", async () => {
+  it("proxies backend 404 status for POST", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockResponse(404, { message: "Not found" })
+    );
+
     const req = new NextRequest("http://localhost:3000/api/alerts", {
       method: "POST",
       headers: { Authorization: AUTH_HEADER },
       body: JSON.stringify({}),
     });
     const res = await POST(req);
-    expect(res.status).not.toBe(404);
+    expect(res.status).toBe(404); // Proxy forwards backend status
+  });
+
+  it("returns 503 on network error", async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(
+      new Error("connect ECONNREFUSED")
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/alerts", {
+      method: "POST",
+      headers: { Authorization: AUTH_HEADER },
+      body: JSON.stringify({ name: "Alerta Teste" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
   });
 });

--- a/frontend/__tests__/cnpj-perfil-sem-historico.test.tsx
+++ b/frontend/__tests__/cnpj-perfil-sem-historico.test.tsx
@@ -23,6 +23,12 @@ jest.mock('next/link', () => {
   };
 });
 
+jest.mock('@/components/FollowButton', () => {
+  return function MockFollowButton() {
+    return <button data-testid="follow-button">Seguir</button>;
+  };
+});
+
 import CnpjPerfilClient from '@/app/cnpj/[cnpj]/CnpjPerfilClient';
 
 const BASE_EMPRESA = {

--- a/frontend/__tests__/repo-013-viability-verdict-pseo.test.tsx
+++ b/frontend/__tests__/repo-013-viability-verdict-pseo.test.tsx
@@ -37,6 +37,12 @@ jest.mock('next/link', () => {
   };
 });
 
+jest.mock('@/components/FollowButton', () => {
+  return function MockFollowButton() {
+    return <button data-testid="follow-button">Seguir</button>;
+  };
+});
+
 // ---------- Imports under test ----------
 
 import CnpjPerfilClient from '@/app/cnpj/[cnpj]/CnpjPerfilClient';

--- a/frontend/app/api/alerts/route.ts
+++ b/frontend/app/api/alerts/route.ts
@@ -1,31 +1,12 @@
 /**
- * UX-434 STUB: Placeholder until alerts feature is implemented (STORY-301).
- * Returns 200 with empty data to eliminate 404 console errors during navigation.
- * Real implementation will proxy to BACKEND_URL/v1/alerts.
+ * STORY-301 / ENTITY-003: API proxy for alerts collection operations.
+ * GET  /api/alerts   -> GET    BACKEND_URL/v1/alerts
+ * POST /api/alerts   -> POST   BACKEND_URL/v1/alerts
  */
-import { NextRequest, NextResponse } from "next/server";
-
-function requireAuth(request: NextRequest): NextResponse | null {
-  if (!request.headers.get("authorization")) {
-    return NextResponse.json(
-      { message: "Autenticação necessária" },
-      { status: 401 },
-    );
-  }
-  return null;
-}
-
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  const authError = requireAuth(request);
-  if (authError) return authError;
-  return NextResponse.json([], { status: 200 });
-}
-
-export async function POST(request: NextRequest): Promise<NextResponse> {
-  const authError = requireAuth(request);
-  if (authError) return authError;
-  return NextResponse.json(
-    { id: null, message: "Funcionalidade em breve" },
-    { status: 200 },
-  );
-}
+import { createProxyRoute } from "../../../lib/create-proxy-route";
+export const { GET, POST } = createProxyRoute({
+  backendPath: "/v1/alerts",
+  methods: ["GET", "POST"],
+  requireAuth: true,
+  errorMessage: "Erro ao processar alertas",
+});

--- a/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
+++ b/frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import StickyTrialCTA from '@/app/components/StickyTrialCTA';
+import FollowButton from '@/components/FollowButton';
 import { ViabilityVerdict } from '@/components/ViabilityVerdict';
 import { AdvisoryDisclaimer } from '@/components/legal/AdvisoryDisclaimer';
 
@@ -137,7 +138,7 @@ export default function CnpjPerfilClient({ perfil }: { perfil: PerfilB2G }) {
       </div>
 
       {/* Score Badge */}
-      <div className="flex flex-wrap gap-3 mb-8">
+      <div className="flex flex-wrap items-center gap-3 mb-8">
         <span className={`inline-flex items-center px-4 py-2 rounded-full text-sm font-bold border ${scoreConfig.color} ring-2 ${scoreConfig.ringColor}`}>
           Score B2G: {scoreConfig.label}
         </span>
@@ -149,6 +150,14 @@ export default function CnpjPerfilClient({ perfil }: { perfil: PerfilB2G }) {
             {empresa.uf}
           </span>
         )}
+        <span className="ml-auto">
+          <FollowButton
+            entityType="fornecedor"
+            entityId={empresa.cnpj}
+            entityName={empresa.razao_social}
+            entityCnpj={empresa.cnpj}
+          />
+        </span>
       </div>
 
       {/* Company info */}

--- a/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
+++ b/frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import Link from 'next/link';
 import StickyTrialCTA from '@/app/components/StickyTrialCTA';
+import FollowButton from '@/components/FollowButton';
 import { trackPseoEvent } from '@/lib/analytics/pseo';
 
 interface LicitacaoRecente {
@@ -46,7 +47,8 @@ interface OrgaoStats {
   aviso_legal: string;
 }
 
-function formatBRL(value: number): string {
+function formatBRL(value: number | null): string {
+  if (value === null) return "—";
   return new Intl.NumberFormat('pt-BR', {
     style: 'currency',
     currency: 'BRL',
@@ -146,7 +148,7 @@ export default function OrgaoPerfilClient({ stats }: { stats: OrgaoStats }) {
       </div>
 
       {/* Badges row */}
-      <div className="flex flex-wrap gap-3 mb-8">
+      <div className="flex flex-wrap items-center gap-3 mb-8">
         <span
           className={`inline-flex items-center px-4 py-2 rounded-full text-sm font-bold border ${activityConfig.color} ring-2 ${activityConfig.ringColor}`}
         >
@@ -162,6 +164,14 @@ export default function OrgaoPerfilClient({ stats }: { stats: OrgaoStats }) {
             {uf}
           </span>
         )}
+        <span className="ml-auto">
+          <FollowButton
+            entityType="orgao"
+            entityId={cnpj}
+            entityName={nome}
+            entityCnpj={cnpj}
+          />
+        </span>
       </div>
 
       {/* Stats cards */}

--- a/frontend/components/FollowButton.tsx
+++ b/frontend/components/FollowButton.tsx
@@ -1,0 +1,88 @@
+'use client';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/components/AuthProvider';
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+import mixpanel from 'mixpanel-browser';
+import { getCookieConsent } from '@/app/components/CookieConsentBanner';
+
+interface FollowButtonProps {
+  entityType: 'orgao' | 'fornecedor';
+  entityId: string;
+  entityName: string;
+  entityCnpj: string;
+}
+interface AlertRecord { id: string; name: string; tracked_orgaos: string[]; tracked_fornecedores: string[]; [key: string]: unknown; }
+
+const PLAN_LIMITS: Record<string, number> = { free_trial: 1, smartlic_pro: 5, consultoria: 20, master: 20 };
+const DEF_LIMIT = 1;
+
+function countTracked(a: AlertRecord[], f: 'tracked_orgaos'|'tracked_fornecedores'): number {
+  const s = new Set<string>(); for (const al of a) { const l = al[f]; if (Array.isArray(l)) l.forEach(c => s.add(c)); } return s.size;
+}
+function canTrack(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (!process.env.NEXT_PUBLIC_MIXPANEL_TOKEN) return false;
+  try { return getCookieConsent()?.analytics === true; } catch { return false; }
+}
+function safeTrack(n: string, p: Record<string, unknown>) {
+  if (!canTrack()) return;
+  try { mixpanel.track(n, { ...p, timestamp: new Date().toISOString(), environment: process.env.NODE_ENV || 'development' }); } catch {}
+}
+
+export default function FollowButton({ entityType, entityId, entityName, entityCnpj }: FollowButtonProps) {
+  const router = useRouter(); const { user, loading: authL } = useAuth();
+  const tf = entityType === 'orgao' ? 'tracked_orgaos' : 'tracked_fornecedores';
+  const el = entityType === 'orgao' ? 'orgao' : 'fornecedor';
+  const fl = entityType === 'orgao' ? 'Seguir orgao' : 'Seguir fornecedor';
+  const [f, sf] = useState(false); const [ck, sck] = useState(true); const [al, sal] = useState(false); const [er, ser] = useState<string|null>(null); const [lr, slr] = useState(false); const [aid, said] = useState<string|null>(null);
+  const mr = useRef(true);
+
+  const check = useCallback(async () => {
+    if (!user) { if (mr.current) sck(false); return; }
+    try {
+      const r = await fetchWithAuth('/api/alerts'); if (!r.ok) { if (mr.current) sck(false); return; }
+      const d = await r.json(); const alr: AlertRecord[] = Array.isArray(d) ? d : (d.alerts ?? []);
+      let fa = null; let it = false;
+      for (const a of alr) { const l = a[tf]; if (Array.isArray(l) && l.includes(entityCnpj)) { it = true; fa = a.id; break; } }
+      if (!it) { const cc = countTracked(alr, tf); const pt = (user.app_metadata?.plan_type as string) ?? 'free_trial'; if (cc >= (PLAN_LIMITS[pt] ?? DEF_LIMIT) && mr.current) slr(true); }
+      if (mr.current) { sf(it); said(fa); sck(false); }
+    } catch { if (mr.current) sck(false); }
+  }, [user, entityCnpj, tf]);
+  useEffect(() => { check(); }, [check]);
+
+  const toggle = useCallback(async () => {
+    ser(null); if (!user) { router.push('/signup?ref=follow-'+entityType+'-'+entityId); return; }
+    sal(true);
+    try {
+      if (f) {
+        if (aid) {
+          const ar = await fetchWithAuth('/api/alerts/'+aid);
+          if (ar.ok) { const aj = await ar.json(); const lst: string[] = aj[tf] ?? []; const rem = lst.filter(c => c !== entityCnpj);
+            if (rem.length === 0) await fetchWithAuth('/api/alerts/'+aid, { method: 'DELETE' });
+            else await fetchWithAuth('/api/alerts/'+aid, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ [tf]: rem }) });
+          }
+        }
+        safeTrack('entity_track_stopped', { entity_type: entityType, entity_id: entityId, entity_name: entityName, entity_cnpj: entityCnpj });
+        if (mr.current) { sf(false); said(null); sal(false); }
+      } else {
+        const cr = await fetchWithAuth('/api/alerts', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: 'Monitoramento - '+entityName, filters: {}, [tf]: [entityCnpj] }) });
+        if (!cr.ok) { const ed = await cr.json().catch(()=>null); const dt = ed?.detail ?? ed?.message ?? ''; if (dt.toLowerCase().includes('limite') || cr.status === 409) { if (mr.current) slr(true); throw new Error(dt || 'Limite'); } throw new Error(dt || 'Erro'); }
+        const cj = await cr.json();
+        safeTrack('entity_track_started', { entity_type: entityType, entity_id: entityId, entity_name: entityName, entity_cnpj: entityCnpj });
+        if (mr.current) { sf(true); said(cj.id); slr(false); sal(false); }
+      }
+    } catch(e) { if (mr.current) { ser(e instanceof Error ? e.message : 'Erro'); sal(false); } }
+  }, [user, f, aid, entityType, entityId, entityName, entityCnpj, tf, router]);
+  useEffect(() => { return () => { mr.current = false; }; }, []);
+
+  const Spinner = ({c}:{c?:string}) => <span className={'w-4 h-4 rounded-full border-2 border-t-transparent animate-spin shrink-0 '+(c||'')}/>;
+  const Bell = ({fi}:{fi:boolean}) => <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill={fi?'currentColor':'none'} stroke="currentColor" strokeWidth={fi?0:2} className="w-4 h-4 shrink-0" aria-hidden="true"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>;
+  const Wrp = ({c,t}:{c:React.ReactNode;t:string}) => <span className="relative inline-block group">{c}<span role="tooltip" className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-800 rounded-md whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none shadow-lg z-50">{t}</span></span>;
+
+  if (ck || authL) return <button type="button" disabled className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 bg-gray-50 text-gray-400 text-sm font-medium cursor-wait" aria-label="Verificando..."><Spinner c="border-gray-300"/><span>Verificando...</span></button>;
+  if (lr && !f) return <Wrp c={<button type="button" disabled className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 bg-gray-50 text-gray-400 text-sm font-medium cursor-not-allowed" aria-label="Limite"><Bell fi={false}/><span>{fl}</span></button>} t={'Limite de '+(el==='orgao'?'orgaos':'fornecedores')+' monitorados atingido. Faca upgrade.'}/>;
+  if (er) return <button type="button" onClick={()=>{ser(null);toggle()}} className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-red-200 bg-red-50 text-red-700 text-sm font-medium hover:bg-red-100" aria-label="Tentar"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="w-4 h-4 shrink-0" aria-hidden="true"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg><span>Tentar novamente</span></button>;
+  if (f) return <Wrp c={<button type="button" onClick={toggle} disabled={al} className={'inline-flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium transition-colors '+(al?'border-gray-200 bg-gray-50 text-gray-400 cursor-wait':'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100')} aria-label={al?'Removendo...':'Deixar de seguir '+el}>{al?<Spinner c="border-emerald-300"/>:<Bell fi/>}<span>{al?'Removendo...':'Seguindo'}</span></button>} t="Clique para deixar de seguir"/>;
+  return <Wrp c={<button type="button" onClick={toggle} disabled={al} className={'inline-flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium transition-colors '+(al?'border-gray-200 bg-gray-50 text-gray-400 cursor-wait':'border-brand-blue text-brand-blue bg-white hover:bg-brand-blue hover:text-white')} aria-label={al?'Seguindo...':fl}>{al?<Spinner c="border-brand-blue"/>:<Bell fi={false}/>}<span>{al?'Seguindo...':fl}</span></button>} t={'Receba alertas quando '+(el==='orgao'?'este orgao':'este fornecedor')+' publicar novos editais'}/>;
+}


### PR DESCRIPTION
## Summary

Adiciona botao Seguir/Seguindo nas paginas de orgaos e CNPJ (#1446).

## Context

ENTITY-001: Permite que usuarios monitorem orgaos publicos e fornecedores com um clique.

- FollowButton component with Seguir/Seguindo toggle states
- Tooltip with contextual message on hover  
- Plan-limit enforcement (trial=1, pro=5, consulting=20)
- Analytics events: entity_track_started, entity_track_stopped
- Update alerts API proxy from stub to real backend proxy

## Changes

### Frontend
- `frontend/app/api/alerts/route.ts` — troca stub por proxy real
- `frontend/components/FollowButton.tsx` — novo componente
- `frontend/app/orgaos/[slug]/OrgaoPerfilClient.tsx` — integra FollowButton
- `frontend/app/cnpj/[cnpj]/CnpjPerfilClient.tsx` — integra FollowButton

## Testing Plan

- Testes unitarios corrigidos: 31/31 passam
- CI Frontend Tests gate deve passar com mocks atualizados

Closes #1446