### PR TITLE
feat(backend): add A/B test split for VIABILITY_DEFAULT_SORT (#1452)

### DIFF
--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -249,6 +249,8 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "TERM_SEARCH_VIABILITY_GENERIC": ("TERM_SEARCH_VIABILITY_GENERIC", "false"),
     "TERM_SEARCH_FILTER_CONTEXT": ("TERM_SEARCH_FILTER_CONTEXT", "false"),
     # --- Data Sources ---
+    # VIAB-UX-005a: A/B test for default sort
+    "VIABILITY_DEFAULT_SORT": ("VIABILITY_DEFAULT_SORT", "false"),
     "COMPRASGOV_ENABLED": ("COMPRASGOV_ENABLED", "false"),
     "PCP_V2_ENABLED": ("PCP_ENABLED", "true"),
     "DATALAKE_ENABLED": ("DATALAKE_ENABLED", "true"),

--- a/backend/pipeline/stages/enrich.py
+++ b/backend/pipeline/stages/enrich.py
@@ -99,6 +99,31 @@ async def stage_enrich(pipeline, ctx: SearchContext) -> None:
             f"Low(<50): {sum(1 for bid in ctx.licitacoes_filtradas if bid.get('_confidence_score', 50) < 50)}"
         )
 
+    # VIAB-UX-005a: A/B test — override default sort when feature flag is active
+    try:
+        from config import get_feature_flag as _get_ff
+        from utils.viability_split import get_viability_sort_group as _get_group
+
+        if _get_ff("VIABILITY_DEFAULT_SORT"):
+            user_id = ctx.user.get("id") if ctx.user else None
+            if user_id:
+                sort_group = _get_group(user_id)
+                if sort_group == "B":
+                    ctx.request.ordenacao = "confianca"
+                    logger.info(
+                        "VIAB-UX-005a: Group B override — sorting by confianca "
+                        f"(user={user_id[:8]}...)"
+                    )
+                else:
+                    logger.debug(
+                        "VIAB-UX-005a: Group A — keeping default sort "
+                        f"(user={user_id[:8]}...)"
+                    )
+    except Exception as exc:
+        logger.warning(
+            f"VIAB-UX-005a: A/B sort override failed — falling through: {exc}"
+        )
+
     # User-requested sorting (applied AFTER confidence re-ranking for non-default)
     if ctx.licitacoes_filtradas and ctx.request.ordenacao != "data_desc":
         logger.debug(f"Applying user sorting: ordenacao='{ctx.request.ordenacao}'")

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -217,6 +217,7 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "COMPRASGOV_CB_ENABLED": "ComprasGov circuit breaker enabled",
     # A/B Testing
     "ab_experiments_enabled": "A/B experiments framework (STORY-A/B)",
+    "VIABILITY_DEFAULT_SORT": "A/B test: default sort order (VIAB-UX-005a)",
     # Schema Contract (STORY-414)
     "SCHEMA_CONTRACT_STRICT": "Strict schema contract validation for external responses (STORY-414)",
     # Datalake Search Improvements
@@ -281,6 +282,7 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "COMPRASGOV_CB_ENABLED": {"owner": "infra", "category": "infra", "lifecycle": "permanent", "created": "2026-02"},
     # A/B Testing
     "ab_experiments_enabled": {"owner": "product", "category": "experimental", "lifecycle": "experimental", "created": "2026-03"},
+    "VIABILITY_DEFAULT_SORT": {"owner": "search", "category": "experimental", "lifecycle": "experimental", "created": "2026-06"},
     # STORY-414: Schema contract gate
     "SCHEMA_CONTRACT_STRICT": {"owner": "data", "category": "validation", "lifecycle": "experimental", "created": "2026-03"},
     # STORY-437: Datalake search improvements

--- a/backend/routes/search/__init__.py
+++ b/backend/routes/search/__init__.py
@@ -250,6 +250,19 @@ async def buscar_licitacoes(
     )
 
     # -----------------------------------------------------------------------
+    # VIAB-UX-005a: Set A/B sort group header when feature flag is active
+    try:
+        from config import get_feature_flag as _get_ff
+        from utils.viability_split import get_viability_sort_group as _get_group
+
+        if _get_ff("VIABILITY_DEFAULT_SORT"):
+            uid = user.get("id")
+            if uid:
+                group = _get_group(uid)
+                http_response.headers["X-Viability-Sort-Group"] = group
+    except Exception:
+        logger.debug("VIAB-UX-005a: Failed to set sort group header — skipping")
+    # -----------------------------------------------------------------------
     # CRIT-CORE-001: Cache-first check BEFORE async decision.
     # If cache has data (fresh or stale), return immediately — no 202, no SSE dependency.
     # This ensures users always get results when cached data exists.

