### PR TITLE
feat(backend): apply user-sector affinity factor to combined score (#1437)

### DIFF
--- a/backend/pipeline/stages/enrich.py
+++ b/backend/pipeline/stages/enrich.py
@@ -9,8 +9,12 @@ from relevance import score_relevance, count_phrase_matches
 from utils.ordenacao import ordenar_licitacoes
 from search_context import SearchContext
 from viability import assess_batch as viability_assess_batch
+from pipeline.budget import _run_with_budget  # STORY-4.4 TD-SYS-003
 
 logger = logging.getLogger(__name__)
+
+# Budget label for affinity DB lookup (STORY-4.4 TD-SYS-003).
+_AFFINITY_BUDGET_S = 5.0  # Lightweight DB call — generous budget, must not block pipeline.
 
 
 async def stage_enrich(pipeline, ctx: SearchContext) -> None:
@@ -53,6 +57,38 @@ async def stage_enrich(pipeline, ctx: SearchContext) -> None:
                 len(matched_terms), len(ctx.custom_terms), phrase_count
             )
 
+    # FEEDBACK-003: Fetch user-sector affinity before scoring.
+    # Formula: affinity_factor = min(1.0, 0.5 + affinity).
+    #   affinity=0.0 → factor=0.5 (50% reduction, never zero).
+    #   affinity=0.5 → factor=1.0 (cold start / neutral).
+    #   affinity=1.0 → factor=1.0 (capped — no excessive boost).
+    affinity_factor = 1.0  # Neutral default
+    if ctx.user and ctx.sector and ctx.licitacoes_filtradas:
+        user_id = ctx.user.get("id")
+        sector_id = getattr(ctx.sector, "id", None)
+        if user_id and sector_id:
+            try:
+                from feedback_affinity import get_affinity
+                from supabase_client import get_supabase
+
+                async def _fetch_affinity():
+                    supabase = get_supabase()
+                    return await get_affinity(supabase, user_id, sector_id)
+
+                affinity = await _run_with_budget(
+                    _fetch_affinity(),
+                    budget=_AFFINITY_BUDGET_S,
+                    phase="enrich",
+                    source="affinity",
+                )
+                affinity_factor = min(1.0, 0.5 + affinity)
+                logger.debug(
+                    f"FEEDBACK-003: affinity={affinity:.2f} factor={affinity_factor:.2f} "
+                    f"user={user_id[:8]}... sector={sector_id}"
+                )
+            except Exception as exc:
+                logger.warning(f"FEEDBACK-003: affinity lookup failed — using neutral factor: {exc}")
+
     # D-02 AC5 + D-04 AC9: Re-ranking by combined score (viability always-on)
     if ctx.licitacoes_filtradas:
         viability_active = any(
@@ -77,12 +113,17 @@ async def stage_enrich(pipeline, ctx: SearchContext) -> None:
                 # D-04 AC9: combined_score = confidence * 0.6 + viability * 0.4
                 viab = lic.get("_viability_score", 50)
                 combined = conf * 0.6 + viab * 0.4 + relevance_boost
+                # FEEDBACK-003: Apply user-sector affinity factor
+                combined *= affinity_factor
                 lic["_combined_score"] = round(combined)
+                lic["_affinity_factor"] = round(affinity_factor, 3)
                 return (-combined, -valor)
 
-            # Fallback for simplified searches without viability scores
+            # FEEDBACK-003: Fallback for simplified searches without viability scores.
+            # Apply affinity consistently so both paths personalize results.
             # Band: 0=high(>=80), 1=medium(50-79), 2=low(<50)
-            boosted_conf = conf + relevance_boost
+            boosted_conf = (conf + relevance_boost) * affinity_factor
+            lic["_affinity_factor"] = round(affinity_factor, 3)
             if boosted_conf >= 80:
                 band = 0
             elif boosted_conf >= 50:

--- a/backend/tests/test_feedback_affinity_enrich.py
+++ b/backend/tests/test_feedback_affinity_enrich.py
@@ -1,0 +1,358 @@
+"""FEEDBACK-003: Tests for user-sector affinity factor in enrichment pipeline.
+
+Covers:
+- Affinity factor formula: min(1.0, 0.5 + affinity)
+- Affinity applied in viability path (combined_score)
+- Affinity applied in simplified/fallback path (boosted_conf)
+- Neutral fallback on DB failure / timeout
+- Neutral default when user/sector missing
+- _run_with_budget wrapping
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from search_context import SearchContext
+from search_pipeline import SearchPipeline
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_bid(objeto: str, conf: float = 50, viab: float | None = None,
+              valor: float = 100_000, relevance_source: str | None = None,
+              term_density: float = 0.0) -> dict:
+    """Create a minimal bid dict for enrichment testing."""
+    bid: dict = {
+        "objetoCompra": objeto,
+        "_confidence_score": conf,
+        "valorTotalEstimado": valor,
+    }
+    if viab is not None:
+        bid["_viability_score"] = viab
+    if relevance_source:
+        bid["_relevance_source"] = relevance_source
+    if term_density:
+        bid["_term_density"] = term_density
+    return bid
+
+
+def _make_ctx(*, user: dict | None = None, sector=None, licitacoes=None,
+              custom_terms=None, ordenacao: str = "data_desc",
+              active_keywords: set | None = None,
+              is_simplified: bool = True) -> SearchContext:
+    """Create a minimal SearchContext.
+
+    Defaults is_simplified=True to skip viability assessment (not under test).
+    """
+    from datetime import datetime, timezone
+
+    if active_keywords is None:
+        active_keywords = set()
+
+    ctx = SearchContext(
+        user=user,
+        sector=sector,
+        licitacoes_filtradas=licitacoes or [],
+        custom_terms=custom_terms or [],
+        active_keywords=active_keywords,
+        request=MagicMock(
+            data_inicial=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            data_final=datetime(2026, 1, 10, tzinfo=timezone.utc),
+            ufs=["SP"],
+            modalidades=[],
+            ordenacao=ordenacao,
+            search_id="test-search-id",
+        ),
+        is_simplified=is_simplified,
+        user_profile=None,
+    )
+    return ctx
+
+
+def _make_deps():
+    """Create minimal pipeline dependencies."""
+    return {}
+
+
+# ── Formula correctness ─────────────────────────────────────────────────────
+
+
+class TestAffinityFactorFormula:
+    """FEEDBACK-003 AC1: affinity_factor = min(1.0, 0.5 + affinity)."""
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_cold_start_neutral(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """affinity=0.5 → factor=min(1.0, 1.0)=1.0 (neutral, no change)."""
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.return_value = 0.5  # cold start
+            mock_ordenar.return_value = []
+
+            bids = [_make_bid("Item A", conf=80, viab=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+                is_simplified=True,  # Skip viability assessment
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            assert bids[0]["_affinity_factor"] == 1.0
+            # combined_score unchanged (no relevance_boost)
+            expected = round(80 * 0.6 + 80 * 0.4)
+            assert bids[0]["_combined_score"] == expected
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_low_affinity_reduces_score(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """affinity=0.0 → factor=min(1.0, 0.5)=0.5 (50% reduction)."""
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.return_value = 0.0
+            mock_ordenar.return_value = []
+
+            bids = [_make_bid("Item A", conf=80, viab=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            assert bids[0]["_affinity_factor"] == 0.5
+            base = 80 * 0.6 + 80 * 0.4  # 80
+            assert bids[0]["_combined_score"] == round(base * 0.5)  # 40
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_high_affinity_capped_at_one(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """affinity=1.0 → factor=min(1.0, 1.5)=1.0 (capped, no boost)."""
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.return_value = 1.0
+            mock_ordenar.return_value = []
+
+            bids = [_make_bid("Item A", conf=80, viab=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            assert bids[0]["_affinity_factor"] == 1.0
+            base = 80 * 0.6 + 80 * 0.4
+            assert bids[0]["_combined_score"] == round(base)  # unchanged
+
+
+# ── Simplified / fallback path ───────────────────────────────────────────────
+
+
+class TestAffinityFactorFallbackPath:
+    """FEEDBACK-003: Affinity applied in simplified search path too."""
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_affinity_applied_in_fallback(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """Simplified search (no viability scores) still gets affinity applied."""
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.return_value = 0.0  # factor=0.5
+            mock_ordenar.return_value = []
+
+            # No _viability_score → viability_active=False → fallback path
+            bids = [_make_bid("Item A", conf=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            assert bids[0]["_affinity_factor"] == 0.5
+            # boosted_conf = (80 + 0) * 0.5 = 40 → band 2
+            # sorting key: (2, -40, -100000) — low conf band
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_fallback_neutral_when_no_user(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """Without user, fallback path uses neutral factor=1.0."""
+        mock_ordenar.return_value = []
+
+        bids = [_make_bid("Item A", conf=80)]
+        ctx = _make_ctx(
+            user=None,  # no user
+            sector=MagicMock(id="sector-99"),
+            licitacoes=bids,
+        )
+        pipeline = SearchPipeline(_make_deps())
+        await pipeline.stage_enrich(ctx)
+
+        assert bids[0]["_affinity_factor"] == 1.0
+
+
+# ── Error resilience ─────────────────────────────────────────────────────────
+
+
+class TestAffinityFactorErrorHandling:
+    """FEEDBACK-003: Affinity lookup failures gracefully fall back to neutral."""
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_db_failure_falls_back_to_neutral(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """When get_affinity raises, factor stays 1.0."""
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.side_effect = RuntimeError("DB connection refused")
+            mock_ordenar.return_value = []
+
+            bids = [_make_bid("Item A", conf=80, viab=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            assert bids[0]["_affinity_factor"] == 1.0
+            base = 80 * 0.6 + 80 * 0.4
+            assert bids[0]["_combined_score"] == round(base)
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    @patch("pipeline.stages.enrich.count_phrase_matches", return_value=0)
+    @patch("pipeline.stages.enrich.score_relevance", return_value=0.0)
+    async def test_timeout_falls_back_to_neutral(
+        self, mock_score, mock_count, mock_ordenar
+    ):
+        """When _run_with_budget times out, factor stays 1.0."""
+        import asyncio
+
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.side_effect = asyncio.TimeoutError("budget exceeded")
+            mock_ordenar.return_value = []
+
+            bids = [_make_bid("Item A", conf=80, viab=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            assert bids[0]["_affinity_factor"] == 1.0
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    async def test_no_user_no_fetch(self, mock_ordenar):
+        """When user is None, get_affinity is never called."""
+        mock_ordenar.return_value = []
+
+        bids = [_make_bid("Item A", conf=80)]
+        ctx = _make_ctx(
+            user=None,
+            sector=MagicMock(id="sector-99"),
+            licitacoes=bids,
+        )
+        pipeline = SearchPipeline(_make_deps())
+        await pipeline.stage_enrich(ctx)
+
+        # _run_with_budget not patched → if it were called it would fail
+        assert bids[0].get("_affinity_factor", 1.0) == 1.0
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    async def test_no_licitacoes_no_fetch(self, mock_ordenar):
+        """When licitacoes_filtradas is empty, get_affinity is never called."""
+        mock_ordenar.return_value = []
+
+        ctx = _make_ctx(
+            user={"id": "user-123"},
+            sector=MagicMock(id="sector-99"),
+            licitacoes=[],
+        )
+        pipeline = SearchPipeline(_make_deps())
+        await pipeline.stage_enrich(ctx)
+
+        # No bids → no _affinity_factor set anywhere, no fetch attempted
+
+
+# ── Budget wrapping ──────────────────────────────────────────────────────────
+
+
+class TestAffinityFactorBudget:
+    """FEEDBACK-003 + STORY-4.4: Affinity fetch uses _run_with_budget."""
+
+    @pytest.mark.asyncio
+    @patch("pipeline.stages.enrich.ordenar_licitacoes")
+    async def test_budget_phase_label(self, mock_ordenar):
+        """_run_with_budget called with phase='enrich', source='affinity'."""
+        from pipeline.stages.enrich import _AFFINITY_BUDGET_S
+
+        with patch(
+            "pipeline.stages.enrich._run_with_budget",
+            new_callable=AsyncMock,
+        ) as mock_budget:
+            mock_budget.return_value = 0.5
+            mock_ordenar.return_value = []
+
+            bids = [_make_bid("Item A", conf=80, viab=80)]
+            ctx = _make_ctx(
+                user={"id": "user-123"},
+                sector=MagicMock(id="sector-99"),
+                licitacoes=bids,
+            )
+            pipeline = SearchPipeline(_make_deps())
+            await pipeline.stage_enrich(ctx)
+
+            mock_budget.assert_called_once()
+            call_kwargs = mock_budget.call_args.kwargs
+            assert call_kwargs["budget"] == _AFFINITY_BUDGET_S
+            assert call_kwargs["phase"] == "enrich"
+            assert call_kwargs["source"] == "affinity"


### PR DESCRIPTION
## Summary

FEEDBACK-003: Apply user-sector affinity factor to combined score during enrich pipeline.

## Context

After computing combined score in the enrichment pipeline, apply an affinity factor based on user sector affinity. Cold start (affinity=0.5) → neutral factor=1.0. Affinity=0.0 → factor=0.5 (50% reduction). Affinity=1.0 → factor=1.0 (neutral).

## Changes

- `backend/pipeline/stages/enrich.py`: Fetch user-sector affinity before scoring, apply factor to combined score

## Testing Plan

CI backend tests validate the enrich pipeline stage. Affinity lookup failures gracefully fall back to neutral factor.

Closes #1437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented user-sector affinity-based personalization for search result ranking. Confidence scores are now dynamically adjusted based on user affinity metrics for more relevant, personalized results.

* **Tests**
  * Added comprehensive test coverage for affinity calculation, fallback mechanisms, error handling, and various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->