### PR TITLE
feat: ENTITY-004: Limite de entidades por plano + upgrade modal (#1447)

### DIFF
--- a/backend/quota/quota_core.py
+++ b/backend/quota/quota_core.py
@@ -196,6 +196,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": True,  # PREDINT-000
         "allow_competitive_intel": True,  # COMPINT-000
         "allow_workspace_basic": True,  # B2GOPS-000
+        "max_tracked_entities": 50,  # ENTITY-004
         "max_requests_per_month": 5000,
         "max_requests_per_min": 120,
         "max_summary_tokens": 20000,

--- a/backend/quota/quota_core.py
+++ b/backend/quota/quota_core.py
@@ -94,6 +94,7 @@ class PlanCapabilities(TypedDict):
     allow_predictive_intel: bool  # PREDINT-000: Inteligência Preditiva (default off, additive)
     allow_competitive_intel: bool  # COMPINT-000: Inteligência Concorrencial (default off, additive)
     allow_workspace_basic: bool  # B2GOPS-000: B2G Operations workspace (default off, additive)
+    max_tracked_entities: int  # ENTITY-004: Max tracked orgaos/fornecedores per plan
     max_requests_per_month: int
     max_requests_per_min: int
     max_summary_tokens: int
@@ -110,6 +111,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 1,  # ENTITY-004
         "max_requests_per_month": 1000,  # STORY-264 AC1: Full access (same as smartlic_pro)
         "max_requests_per_min": 2,  # STORY-264 AC2: Anti-abuse rate limit kept
         "max_summary_tokens": 10000,  # GTM-003: Full AI analysis (same as smartlic_pro)
@@ -123,6 +125,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 1,  # ENTITY-004
         "max_requests_per_month": 50,
         "max_requests_per_min": 10,
         "max_summary_tokens": 200,
@@ -136,6 +139,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 5,  # ENTITY-004
         "max_requests_per_month": 300,
         "max_requests_per_min": 30,
         "max_summary_tokens": 500,
@@ -149,6 +153,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 20,  # ENTITY-004
         "max_requests_per_month": 1000,
         "max_requests_per_min": 60,
         "max_summary_tokens": 10000,
@@ -162,6 +167,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 5,  # ENTITY-004
         "max_requests_per_month": 1000,
         "max_requests_per_min": 60,
         "max_summary_tokens": 10000,
@@ -176,6 +182,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 5,  # ENTITY-004
         "max_requests_per_month": 1000,
         "max_requests_per_min": 60,
         "max_summary_tokens": 10000,
@@ -190,6 +197,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 20,  # ENTITY-004
         "max_requests_per_month": 5000,  # 1000 x 5 members
         "max_requests_per_min": 10,  # Rate limit per org
         "max_summary_tokens": 10000,
@@ -204,6 +212,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 0,  # ENTITY-004
         "max_requests_per_month": 10,
         "max_requests_per_min": 2,
         "max_summary_tokens": 200,
@@ -217,6 +226,7 @@ PLAN_CAPABILITIES: dict[str, PlanCapabilities] = {
         "allow_predictive_intel": False,  # PREDINT-000
         "allow_competitive_intel": False,  # COMPINT-000
         "allow_workspace_basic": False,  # B2GOPS-000
+        "max_tracked_entities": 99999,  # ENTITY-004
         "max_requests_per_month": 99999,
         "max_requests_per_min": 120,
         "max_summary_tokens": 10000,
@@ -283,6 +293,7 @@ _UNKNOWN_PLAN_DEFAULTS = PlanCapabilities(
     allow_predictive_intel=False,  # PREDINT-000
     allow_competitive_intel=False,  # COMPINT-000
     allow_workspace_basic=False,  # B2GOPS-000
+    max_tracked_entities=1,  # ENTITY-004
     max_requests_per_month=10,
     max_requests_per_min=5,
     max_summary_tokens=200,
@@ -332,6 +343,7 @@ def _coerce_capabilities_row(plan_id: str, raw: Optional[dict], max_searches: Op
             # B2GOPS-000: optional jsonb key — defaults False when absent so
             # existing DB rows without it still coerce (non-regression).
             allow_workspace_basic=bool(raw.get("allow_workspace_basic", False)),
+            max_tracked_entities=int(raw.get("max_tracked_entities", 1)),  # ENTITY-004
             # max_searches column wins when set (legacy override path)
             max_requests_per_month=int(max_searches) if max_searches else int(raw["max_requests_per_month"]),
             max_requests_per_min=int(raw["max_requests_per_min"]),
@@ -398,6 +410,7 @@ def _load_plan_capabilities_from_db() -> dict[str, PlanCapabilities]:
                         allow_predictive_intel=base_caps.get("allow_predictive_intel", False),  # PREDINT-000
                         allow_competitive_intel=base_caps.get("allow_competitive_intel", False),  # COMPINT-000
                         allow_workspace_basic=base_caps.get("allow_workspace_basic", False),  # B2GOPS-000
+                        max_tracked_entities=base_caps.get("max_tracked_entities", 1),  # ENTITY-004
                         max_requests_per_month=int(max_searches) if max_searches else base_caps["max_requests_per_month"],
                         max_requests_per_min=base_caps["max_requests_per_min"],
                         max_summary_tokens=base_caps["max_summary_tokens"],
@@ -416,6 +429,7 @@ def _load_plan_capabilities_from_db() -> dict[str, PlanCapabilities]:
                         allow_predictive_intel=_UNKNOWN_PLAN_DEFAULTS["allow_predictive_intel"],  # PREDINT-000
                         allow_competitive_intel=_UNKNOWN_PLAN_DEFAULTS["allow_competitive_intel"],  # COMPINT-000
                         allow_workspace_basic=_UNKNOWN_PLAN_DEFAULTS["allow_workspace_basic"],  # B2GOPS-000
+                        max_tracked_entities=_UNKNOWN_PLAN_DEFAULTS["max_tracked_entities"],  # ENTITY-004
                         max_requests_per_month=int(max_searches) if max_searches else _UNKNOWN_PLAN_DEFAULTS["max_requests_per_month"],
                         max_requests_per_min=_UNKNOWN_PLAN_DEFAULTS["max_requests_per_min"],
                         max_summary_tokens=_UNKNOWN_PLAN_DEFAULTS["max_summary_tokens"],

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -24,6 +24,20 @@ from auth import require_auth
 from log_sanitizer import mask_user_id
 from schemas.common import SuccessMessageResponse
 
+# ENTITY-004: Max tracked entities per plan tier (hardcoded fallback for
+# alert-specific enforcement; source of truth is PlanCapabilities in quota_core).
+_PLAN_TRACKED_ENTITY_LIMITS: dict[str, int] = {
+    "free": 0,
+    "free_trial": 1,
+    "consultor_agil": 1,
+    "maquina": 5,
+    "sala_guerra": 20,
+    "smartlic_pro": 5,
+    "founding_member": 5,
+    "consultoria": 20,
+    "master": 99999,
+}
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["alerts"])
@@ -43,6 +57,96 @@ _PLAN_ALERT_LIMITS: dict[str, int] = {
     "consultoria": 20,
     "master": 20,
 }
+
+
+async def _get_entity_tracked_limit(user_id: str) -> int:
+    """Get max tracked entities allowed for user based on their plan type.
+
+    ENTITY-004: Checks profiles.plan_type and returns the per-plan limit.
+    Falls back to _PLAN_TRACKED_ENTITY_LIMITS dict (hardcoded fallback).
+    """
+    from supabase_client import get_supabase, sb_execute
+    try:
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("profiles")
+            .select("plan_type")
+            .eq("id", user_id)
+            .single()
+        )
+        plan_type = (result.data or {}).get("plan_type", "free")
+        return _PLAN_TRACKED_ENTITY_LIMITS.get(plan_type, 1)
+    except Exception:
+        logger.warning(f"Failed to get plan for user {mask_user_id(user_id)}, defaulting to trial entity limit")
+        return _PLAN_TRACKED_ENTITY_LIMITS.get("free_trial", 1)
+
+
+async def _count_user_tracked_entities(user_id: str, tracked_field: str) -> int:
+    """Count unique tracked entities across all user's alerts for a given field.
+
+    ENTITY-004: Aggregates tracked_orgaos and tracked_fornecedores from all user
+    alerts, deduplicating CNPJs to accurately enforce the per-plan entity limit.
+    """
+    from supabase_client import get_supabase, sb_execute
+    try:
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("alerts")
+            .select(tracked_field)
+            .eq("user_id", user_id)
+        )
+        all_entities: set[str] = set()
+        for row in (result.data or []):
+            entities = row.get(tracked_field)
+            if isinstance(entities, list):
+                all_entities.update(entities)
+        return len(all_entities)
+    except Exception as e:
+        logger.warning(f"Failed to count tracked entities for user {mask_user_id(user_id)}: {e}")
+        return 0
+
+
+async def _check_entity_limit(user_id: str, tracked_field: str, additional_entities: list[str]) -> None:
+    """Raise 422 if adding tracked entities would exceed the plan limit.
+
+    ENTITY-004: Counts existing + new unique entities and compares against plan cap.
+    Skips check for plans with max_tracked_entities >= 99999 (unlimited, e.g. master).
+    """
+    max_entities = await _get_entity_tracked_limit(user_id)
+    if max_entities >= 99999:
+        return  # Unlimited plan — skip check
+
+    current_count = await _count_user_tracked_entities(user_id, tracked_field)
+
+    # Calculate projected count (deduplicate against existing entities)
+    existing_set: set[str] = set()
+    try:
+        from supabase_client import get_supabase, sb_execute
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("alerts")
+            .select(tracked_field)
+            .eq("user_id", user_id)
+        )
+        for row in (result.data or []):
+            entities = row.get(tracked_field)
+            if isinstance(entities, list):
+                existing_set.update(entities)
+    except Exception:
+        pass
+
+    projected = len(existing_set) + sum(1 for e in additional_entities if e not in existing_set)
+
+    if projected > max_entities:
+        field_label = "órgãos" if tracked_field == "tracked_orgaos" else "fornecedores"
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Seu plano permite monitorar até {max_entities} {field_label}. "
+                f"Você já está monitorando {len(existing_set)} e não pode adicionar mais. "
+                "Faça upgrade do seu plano para monitorar mais entidades."
+            ),
+        )
 
 
 async def _get_alert_limit(user_id: str) -> int:
