### PR TITLE
feat(frontend): extend banned phrase validation to blog and search components (#1443)

### DIFF
--- a/.github/workflows/banned-phrases-check.yml
+++ b/.github/workflows/banned-phrases-check.yml
@@ -20,5 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for git diff against base ref
       - name: Run banned phrase scan
         run: bash scripts/check-banned-phrases.sh

--- a/.github/workflows/banned-phrases-check.yml
+++ b/.github/workflows/banned-phrases-check.yml
@@ -1,0 +1,24 @@
+name: Banned Phrases Check (NO-JARGON-004)
+
+on:
+  pull_request:
+    paths:
+      - "frontend/app/blog/**"
+      - "frontend/app/buscar/**"
+      - "frontend/components/**"
+      - "frontend/lib/copy/**"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/app/blog/**"
+      - "frontend/app/buscar/**"
+      - "frontend/components/**"
+      - "frontend/lib/copy/**"
+
+jobs:
+  check-banned-phrases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run banned phrase scan
+        run: bash scripts/check-banned-phrases.sh

--- a/frontend/lib/copy/b2gIntelCopy.ts
+++ b/frontend/lib/copy/b2gIntelCopy.ts
@@ -270,6 +270,17 @@ export const REPO_COMMS_BANNED_WORDS = [
   "buscar",
   "encontrar",
   "dados abertos",
+  // NO-JARGON-004: Technical jargon — sync with BANNED_PHRASES
+  "datalake",
+  "data lake",
+  "GPT-4",
+  "GPT-3.5",
+  "GPT",
+  "LLM",
+  "large language model",
+  "cache expirado",
+  "em cache",
+  "quota",
 ];
 
 // ============================================================================

--- a/scripts/check-banned-phrases.sh
+++ b/scripts/check-banned-phrases.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# NO-JARGON-004: Banned phrase validation for blog and search components.
+# Scans frontend source files for banned technical jargon.
+# Exit 0 = clean, Exit 1 = violations found.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+
+# Banned phrases — keep in sync with BANNED_PHRASES in lib/copy/valueProps.ts
+# and REPO_COMMS_BANNED_WORDS in lib/copy/b2gIntelCopy.ts
+BANNED=(
+  "datalake"
+  "data lake"
+  "GPT-4"
+  "GPT-3.5"
+  "GPT"
+  "LLM"
+  "large language model"
+  "machine learning"
+  "cache expirado"
+  "em cache"
+  "quota"
+)
+
+# Directories to scan (user-facing content)
+SCAN_DIRS=(
+  "$FRONTEND_DIR/app/blog"
+  "$FRONTEND_DIR/app/buscar"
+  "$FRONTEND_DIR/components"
+  "$FRONTEND_DIR/lib/copy"
+)
+
+# Exceptions: dev-facing docs and config files
+EXCLUDE_PATTERNS="node_modules|.next|.git|worktrees|__tests__|api-types|.storybook"
+
+violations=0
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [ ! -d "$dir" ]; then
+    continue
+  fi
+  for phrase in "${BANNED[@]}"; do
+    while IFS= read -r -d '' file; do
+      # Skip excluded paths
+      if echo "$file" | grep -qE "$EXCLUDE_PATTERNS"; then
+        continue
+      fi
+      # Search for the phrase (case-insensitive, whole-word where possible)
+      if grep -nHi "$phrase" "$file" 2>/dev/null; then
+        violations=$((violations + 1))
+      fi
+    done < <(find "$dir" -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.mdx" \) -print0 2>/dev/null || true)
+  done
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "❌ NO-JARGON-004: Found $violations banned phrase violation(s)."
+  echo "   Replace technical jargon with user-facing alternatives."
+  echo "   See: frontend/lib/copy/valueProps.ts (BANNED_PHRASES)"
+  echo "        frontend/lib/copy/b2gIntelCopy.ts (REPO_COMMS_BANNED_WORDS)"
+  exit 1
+fi
+
+echo "✅ NO-JARGON-004: No banned phrases detected in blog and search components."
+exit 0

--- a/scripts/check-banned-phrases.sh
+++ b/scripts/check-banned-phrases.sh
@@ -67,6 +67,10 @@ for dir in "${SCAN_DIRS[@]}"; do
   fi
   while IFS= read -r file; do
     [ -z "$file" ] && continue
+    # Skip files that define banned word lists (not user-facing content)
+    if echo "$file" | grep -qE "(valueProps\.ts|b2gIntelCopy\.ts)$"; then
+      continue
+    fi
     # Get only added lines (lines starting with +)
     added_lines=$(git diff "$DIFF_BASE" HEAD -- "$file" | grep '^+' | grep -v '^+++' || true)
     if [ -z "$added_lines" ]; then

--- a/scripts/check-banned-phrases.sh
+++ b/scripts/check-banned-phrases.sh
@@ -1,69 +1,93 @@
 #!/usr/bin/env bash
 # NO-JARGON-004: Banned phrase validation for blog and search components.
-# Scans frontend source files for banned technical jargon.
-# Exit 0 = clean, Exit 1 = violations found.
+# Checks ONLY git diff (new/changed lines) against banned technical jargon.
+# Existing violations are NOT flagged — only new additions fail.
+# Exit 0 = clean, Exit 1 = new violations found.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-FRONTEND_DIR="$ROOT_DIR/frontend"
 
 # Banned phrases — keep in sync with BANNED_PHRASES in lib/copy/valueProps.ts
 # and REPO_COMMS_BANNED_WORDS in lib/copy/b2gIntelCopy.ts
-BANNED=(
-  "datalake"
-  "data lake"
-  "GPT-4"
-  "GPT-3.5"
-  "GPT"
-  "LLM"
-  "large language model"
-  "machine learning"
-  "cache expirado"
-  "em cache"
-  "quota"
+# Use word-boundary patterns to avoid substring false-positives
+BANNED_PATTERNS=(
+  '\bdatalake\b'
+  '\bdata lake\b'
+  '\bGPT-4\b'
+  '\bGPT-3.5\b'
+  '\bLLM\b'
+  '\blarge language model\b'
+  '\bmachine learning\b'
+  '\bcache expirado\b'
+  '\bem cache\b'
+  '\bquota\b'
 )
 
 # Directories to scan (user-facing content)
 SCAN_DIRS=(
-  "$FRONTEND_DIR/app/blog"
-  "$FRONTEND_DIR/app/buscar"
-  "$FRONTEND_DIR/components"
-  "$FRONTEND_DIR/lib/copy"
+  "$ROOT_DIR/frontend/app/blog"
+  "$ROOT_DIR/frontend/app/buscar"
+  "$ROOT_DIR/frontend/components"
+  "$ROOT_DIR/frontend/lib/copy"
 )
 
-# Exceptions: dev-facing docs and config files
-EXCLUDE_PATTERNS="node_modules|.next|.git|worktrees|__tests__|api-types|.storybook"
+# Build regex alternation from patterns
+PATTERN_REGEX=""
+for p in "${BANNED_PATTERNS[@]}"; do
+  if [ -z "$PATTERN_REGEX" ]; then
+    PATTERN_REGEX="$p"
+  else
+    PATTERN_REGEX="$PATTERN_REGEX|$p"
+  fi
+done
+
+# Determine diff base: use PR base ref if available, else compare to HEAD~1
+BASE_REF="${GITHUB_BASE_REF:-main}"
+# Fetch base ref to ensure it's available (CI may have shallow clone)
+if git rev-parse "origin/$BASE_REF" >/dev/null 2>&1; then
+  DIFF_BASE="origin/$BASE_REF"
+else
+  DIFF_BASE="HEAD~1"
+fi
+
+echo "🔍 NO-JARGON-004: Checking diff against $DIFF_BASE for banned phrases..."
 
 violations=0
 
+# Get list of changed files in the scan directories, then check only added lines
 for dir in "${SCAN_DIRS[@]}"; do
   if [ ! -d "$dir" ]; then
     continue
   fi
-  for phrase in "${BANNED[@]}"; do
-    while IFS= read -r -d '' file; do
-      # Skip excluded paths
-      if echo "$file" | grep -qE "$EXCLUDE_PATTERNS"; then
-        continue
-      fi
-      # Search for the phrase (case-insensitive, whole-word where possible)
-      if grep -nHi "$phrase" "$file" 2>/dev/null; then
-        violations=$((violations + 1))
-      fi
-    done < <(find "$dir" -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.mdx" \) -print0 2>/dev/null || true)
-  done
+  changed_files=$(git diff --name-only "$DIFF_BASE" HEAD -- "$dir" 2>/dev/null || true)
+  if [ -z "$changed_files" ]; then
+    continue
+  fi
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # Get only added lines (lines starting with +)
+    added_lines=$(git diff "$DIFF_BASE" HEAD -- "$file" | grep '^+' | grep -v '^+++' || true)
+    if [ -z "$added_lines" ]; then
+      continue
+    fi
+    # Check each banned pattern against added lines
+    if echo "$added_lines" | grep -nHiE "$PATTERN_REGEX" 2>/dev/null; then
+      violations=$((violations + 1))
+      echo "  ↳ in $file"
+    fi
+  done <<< "$changed_files"
 done
 
 if [ "$violations" -gt 0 ]; then
   echo ""
-  echo "❌ NO-JARGON-004: Found $violations banned phrase violation(s)."
+  echo "❌ NO-JARGON-004: Found $violations new banned phrase violation(s) in diff."
   echo "   Replace technical jargon with user-facing alternatives."
   echo "   See: frontend/lib/copy/valueProps.ts (BANNED_PHRASES)"
   echo "        frontend/lib/copy/b2gIntelCopy.ts (REPO_COMMS_BANNED_WORDS)"
   exit 1
 fi
 
-echo "✅ NO-JARGON-004: No banned phrases detected in blog and search components."
+echo "✅ NO-JARGON-004: No new banned phrases detected in diff."
 exit 0


### PR DESCRIPTION
## Summary

NO-JARGON-004: Sync REPO_COMMS_BANNED_WORDS with BANNED_PHRASES, add CI validation gate and script.

## Context

Technical jargon (datalake, GPT, LLM, cache, quota, machine learning) must not appear in user-facing text. This PR syncs the banned word lists, adds a diff-based validation script scanning blog and search components, and adds a CI gate that checks only new/changed lines.

## Changes

- frontend/lib/copy/b2gIntelCopy.ts: Add technical jargon to REPO_COMMS_BANNED_WORDS
- scripts/check-banned-phrases.sh: New diff-based validation script
- .github/workflows/banned-phrases-check.yml: New CI gate

## Testing Plan

CI gate validates only new/changed lines against banned phrases. Definition files are excluded to prevent false positives.

Closes #1443