### PR TITLE
feat(backend): implement DIGEST-001 — frequency column, pg_cron schedules, DIGEST_ENABLED flag (#1410)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,15 @@ FRONTEND_REVALIDATE_URL=https://smartlic.tech/api/revalidate
 REVALIDATE_SECRET=
 
 # --------------------------------------------
+# Feature Flags
+# --------------------------------------------
+
+# DIGEST-001: Email digest delivery. When enabled, pg_cron jobs send daily,
+# twice_weekly, and weekly digest emails to users with matching preferences.
+# Default: false in dev; set to true in production Railway env.
+DIGEST_ENABLED=false
+
+# --------------------------------------------
 # Custom Configuration
 # --------------------------------------------
 # Add your custom API keys below

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -523,8 +523,10 @@ async def get_alert_preferences(
         )
 
         if result.data:
+            # DIGEST-001: normalize DB value "none" -> API value "off"
+            api_frequency = "off" if result.data["frequency"] == "none" else result.data["frequency"]
             return AlertPreferencesResponse(
-                frequency=result.data["frequency"],
+                frequency=api_frequency,
                 enabled=result.data["enabled"],
                 last_digest_sent_at=result.data.get("last_digest_sent_at"),
             )
@@ -559,21 +561,28 @@ async def update_alert_preferences(
             detail=f"Frequencia invalida. Opcoes: {', '.join(valid_frequencies)}"
         )
 
+    # DIGEST-001: normalize API value "off" -> DB value "none"
+    db_frequency = "none" if prefs.frequency == "off" else prefs.frequency
+
     try:
         # Upsert: insert or update
         result = await sb_execute(
             user_db.table("alert_preferences").upsert({
                 "user_id": user_id,
-                "frequency": prefs.frequency,
+                "frequency": db_frequency,
                 "enabled": prefs.enabled,
             }, on_conflict="user_id")
         )
 
         data = result.data[0] if result.data else {}
 
+        # DIGEST-001: normalize DB value "none" -> API value "off" for response
+        raw_frequency = data.get("frequency", prefs.frequency)
+        api_frequency = "off" if raw_frequency == "none" else raw_frequency
+
         log_user_action(logger, "alert_preferences_updated", user_id)
         return AlertPreferencesResponse(
-            frequency=data.get("frequency", prefs.frequency),
+            frequency=api_frequency,
             enabled=data.get("enabled", prefs.enabled),
             last_digest_sent_at=data.get("last_digest_sent_at"),
         )

--- a/backend/tests/test_alert_preferences.py
+++ b/backend/tests/test_alert_preferences.py
@@ -148,12 +148,13 @@ class TestUpdateAlertPreferences:
         assert response.status_code == 400
         assert "invalida" in response.json()["detail"].lower()
 
-    def test_updates_to_off(self, app, client):
+    def test_updates_to_off__normalizes_to_none_in_db(self, app, client):
+        """DIGEST-001: API accepts 'off', normalizes to 'none' in DB, returns 'off'."""
         mock_db = MagicMock()
         result = MagicMock()
         result.data = [{
             "user_id": "test-user-123",
-            "frequency": "off",
+            "frequency": "none",  # DB stores "none" per CHECK constraint
             "enabled": False,
             "last_digest_sent_at": None,
         }]
@@ -167,8 +168,32 @@ class TestUpdateAlertPreferences:
 
         assert response.status_code == 200
         data = response.json()
+        # API contract: returns "off" (normalized from DB "none")
         assert data["frequency"] == "off"
         assert data["enabled"] is False
+
+        # Verify DB write used "none", not "off"
+        upsert_kwargs = mock_db.table.return_value.upsert.call_args[0][0]
+        assert upsert_kwargs["frequency"] == "none"
+
+    def test_get_normalizes_none_to_off(self, app, client):
+        """DIGEST-001: GET returns 'off' when DB stores 'none'."""
+        mock_db = MagicMock()
+        result = MagicMock()
+        result.data = {
+            "frequency": "none",  # DB value
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }
+        mock_db.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = result
+        _override_db(app, mock_db)
+
+        response = client.get("/v1/profile/alert-preferences")
+
+        assert response.status_code == 200
+        data = response.json()
+        # API contract: returns "off" (normalized from DB "none")
+        assert data["frequency"] == "off"
 
     def test_handles_db_error(self, app, client):
         mock_db = MagicMock()

--- a/supabase/migrations/20260606032254_add_alert_preferences_frequency.down.sql
+++ b/supabase/migrations/20260606032254_add_alert_preferences_frequency.down.sql
@@ -1,0 +1,26 @@
+-- DIGEST-001: Rollback — revert frequency to alert_frequency enum.
+-- Ensure the alert_frequency type still exists (recreated if necessary).
+
+-- Step 1: Drop CHECK constraint
+ALTER TABLE public.alert_preferences DROP CONSTRAINT IF EXISTS chk_alert_preferences_frequency;
+
+-- Step 2: Recreate the enum type if it was dropped (idempotent)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'alert_frequency'
+    ) THEN
+        CREATE TYPE alert_frequency AS ENUM ('daily', 'twice_weekly', 'weekly', 'off');
+    END IF;
+END $$;
+
+-- Step 3: Convert VARCHAR(20) back to alert_frequency; migrate 'none' → 'off'
+ALTER TABLE public.alert_preferences
+    ALTER COLUMN frequency TYPE alert_frequency
+    USING CASE WHEN frequency::text = 'none' THEN 'off'::alert_frequency
+               ELSE frequency::text::alert_frequency
+          END;
+
+-- Step 4: Restore comment
+COMMENT ON COLUMN public.alert_preferences.frequency IS
+    'Frequency for digest emails: daily, twice_weekly, weekly, off.';

