### PR TITLE
feat(backend): implement DIGEST-002 — digest builder with sector queries, tier limits, fallback (#1411)

### DIFF
--- a/backend/services/digest_service.py
+++ b/backend/services/digest_service.py
@@ -1,13 +1,19 @@
 """
-STORY-278 AC2: Digest Service — builds per-user opportunity digest.
+STORY-278 AC2 + DIGEST-002 (#1411): Digest Service — personalized digest builder.
 
-Queries search_results_cache filtered by user's profile_context (setor + UFs),
-returns top N opportunities sorted by viability_score.
+DIGEST-002 adds sector-based query with tier limits, frequency-based lookback
+windows, and zero-results fallback.
+
+Queries:
+  - build_digest_for_user() — legacy, uses search_results_cache
+  - build_personalized_digest() — DIGEST-002, queries datalake per sector
 
 Usage:
     from services.digest_service import build_digest_for_user
+    from services.digest_service import build_personalized_digest
 
     opportunities = await build_digest_for_user(user_id, max_items=10)
+    digest = await build_personalized_digest(user_id)
 """
 
 import logging
@@ -17,6 +23,26 @@ from typing import Optional
 from supabase_client import sb_execute
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# DIGEST-002: Tier limits and frequency lookback windows
+# ---------------------------------------------------------------------------
+
+# Max opportunities per sector per plan tier
+TIER_LIMITS: dict[str, int] = {
+    "free_trial": 5,
+    "smartlic_pro": 20,
+    "smartlic_consulting": 20,
+    "consultoria": 20,
+    "master": 20,
+}
+
+# Lookback window per frequency (used by build_personalized_digest)
+FREQUENCY_WINDOWS: dict[str, timedelta] = {
+    "daily": timedelta(days=1),
+    "twice_weekly": timedelta(days=3),
+    "weekly": timedelta(days=7),
+}
 
 
 async def _get_user_profile_context(user_id: str, db) -> Optional[dict]:
@@ -329,3 +355,353 @@ async def mark_digest_sent(user_id: str, db=None) -> None:
         )
     except Exception as e:
         logger.warning(f"Failed to update last_digest_sent_at for {user_id[:8]}: {e}")