--- a/backend/tests/test_viability_split.py
+++ b/backend/tests/test_viability_split.py
@@ -1,0 +1,479 @@
+"""VIAB-UX-005a: Tests for A/B split utility and integration with enrich stage.
+
+Tests cover:
+- Deterministic split: same user_id -> same group
+- 50/50 distribution: ~50% in each group (binomial validation)
+- Edge cases: empty user_id raises ValueError
+- Integration: enrich stage applies sort override when flag is active
+- Integration: enrich stage does NOT override when flag is false (zero impact)
+"""
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.viability_split import get_viability_sort_group
+
+
+class TestGetViabilitySortGroup:
+    """Tests for get_viability_sort_group deterministic split."""
+
+    def test_same_user_always_same_group(self):
+        """Same user_id always maps to same group (deterministic)."""
+        user_ids = [
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "00000000-0000-0000-0000-000000000000",
+            "user-123",
+            "admin@smartlic.tech",
+        ]
+        for uid in user_ids:
+            group1 = get_viability_sort_group(uid)
+            group2 = get_viability_sort_group(uid)
+            group3 = get_viability_sort_group(uid)
+            assert group1 == group2 == group3, f"User {uid} got inconsistent groups"
+
+    def test_group_is_a_or_b(self):
+        """Group is always 'A' or 'B'."""
+        user_ids = [
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "00000000-0000-0000-0000-000000000000",
+            "user-123",
+            "admin@smartlic.tech",
+            "550e8400-e29b-41d4-a716-446655440000",
+        ]
+        for uid in user_ids:
+            group = get_viability_sort_group(uid)
+            assert group in ("A", "B"), f"Unexpected group {group} for user {uid}"
+
+    def test_md5_hash_even_is_a_odd_is_b(self):
+        """Group A = even MD5 first byte, Group B = odd MD5 first byte."""
+        test_cases = [
+            ("aaaa", "A" if hashlib.md5(b"aaaa").digest()[0] % 2 == 0 else "B"),
+            ("bbbb", "A" if hashlib.md5(b"bbbb").digest()[0] % 2 == 0 else "B"),
+            ("cccc", "A" if hashlib.md5(b"cccc").digest()[0] % 2 == 0 else "B"),
+        ]
+        for uid, expected in test_cases:
+            assert get_viability_sort_group(uid) == expected, (
+                f"User {uid} expected {expected}"
+            )
+
+    def test_empty_user_id_raises_value_error(self):
+        """Empty user_id raises ValueError."""
+        with pytest.raises(ValueError, match="user_id must be a non-empty string"):
+            get_viability_sort_group("")
+
+    def test_none_user_id_raises_value_error(self):
+        """Empty string user_id raises ValueError."""
+        with pytest.raises(ValueError, match="user_id must be a non-empty string"):
+            get_viability_sort_group("")
+
+    def test_binomial_distribution_100_users(self):
+        """~50 users in each group out of 100 (binomial distribution).
+
+        With 100 users, expected ~50 in each group. Acceptable range:
+        35-65 (3 sigma for binomial with p=0.5, n=100).
+        """
+        user_ids = [f"user-{i:04d}" for i in range(100)]
+        group_counts = {"A": 0, "B": 0}
+
+        for uid in user_ids:
+            group = get_viability_sort_group(uid)
+            group_counts[group] += 1
+
+        total = sum(group_counts.values())
+        assert total == 100, f"Expected 100 total users, got {total}"
+        # 3 sigma range for binomial(100, 0.5): mean=50, sigma=5
+        assert 35 <= group_counts["A"] <= 65, (
+            f"Group A count {group_counts['A']} outside expected range 35-65"
+        )
+        assert 35 <= group_counts["B"] <= 65, (
+            f"Group B count {group_counts['B']} outside expected range 35-65"
+        )
+
+    def test_binomial_distribution_1000_users(self):
+        """~500 users in each group out of 1000.
+
+        With 1000 users, expected ~500 in each group. Acceptable range:
+        450-550 (3 sigma for binomial with p=0.5, n=1000: sigma~15.8).
+        """
+        user_ids = [f"uuid-{i:05d}" for i in range(1000)]
+        group_counts = {"A": 0, "B": 0}
+
+        for uid in user_ids:
+            group = get_viability_sort_group(uid)
+            group_counts[group] += 1
+
+        total = sum(group_counts.values())
+        assert total == 1000, f"Expected 1000 total users, got {total}"
+        # 3 sigma range for binomial(1000, 0.5): mean=500, sigma~15.8
+        assert 450 <= group_counts["A"] <= 550, (
+            f"Group A count {group_counts['A']} outside expected range 450-550"
+        )
+        assert 450 <= group_counts["B"] <= 550, (
+            f"Group B count {group_counts['B']} outside expected range 450-550"
+        )
+
+
+class TestViabilitySortIntegration:
+    """Integration tests: enrich stage applies sort override when flag is active."""
+
+    @pytest.mark.asyncio
+    @patch("config.features._feature_flag_cache", {})
+    @patch("config.get_feature_flag")
+    async def test_flag_active_group_b_overrides_sort(self, mock_get_ff):
+        """When flag is active and user is Group B, sort is overridden to confianca."""
+        from pipeline.stages.enrich import stage_enrich
+        from search_pipeline import SearchPipeline
+        from search_context import SearchContext
+        from types import SimpleNamespace
+
+        # Mock: flag is ON, user gets Group B
+        mock_get_ff.return_value = True
+
+        # Use a user_id known to hash to odd byte (Group B)
+        user_b_id = None
+        for i in range(100):
+            test_uid = f"b-user-{i:04d}"
+            if get_viability_sort_group(test_uid) == "B":
+                user_b_id = test_uid
+                break
+        assert user_b_id is not None, "Could not find a Group B user"
+
+        items = [
+            {"_viability_score": 90, "_confidence_score": 95, "valorTotalEstimado": 500000},
+            {"_viability_score": 50, "_confidence_score": 60, "valorTotalEstimado": 100000},
+        ]
+
+        request = MagicMock(
+            ufs=["SC"],
+            data_inicial="2026-01-01",
+            data_final="2026-01-07",
+            setor_id="v",
+            status=MagicMock(value="todos"),
+            ordenacao="data_desc",
+            termos_busca=None,
+            show_all_matches=False,
+            exclusion_terms=None,
+            modalidades=None,
+            valor_minimo=None,
+            valor_maximo=None,
+            esferas=None,
+            municipios=None,
+            search_id="ts",
+            modo_busca=None,
+            check_sanctions=False,
+        )
+
+        ctx = SearchContext(
+            request=request,
+            user={"id": user_b_id, "email": "b@test.com"},
+        )
+        ctx.is_simplified = True  # Skip viability assessment
+        ctx.active_keywords = {"x"}
+        ctx.custom_terms = []
+        ctx.licitacoes_filtradas = list(items)
+
+        deps = SimpleNamespace(
+            ENABLE_NEW_PRICING=False,
+            PNCPClient=MagicMock(),
+            buscar_todas_ufs_paralelo=MagicMock(return_value=[]),
+            aplicar_todos_filtros=MagicMock(return_value=([], {})),
+            create_excel=MagicMock(),
+            rate_limiter=MagicMock(),
+            check_user_roles=MagicMock(return_value=(False, False)),
+            match_keywords=MagicMock(return_value=(True, [])),
+            KEYWORDS_UNIFORMES=set(),
+            KEYWORDS_EXCLUSAO=set(),
+            validate_terms=MagicMock(return_value={"valid": [], "ignored": [], "reasons": {}}),
+        )
+
+        pipeline = SearchPipeline(deps)
+        await stage_enrich(pipeline, ctx)
+
+        # Assert: sort was overridden to confianca for Group B
+        assert request.ordenacao == "confianca", (
+            f"Expected ordenacao='confianca' for Group B, got '{request.ordenacao}'"
+        )
+
+    @pytest.mark.asyncio
+    @patch("config.features._feature_flag_cache", {})
+    @patch("config.get_feature_flag")
+    async def test_flag_active_group_a_keeps_default(self, mock_get_ff):
+        """When flag is active and user is Group A, sort stays as default (data_desc)."""
+        from pipeline.stages.enrich import stage_enrich
+        from search_pipeline import SearchPipeline
+        from search_context import SearchContext
+        from types import SimpleNamespace
+
+        # Mock: flag is ON, user gets Group A
+        mock_get_ff.return_value = True
+
+        # Find a user_id that maps to group A
+        user_a_id = None
+        for i in range(100):
+            test_uid = f"a-user-{i:04d}"
+            if get_viability_sort_group(test_uid) == "A":
+                user_a_id = test_uid
+                break
+        assert user_a_id is not None, "Could not find a Group A user"
+
+        items = [
+            {"_viability_score": 90, "_confidence_score": 95, "valorTotalEstimado": 500000},
+        ]
+
+        request = MagicMock(
+            ufs=["SC"],
+            data_inicial="2026-01-01",
+            data_final="2026-01-07",
+            setor_id="v",
+            status=MagicMock(value="todos"),
+            ordenacao="data_desc",
+            termos_busca=None,
+            show_all_matches=False,
+            exclusion_terms=None,
+            modalidades=None,
+            valor_minimo=None,
+            valor_maximo=None,
+            esferas=None,
+            municipios=None,
+            search_id="ts",
+            modo_busca=None,
+            check_sanctions=False,
+        )
+
+        ctx = SearchContext(
+            request=request,
+            user={"id": user_a_id, "email": "a@test.com"},
+        )
+        ctx.is_simplified = True
+        ctx.active_keywords = {"x"}
+        ctx.custom_terms = []
+        ctx.licitacoes_filtradas = list(items)
+
+        deps = SimpleNamespace(
+            ENABLE_NEW_PRICING=False,
+            PNCPClient=MagicMock(),
+            buscar_todas_ufs_paralelo=MagicMock(return_value=[]),
+            aplicar_todos_filtros=MagicMock(return_value=([], {})),
+            create_excel=MagicMock(),
+            rate_limiter=MagicMock(),
+            check_user_roles=MagicMock(return_value=(False, False)),
+            match_keywords=MagicMock(return_value=(True, [])),
+            KEYWORDS_UNIFORMES=set(),
+            KEYWORDS_EXCLUSAO=set(),
+            validate_terms=MagicMock(return_value={"valid": [], "ignored": [], "reasons": {}}),
+        )
+
+        pipeline = SearchPipeline(deps)
+        await stage_enrich(pipeline, ctx)
+
+        # Assert: sort stays as default (data_desc) for Group A
+        assert request.ordenacao == "data_desc", (
+            f"Expected ordenacao='data_desc' for Group A, got '{request.ordenacao}'"
+        )
+
+    @pytest.mark.asyncio
+    @patch("config.features._feature_flag_cache", {})
+    @patch("config.get_feature_flag")
+    async def test_flag_inactive_no_override(self, mock_get_ff):
+        """When flag is inactive, sort is NEVER overridden (zero impact)."""
+        from pipeline.stages.enrich import stage_enrich
+        from search_pipeline import SearchPipeline
+        from search_context import SearchContext
+        from types import SimpleNamespace
+
+        # Mock: flag is OFF
+        mock_get_ff.return_value = False
+
+        items = [
+            {"_viability_score": 90, "_confidence_score": 95, "valorTotalEstimado": 500000},
+        ]
+
+        request = MagicMock(
+            ufs=["SC"],
+            data_inicial="2026-01-01",
+            data_final="2026-01-07",
+            setor_id="v",
+            status=MagicMock(value="todos"),
+            ordenacao="data_desc",
+            termos_busca=None,
+            show_all_matches=False,
+            exclusion_terms=None,
+            modalidades=None,
+            valor_minimo=None,
+            valor_maximo=None,
+            esferas=None,
+            municipios=None,
+            search_id="ts",
+            modo_busca=None,
+            check_sanctions=False,
+        )
+
+        ctx = SearchContext(
+            request=request,
+            user={"id": "any-user-id", "email": "any@test.com"},
+        )
+        ctx.is_simplified = True
+        ctx.active_keywords = {"x"}
+        ctx.custom_terms = []
+        ctx.licitacoes_filtradas = list(items)
+
+        deps = SimpleNamespace(
+            ENABLE_NEW_PRICING=False,
+            PNCPClient=MagicMock(),
+            buscar_todas_ufs_paralelo=MagicMock(return_value=[]),
+            aplicar_todos_filtros=MagicMock(return_value=([], {})),
+            create_excel=MagicMock(),
+            rate_limiter=MagicMock(),
+            check_user_roles=MagicMock(return_value=(False, False)),
+            match_keywords=MagicMock(return_value=(True, [])),
+            KEYWORDS_UNIFORMES=set(),
+            KEYWORDS_EXCLUSAO=set(),
+            validate_terms=MagicMock(return_value={"valid": [], "ignored": [], "reasons": {}}),
+        )
+
+        pipeline = SearchPipeline(deps)
+        await stage_enrich(pipeline, ctx)
+
+        # Assert: sort stays as-is when flag is inactive
+        assert request.ordenacao == "data_desc", (
+            f"Expected ordenacao='data_desc' when flag=false, got '{request.ordenacao}'"
+        )
+
+    @pytest.mark.asyncio
+    @patch("config.features._feature_flag_cache", {})
+    @patch("config.get_feature_flag")
+    async def test_flag_active_but_no_user_id_falls_through(self, mock_get_ff):
+        """When flag is active but user has no id, no crash -- falls through gracefully."""
+        from pipeline.stages.enrich import stage_enrich
+        from search_pipeline import SearchPipeline
+        from search_context import SearchContext
+        from types import SimpleNamespace
+
+        mock_get_ff.return_value = True
+
+        items = [
+            {"_viability_score": 90, "_confidence_score": 95, "valorTotalEstimado": 500000},
+        ]
+
+        request = MagicMock(
+            ufs=["SC"],
+            data_inicial="2026-01-01",
+            data_final="2026-01-07",
+            setor_id="v",
+            status=MagicMock(value="todos"),
+            ordenacao="data_desc",
+            termos_busca=None,
+            show_all_matches=False,
+            exclusion_terms=None,
+            modalidades=None,
+            valor_minimo=None,
+            valor_maximo=None,
+            esferas=None,
+            municipios=None,
+            search_id="ts",
+            modo_busca=None,
+            check_sanctions=False,
+        )
+
+        ctx = SearchContext(
+            request=request,
+            user={"id": None, "email": "no-id@test.com"},
+        )
+        ctx.is_simplified = True
+        ctx.active_keywords = {"x"}
+        ctx.custom_terms = []
+        ctx.licitacoes_filtradas = list(items)
+
+        deps = SimpleNamespace(
+            ENABLE_NEW_PRICING=False,
+            PNCPClient=MagicMock(),
+            buscar_todas_ufs_paralelo=MagicMock(return_value=[]),
+            aplicar_todos_filtros=MagicMock(return_value=([], {})),
+            create_excel=MagicMock(),
+            rate_limiter=MagicMock(),
+            check_user_roles=MagicMock(return_value=(False, False)),
+            match_keywords=MagicMock(return_value=(True, [])),
+            KEYWORDS_UNIFORMES=set(),
+            KEYWORDS_EXCLUSAO=set(),
+            validate_terms=MagicMock(return_value={"valid": [], "ignored": [], "reasons": {}}),
+        )
+
+        pipeline = SearchPipeline(deps)
+        # Should NOT raise ValueError from get_viability_sort_group
+        await stage_enrich(pipeline, ctx)
+
+        # Sort should remain default since user has no id
+        assert request.ordenacao == "data_desc", (
+            f"Expected ordenacao='data_desc' when no user id, got '{request.ordenacao}'"
+        )
+
+    @pytest.mark.asyncio
+    @patch("config.features._feature_flag_cache", {})
+    @patch("config.get_feature_flag")
+    async def test_flag_active_get_feature_flag_fails_falls_through(self, mock_get_ff):
+        """When get_feature_flag raises, no crash -- falls through gracefully."""
+        from pipeline.stages.enrich import stage_enrich
+        from search_pipeline import SearchPipeline
+        from search_context import SearchContext
+        from types import SimpleNamespace
+
+        mock_get_ff.side_effect = Exception("Redis unavailable")
+
+        items = [
+            {"_viability_score": 90, "_confidence_score": 95, "valorTotalEstimado": 500000},
+        ]
+
+        request = MagicMock(
+            ufs=["SC"],
+            data_inicial="2026-01-01",
+            data_final="2026-01-07",
+            setor_id="v",
+            status=MagicMock(value="todos"),
+            ordenacao="data_desc",
+            termos_busca=None,
+            show_all_matches=False,
+            exclusion_terms=None,
+            modalidades=None,
+            valor_minimo=None,
+            valor_maximo=None,
+            esferas=None,
+            municipios=None,
+            search_id="ts",
+            modo_busca=None,
+            check_sanctions=False,
+        )
+
+        ctx = SearchContext(
+            request=request,
+            user={"id": "any-user-for-failure-test", "email": "fail@test.com"},
+        )
+        ctx.is_simplified = True
+        ctx.active_keywords = {"x"}
+        ctx.custom_terms = []
+        ctx.licitacoes_filtradas = list(items)
+
+        deps = SimpleNamespace(
+            ENABLE_NEW_PRICING=False,
+            PNCPClient=MagicMock(),
+            buscar_todas_ufs_paralelo=MagicMock(return_value=[]),
+            aplicar_todos_filtros=MagicMock(return_value=([], {})),
+            create_excel=MagicMock(),
+            rate_limiter=MagicMock(),
+            check_user_roles=MagicMock(return_value=(False, False)),
+            match_keywords=MagicMock(return_value=(True, [])),
+            KEYWORDS_UNIFORMES=set(),
+            KEYWORDS_EXCLUSAO=set(),
+            validate_terms=MagicMock(return_value={"valid": [], "ignored": [], "reasons": {}}),
+        )
+
+        pipeline = SearchPipeline(deps)
+        # Should NOT raise despite get_feature_flag failure
+        await stage_enrich(pipeline, ctx)
+
+        # Sort should remain default since get_feature_flag failed
+        assert request.ordenacao == "data_desc", (
+            f"Expected ordenacao='data_desc' when get_feature_flag fails, "
+            f"got '{request.ordenacao}'"
+        )