--- a/supabase/migrations/20260606032254_add_alert_preferences_frequency.sql
+++ b/supabase/migrations/20260606032254_add_alert_preferences_frequency.sql
@@ -1,0 +1,33 @@
+-- DIGEST-001: Convert frequency from alert_frequency enum to VARCHAR(20) with CHECK
+--
+-- The frequency column was originally created as alert_frequency ENUM in
+-- migration 20260226100000 with values (daily, twice_weekly, weekly, off).
+-- This migration converts it to VARCHAR(20) for flexibility and adds a CHECK
+-- constraint. The value 'off' is migrated to 'none' (DIGEST-001 naming).
+--
+-- Idempotent: safe to re-run. The ADD CONSTRAINT IF NOT EXISTS is emulated
+-- via a DO block since PostgreSQL doesn't support IF NOT EXISTS for CHECK.
+
+-- Step 1: Convert enum column to VARCHAR(20); migrate 'off' → 'none'
+ALTER TABLE public.alert_preferences
+    ALTER COLUMN frequency TYPE VARCHAR(20)
+    USING CASE WHEN frequency::text = 'off' THEN 'none'
+               ELSE frequency::text
+          END;
+
+-- Step 2: Add CHECK constraint (idempotent via DO block)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_alert_preferences_frequency'
+          AND connamespace = 'public'::regnamespace
+    ) THEN
+        ALTER TABLE public.alert_preferences
+            ADD CONSTRAINT chk_alert_preferences_frequency
+            CHECK (frequency IN ('daily', 'twice_weekly', 'weekly', 'none'));
+    END IF;
+END $$;
+
+COMMENT ON COLUMN public.alert_preferences.frequency IS
+    'DIGEST-001 — Frequency for digest emails: daily, twice_weekly (mon+thu), weekly (mon), none.';

--- a/supabase/migrations/20260606032255_setup_digest_pgcron.down.sql
+++ b/supabase/migrations/20260606032255_setup_digest_pgcron.down.sql
@@ -1,0 +1,10 @@
+-- DIGEST-001: Rollback — unschedule all digest cron jobs.
+
+SELECT cron.unschedule('digest-daily')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'digest-daily');
+
+SELECT cron.unschedule('digest-twice-weekly')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'digest-twice-weekly');
+
+SELECT cron.unschedule('digest-weekly')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'digest-weekly');

--- a/supabase/migrations/20260606032255_setup_digest_pgcron.sql
+++ b/supabase/migrations/20260606032255_setup_digest_pgcron.sql
@@ -1,0 +1,43 @@
+-- DIGEST-001: Schedule pg_cron jobs for email digest delivery
+--
+-- Creates 3 cron schedules for the three digest frequencies:
+--   daily         — every day at 07:00 BRT (10:00 UTC)
+--   twice_weekly  — Mon + Thu at 07:00 BRT (10:00 UTC)
+--   weekly        — Mon at 07:00 BRT (10:00 UTC)
+--
+-- The underlying SQL functions (send_daily_digest, send_twice_weekly_digest,
+-- send_weekly_digest) will be created separately — pg_cron validates the
+-- schedule syntax at registration time, not the function existence. Functions
+-- must exist at runtime when the cron fires.
+--
+-- Idempotent: unschedule + schedule pattern (existing convention in this repo).
+
+-- ── 1. daily — every day at 07:00 BRT ──────────────────────────────────────
+SELECT cron.unschedule('digest-daily')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'digest-daily');
+
+SELECT cron.schedule(
+    'digest-daily',
+    '0 10 * * *',
+    $$SELECT public.send_daily_digest()$$
+);
+
+-- ── 2. twice_weekly — Mon + Thu at 07:00 BRT ───────────────────────────────
+SELECT cron.unschedule('digest-twice-weekly')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'digest-twice-weekly');
+
+SELECT cron.schedule(
+    'digest-twice-weekly',
+    '0 10 * * 1,4',
+    $$SELECT public.send_twice_weekly_digest()$$
+);
+
+-- ── 3. weekly — Mon at 07:00 BRT ───────────────────────────────────────────
+SELECT cron.unschedule('digest-weekly')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'digest-weekly');
+
+SELECT cron.schedule(
+    'digest-weekly',
+    '0 10 * * 1',
+    $$SELECT public.send_weekly_digest()$$
+);


### PR DESCRIPTION
## Context
DIGEST-001: Adicionar coluna frequency à tabela alert_preferences, configurar pg_cron schedules para cada frequência de digest, e ativar feature flag DIGEST_ENABLED.

## Changes
- **Migration** alert_preferences.frequency: converte ENUM → VARCHAR(20) com CHECK constraint (daily/twice_weekly/weekly/none)
- **Migration** pg_cron: schedules para daily (07:00 BRT), twice_weekly (seg+qui), weekly (seg)
- **Feature flag**: DIGEST_ENABLED adicionado ao .env.example (já existia no registry)
- Migrations com down.sql pareados

## Testing Plan
- [ ] Migration aplica sem erros em staging
- [ ] SELECT * FROM cron.job mostra 3 novos jobs
- [ ] Feature flag DIGEST_ENABLED=false → sistema não envia emails

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)