### PR TITLE
feat(backend): add feature flags and gate middleware for Command tier capabilities (#1450)

### DIFF
--- a/backend/command_feature_gate.py
+++ b/backend/command_feature_gate.py
@@ -1,0 +1,68 @@
+"""TIER-COMMAND-003: Feature flag gate for Command tier capabilities.
+
+Each Command capability is gated behind a feature flag that must be
+explicitly enabled. All flags default to False (fail-closed).
+
+Usage:
+    from command_feature_gate import check_command_capability
+
+    if not check_command_capability("allow_command_api_access", user_plan):
+        raise HTTPException(status_code=503, detail="Feature not available")
+"""
+
+import logging
+from typing import Optional
+
+from config.features import get_feature_flag
+from quota.quota_core import get_plan_capabilities
+
+logger = logging.getLogger(__name__)
+
+# Map PlanCapabilities keys to feature flag names
+CAPABILITY_FLAG_MAP: dict[str, str] = {
+    "allow_command_api_access": "COMMAND_API_ACCESS",
+    "allow_command_multi_user": "COMMAND_MULTI_USER",
+    "allow_command_executive_reports": "COMMAND_EXECUTIVE_REPORTS",
+    "allow_command_regional_intel": "COMMAND_REGIONAL_INTEL",
+    "allow_command_workspace_advanced": "COMMAND_WORKSPACE_ADVANCED",
+    "allow_command_data_export": "COMMAND_DATA_EXPORT",
+    "allow_command_custom_alerts": "COMMAND_CUSTOM_ALERTS",
+}
+
+
+def check_command_capability(
+    capability: str,
+    user_plan: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> bool:
+    """Check if a Command capability is enabled for the user.
+
+    Gate order:
+    1. Plan must have the capability enabled (plan-level gate)
+    2. Feature flag must be enabled (global kill-switch, fail-closed)
+
+    Returns True if both gates pass.
+    """
+    flag_name = CAPABILITY_FLAG_MAP.get(capability)
+    if not flag_name:
+        logger.warning(f"Unknown Command capability: {capability}")
+        return False
+
+    # Plan-level gate
+    if user_plan:
+        caps = get_plan_capabilities().get(user_plan)
+        if not caps or not caps.get(capability):
+            logger.debug(
+                f"Command capability '{capability}' not in plan '{user_plan}'"
+            )
+            return False
+
+    # Feature flag gate (fail-closed: default False)
+    if not get_feature_flag(flag_name):
+        logger.info(
+            f"Command feature flag '{flag_name}' is disabled "
+            f"(user={user_id[:8] if user_id else 'unknown'}...)"
+        )
+        return False
+
+    return True

--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -299,6 +299,14 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "TRIGRAM_FALLBACK_ENABLED": ("TRIGRAM_FALLBACK_ENABLED", "true"),
     # --- STORY-438: Semantic embeddings ---
     "EMBEDDING_ENABLED": ("EMBEDDING_ENABLED", "false"),
+    # --- TIER-COMMAND-003: Command tier feature flags (fail-closed: all default false) ---
+    "COMMAND_API_ACCESS": ("COMMAND_API_ACCESS", "false"),
+    "COMMAND_MULTI_USER": ("COMMAND_MULTI_USER", "false"),
+    "COMMAND_EXECUTIVE_REPORTS": ("COMMAND_EXECUTIVE_REPORTS", "false"),
+    "COMMAND_REGIONAL_INTEL": ("COMMAND_REGIONAL_INTEL", "false"),
+    "COMMAND_WORKSPACE_ADVANCED": ("COMMAND_WORKSPACE_ADVANCED", "false"),
+    "COMMAND_DATA_EXPORT": ("COMMAND_DATA_EXPORT", "false"),
+    "COMMAND_CUSTOM_ALERTS": ("COMMAND_CUSTOM_ALERTS", "false"),
 }
 
 

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -225,6 +225,14 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "EMBEDDING_ENABLED": "Semantic embedding search for datalake (STORY-438)",
     # Founders Offer
     "FOUNDERS_OFFER_ENABLED": "Kill switch for the Founders lifetime offer (epic:fundadores — BIZ-FOUND-002)",
+    # TIER-COMMAND-003: Command tier feature flags
+    "COMMAND_API_ACCESS": "Command tier: API access capability (TIER-COMMAND-003)",
+    "COMMAND_MULTI_USER": "Command tier: multi-user capability (TIER-COMMAND-003)",
+    "COMMAND_EXECUTIVE_REPORTS": "Command tier: executive reports capability (TIER-COMMAND-003)",
+    "COMMAND_REGIONAL_INTEL": "Command tier: regional intelligence capability (TIER-COMMAND-003)",
+    "COMMAND_WORKSPACE_ADVANCED": "Command tier: advanced workspace capability (TIER-COMMAND-003)",
+    "COMMAND_DATA_EXPORT": "Command tier: data export capability (TIER-COMMAND-003)",
+    "COMMAND_CUSTOM_ALERTS": "Command tier: custom alerts capability (TIER-COMMAND-003)",
 }
 
 
@@ -299,6 +307,14 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "COMPETITIVE_INTEL_ENABLED": {"owner": "product", "category": "competitive", "lifecycle": "permanent", "created": "2026-05"},
     # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations workspace_basic gate
     "B2G_OPS_ENABLED": {"owner": "product", "category": "b2gops", "lifecycle": "permanent", "created": "2026-05"},
+    # TIER-COMMAND-003: Command tier feature flags
+    "COMMAND_API_ACCESS": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    "COMMAND_MULTI_USER": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    "COMMAND_EXECUTIVE_REPORTS": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    "COMMAND_REGIONAL_INTEL": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    "COMMAND_WORKSPACE_ADVANCED": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    "COMMAND_DATA_EXPORT": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    "COMMAND_CUSTOM_ALERTS": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
 }
 
 


### PR DESCRIPTION
## Summary

TIER-COMMAND-003: Add per-capability feature flags for Command tier with fail-closed gate middleware.

## Context

Each Command capability needs a feature flag for gradual rollout. All flags default to false (fail-closed). The middleware checks both plan capability and feature flag before granting access.

## Changes

- backend/config/features.py: Add 7 feature flags to registry
- backend/command_feature_gate.py: New middleware with dual-gate check
- backend/routes/feature_flags.py: Add descriptions and lifecycle metadata

## Testing Plan

CI backend tests validate feature flag matrix (descriptions + lifecycles for all flags). Gate logic: plan capability + feature flag must both be true. Fail-closed: absent flag returns False.

Closes #1450