--- a/backend/utils/viability_split.py
+++ b/backend/utils/viability_split.py
@@ -1,0 +1,31 @@
+"""VIAB-UX-005a: A/B test split utility for viability default sort.
+
+Provides deterministic 50/50 user assignment via MD5 hash of user_id.
+
+- Group A: data_desc (control)
+- Group B: confianca (treatment)
+"""
+
+import hashlib
+
+
+def get_viability_sort_group(user_id: str) -> str:
+    """Deterministic 50/50 A/B split based on MD5 hash of user_id.
+
+    The same user_id always maps to the same group.
+    Expected distribution: ~50% in Group A, ~50% in Group B.
+
+    Args:
+        user_id: User UUID string. Must be non-empty.
+
+    Returns:
+        'A' for control (data_desc) or 'B' for treatment (confianca).
+
+    Raises:
+        ValueError: If user_id is empty or None.
+    """
+    if not user_id:
+        raise ValueError("user_id must be a non-empty string")
+
+    hash_val = hashlib.md5(user_id.encode()).digest()[0]
+    return "A" if hash_val % 2 == 0 else "B"


### PR DESCRIPTION
## Summary

VIAB-UX-005a: Implement A/B test split for viability default sort.

### Changes

1. **New utility** `backend/utils/viability_split.py`: Deterministic 50/50 split via MD5 hash of user_id
   - Group A (hash even): `data_desc` (control)
   - Group B (hash odd): `confianca` (treatment)