+
+
+# ============================================================================
+# DIGEST-002 (#1411): Personalized digest builder
+# ============================================================================
+
+
+async def get_user_plan_tier(user_id: str, db=None) -> str:
+    """Determine user's plan tier for digest limit enforcement.
+
+    Checks ``user_subscriptions`` (active subscription) first, then falls
+    back to ``profiles.plan_type``. Returns ``"free_trial"`` as default.
+
+    Args:
+        user_id: User UUID.
+        db: Supabase client (fetched if None).
+
+    Returns:
+        Plan tier string (e.g. ``"free_trial"``, ``"smartlic_pro"``).
+    """
+    if db is None:
+        from supabase_client import get_supabase
+        db = get_supabase()
+
+    # Check active subscription first
+    try:
+        result = await sb_execute(
+            db.table("user_subscriptions")
+            .select("plan_id")
+            .eq("user_id", user_id)
+            .eq("is_active", True)
+            .limit(1)
+        )
+        if result.data:
+            plan_id = result.data[0]["plan_id"]
+            if "consulting" in plan_id or "consultoria" in plan_id:
+                return "smartlic_consulting"
+            return "smartlic_pro"
+    except Exception as e:
+        logger.warning(
+            "Failed to get subscription tier for user %s: %s",
+            user_id[:8], e,
+        )
+
+    # Fallback to profile plan_type
+    try:
+        result = await sb_execute(
+            db.table("profiles")
+            .select("plan_type")
+            .eq("id", user_id)
+            .limit(1)
+        )
+        if result.data:
+            pt = result.data[0].get("plan_type", "free_trial")
+            return pt or "free_trial"
+    except Exception as e:
+        logger.warning(
+            "Failed to get profile plan_type for user %s: %s",
+            user_id[:8], e,
+        )
+
+    return "free_trial"
+
+
+async def get_user_sectors(user_id: str, db=None) -> list[str]:
+    """Get user's selected sectors for digest personalization.
+
+    Checks ``user_sector_affinity`` first (multi-sector support), then falls
+    back to ``profiles.context_data`` / ``profiles.sector`` (legacy single-sector).
+
+    Args:
+        user_id: User UUID.
+        db: Supabase client (fetched if None).
+
+    Returns:
+        List of sector IDs (e.g. ``["vestuario", "informatica"]``).
+    """
+    if db is None:
+        from supabase_client import get_supabase
+        db = get_supabase()
+
+    # 1. Check user_sector_affinity (primary — multi-sector)
+    try:
+        result = await sb_execute(
+            db.table("user_sector_affinity")
+            .select("sector_id")
+            .eq("user_id", user_id)
+        )
+        if result.data:
+            sectors = [r["sector_id"] for r in result.data if r.get("sector_id")]
+            if sectors:
+                return sectors
+    except Exception as e:
+        logger.warning(
+            "Failed to get user_sector_affinity for %s: %s",
+            user_id[:8], e,
+        )
+
+    # 2. Fallback: profile context_data (legacy single-sector)
+    try:
+        result = await sb_execute(
+            db.table("profiles")
+            .select("context_data, sector")
+            .eq("id", user_id)
+            .limit(1)
+        )
+        if result.data:
+            profile = result.data[0]
+            ctx = profile.get("context_data") or {}
+            if ctx.get("setor_id"):
+                return [ctx["setor_id"]]
+            if profile.get("sector"):
+                return [profile["sector"]]
+    except Exception as e:
+        logger.warning(
+            "Failed to get profile sector for %s: %s",
+            user_id[:8], e,
+        )
+
+    return []
+
+
+async def get_user_frequency(user_id: str, db=None) -> str:
+    """Get user's digest frequency from ``alert_preferences``.
+
+    Args:
+        user_id: User UUID.
+        db: Supabase client (fetched if None).
+
+    Returns:
+        Frequency string: ``"daily"``, ``"twice_weekly"``, ``"weekly"``, or
+        ``"daily"`` as default.
+    """
+    if db is None:
+        from supabase_client import get_supabase
+        db = get_supabase()
+
+    try:
+        result = await sb_execute(
+            db.table("alert_preferences")
+            .select("frequency")
+            .eq("user_id", user_id)
+            .limit(1)
+        )
+        if result.data:
+            return result.data[0].get("frequency", "daily")
+    except Exception as e:
+        logger.warning(
+            "Failed to get frequency for user %s: %s",
+            user_id[:8], e,
+        )
+
+    return "daily"
+
+
+async def find_opportunities_for_sector(
+    sector_id: str,
+    lookback_days: int,
+    limit: int,
+    db=None,
+) -> list[dict]:
+    """Query the datalake for new opportunities matching a sector.
+
+    Uses the sector's keywords as tsquery terms via ``query_datalake``,
+    searching across all 27 UFs within the lookback window.
+
+    Args:
+        sector_id: Sector ID (e.g. ``"vestuario"``).
+        lookback_days: Number of days to look back.
+        limit: Max opportunities to return (tier-enforced upstream).
+        db: Supabase client (used only for sector data, not direct query).
+
+    Returns:
+        List of normalized opportunity dicts. Empty list on failure.
+    """
+    from datalake_query import query_datalake
+    from sectors import SECTORS
+    from unified_schemas.unified import VALID_UFS
+
+    since = (datetime.now(timezone.utc) - timedelta(days=lookback_days)).isoformat()
+    today = datetime.now(timezone.utc).isoformat()
+
+    # Get sector keywords for datalake FTS query
+    sector_obj = SECTORS.get(sector_id)
+    keywords: list[str] | None = None
+    if sector_obj and hasattr(sector_obj, "keywords") and sector_obj.keywords:
+        keywords = list(sector_obj.keywords)
+
+    all_ufs = sorted(VALID_UFS)
+
+    try:
+        results = await query_datalake(
+            ufs=all_ufs,
+            data_inicial=since[:10],
+            data_final=today[:10],
+            keywords=keywords,
+            limit=limit * 3,  # Request extra to account for post-filtering
+            modo_busca="publicacao",
+        )
+
+        # Normalize results to match the format used by digest consumers
+        normalized = []
+        seen_ids: set[str] = set()
+        for item in (results or []):
+            if not isinstance(item, dict):
+                continue
+            item_id = (
+                item.get("numeroControlePNCP")
+                or item.get("codigoCompra")
+                or item.get("id")
+                or ""
+            )
+            if not item_id or item_id in seen_ids:
+                continue
+            seen_ids.add(item_id)
+
+            normalized.append({
+                "id": item_id,
+                "titulo": (
+                    item.get("objetoCompra")
+                    or item.get("titulo")
+                    or "Sem titulo"
+                ),
+                "orgao": (
+                    item.get("nomeOrgao")
+                    or item.get("orgao")
+                    or "Nao informado"
+                ),
+                "valor_estimado": float(
+                    item.get("valorTotalEstimado")
+                    or item.get("valor_estimado")
+                    or 0
+                ),
+                "uf": item.get("uf") or item.get("unidadeFederativa", ""),
+                "modalidade": (
+                    item.get("modalidadeNome")
+                    or item.get("modalidade")
+                    or ""
+                ),
+                "data_publicacao": (
+                    item.get("dataPublicacaoFormatted")
+                    or item.get("dataPublicacao")
+                    or ""
+                ),
+                "link_pncp": item.get("linkSistemaOrigem") or "",
+                "viability_score": item.get("viability_score"),
+            })
+
+        # Sort by viability_score DESC, then valor_estimado DESC
+        normalized.sort(
+            key=lambda x: (
+                x.get("viability_score") or 0.0,
+                x.get("valor_estimado") or 0.0,
+            ),
+            reverse=True,
+        )
+
+        return normalized[:limit]
+
+    except Exception as e:
+        logger.error(
+            "Failed to query opportunities for sector %s: %s",
+            sector_id, e,
+        )
+        return []
+
+
+async def build_personalized_digest(
+    user_id: str,
+    db=None,
+) -> dict:
+    """Build a personalized digest for a user by sector.
+
+    DIGEST-002: Queries the datalake per sector, applies tier-based limits
+    and frequency-based lookback windows. Returns structured digest with
+    per-sector opportunity lists.
+
+    Args:
+        user_id: User UUID.
+        db: Supabase client (fetched if None).
+
+    Returns:
+        Digest dict with structure::
+            {
+                "user_id": str,
+                "frequency": str,
+                "tier": str,
+                "sectors": {sector_id: {"opportunities": [...], "count": int}},
+                "total_opportunities": int,
+                "has_content": bool,
+                "generated_at": str (ISO 8601)
+            }
+    """
+    if db is None:
+        from supabase_client import get_supabase
+        db = get_supabase()
+
+    tier = await get_user_plan_tier(user_id, db)
+    sectors = await get_user_sectors(user_id, db)
+    frequency = await get_user_frequency(user_id, db)
+
+    if not sectors:
+        logger.info("No sectors configured for user %s", user_id[:8])
+        return {
+            "user_id": user_id,
+            "frequency": frequency,
+            "tier": tier,
+            "sectors": {},
+            "total_opportunities": 0,
+            "has_content": False,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    limit = TIER_LIMITS.get(tier, 5)
+    lookback_window = FREQUENCY_WINDOWS.get(frequency, timedelta(days=1))
+    lookback_days = lookback_window.days
+
+    digest_sectors: dict[str, dict] = {}
+    total_opps = 0
+
+    for sector_id in sectors:
+        opportunities = await find_opportunities_for_sector(
+            sector_id=sector_id,
+            lookback_days=lookback_days,
+            limit=limit,
+            db=db,
+        )
+        digest_sectors[sector_id] = {
+            "opportunities": opportunities,
+            "count": len(opportunities),
+        }
+        total_opps += len(opportunities)
+
+    has_content = total_opps > 0
+
+    if not has_content:
+        logger.info(
+            "No opportunities for user %s across %d sectors",
+            user_id[:8], len(sectors),
+        )
+
+    return {
+        "user_id": user_id,
+        "frequency": frequency,
+        "tier": tier,
+        "sectors": digest_sectors,
+        "total_opportunities": total_opps,
+        "has_content": has_content,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/backend/tests/test_digest_builder.py
+++ b/backend/tests/test_digest_builder.py
@@ -1,0 +1,656 @@
+"""Tests for DIGEST-002 (#1411): Digest builder logic.
+
+Tests get_user_plan_tier(), get_user_sectors(), get_user_frequency(),
+find_opportunities_for_sector(), and build_personalized_digest().
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import timedelta
+
+
+# ============================================================================
+# Helper: mock sb_execute
+# ============================================================================
+
+def _make_sb_result(data: list | dict | None) -> MagicMock:
+    """Create a mock sb_execute return value with data."""
+    r = MagicMock()
+    r.data = data
+    return r
+
+
+# ============================================================================
+# get_user_plan_tier() tests
+# ============================================================================
+
+class TestGetUserPlanTier:
+    """Test plan tier resolution."""
+
+    @pytest.mark.asyncio
+    async def test_subscription_consulting(self):
+        from services.digest_service import get_user_plan_tier
+
+        mock_db = MagicMock()
+        sub_result = _make_sb_result([{"plan_id": "smartlic_consulting_mensal"}])
+
+        with patch("services.digest_service.sb_execute", return_value=sub_result):
+            tier = await get_user_plan_tier("user-123", db=mock_db)
+
+        assert tier == "smartlic_consulting"
+
+    @pytest.mark.asyncio
+    async def test_subscription_pro(self):
+        from services.digest_service import get_user_plan_tier
+
+        mock_db = MagicMock()
+        sub_result = _make_sb_result([{"plan_id": "smartlic_pro_mensal"}])
+
+        with patch("services.digest_service.sb_execute", return_value=sub_result):
+            tier = await get_user_plan_tier("user-123", db=mock_db)
+
+        assert tier == "smartlic_pro"
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_profile(self):
+        from services.digest_service import get_user_plan_tier
+
+        mock_db = MagicMock()
+        profile_result = _make_sb_result([{"plan_type": "free_trial"}])
+
+        # First call (subscription) returns empty; second (profile) succeeds
+        empty_result = _make_sb_result([])
+
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=[empty_result, profile_result],
+        ):
+            tier = await get_user_plan_tier("user-123", db=mock_db)
+
+        assert tier == "free_trial"
+
+    @pytest.mark.asyncio
+    async def test_default_on_error(self):
+        from services.digest_service import get_user_plan_tier
+
+        mock_db = MagicMock()
+
+        # Both subscription and profile queries fail
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=[Exception("sub error"), Exception("profile error")],
+        ):
+            tier = await get_user_plan_tier("user-123", db=mock_db)
+
+        assert tier == "free_trial"
+
+    @pytest.mark.asyncio
+    async def test_subscription_consultoria(self):
+        """'consultoria' plan_id should map to smartlic_consulting."""
+        from services.digest_service import get_user_plan_tier
+
+        mock_db = MagicMock()
+        sub_result = _make_sb_result([{"plan_id": "consultoria_mensal"}])
+
+        with patch("services.digest_service.sb_execute", return_value=sub_result):
+            tier = await get_user_plan_tier("user-123", db=mock_db)
+
+        assert tier == "smartlic_consulting"
+
+
+# ============================================================================
+# get_user_sectors() tests
+# ============================================================================
+
+class TestGetUserSectors:
+    """Test sector resolution."""
+
+    @pytest.mark.asyncio
+    async def test_from_user_sector_affinity(self):
+        from services.digest_service import get_user_sectors
+
+        mock_db = MagicMock()
+        aff_result = _make_sb_result([
+            {"sector_id": "vestuario"},
+            {"sector_id": "informatica"},
+        ])
+
+        with patch("services.digest_service.sb_execute", return_value=aff_result):
+            sectors = await get_user_sectors("user-123", db=mock_db)
+
+        assert sectors == ["vestuario", "informatica"]
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_context_data(self):
+        from services.digest_service import get_user_sectors
+
+        mock_db = MagicMock()
+        profile_result = _make_sb_result([{
+            "context_data": {"setor_id": "engenharia"},
+            "sector": None,
+        }])
+
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=[_make_sb_result([]), profile_result],
+        ):
+            sectors = await get_user_sectors("user-123", db=mock_db)
+
+        assert sectors == ["engenharia"]
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_profile_sector(self):
+        from services.digest_service import get_user_sectors
+
+        mock_db = MagicMock()
+        profile_result = _make_sb_result([{
+            "context_data": None,
+            "sector": "vestuario",
+        }])
+
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=[Exception("affinity error"), profile_result],
+        ):
+            sectors = await get_user_sectors("user-123", db=mock_db)
+
+        assert sectors == ["vestuario"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_sectors(self):
+        from services.digest_service import get_user_sectors
+
+        mock_db = MagicMock()
+        profile_result = _make_sb_result([{
+            "context_data": None,
+            "sector": None,
+        }])
+
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=[_make_sb_result([]), profile_result],
+        ):
+            sectors = await get_user_sectors("user-123", db=mock_db)
+
+        assert sectors == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_db_error(self):
+        from services.digest_service import get_user_sectors
+
+        mock_db = MagicMock()
+
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=[Exception("affinity error"), Exception("profile error")],
+        ):
+            sectors = await get_user_sectors("user-123", db=mock_db)
+
+        assert sectors == []
+
+
+# ============================================================================
+# get_user_frequency() tests
+# ============================================================================
+
+class TestGetUserFrequency:
+    """Test frequency resolution."""
+
+    @pytest.mark.asyncio
+    async def test_returns_configured_frequency(self):
+        from services.digest_service import get_user_frequency
+
+        mock_db = MagicMock()
+        freq_result = _make_sb_result([{"frequency": "weekly"}])
+
+        with patch("services.digest_service.sb_execute", return_value=freq_result):
+            freq = await get_user_frequency("user-123", db=mock_db)
+
+        assert freq == "weekly"
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_daily_on_error(self):
+        from services.digest_service import get_user_frequency
+
+        mock_db = MagicMock()
+
+        with patch(
+            "services.digest_service.sb_execute",
+            side_effect=Exception("DB error"),
+        ):
+            freq = await get_user_frequency("user-123", db=mock_db)
+
+        assert freq == "daily"
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_daily_when_no_data(self):
+        from services.digest_service import get_user_frequency
+
+        mock_db = MagicMock()
+        freq_result = _make_sb_result([])
+
+        with patch("services.digest_service.sb_execute", return_value=freq_result):
+            freq = await get_user_frequency("user-123", db=mock_db)
+
+        assert freq == "daily"
+
+
+# ============================================================================
+# find_opportunities_for_sector() tests
+# ============================================================================
+
+class TestFindOpportunitiesForSector:
+    """Test sector-based opportunity query."""
+
+    @pytest.mark.asyncio
+    async def test_returns_normalized_opportunities(self):
+        from services.digest_service import find_opportunities_for_sector
+
+        mock_db = MagicMock()
+        mock_sector = MagicMock()
+        mock_sector.keywords = ["uniforme", "fardamento"]
+
+        with (
+            patch("sectors.SECTORS", {"vestuario": mock_sector}),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            mock_query.return_value = [
+                {
+                    "numeroControlePNCP": "12345",
+                    "objetoCompra": "Uniformes escolares",
+                    "nomeOrgao": "Prefeitura SP",
+                    "valorTotalEstimado": 500000.0,
+                    "uf": "SP",
+                    "modalidadeNome": "Pregão Eletrônico",
+                    "dataPublicacaoFormatted": "2026-06-01",
+                    "linkSistemaOrigem": "https://pncp.gov.br/12345",
+                    "viability_score": 0.85,
+                },
+                {
+                    "numeroControlePNCP": "67890",
+                    "objetoCompra": "Camisetas",
+                    "nomeOrgao": "Prefeitura RJ",
+                    "valorTotalEstimado": 200000.0,
+                    "uf": "RJ",
+                    "modalidadeNome": "Dispensa",
+                    "dataPublicacaoFormatted": "2026-06-02",
+                    "viability_score": 0.45,
+                },
+            ]
+
+            results = await find_opportunities_for_sector(
+                sector_id="vestuario",
+                lookback_days=1,
+                limit=5,
+                db=mock_db,
+            )
+
+        assert len(results) == 2
+        assert results[0]["id"] == "12345"
+        assert results[0]["titulo"] == "Uniformes escolares"
+        assert results[0]["orgao"] == "Prefeitura SP"
+        assert results[0]["valor_estimado"] == 500000.0
+        assert results[0]["uf"] == "SP"
+        assert results[0]["viability_score"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_by_id(self):
+        from services.digest_service import find_opportunities_for_sector
+
+        mock_db = MagicMock()
+        mock_sector = MagicMock()
+        mock_sector.keywords = ["uniforme"]
+
+        with (
+            patch("sectors.SECTORS", {"vestuario": mock_sector}),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            mock_query.return_value = [
+                {"numeroControlePNCP": "12345", "objetoCompra": "Item A"},
+                {"numeroControlePNCP": "12345", "objetoCompra": "Item A dup"},
+                {"numeroControlePNCP": "67890", "objetoCompra": "Item B"},
+            ]
+
+            results = await find_opportunities_for_sector(
+                sector_id="vestuario",
+                lookback_days=1,
+                limit=10,
+                db=mock_db,
+            )
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_query_error(self):
+        from services.digest_service import find_opportunities_for_sector
+
+        mock_db = MagicMock()
+        mock_sector = MagicMock()
+        mock_sector.keywords = ["uniforme"]
+
+        with (
+            patch("sectors.SECTORS", {"vestuario": mock_sector}),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            mock_query.side_effect = Exception("Datalake error")
+
+            results = await find_opportunities_for_sector(
+                sector_id="vestuario",
+                lookback_days=1,
+                limit=5,
+                db=mock_db,
+            )
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_sorts_by_viability_then_value(self):
+        from services.digest_service import find_opportunities_for_sector
+
+        mock_db = MagicMock()
+        mock_sector = MagicMock()
+        mock_sector.keywords = ["servico"]
+
+        with (
+            patch("sectors.SECTORS", {"servicos": mock_sector}),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            mock_query.return_value = [
+                {"numeroControlePNCP": "a", "objetoCompra": "A", "valorTotalEstimado": 100, "viability_score": 0.3},
+                {"numeroControlePNCP": "b", "objetoCompra": "B", "valorTotalEstimado": 200, "viability_score": 0.9},
+                {"numeroControlePNCP": "c", "objetoCompra": "C", "valorTotalEstimado": 300, "viability_score": 0.3},
+            ]
+
+            results = await find_opportunities_for_sector(
+                sector_id="servicos",
+                lookback_days=1,
+                limit=5,
+                db=mock_db,
+            )
+
+        assert len(results) == 3
+        # Highest viability first, then by value
+        assert results[0]["id"] == "b"
+        assert results[1]["id"] == "c"  # 0.3 viability, 300 value
+        assert results[2]["id"] == "a"  # 0.3 viability, 100 value
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self):
+        from services.digest_service import find_opportunities_for_sector
+
+        mock_db = MagicMock()
+        mock_sector = MagicMock()
+        mock_sector.keywords = ["item"]
+
+        with (
+            patch("sectors.SECTORS", {"setor": mock_sector}),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            mock_query.return_value = [
+                {"numeroControlePNCP": str(i), "objetoCompra": f"Item {i}"}
+                for i in range(20)
+            ]
+
+            results = await find_opportunities_for_sector(
+                sector_id="setor",
+                lookback_days=1,
+                limit=3,
+                db=mock_db,
+            )
+
+        assert len(results) == 3
+
+
+# ============================================================================
+# TIER_LIMITS / FREQUENCY_WINDOWS tests
+# ============================================================================
+
+class TestDigestConstants:
+    """Test DIGEST-002 constants."""
+
+    def test_tier_limits_free_trial(self):
+        from services.digest_service import TIER_LIMITS
+        assert TIER_LIMITS.get("free_trial") == 5
+
+    def test_tier_limits_pro(self):
+        from services.digest_service import TIER_LIMITS
+        assert TIER_LIMITS.get("smartlic_pro") == 20
+
+    def test_tier_limits_consulting(self):
+        from services.digest_service import TIER_LIMITS
+        assert TIER_LIMITS.get("smartlic_consulting") == 20
+
+    def test_tier_limits_consultoria(self):
+        from services.digest_service import TIER_LIMITS
+        assert TIER_LIMITS.get("consultoria") == 20
+
+    def test_frequency_windows_daily(self):
+        from services.digest_service import FREQUENCY_WINDOWS
+        assert FREQUENCY_WINDOWS["daily"] == timedelta(days=1)
+
+    def test_frequency_windows_twice_weekly(self):
+        from services.digest_service import FREQUENCY_WINDOWS
+        assert FREQUENCY_WINDOWS["twice_weekly"] == timedelta(days=3)
+
+    def test_frequency_windows_weekly(self):
+        from services.digest_service import FREQUENCY_WINDOWS
+        assert FREQUENCY_WINDOWS["weekly"] == timedelta(days=7)
+
+
+# ============================================================================
+# build_personalized_digest() tests
+# ============================================================================
+
+class TestBuildPersonalizedDigest:
+    """Test the main DIGEST-002 digest builder."""
+
+    @pytest.mark.asyncio
+    async def test_returns_expected_structure(self):
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+
+        # Four sb_execute calls: subscription (empty) -> profile (free_trial), sectors, frequency
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([]),  # subscription empty -> fallback to profile
+                    _make_sb_result([{"plan_type": "free_trial"}]),  # profile
+                    _make_sb_result([{"sector_id": "vestuario"}]),
+                    _make_sb_result([{"frequency": "daily"}]),
+                ],
+            ),
+            patch("sectors.SECTORS", {"vestuario": MagicMock(keywords=["uniforme"])}),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            mock_query.return_value = [
+                {"numeroControlePNCP": "1", "objetoCompra": "Uniformes",
+                 "nomeOrgao": "Orgao", "uf": "SP"},
+            ]
+
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        assert result["user_id"] == "user-123"
+        assert result["frequency"] == "daily"
+        assert result["tier"] == "free_trial"
+        assert "vestuario" in result["sectors"]
+        assert result["sectors"]["vestuario"]["count"] == 1
+        assert result["has_content"] is True
+        assert result["total_opportunities"] == 1
+        assert "generated_at" in result
+        assert result["sectors"]["vestuario"]["opportunities"][0]["titulo"] == "Uniformes"
+
+    @pytest.mark.asyncio
+    async def test_has_content_false_when_no_opportunities(self):
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([{"plan_id": "free_trial"}]),
+                    _make_sb_result([{"sector_id": "vestuario"}]),
+                    _make_sb_result([{"frequency": "daily"}]),
+                ],
+            ),
+            patch("sectors.SECTORS", {"vestuario": MagicMock(keywords=["uniforme"])}),
+            patch("datalake_query.query_datalake", return_value=[]),
+        ):
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        assert result["has_content"] is False
+        assert result["total_opportunities"] == 0
+        assert result["sectors"]["vestuario"]["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_sectors(self):
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([{"plan_id": "free_trial"}]),
+                    _make_sb_result([]),  # empty user_sector_affinity
+                    _make_sb_result([{"context_data": None, "sector": None}]),  # profile fallback
+                ],
+            ),
+            patch("sectors.SECTORS", {}),
+            patch("datalake_query.query_datalake"),
+        ):
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        assert result["has_content"] is False
+        assert result["total_opportunities"] == 0
+        assert result["sectors"] == {}
+
+    @pytest.mark.asyncio
+    async def test_applies_tier_limit(self):
+        """free_trial tier should limit to 5 per sector."""
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+        many_items = [
+            {"numeroControlePNCP": str(i), "objetoCompra": f"Item {i}"}
+            for i in range(50)
+        ]
+
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([]),  # subscription empty
+                    _make_sb_result([{"plan_type": "free_trial"}]),  # profile
+                    _make_sb_result([{"sector_id": "vestuario"}]),
+                    _make_sb_result([{"frequency": "daily"}]),
+                ],
+            ),
+            patch("sectors.SECTORS", {"vestuario": MagicMock(keywords=["uniforme"])}),
+            patch("datalake_query.query_datalake", return_value=many_items),
+        ):
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        # free_trial limit = 5
+        assert result["sectors"]["vestuario"]["count"] == 5
+        assert result["total_opportunities"] == 5
+
+    @pytest.mark.asyncio
+    async def test_applies_pro_tier_limit(self):
+        """smartlic_pro tier should limit to 20 per sector."""
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+        many_items = [
+            {"numeroControlePNCP": str(i), "objetoCompra": f"Item {i}"}
+            for i in range(50)
+        ]
+
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([{"plan_id": "smartlic_pro_mensal"}]),
+                    _make_sb_result([{"sector_id": "informatica"}]),
+                    _make_sb_result([{"frequency": "daily"}]),
+                ],
+            ),
+            patch("sectors.SECTORS", {"informatica": MagicMock(keywords=["software"])}),
+            patch("datalake_query.query_datalake", return_value=many_items),
+        ):
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        # smartlic_pro limit = 20
+        assert result["sectors"]["informatica"]["count"] == 20
+        assert result["total_opportunities"] == 20
+
+    @pytest.mark.asyncio
+    async def test_uses_frequency_lookback(self):
+        """Weekly frequency should use 7-day lookback."""
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([{"plan_id": "free_trial"}]),
+                    _make_sb_result([{"sector_id": "vestuario"}]),
+                    _make_sb_result([{"frequency": "weekly"}]),
+                ],
+            ),
+            patch("sectors.SECTORS", {"vestuario": MagicMock(keywords=["uniforme"])}),
+            patch("datalake_query.query_datalake", return_value=[
+                {"numeroControlePNCP": "1", "objetoCompra": "Uniformes"},
+            ]),
+        ):
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        assert result["frequency"] == "weekly"
+        assert result["has_content"] is True
+
+    @pytest.mark.asyncio
+    async def test_multiple_sectors(self):
+        from services.digest_service import build_personalized_digest
+
+        mock_db = MagicMock()
+
+        with (
+            patch(
+                "services.digest_service.sb_execute",
+                side_effect=[
+                    _make_sb_result([{"plan_id": "free_trial"}]),
+                    _make_sb_result([
+                        {"sector_id": "vestuario"},
+                        {"sector_id": "informatica"},
+                    ]),
+                    _make_sb_result([{"frequency": "daily"}]),
+                ],
+            ),
+            patch(
+                "sectors.SECTORS",
+                {
+                    "vestuario": MagicMock(keywords=["uniforme"]),
+                    "informatica": MagicMock(keywords=["software"]),
+                },
+            ),
+            patch("datalake_query.query_datalake") as mock_query,
+        ):
+            def query_side_effect(*, sector_id=None, **kwargs):
+                if sector_id == "vestuario":
+                    return [{"numeroControlePNCP": "1", "objetoCompra": "Uniforme A"}]
+                return [{"numeroControlePNCP": "2", "objetoCompra": "Software B"}]
+
+            mock_query.side_effect = query_side_effect
+
+            result = await build_personalized_digest("user-123", db=mock_db)
+
+        assert len(result["sectors"]) == 2
+        assert result["sectors"]["vestuario"]["count"] == 1
+        assert result["sectors"]["informatica"]["count"] == 1
+        assert result["total_opportunities"] == 2


### PR DESCRIPTION
## Context
DIGEST-002: Implementar lógica de build do digest personalizado — query de oportunidades por setor, top N por tier, fallback informativo quando zero resultados.

## Changes
- **digest_service.py** (382 linhas): serviço de build de digest com:
  - TIER_LIMITS: trial=5, pro=20, consulting=20
  - FREQUENCY_WINDOWS: daily=1d, twice_weekly=3d, weekly=7d
  - get_user_plan_tier(): resolve tier via user_subscriptions → profiles.plan_type
  - get_user_sectors(): busca setores via user_sector_affinity com fallback
  - get_user_frequency(): obtém frequência de alert_preferences
  - find_opportunities_for_sector(): query datalake por keywords do setor, 27 UFs
  - build_personalized_digest(): monta digest completo por usuário
- **Tests** (656 linhas, 32 testes): plan_tier, setores, frequência, query, constantes, digest completo
- Zero resultados → has_content: False

## Testing Plan
- [x] 32/32 tests passing
- [ ] Teste manual: build digest para usuário de teste
- [ ] Validação com dados reais de staging

Closes #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)