### PR TITLE
feat(backend): add GET /profile/sector-affinity endpoint (#1438)

### DIFF
--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -23,6 +23,7 @@ from database import get_db, get_user_db
 from schemas import (
     UserProfileResponse, SuccessResponse, DeleteAccountResponse,
     PerfilContexto, PerfilContextoResponse, ProfileCompletenessResponse, validate_password,
+    SectorAffinityResponse,
 )
 from schemas.parity import TrialExitSurveysResponse
 from log_sanitizer import mask_user_id, log_user_action
@@ -885,3 +886,135 @@ async def get_exit_surveys_admin(
     except Exception as e:
         logger.error(f"Error fetching exit surveys: {e}")
         raise HTTPException(status_code=503, detail="Erro ao buscar surveys")
+
+
+# =============================================================================
+# FEEDBACK-004: Sector Affinity Endpoint
+# =============================================================================
+
+_SECTOR_AFFINITY_CACHE_TTL = 300  # 5 minutes
+_SECTOR_NAMES: dict[str, str] | None = None
+
+
+def _get_sector_names() -> dict[str, str]:
+    """Load sector names from sectors_data.yaml as fallback mapping."""
+    global _SECTOR_NAMES
+    if _SECTOR_NAMES is not None:
+        return _SECTOR_NAMES
+    try:
+        import os
+        import yaml
+        yaml_path = os.path.join(os.path.dirname(__file__), "..", "sectors_data.yaml")
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+        _SECTOR_NAMES = {sid: cfg["name"] for sid, cfg in data.get("sectors", {}).items()}
+    except Exception:
+        _SECTOR_NAMES = {}
+    return _SECTOR_NAMES
+
+
+async def _get_cached_sector_affinity(cache_key: str) -> list | None:
+    """Best-effort Redis cache read for sector affinity data."""
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+        if redis is None:
+            return None
+        raw = await redis.get(cache_key)
+        if raw is None:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+    except Exception:
+        return None
+
+
+async def _set_cached_sector_affinity(cache_key: str, data: list) -> None:
+    """Best-effort Redis cache write for sector affinity data."""
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+        if redis is None:
+            return
+        await redis.set(cache_key, json.dumps(data), ex=_SECTOR_AFFINITY_CACHE_TTL)
+    except Exception:
+        pass
+
+
+@router.get("/profile/sector-affinity", response_model=list[SectorAffinityResponse])
+async def get_sector_affinity(
+    user: dict = Depends(require_auth),
+):
+    """FEEDBACK-004: Return user's sector affinities ordered by score DESC.
+
+    Reads from user_sector_affinity table, joined with sector names from
+    sectors_data.yaml. Results are cached for 5 minutes per user.
+    Returns empty list if the table doesn't exist yet (migration pending).
+    """
+    user_id = user.get("sub") or user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="User ID not found in token")
+
+    cache_key = f"sector_affinity:{user_id}"
+
+    # Try cache first
+    cached = await _get_cached_sector_affinity(cache_key)
+    if cached is not None:
+        return [SectorAffinityResponse(**item) for item in cached]
+
+    # Load sector name mapping
+    sector_names = _get_sector_names()
+
+    # Query user_sector_affinity table
+    try:
+        from supabase_client import get_supabase
+        db = get_supabase()
+
+        result = await sb_execute(
+            db.table("user_sector_affinity")
+            .select("sector_id, affinity_score")
+            .eq("user_id", user_id)
+            .order("affinity_score", desc=True)
+        )
+
+        rows = result.data or []
+    except Exception as exc:
+        error_str = str(exc).lower()
+        # Table doesn't exist yet — migration not applied
+        if "relation" in error_str and "does not exist" in error_str:
+            logger.warning(
+                "user_sector_affinity table not found. Returning empty list for user %s",
+                mask_user_id(user_id),
+            )
+            return []
+        # Other errors — return empty list gracefully
+        logger.error(
+            "Failed to query sector affinity for %s: %s",
+            mask_user_id(user_id),
+            exc,
+        )
+        return []
+
+    # Map sector_id to sector_name
+    result_items = []
+    for row in rows:
+        sector_id = row.get("sector_id", "")
+        result_items.append(SectorAffinityResponse(
+            sector_id=sector_id,
+            sector_name=sector_names.get(sector_id, sector_id),
+            affinity_score=float(row.get("affinity_score", 0.0)),
+        ))
+
+    # Cache the result
+    data_for_cache = [
+        {
+            "sector_id": item.sector_id,
+            "sector_name": item.sector_name,
+            "affinity_score": item.affinity_score,
+        }
+        for item in result_items
+    ]
+    await _set_cached_sector_affinity(cache_key, data_for_cache)
+
+    return result_items

--- a/backend/schemas/feedback.py
+++ b/backend/schemas/feedback.py
@@ -64,6 +64,16 @@ class FPKeywordSuggestion(BaseModel):
     suggestion: str
 
 
+class SectorAffinityResponse(BaseModel):
+    """FEEDBACK-004: User affinity score for a sector.
+
+    Returned by GET /v1/profile/sector-affinity.
+    """
+    sector_id: str = Field(..., description="Sector identifier (e.g., 'vestuario')")
+    sector_name: str = Field(..., description="Display name of the sector")
+    affinity_score: float = Field(..., ge=0.0, le=1.0, description="Affinity score from 0.0 to 1.0")
+
+
 class FeedbackPatternsResponse(BaseModel):
     """GET /v1/admin/feedback/patterns response body."""
     total_feedbacks: int

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -13489,6 +13489,35 @@
         "title": "SeasonalCalendarStats",
         "type": "object"
       },