2. **Feature flag** `VIABILITY_DEFAULT_SORT`: Added to feature flag registry (`backend/config/features.py`)
   - Default: `false` (no impact when inactive)
   - When active: enables the A/B split

3. **Pipeline integration** (`backend/pipeline/stages/enrich.py`): When flag is active and user is Group B, overrides default sort to `confianca`

4. **Response header** (`backend/routes/search/__init__.py`): Sets `X-Viability-Sort-Group: A|B` when flag is active

5. **Tests** (`backend/tests/test_viability_split.py`): 12 tests covering:
   - Deterministic split (same user → same group)
   - 50/50 binomial distribution (100 and 1000 users)
   - Edge cases (empty user_id raises ValueError)
   - Integration: Group B override, Group A keeps default
   - Integration: zero impact when flag=false
   - Graceful degradation when get_feature_flag fails

### Acceptance Criteria

- [x] Feature flag via env var + Redis (fail-closed: false = data_desc)
- [x] Split 50/50 via hash(user_id) % 2
- [x] Deterministic split: same user_id always same group
- [x] Header X-Viability-Sort-Group: A|B in response for analytics
- [x] Zero impacto when flag=false
- [x] Test: 100 users → ~50 in each group

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a feature flag to enable A/B testing of search result sorting behavior
  * Some users may receive results sorted by confidence score while others receive the default sort order
  * User group assignments are now tracked and communicated via response headers

* **Tests**
  * Added comprehensive test coverage for group assignment logic and sort override functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->