### PR TITLE
feat(frontend): add progress bars to viability tooltip (#1432)

### DIFF
--- a/frontend/__tests__/viability-badge.test.tsx
+++ b/frontend/__tests__/viability-badge.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import ViabilityBadge from "../components/ViabilityBadge";
 import type { ViabilityFactors } from "../components/ViabilityBadge";
 
@@ -75,15 +75,15 @@ describe("ViabilityBadge", () => {
   });
 
   // AC11: Tooltip with factor breakdown
-  it("shows tooltip with factor breakdown", () => {
+  it("shows tooltip with factor breakdown including weights", () => {
     render(<ViabilityBadge level="alta" score={95} factors={mockFactors} />);
     const badge = screen.getByTestId("viability-badge");
     const tooltipContent = getTooltipContent(badge);
     expect(tooltipContent).toContain("Viabilidade: 95/100");
-    expect(tooltipContent).toContain("Modalidade: Ótimo (100/100)");
-    expect(tooltipContent).toContain("Prazo: 12 dias (80/100)");
-    expect(tooltipContent).toContain("Valor: Ideal (100/100)");
-    expect(tooltipContent).toContain("UF: Sua região (100/100)");
+    expect(tooltipContent).toContain("Modalidade (30%): Ótimo (100/100)");
+    expect(tooltipContent).toContain("Prazo (25%): 12 dias (80/100)");
+    expect(tooltipContent).toContain("Valor (25%): Ideal (100/100)");
+    expect(tooltipContent).toContain("UF (20%): Sua região (100/100)");
   });
 
   it("shows basic tooltip without factors", () => {
@@ -92,6 +92,55 @@ describe("ViabilityBadge", () => {
     const tooltipContent = getTooltipContent(badge);
     expect(tooltipContent).toContain("Viabilidade: 60/100");
     expect(tooltipContent).not.toContain("Modalidade");
+  });
+
+  // VIAB-UX-003: Progress bars
+  it("renders progress bars with correct widths when tooltip opens", () => {
+    const { container } = render(
+      <ViabilityBadge level="alta" score={85} factors={mockFactors} />
+    );
+    const badge = screen.getByTestId("viability-badge");
+
+    // Open tooltip via focus
+    fireEvent.focus(badge);
+
+    const bars = container.querySelectorAll('[role="progressbar"]');
+    expect(bars).toHaveLength(4);
+    // mockFactors: modalidade=100, timeline=80, value_fit=100, geography=100
+    expect(bars[0]).toHaveAttribute("aria-valuenow", "100");
+    expect(bars[1]).toHaveAttribute("aria-valuenow", "80");
+    expect(bars[2]).toHaveAttribute("aria-valuenow", "100");
+    expect(bars[3]).toHaveAttribute("aria-valuenow", "100");
+  });
+
+  it("applies correct progress bar colors by score range", () => {
+    const mixedFactors: ViabilityFactors = {
+      modalidade: 85,  // >= 70 → green (bg-emerald-400)
+      timeline: 55,    // 40-69 → yellow (bg-yellow-400)
+      value_fit: 20,   // < 40 → gray (bg-gray-400)
+      geography: 70,   // >= 70 → green
+      modalidade_label: "Bom",
+      timeline_label: "Médio",
+      value_fit_label: "Baixo",
+      geography_label: "OK",
+    };
+
+    const { container } = render(
+      <ViabilityBadge level="media" score={55} factors={mixedFactors} />
+    );
+    const badge = screen.getByTestId("viability-badge");
+
+    // Open tooltip via focus
+    fireEvent.focus(badge);
+
+    const bars = container.querySelectorAll('[role="progressbar"]');
+    expect(bars).toHaveLength(4);
+
+    // Order: Modalidade, Prazo, Valor, UF
+    expect(bars[0]).toHaveClass("bg-emerald-400");
+    expect(bars[1]).toHaveClass("bg-yellow-400");
+    expect(bars[2]).toHaveClass("bg-gray-400");
+    expect(bars[3]).toHaveClass("bg-emerald-400");
   });
 
   // Accessibility

--- a/frontend/components/ViabilityBadge.tsx
+++ b/frontend/components/ViabilityBadge.tsx
@@ -21,9 +21,62 @@ interface ViabilityBadgeProps {
   valueSource?: "estimated" | "missing" | null;
 }
 
-/** Factor label for tooltip display */
-function factorLine(name: string, score: number, label: string): string {
-  return `${name}: ${label} (${score}/100)`;
+/** Factor line for data-tooltip-content text summary */
+function factorLine(name: string, weight: string, score: number, label: string): string {
+  return `${name} (${weight}): ${label} (${score}/100)`;
+}
+
+/** Progress bar color class based on score range: green >=70, yellow 40-69, gray <40 */
+function barColor(score: number): string {
+  if (score >= 70) return "bg-emerald-400";
+  if (score >= 40) return "bg-yellow-400";
+  return "bg-gray-400";
+}
+
+/** Progress bar background color class based on score range */
+function barBgColor(score: number): string {
+  if (score >= 70) return "bg-emerald-900/40";
+  if (score >= 40) return "bg-yellow-900/40";
+  return "bg-gray-700";
+}
+
+/** VIAB-UX-003: Individual factor row with label, score, weight, contextual explanation, and progress bar */
+function FactorRow({
+  name,
+  weight,
+  score,
+  label,
+}: {
+  name: string;
+  weight: string;
+  score: number;
+  label: string;
+}) {
+  return (
+    <div className="text-gray-300" role="group" aria-label={`${name} ${weight}`}>
+      <div className="flex items-baseline justify-between">
+        <span className="text-white text-[10px] font-medium">
+          {name}
+          <span className="text-gray-400 font-normal"> {weight}</span>
+        </span>
+        <span className="text-[10px] tabular-nums">{score}/100</span>
+      </div>
+      <div className="text-[9px] text-gray-400/80 mt-0.5 mb-1 leading-tight line-clamp-2">
+        {label}
+      </div>
+      <div className={`h-1.5 rounded-full w-full ${barBgColor(score)}`}>
+        <div
+          className={`h-full rounded-full ${barColor(score)}`}
+          style={{ width: `${Math.min(100, Math.max(0, score))}%` }}
+          role="progressbar"
+          aria-valuenow={score}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${name}: ${score} de 100`}
+        />
+      </div>
+    </div>
+  );
 }
 
 /** D-04 AC8: Viability badge with accessible tooltip showing factor breakdown
@@ -82,14 +135,14 @@ export default function ViabilityBadge({
   const c = config[level] ?? config["baixa"];
   if (!c) return null;
 
-  // Build tooltip lines
+  // Build tooltip text for data attribute (test introspection)
   const tooltipLines: string[] = [`Viabilidade: ${score ?? "?"}/100`];
   if (factors) {
     tooltipLines.push(
-      factorLine("Modalidade", factors.modalidade, factors.modalidade_label),
-      factorLine("Prazo", factors.timeline, factors.timeline_label),
-      factorLine("Valor", factors.value_fit, factors.value_fit_label),
-      factorLine("UF", factors.geography, factors.geography_label),
+      factorLine("Modalidade", "30%", factors.modalidade, factors.modalidade_label),
+      factorLine("Prazo", "25%", factors.timeline, factors.timeline_label),
+      factorLine("Valor", "25%", factors.value_fit, factors.value_fit_label),
+      factorLine("UF", "20%", factors.geography, factors.geography_label),
     );
   }
   if (valueSource === "missing") {
@@ -101,6 +154,9 @@ export default function ViabilityBadge({
   return (
     <ViabilityTooltip
       tooltipLines={tooltipLines}
+      factors={factors}
+      score={score}
+      valueSource={valueSource}
       ariaLabel={c.ariaLabel}
       bg={c.bg}
       level={level}
@@ -116,16 +172,23 @@ export default function ViabilityBadge({
  * - Mobile tap-to-toggle support
  * - ARIA: role="tooltip" + aria-describedby linkage
  * - Dismisses on Escape key and outside click
+ * VIAB-UX-003: Rich content with progress bars and factor breakdown
  */
 function ViabilityTooltip({
   children,
   tooltipLines,
+  factors,
+  score,
+  valueSource,
   ariaLabel,
   bg,
   level,
 }: {
   children: React.ReactNode;
   tooltipLines: string[];
+  factors?: ViabilityFactors | null;
+  score?: number | null;
+  valueSource?: "estimated" | "missing" | null;
   ariaLabel: string;
   bg: string;
   level: string;
@@ -190,17 +253,54 @@ function ViabilityTooltip({
           role="tooltip"
           className={[
             "absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2",
-            "w-max max-w-[240px]",
+            "w-max max-w-[260px]",
             "bg-gray-900 dark:bg-gray-800 text-white text-[10px] leading-relaxed",
             "rounded-md px-2.5 py-2 shadow-lg",
             "pointer-events-none",
           ].join(" ")}
         >
-          {tooltipLines.map((line, i) => (
-            <p key={i} className={i === 0 ? "font-semibold mb-1" : "text-gray-300"}>
-              {line}
-            </p>
-          ))}
+          {/* Total score */}
+          <div className="font-semibold mb-2 text-white text-[11px]">
+            Viabilidade: {score ?? "?"}/100
+          </div>
+
+          {/* Factor rows with progress bars — VIAB-UX-003 */}
+          {factors && (
+            <div className="space-y-2">
+              <FactorRow
+                name="Modalidade"
+                weight="30%"
+                score={factors.modalidade}
+                label={factors.modalidade_label}
+              />
+              <FactorRow
+                name="Prazo"
+                weight="25%"
+                score={factors.timeline}
+                label={factors.timeline_label}
+              />
+              <FactorRow
+                name="Valor"
+                weight="25%"
+                score={factors.value_fit}
+                label={factors.value_fit_label}
+              />
+              <FactorRow
+                name="UF"
+                weight="20%"
+                score={factors.geography}
+                label={factors.geography_label}
+              />
+            </div>
+          )}
+
+          {/* Missing value warning */}
+          {valueSource === "missing" && (
+            <div className="mt-1.5 text-[9px] text-yellow-400 leading-tight">
+              ⚠ Valor estimado não informado pelo órgão — viabilidade pode ser maior
+            </div>
+          )}
+
           {/* Arrow */}
           <span
             aria-hidden="true"


### PR DESCRIPTION
## Summary

Upgrade do tooltip do ViabilityBadge com barras de progresso coloridas e explicações contextuais por fator de viabilidade.

## Context

VIAB-UX-003 (#1432): O tooltip atual mostra apenas texto. Esta mudança adiciona visualização com barras de progresso para cada um dos 4 fatores de viabilidade, com cores por faixa e indicação de pesos relativos.

## Changes

- **ViabilityBadge.tsx**: Novo componente `FactorRow` com progress bar colorida, score numérico, label descritivo e peso do fator
- Cores: verde (≥70), amarelo (40-69), cinza (<40)
- Pesos: Modalidade (30%), Prazo (25%), Valor (25%), UF (20%)
- ARIA: `role="progressbar"` com `aria-valuenow/min/max` + `aria-label`
- **viability-badge.test.tsx**: Testes de renderização das barras, cores e larguras

## Testing Plan

- [x] Testes de unidade: renderização de cada fator, cores corretas por faixa
- [x] Acessibilidade: role progressbar + aria attributes
- [ ] CI: Frontend Tests, Build, Chromatic Visual Regression

Closes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>