+      "SectorAffinityResponse": {
+        "description": "FEEDBACK-004: User affinity score for a sector.\n\nReturned by GET /v1/profile/sector-affinity.",
+        "properties": {
+          "affinity_score": {
+            "description": "Affinity score from 0.0 to 1.0",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Affinity Score",
+            "type": "number"
+          },
+          "sector_id": {
+            "description": "Sector identifier (e.g., 'vestuario')",
+            "title": "Sector Id",
+            "type": "string"
+          },
+          "sector_name": {
+            "description": "Display name of the sector",
+            "title": "Sector Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sector_id",
+          "sector_name",
+          "affinity_score"
+        ],
+        "title": "SectorAffinityResponse",
+        "type": "object"
+      },
       "SectorAggregate": {
         "properties": {
           "avg_value": {
@@ -26515,6 +26544,37 @@
           }
         ],
         "summary": "Save Profile Context",
+        "tags": [
+          "user"
+        ]
+      }
+    },
+    "/v1/profile/sector-affinity": {
+      "get": {
+        "description": "FEEDBACK-004: Return user's sector affinities ordered by score DESC.\n\nReads from user_sector_affinity table, joined with sector names from\nsectors_data.yaml. Results are cached for 5 minutes per user.\nReturns empty list if the table doesn't exist yet (migration pending).",
+        "operationId": "get_sector_affinity_v1_profile_sector_affinity_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SectorAffinityResponse"
+                  },
+                  "title": "Response Get Sector Affinity V1 Profile Sector Affinity Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Sector Affinity",
         "tags": [
           "user"
         ]

--- a/backend/tests/test_sector_affinity.py
+++ b/backend/tests/test_sector_affinity.py
@@ -1,0 +1,214 @@
+"""Tests for FEEDBACK-004: GET /v1/profile/sector-affinity endpoint.
+
+Tests:
+1. Returns empty list for user with no sector affinity data
+2. Returns sector affinities ordered by score DESC
+3. RLS: User A does not see User B's affinities
+4. Cache: second call returns cached data
+5. Unauthenticated returns 401
+6. Handles gracefully when table doesn't exist (migration pending)
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def test_user():
+    return {"id": "550e8400-e29b-41d4-a716-446655440000", "sub": "550e8400-e29b-41d4-a716-446655440000", "email": "test@example.com"}
+
+
+@pytest.fixture
+def client(test_user):
+    from main import app
+    from auth import require_auth
+
+    app.dependency_overrides[require_auth] = lambda: test_user
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_no_auth():
+    from main import app
+    from auth import require_auth
+
+    app.dependency_overrides.pop(require_auth, None)
+    return TestClient(app)
+
+
+def _mock_supabase_select(rows):
+    """Helper: create a mock Supabase table.select().eq().order().execute() chain."""
+    mock = MagicMock()
+    mock.table.return_value = mock
+    mock.select.return_value = mock
+    mock.eq.return_value = mock
+    mock.order.return_value = mock
+    mock.execute.return_value = MagicMock(data=rows)
+    mock.single.return_value = mock
+    return mock
+
+
+class TestSectorAffinityEndpoint:
+    """FEEDBACK-004: GET /v1/profile/sector-affinity tests."""
+
+    # Test 1: Empty list for user without affinities
+
+    @patch("routes.user._get_cached_sector_affinity", return_value=None)
+    @patch("routes.user._set_cached_sector_affinity", return_value=None)
+    def test_empty_list_when_no_affinities(self, mock_set, mock_get, client):
+        """Test 1: Returns empty list for user with no sector affinity data."""
+        with patch("supabase_client.get_supabase", return_value=_mock_supabase_select([])):
+            with patch("supabase_client.sb_execute", return_value=MagicMock(data=[])):
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == []
+
+    # Test 2: Returns affinities ordered by score DESC
+
+    @patch("routes.user._get_cached_sector_affinity", return_value=None)
+    @patch("routes.user._set_cached_sector_affinity", return_value=None)
+    @patch("routes.user._get_sector_names")
+    def test_returns_affinities_ordered_by_score(self, mock_names, mock_set, mock_get, client):
+        """Test 2: Returns sector affinities ordered by affinity_score DESC."""
+        mock_names.return_value = {
+            "vestuario": "Vestuário e Uniformes",
+            "alimentos": "Alimentos e Bebidas",
+            "saude": "Saúde",
+        }
+
+        mock_rows = [
+            {"sector_id": "saude", "affinity_score": 0.9},
+            {"sector_id": "vestuario", "affinity_score": 0.7},
+            {"sector_id": "alimentos", "affinity_score": 0.3},
+        ]
+
+        with patch("supabase_client.get_supabase", return_value=_mock_supabase_select(mock_rows)):
+            with patch("supabase_client.sb_execute", return_value=MagicMock(data=mock_rows)):
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+        assert data[0]["sector_id"] == "saude"
+        assert data[0]["affinity_score"] == 0.9
+        assert data[0]["sector_name"] == "Saúde"
+        assert data[1]["sector_id"] == "vestuario"
+        assert data[1]["affinity_score"] == 0.7
+        assert data[2]["sector_id"] == "alimentos"
+        assert data[2]["affinity_score"] == 0.3
+
+    # Test 3: User A cannot see User B's data (endpoint only queries for auth user)
+
+    @patch("routes.user._get_cached_sector_affinity", return_value=None)
+    @patch("routes.user._set_cached_sector_affinity", return_value=None)
+    @patch("routes.user._get_sector_names")
+    def test_user_a_does_not_see_user_b_data(self, mock_names, mock_set, mock_get, client):
+        """Test 3: RLS — user A cannot see user B's affinities."""
+        mock_names.return_value = {"vestuario": "Vestuário e Uniformes"}
+        mock_rows = [
+            {"sector_id": "vestuario", "affinity_score": 0.8},
+        ]
+
+        with patch("supabase_client.get_supabase", return_value=_mock_supabase_select(mock_rows)):
+            with patch("supabase_client.sb_execute", return_value=MagicMock(data=mock_rows)):
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        sector_ids = [item["sector_id"] for item in data]
+        assert sector_ids == ["vestuario"]
+
+    # Test 4: Cache returns cached data
+
+    def test_cache_returns_cached_data(self, client):
+        """Test 4: Second call returns cached data without hitting Supabase."""
+        cached_data = [
+            {"sector_id": "vestuario", "sector_name": "Vestuário e Uniformes",
+             "affinity_score": 0.8},
+        ]
+
+        with patch("routes.user._get_cached_sector_affinity", return_value=cached_data):
+            with patch("routes.user._set_cached_sector_affinity") as _:
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["sector_id"] == "vestuario"
+        assert data[0]["affinity_score"] == 0.8
+
+    # Test 5: Unauthenticated returns 401
+
+    def test_unauthenticated_returns_401(self, client_no_auth):
+        """Test 5: Unauthenticated requests should return 401."""
+        response = client_no_auth.get("/v1/profile/sector-affinity")
+        assert response.status_code == 401
+
+    # Test 6: Handles missing table gracefully
+
+    @patch("routes.user._get_cached_sector_affinity", return_value=None)
+    @patch("routes.user._set_cached_sector_affinity", return_value=None)
+    def test_missing_table_returns_empty_list(self, mock_set, mock_get, client):
+        """Test 6: Returns empty list when user_sector_affinity table doesn't exist."""
+
+        class TableNotFoundError(Exception):
+            def __init__(self):
+                super().__init__('relation "user_sector_affinity" does not exist')
+
+        with patch("supabase_client.get_supabase"):
+            with patch("supabase_client.sb_execute", side_effect=TableNotFoundError()):
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == []
+
+    # Test 7: Generic DB error returns empty list
+
+    @patch("routes.user._get_cached_sector_affinity", return_value=None)
+    @patch("routes.user._set_cached_sector_affinity", return_value=None)
+    def test_generic_db_error_returns_empty_list(self, mock_set, mock_get, client):
+        """Test 7: Generic database error gracefully returns empty list."""
+        with patch("supabase_client.get_supabase"):
+            with patch("supabase_client.sb_execute", side_effect=Exception("connection timeout")):
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == []
+
+    # Test 8: Response schema matches OpenAPI contract
+
+    @patch("routes.user._get_cached_sector_affinity", return_value=None)
+    @patch("routes.user._set_cached_sector_affinity", return_value=None)
+    @patch("routes.user._get_sector_names")
+    def test_response_schema(self, mock_names, mock_set, mock_get, client):
+        """Test 8: Response matches SectorAffinityResponse schema."""
+        mock_names.return_value = {"saude": "Saúde"}
+        mock_rows = [
+            {"sector_id": "saude", "affinity_score": 0.85},
+        ]
+
+        with patch("supabase_client.get_supabase", return_value=_mock_supabase_select(mock_rows)):
+            with patch("supabase_client.sb_execute", return_value=MagicMock(data=mock_rows)):
+                response = client.get("/v1/profile/sector-affinity")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        item = data[0]
+        assert "sector_id" in item
+        assert "sector_name" in item
+        assert "affinity_score" in item
+        assert isinstance(item["sector_id"], str)
+        assert isinstance(item["sector_name"], str)
+        assert isinstance(item["affinity_score"], (int, float))
+        assert item["sector_id"] == "saude"
+        assert item["sector_name"] == "Saúde"
+        assert item["affinity_score"] == 0.85

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4717,6 +4717,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/profile/sector-affinity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sector Affinity
+         * @description FEEDBACK-004: Return user's sector affinities ordered by score DESC.
+         *
+         *     Reads from user_sector_affinity table, joined with sector names from
+         *     sectors_data.yaml. Results are cached for 5 minutes per user.
+         *     Returns empty list if the table doesn't exist yet (migration pending).
+         */
+        get: operations["get_sector_affinity_v1_profile_sector_affinity_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/pseo/recent-editais": {
         parameters: {
             query?: never;
@@ -11886,6 +11910,29 @@ export interface components {
              * @description UF code (uppercase)
              */
             uf: string;
+        };
+        /**
+         * SectorAffinityResponse
+         * @description FEEDBACK-004: User affinity score for a sector.
+         *
+         *     Returned by GET /v1/profile/sector-affinity.
+         */
+        SectorAffinityResponse: {
+            /**
+             * Affinity Score
+             * @description Affinity score from 0.0 to 1.0
+             */
+            affinity_score: number;
+            /**
+             * Sector Id
+             * @description Sector identifier (e.g., 'vestuario')
+             */
+            sector_id: string;
+            /**
+             * Sector Name
+             * @description Display name of the sector
+             */
+            sector_name: string;
         };
         /** SectorAggregate */
         SectorAggregate: {
@@ -19532,6 +19579,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_sector_affinity_v1_profile_sector_affinity_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorAffinityResponse"][];
                 };
             };
         };


### PR DESCRIPTION
## Context
FEEDBACK-004: Endpoint de transparência que retorna as afinidades do usuário por setor, com cache Redis de 5 minutos. Parte do ecossistema de feedback loop.

## Changes
- `schemas/feedback.py` — SectorAffinityResponse (sector_id, sector_name, affinity_score)
- `routes/user.py` — GET /v1/profile/sector-affinity com Redis cache TTL 300s
- `tests/test_sector_affinity.py` — 8 casos de teste
- Adaptado para schema existente da migration `20260604135548` (PR #1475)

## Testing Plan
- [x] Python syntax check passa
- [ ] Backend tests: `pytest tests/test_sector_affinity.py -v`
- [ ] Cache invalidação em 5min

## Dependencies
- Migration: #1436 (PR #1475) — tabela user_sector_affinity

## Risks & Rollback
Baixo risco — graceful degradation se tabela não existir (retorna []). Reverter via `git revert`.

## Closes
Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)