@@ -276,6 +380,12 @@ async def create_alert(
         logger.warning(f"Failed to check alert count for user {mask_user_id(user_id)}: {e}")
         # Continue — better to allow than to block on a count check failure
 
+    # ENTITY-004: Enforce per-plan tracked entity limit
+    if body.tracked_orgaos:
+        await _check_entity_limit(user_id, "tracked_orgaos", body.tracked_orgaos)
+    if body.tracked_fornecedores:
+        await _check_entity_limit(user_id, "tracked_fornecedores", body.tracked_fornecedores)
+
     now = datetime.now(timezone.utc).isoformat()
 
     insert_data = {
@@ -401,9 +511,14 @@ async def update_alert(
         payload["filters"] = body.filters.model_dump(exclude_none=True)
     if body.active is not None:
         payload["active"] = body.active
+
+    # ENTITY-004: Enforce per-plan tracked entity limit on PATCH
+    # Client sends the full replacement list — validate projected count.
     if body.tracked_orgaos is not None:
+        await _check_entity_limit(user_id, "tracked_orgaos", body.tracked_orgaos)
         payload["tracked_orgaos"] = body.tracked_orgaos
     if body.tracked_fornecedores is not None:
+        await _check_entity_limit(user_id, "tracked_fornecedores", body.tracked_fornecedores)
         payload["tracked_fornecedores"] = body.tracked_fornecedores
 
     if not payload:

--- a/backend/tests/test_alerts.py
+++ b/backend/tests/test_alerts.py
@@ -1630,7 +1630,11 @@ class TestTrackedEntities:
         async def fake_sb_execute(query):
             return MockResponse(data=[row], count=0)
 
-        with patch("supabase_client.get_supabase", return_value=sb),              patch("supabase_client.sb_execute", side_effect=fake_sb_execute):
+        # ENTITY-004: mock _check_entity_limit to no-op (test is about alert
+        # creation with entity fields, not about limit enforcement).
+        with patch("routes.alerts._check_entity_limit", new_callable=AsyncMock), \
+             patch("supabase_client.get_supabase", return_value=sb), \
+             patch("supabase_client.sb_execute", side_effect=fake_sb_execute):
             resp = client.post(
                 "/v1/alerts",
                 json={

--- a/backend/tests/test_entity_limit.py
+++ b/backend/tests/test_entity_limit.py
@@ -24,7 +24,7 @@ from quota.quota_core import (
 # Mock the module-level dependencies of routes.alerts so we can import
 # the Pydantic models and helper functions without pulling in FastAPI/auth.
 # ---------------------------------------------------------------------------
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def _mock_alerts_deps():
     """Mock dependencies of routes.alerts module before any test imports from it.
 

--- a/backend/tests/test_entity_limit.py
+++ b/backend/tests/test_entity_limit.py
@@ -168,7 +168,7 @@ class TestCheckEntityLimit:
         from routes.alerts import _check_entity_limit
 
         # Should not raise — unlimited
-        await _check_entity_limit("user-master", "tracked_orgaos", ["cnpj-1"])
+        await _check_entity_limit("user-master", "tracked_orgaos", ["12345678000195"])
 
 
 # ===========================================================================
@@ -239,9 +239,9 @@ class TestCreateAlertRequestIncludesTrackedEntities:
         req = CreateAlertRequest(
             name="Test",
             filters=AlertFilters(),
-            tracked_orgaos=["cnpj-1", "cnpj-2"],
+            tracked_orgaos=["12345678000195", "22345678000195"],
         )
-        assert req.tracked_orgaos == ["cnpj-1", "cnpj-2"]
+        assert req.tracked_orgaos == ["12345678000195", "22345678000195"]
 
     def test_create_alert_request_has_tracked_fornecedores(self):
         """CreateAlertRequest accepts tracked_fornecedores."""
@@ -250,9 +250,9 @@ class TestCreateAlertRequestIncludesTrackedEntities:
         req = CreateAlertRequest(
             name="Test",
             filters=AlertFilters(),
-            tracked_fornecedores=["cnpj-3"],
+            tracked_fornecedores=["32345678000195"],
         )
-        assert req.tracked_fornecedores == ["cnpj-3"]
+        assert req.tracked_fornecedores == ["32345678000195"]
 
 
 class TestUpdateAlertRequestIncludesTrackedEntities:
@@ -262,8 +262,8 @@ class TestUpdateAlertRequestIncludesTrackedEntities:
         """UpdateAlertRequest accepts tracked_orgaos."""
         from routes.alerts import UpdateAlertRequest
 
-        req = UpdateAlertRequest(tracked_orgaos=["cnpj-1"])
-        assert req.tracked_orgaos == ["cnpj-1"]
+        req = UpdateAlertRequest(tracked_orgaos=["12345678000195"])
+        assert req.tracked_orgaos == ["12345678000195"]
 
     def test_update_alert_request_tracked_fornecedores_none_by_default(self):
         """UpdateAlertRequest has tracked_fornecedores as None by default."""

--- a/backend/tests/test_entity_limit.py
+++ b/backend/tests/test_entity_limit.py
@@ -1,0 +1,257 @@
+"""
+ENTITY-004: Tests for tracked entity limits per plan tier.
+
+Tests cover:
+- PlanCapabilities includes max_tracked_entities
+- Each plan has the correct limit (trial=1, pro=5, consulting=20, master=unlimited)
+- Entity limit validation logic in alerts routes
+"""
+
+import sys
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, Field
+
+from quota.quota_core import (
+    PLAN_CAPABILITIES,
+    PlanCapabilities,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock the module-level dependencies of routes.alerts so we can import
+# the Pydantic models and helper functions without pulling in FastAPI/auth.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _mock_alerts_deps():
+    """Mock dependencies of routes.alerts module before any test imports from it."""
+    mock_auth = MagicMock()
+    mock_auth.require_auth = MagicMock()
+    sys.modules["auth"] = mock_auth
+
+    mock_log_sanitizer = MagicMock()
+    mock_log_sanitizer.mask_user_id = lambda x: x[:8] + "..." if len(x or "") > 8 else x
+    sys.modules["log_sanitizer"] = mock_log_sanitizer
+
+    # schemas.common may not have SuccessMessageResponse — create minimal stub
+    mock_schemas_common = MagicMock()
+
+    class MockSuccessMessageResponse(BaseModel):
+        success: bool = True
+        message: str = ""
+
+    mock_schemas_common.SuccessMessageResponse = MockSuccessMessageResponse
+    sys.modules["schemas.common"] = mock_schemas_common
+
+    # Also mock supabase_client since routes.alerts imports it at function level
+    mock_supabase = MagicMock()
+    sys.modules["supabase_client"] = mock_supabase
+
+    yield
+
+    # Cleanup so other tests aren't affected
+    for mod in ["auth", "log_sanitizer", "schemas.common", "supabase_client"]:
+        sys.modules.pop(mod, None)
+
+
+# ===========================================================================
+# PlanCapabilities Tests
+# ===========================================================================
+
+
+class TestEntityPlanLimits:
+    """ENTITY-004 AC1: PlanCapabilities max_tracked_entries per tier."""
+
+    def test_plan_capabilities_has_max_tracked_entities_field(self):
+        """max_tracked_entities is present in the PlanCapabilities TypedDict."""
+        caps = PlanCapabilities(
+            max_history_days=30,
+            allow_excel=False,
+            allow_pipeline=False,
+            allow_subcontract_intel=False,
+            allow_predictive_intel=False,
+            allow_competitive_intel=False,
+            allow_workspace_basic=False,
+            max_requests_per_month=10,
+            max_requests_per_min=2,
+            max_summary_tokens=200,
+            max_tracked_entities=1,
+            priority="normal",
+        )
+        assert caps["max_tracked_entities"] == 1
+
+    def test_trial_has_limit_1(self):
+        """free_trial plan allows 1 tracked entity."""
+        assert PLAN_CAPABILITIES["free_trial"]["max_tracked_entities"] == 1
+
+    def test_smartlic_pro_has_limit_5(self):
+        """smartlic_pro plan allows 5 tracked entities."""
+        assert PLAN_CAPABILITIES["smartlic_pro"]["max_tracked_entities"] == 5
+
+    def test_consultoria_has_limit_20(self):
+        """consultoria plan allows 20 tracked entities."""
+        assert PLAN_CAPABILITIES["consultoria"]["max_tracked_entities"] == 20
+
+    def test_master_has_unlimited(self):
+        """master plan allows unlimited tracked entities."""
+        assert PLAN_CAPABILITIES["master"]["max_tracked_entities"] >= 99999
+
+    def test_free_plan_has_no_tracking(self):
+        """free plan allows 0 tracked entities."""
+        assert PLAN_CAPABILITIES["free"]["max_tracked_entities"] == 0
+
+    def test_founding_member_same_as_pro(self):
+        """founding_member has same limit as smartlic_pro (5)."""
+        assert PLAN_CAPABILITIES["founding_member"]["max_tracked_entities"] == 5
+
+    def test_all_plans_have_max_tracked_entities(self):
+        """Every plan definition includes max_tracked_entities."""
+        for plan_id, caps in PLAN_CAPABILITIES.items():
+            assert "max_tracked_entities" in caps, f"Plan {plan_id} missing max_tracked_entities"
+            assert isinstance(caps["max_tracked_entities"], int)
+
+    def test_unknown_plan_default(self):
+        """Unknown plan defaults to conservative limit of 1 (same as trial)."""
+        from quota.quota_core import _UNKNOWN_PLAN_DEFAULTS
+        assert _UNKNOWN_PLAN_DEFAULTS["max_tracked_entities"] == 1
+
+
+# ===========================================================================
+# _check_entity_limit Unit Tests
+# ===========================================================================
+
+
+class TestCheckEntityLimit:
+    """ENTITY-004: Unit tests for _check_entity_limit."""
+
+    @pytest.mark.asyncio
+    @patch("routes.alerts._get_entity_tracked_limit", new_callable=AsyncMock)
+    @patch("routes.alerts._count_user_tracked_entities", new_callable=AsyncMock)
+    async def test_passes_when_under_limit(
+        self,
+        mock_count: AsyncMock,
+        mock_limit: AsyncMock,
+    ):
+        """User with room can add entities."""
+        mock_limit.return_value = 5
+        mock_count.return_value = 2
+
+        from routes.alerts import _check_entity_limit
+
+        # Should not raise
+        await _check_entity_limit("user-1", "tracked_orgaos", ["cnpj-new"])
+
+    @pytest.mark.asyncio
+    @patch("routes.alerts._get_entity_tracked_limit", new_callable=AsyncMock)
+    async def test_skipped_for_unlimited_plan(self, mock_limit: AsyncMock):
+        """Master/unlimited plans skip the check."""
+        mock_limit.return_value = 99999
+
+        from routes.alerts import _check_entity_limit
+
+        # Should not raise — unlimited
+        await _check_entity_limit("user-master", "tracked_orgaos", ["cnpj-1"])
+
+
+# ===========================================================================
+# _PLAN_TRACKED_ENTITY_LIMITS Dict Tests
+# ===========================================================================
+
+
+class TestPlanTrackedEntityLimits:
+    """ENTITY-004: _PLAN_TRACKED_ENTITY_LIMITS hardcoded fallback."""
+
+    def test_limits_defined_for_all_tiers(self):
+        """All major plan tiers have entity limits defined."""
+        from routes.alerts import _PLAN_TRACKED_ENTITY_LIMITS
+
+        assert _PLAN_TRACKED_ENTITY_LIMITS["free"] == 0
+        assert _PLAN_TRACKED_ENTITY_LIMITS["free_trial"] == 1
+        assert _PLAN_TRACKED_ENTITY_LIMITS["smartlic_pro"] == 5
+        assert _PLAN_TRACKED_ENTITY_LIMITS["consultoria"] == 20
+        assert _PLAN_TRACKED_ENTITY_LIMITS["master"] >= 99999
+
+
+# ===========================================================================
+# Pydantic Model Tests
+# ===========================================================================
+
+
+class TestAlertResponseHasTrackedEntities:
+    """ENTITY-004: AlertResponse model includes tracked entity fields."""
+
+    def test_alert_response_includes_tracked_orgaos(self):
+        """AlertResponse has tracked_orgaos field defaulting to empty list."""
+        from routes.alerts import AlertResponse
+
+        resp = AlertResponse(
+            id="test-id",
+            user_id="user-1",
+            name="Test Alert",
+            filters={},
+            active=True,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        assert resp.tracked_orgaos == []
+
+    def test_alert_response_includes_tracked_fornecedores(self):
+        """AlertResponse has tracked_fornecedores field defaulting to empty list."""
+        from routes.alerts import AlertResponse
+
+        resp = AlertResponse(
+            id="test-id",
+            user_id="user-1",
+            name="Test Alert",
+            filters={},
+            active=True,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        assert resp.tracked_fornecedores == []
+
+
+class TestCreateAlertRequestIncludesTrackedEntities:
+    """ENTITY-004: CreateAlertRequest model includes tracked entity fields."""
+
+    def test_create_alert_request_has_tracked_orgaos(self):
+        """CreateAlertRequest accepts tracked_orgaos."""
+        from routes.alerts import CreateAlertRequest, AlertFilters
+
+        req = CreateAlertRequest(
+            name="Test",
+            filters=AlertFilters(),
+            tracked_orgaos=["cnpj-1", "cnpj-2"],
+        )
+        assert req.tracked_orgaos == ["cnpj-1", "cnpj-2"]
+
+    def test_create_alert_request_has_tracked_fornecedores(self):
+        """CreateAlertRequest accepts tracked_fornecedores."""
+        from routes.alerts import CreateAlertRequest, AlertFilters
+
+        req = CreateAlertRequest(
+            name="Test",
+            filters=AlertFilters(),
+            tracked_fornecedores=["cnpj-3"],
+        )
+        assert req.tracked_fornecedores == ["cnpj-3"]
+
+
+class TestUpdateAlertRequestIncludesTrackedEntities:
+    """ENTITY-004: UpdateAlertRequest model includes tracked entity fields."""
+
+    def test_update_alert_request_has_tracked_orgaos(self):
+        """UpdateAlertRequest accepts tracked_orgaos."""
+        from routes.alerts import UpdateAlertRequest
+
+        req = UpdateAlertRequest(tracked_orgaos=["cnpj-1"])
+        assert req.tracked_orgaos == ["cnpj-1"]
+
+    def test_update_alert_request_tracked_fornecedores_none_by_default(self):
+        """UpdateAlertRequest has tracked_fornecedores as None by default."""
+        from routes.alerts import UpdateAlertRequest
+
+        req = UpdateAlertRequest()
+        assert req.tracked_fornecedores is None

--- a/backend/tests/test_entity_limit.py
+++ b/backend/tests/test_entity_limit.py
@@ -26,7 +26,19 @@ from quota.quota_core import (
 # ---------------------------------------------------------------------------
 @pytest.fixture(autouse=True)
 def _mock_alerts_deps():
-    """Mock dependencies of routes.alerts module before any test imports from it."""
+    """Mock dependencies of routes.alerts module before any test imports from it.
+
+    IMPORTANT: Save original modules BEFORE mocking and restore them in cleanup.
+    Removing real modules from sys.modules corrupts imports for the entire test suite
+    (CRIT-091: caused 191 cascading 401 failures across unrelated test files).
+    """
+    _MOCK_MODULES = ["auth", "log_sanitizer", "schemas.common", "supabase_client"]
+
+    # Save original modules so we can restore them without corrupting the suite
+    _saved: dict[str, object] = {}
+    for mod_name in _MOCK_MODULES:
+        _saved[mod_name] = sys.modules.get(mod_name)
+
     mock_auth = MagicMock()
     mock_auth.require_auth = MagicMock()
     sys.modules["auth"] = mock_auth
@@ -51,9 +63,13 @@ def _mock_alerts_deps():
 
     yield
 
-    # Cleanup so other tests aren't affected
-    for mod in ["auth", "log_sanitizer", "schemas.common", "supabase_client"]:
-        sys.modules.pop(mod, None)
+    # Restore original modules — never leave holes in sys.modules
+    for mod_name in _MOCK_MODULES:
+        original = _saved.get(mod_name)
+        if original is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original
 
 
 # ===========================================================================

--- a/backend/tests/test_plan_capabilities.py
+++ b/backend/tests/test_plan_capabilities.py
@@ -29,6 +29,7 @@ class TestPlanCapabilities:
             "allow_predictive_intel",  # PREDINT-000 (EPIC-PREDINT #1260)
             "allow_competitive_intel",  # COMPINT-000 (EPIC-COMPINT #1261)
             "allow_workspace_basic",  # B2GOPS-000 (EPIC-B2GOPS #1262)
+            "max_tracked_entities",  # ENTITY-004
             "max_requests_per_month",
             "max_requests_per_min",
             "max_summary_tokens",


### PR DESCRIPTION
## ENTITY-004: Limite de entidades por tier de plano

Implementa verificacao de limite de entidades monitoradas por plano.

### Alteracoes

**Backend (quota_core.py):**
- Adicionado `max_tracked_entities` ao `PlanCapabilities` TypedDict
- Limites: free_trial=1, smartlic_pro=5, consultoria=20, master=99999 (ilimitado), free=0
- Propagado para `_coerce_capabilities_row`, `_UNKNOWN_PLAN_DEFAULTS`, e fallbacks

**Backend (routes/alerts.py):**
- Adicionado `tracked_orgaos`/`tracked_fornecedores` aos models `CreateAlertRequest`, `UpdateAlertRequest`, `AlertResponse`
- Nova funcao `_check_entity_limit()` que valida limite antes de POST/PATCH
- Retorna HTTP 422 com mensagem clara se exceder
- `_PLAN_TRACKED_ENTITY_LIMITS` hardcoded fallback para enforcement sem dep circulares

**Frontend (FollowButton.tsx):**
- Modal de upgrade ao atingir limite (ao clicar no botao desabilitado)
- Mensagem: "Seu plano X permite seguir ate Y entidades. Faca upgrade para monitorar mais."
- CTA "Ver planos disponiveis" linka para /planos?ref=entity-limit
- Analytics: `entity_limit_reached`, `entity_limit_upgrade_clicked`
- PLAN_LIMITS expandido para todos os tiers

**Testes (test_entity_limit.py):**
- 18 testes: PlanCapabilities, _check_entity_limit, Pydantic models, _PLAN_TRACKED_ENTITY_LIMITS dict

### Acceptance Criteria

- [x] PlanCapabilities: max_tracked_entities por tier (trial=1, pro=5, consulting=20)
- [x] Backend: POST/PATCH rejeita se exceder limite (422 + mensagem)
- [x] Frontend: modal de upgrade ao tentar seguir alem do limite
- [x] CTA do modal linka para checkout do tier superior
- [x] Analytics: entity_limit_reached

Closes #1447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-plan tracked-entity limits for email alerts.
  * Users can specify tracked organizations and suppliers when creating or updating alerts.

* **Validation**
  * Plan tiers now enforce caps (free: 0, trial: 1, pro/founding: 5, consultoria/enterprise: 20, master: unlimited).
  * Creation and update requests are validated to prevent exceeding plan limits.

* **Tests**
  * Added tests covering plan limits, validation behavior, and request/response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->