### PR TITLE
feat(backend): implement FOUNDER-002 — Redis cache for metrics + pg_cron daily refresh (#1415)

### DIFF
--- a/backend/jobs/cron/metrics_refresh.py
+++ b/backend/jobs/cron/metrics_refresh.py
@@ -1,0 +1,121 @@
+"""jobs.cron.metrics_refresh — Daily financial metrics cache refresh.
+
+FOUNDER-002: Runs once at startup, then every 24h at 02:00 BRT (05:00 UTC).
+Computes all financial metrics via Supabase RPCs and caches them in Redis
+with a 1-hour TTL.
+
+Mirrors the pattern from ``auth_cleanup.py`` and sibling crons.
+
+Schedule:
+    - On startup (after app is ready)
+    - Every 24h thereafter, aligned to 05:00 UTC
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+METRICS_REFRESH_INTERVAL_SECONDS = 24 * 60 * 60  # 24h
+TARGET_UTC_HOUR = 5  # 05:00 UTC = 02:00 BRT
+
+
+def _next_run_delay(target_hour: int = TARGET_UTC_HOUR) -> float:
+    """Calculate seconds until the next target hour UTC.
+
+    Returns a float suitable for ``asyncio.sleep()``, minimum 60s.
+    """
+    now = datetime.now(timezone.utc)
+    next_run = now.replace(hour=target_hour, minute=0, second=0, microsecond=0)
+    if now.hour >= target_hour:
+        next_run += timedelta(days=1)
+    delay = (next_run - now).total_seconds()
+    return max(60.0, delay)
+
+
+def _is_cb_or_connection_error(exc: BaseException) -> bool:
+    """Best-effort detection of circuit-breaker / Supabase connection errors.
+
+    Mirrors pattern from sibling crons to downgrade to WARNING instead of ERROR.
+    """
+    name = type(exc).__name__.lower()
+    msg = str(exc).lower()
+    return (
+        "circuitbreaker" in name
+        or "circuit" in msg
+        or "connectionerror" in name
+        or "timeout" in name
+    )
+
+
+async def run_metrics_refresh_once() -> dict:
+    """Compute and cache all financial metrics in a single run.
+
+    Returns:
+        Dict with outcome — {"status": "ok", "metrics_count": N} on success,
+        or {"status": "error", "error": "..."} on failure.
+    """
+    try:
+        from services.metrics_cron import refresh_metrics_cache
+
+        result = await refresh_metrics_cache()
+        logger.info(
+            "Metrics refresh completed: %s", result
+        )
+        return result
+    except Exception as exc:
+        if _is_cb_or_connection_error(exc):
+            logger.warning("Metrics refresh skipped (Supabase/Redis unavailable): %s", exc)
+            return {"status": "skipped", "error": str(exc)}
+        logger.error("Metrics refresh error: %s", exc, exc_info=True)
+        return {"status": "error", "error": str(exc)}
+
+
+async def _metrics_refresh_loop() -> None:
+    """Background loop — runs at startup, then every 24h at 05:00 UTC.
+
+    Mirrors the pattern from ``auth_cleanup._auth_cleanup_loop``.
+    """
+    # Initial run at startup
+    try:
+        await run_metrics_refresh_once()
+    except Exception as exc:
+        if _is_cb_or_connection_error(exc):
+            logger.warning("Initial metrics refresh skipped (Supabase/Redis unavailable): %s", exc)
+        else:
+            logger.error("Initial metrics refresh error: %s", exc, exc_info=True)
+
+    # Schedule next run at 05:00 UTC
+    delay = _next_run_delay()
+    logger.info("Next metrics refresh in %.0fs (05:00 UTC)", delay)
+    await asyncio.sleep(delay)
+
+    while True:
+        try:
+            await run_metrics_refresh_once()
+            logger.info("Next metrics refresh in 24h")
+            await asyncio.sleep(METRICS_REFRESH_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            logger.info("Metrics refresh task cancelled")
+            break
+        except Exception as exc:
+            if _is_cb_or_connection_error(exc):
+                logger.warning("Metrics refresh cycle skipped: %s", exc)
+            else:
+                logger.error("Metrics refresh cycle error: %s", exc, exc_info=True)
+            await asyncio.sleep(300)  # Retry in 5 minutes on error
+
+
+async def start_metrics_refresh_task() -> asyncio.Task:
+    """Lifespan hook: kick off the metrics refresh background loop.
+
+    Call from ``register_all_cron_tasks()`` in ``scheduler.py``.
+    """
+    task = asyncio.create_task(
+        _metrics_refresh_loop(), name="metrics_refresh"
+    )
+    logger.info("Metrics refresh background task started (interval: 24h, target: 05:00 UTC)")
+    return task

--- a/backend/jobs/cron/scheduler.py
+++ b/backend/jobs/cron/scheduler.py
@@ -19,6 +19,7 @@ from jobs.cron.llm_batch_poll import start_llm_batch_poll_task  # noqa: F401
 from jobs.cron.auth_cleanup import start_auth_cleanup_task  # noqa: F401
 from jobs.cron.seo_coverage_manifest import start_seo_coverage_manifest_task  # noqa: F401
 from jobs.cron.send_lead_magnet import start_lead_magnet_batch_task  # noqa: F401
+from jobs.cron.metrics_refresh import start_metrics_refresh_task  # noqa: F401
 
 
 def register_all_cron_tasks() -> list:
@@ -39,4 +40,5 @@ def register_all_cron_tasks() -> list:
         start_auth_cleanup_task,
         start_seo_coverage_manifest_task,  # SEO-COVERAGE-MANIFEST-001: 06:00 UTC daily
         start_lead_magnet_batch_task,  # LEAD-MAGNET-001: lead magnet PDF delivery batch
+        start_metrics_refresh_task,  # FOUNDER-002: daily metrics cache refresh at 02:00 BRT
     ]

--- a/backend/services/metrics_cache.py
+++ b/backend/services/metrics_cache.py
@@ -1,0 +1,209 @@
+"""Metrics cache service — compute financial metrics and cache in Redis.
+
+FOUNDER-002: Redis cache for revenue/financial metrics with 1h TTL.
+Cache-first with graceful degradation (recompute on miss).
+
+Usage:
+    from services.metrics_cache import get_cached_metrics, invalidate_metrics_cache
+
+    metrics = await get_cached_metrics()
+    # => {"mrr_current": ..., "churn_rate_30d": ..., ...}
+
+    await invalidate_metrics_cache()
+    # => clears all metrics:revenue:* keys
+"""
+
+import json
+import logging
+from datetime import date, timedelta
+
+logger = logging.getLogger(__name__)
+
+METRICS_TTL = 3600  # 1 hour
+METRICS_PREFIX = "metrics:revenue"
+
+METRICS = [
+    "mrr_current",
+    "churn_rate_30d",
+    "trial_to_paid_30d",
+    "trial_to_paid_90d",
+    "d7_retention",
+    "arpa",
+]
+
+
+async def compute_all_metrics() -> dict:
+    """Compute all financial metrics from SQL functions.
+
+    Calls Supabase RPCs for each metric and assembles a single dict.
+    Graceful degradation: returns 0 / empty values on error.
+    """
+    from supabase_client import get_supabase, sb_execute
+
+    sb = get_supabase()
+    end_date = date.today()
+    start_date = end_date - timedelta(days=365)
+
+    results = {}
+
+    # MRR (current month — last entry in the time series)
+    try:
+        mrr_data = await sb_execute(
+            sb.rpc("get_mrr", {
+                "start_date": start_date.isoformat(),
+                "end_date": end_date.isoformat(),
+            }),
+            category="rpc",
+        )
+        data = mrr_data.data or []
+        results["mrr_current"] = data[-1] if data else {
+            "month": end_date.isoformat(), "mrr": 0, "subscriber_count": 0
+        }
+    except Exception as exc:
+        logger.warning("Failed to compute MRR: %s", exc)
+        results["mrr_current"] = {
+            "month": end_date.isoformat(), "mrr": 0, "subscriber_count": 0
+        }
+
+    # Churn rate (30d)
+    try:
+        churn = await sb_execute(sb.rpc("get_churn_rate_30d"), category="rpc")
+        results["churn_rate_30d"] = float(churn.data) if churn.data else 0.0
+    except Exception as exc:
+        logger.warning("Failed to compute churn rate: %s", exc)
+        results["churn_rate_30d"] = 0.0
+
+    # Trial to paid (30d)
+    try:
+        ttp30 = await sb_execute(sb.rpc("get_trial_to_paid_30d"), category="rpc")
+        results["trial_to_paid_30d"] = float(ttp30.data) if ttp30.data else 0.0
+    except Exception as exc:
+        logger.warning("Failed to compute trial_to_paid_30d: %s", exc)
+        results["trial_to_paid_30d"] = 0.0
+
+    # Trial to paid (90d)
+    try:
+        ttp90 = await sb_execute(sb.rpc("get_trial_to_paid_90d"), category="rpc")
+        results["trial_to_paid_90d"] = float(ttp90.data) if ttp90.data else 0.0
+    except Exception as exc:
+        logger.warning("Failed to compute trial_to_paid_90d: %s", exc)
+        results["trial_to_paid_90d"] = 0.0
+
+    # D7 retention
+    try:
+        d7 = await sb_execute(sb.rpc("get_d7_retention"), category="rpc")
+        results["d7_retention"] = float(d7.data) if d7.data else 0.0
+    except Exception as exc:
+        logger.warning("Failed to compute D7 retention: %s", exc)
+        results["d7_retention"] = 0.0
+
+    # ARPA
+    try:
+        arpa = await sb_execute(sb.rpc("get_arpa"), category="rpc")
+        results["arpa"] = float(arpa.data) if arpa.data else 0.0
+    except Exception as exc:
+        logger.warning("Failed to compute ARPA: %s", exc)
+        results["arpa"] = 0.0
+
+    logger.info(
+        "Computed all metrics: mrr=%.2f churn=%.2f%% ttp30=%.2f%% d7=%.2f%% arpa=%.2f",
+        results.get("mrr_current", {}).get("mrr", 0),
+        results.get("churn_rate_30d", 0),
+        results.get("trial_to_paid_30d", 0),
+        results.get("d7_retention", 0),
+        results.get("arpa", 0),
+    )
+    return results
+
+
+async def cache_metrics(metrics: dict) -> None:
+    """Store metrics in Redis with TTL.
+
+    Each metric is serialised to JSON and stored under ``metrics:revenue:{name}``.
+    Uses a Redis pipeline for atomic batch write.
+    Falls back gracefully if Redis is unavailable.
+    """
+    try:
+        from redis_pool import get_redis_pool
+
+        redis = await get_redis_pool()
+        if redis is None:
+            logger.warning(
+                "Redis unavailable — metrics not cached (InMemoryCache will serve)"
+            )
+            return
+
+        pipe = redis.pipeline()
+        for key, value in metrics.items():
+            pipe.setex(
+                f"{METRICS_PREFIX}:{key}", METRICS_TTL, json.dumps(value, default=str)
+            )
+        await pipe.execute()
+        logger.info("Cached %d metrics to Redis (TTL=%ds)", len(metrics), METRICS_TTL)
+    except Exception as exc:
+        logger.warning("Failed to cache metrics: %s", exc)
+
+
+async def get_cached_metrics() -> dict:
+    """Get all metrics from cache, recomputing on cache miss.
+
+    Cache-first strategy: reads each metric key from Redis.
+    If any key is missing, recomputes ALL metrics and re-caches.
+    Returns the full dict in both cases.
+    """
+    try:
+        from redis_pool import get_redis_pool
+
+        redis = await get_redis_pool()
+    except Exception:
+        redis = None
+
+    if redis:
+        results = {}
+        needs_compute = False
+
+        for metric in METRICS:
+            try:
+                cached = await redis.get(f"{METRICS_PREFIX}:{metric}")
+                if cached:
+                    results[metric] = json.loads(cached)
+                else:
+                    needs_compute = True
+            except Exception as exc:
+                logger.debug("Cache read failed for %s: %s", metric, exc)
+                needs_compute = True
+
+        if not needs_compute:
+            return results
+
+        logger.info("Cache miss for some metrics, recomputing all")
+        computed = await compute_all_metrics()
+        await cache_metrics(computed)
+        return computed
+
+    # Redis unavailable — compute directly (graceful degradation)
+    logger.info("Redis unavailable, computing metrics directly")
+    return await compute_all_metrics()
+
+
+async def invalidate_metrics_cache() -> int:
+    """Delete all metrics cache keys from Redis.
+
+    Returns:
+        Number of deleted keys.
+    """
+    try:
+        from redis_pool import get_redis_pool
+
+        redis = await get_redis_pool()
+        if redis is None:
+            logger.warning("Redis unavailable — cannot invalidate metrics cache")
+            return 0
+        keys = await redis.keys(f"{METRICS_PREFIX}:*")
+        if keys:
+            await redis.delete(*keys)
+        logger.info("Invalidated %d metrics cache keys", len(keys))
+        return len(keys)
+    except Exception as exc:
+        logger.warning("Failed to invalidate metrics cache: %s", exc)
+        return 0

--- a/backend/services/metrics_cron.py
+++ b/backend/services/metrics_cron.py
@@ -1,0 +1,37 @@
+"""Metrics cron wrapper — called by pg_cron daily at 02:00 BRT.
+
+FOUNDER-002: Daily refresh of financial metrics cache.
+
+This module provides the function that pg_cron triggers (via pg_net HTTP
+request to the backend). The actual scheduling is also handled by the
+lifespan background loop in ``jobs.cron.metrics_refresh``.
+
+Usage:
+    from services.metrics_cron import refresh_metrics_cache
+    await refresh_metrics_cache()
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def refresh_metrics_cache() -> dict:
+    """Compute and cache all financial metrics.
+
+    Called by:
+    1. Pg_cron daily at 02:00 BRT (via pg_net → backend endpoint)
+    2. Lifespan background loop (every 24h, see ``jobs.cron.metrics_refresh``)
+    3. Admin endpoint (on-demand)
+
+    Returns:
+        Dict with computation status, e.g.:
+        {"status": "ok", "metrics_count": 6}
+    """
+    from services.metrics_cache import compute_all_metrics, cache_metrics
+
+    logger.info("Starting metrics cache refresh")
+    metrics = await compute_all_metrics()
+    await cache_metrics(metrics)
+    logger.info("Metrics cache refresh complete (%d metrics)", len(metrics))
+    return {"status": "ok", "metrics_count": len(metrics)}

--- a/backend/tests/test_metrics_cache.py
+++ b/backend/tests/test_metrics_cache.py
@@ -1,0 +1,428 @@
+"""Tests for FOUNDER-002: Redis cache for financial metrics.
+
+Key mock patterns:
+  - Supabase: patch("supabase_client.sb_execute") + patch("supabase_client.get_supabase")
+    (because services.metrics_cache uses lazy imports inside function body)
+  - Redis: patch("redis_pool.get_redis_pool") with AsyncMock
+  - Cron services: patch("services.metrics_cache.compute_all_metrics") etc.
+    (because services.metrics_cron also uses lazy imports inside function body)
+"""
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from datetime import date
+
+
+# ============================================================================
+# Shared test data
+# ============================================================================
+
+MOCK_MRR_DATA = [
+    {"month": "2025-06-01", "mrr": 1000.0, "subscriber_count": 5},
+    {"month": "2026-05-01", "mrr": 5000.0, "subscriber_count": 12},
+    {"month": "2026-06-01", "mrr": 5200.0, "subscriber_count": 14},
+]
+
+MOCK_CHURN = 0.05  # 5%
+MOCK_TTP30 = 0.12  # 12%
+MOCK_TTP90 = 0.20  # 20%
+MOCK_D7 = 0.65     # 65%
+MOCK_ARPA = 397.0  # R$ 397
+
+MOCK_METRICS = {
+    "mrr_current": MOCK_MRR_DATA[-1],
+    "churn_rate_30d": MOCK_CHURN,
+    "trial_to_paid_30d": MOCK_TTP30,
+    "trial_to_paid_90d": MOCK_TTP90,
+    "d7_retention": MOCK_D7,
+    "arpa": MOCK_ARPA,
+}
+
+# RPC calls are made in deterministic order: get_mrr, get_churn_rate_30d,
+# get_trial_to_paid_30d, get_trial_to_paid_90d, get_d7_retention, get_arpa
+_RPC_RESULTS_ORDER = [
+    MOCK_MRR_DATA,     # get_mrr
+    MOCK_CHURN,        # get_churn_rate_30d
+    MOCK_TTP30,        # get_trial_to_paid_30d
+    MOCK_TTP90,        # get_trial_to_paid_90d
+    MOCK_D7,           # get_d7_retention
+    MOCK_ARPA,         # get_arpa
+]
+
+
+def _make_rpc_result(data):
+    """Create a mock sb_execute result with .data attribute."""
+    return MagicMock(data=data)
+
+
+def _build_rpc_side_effect(results=None):
+    """Build a side_effect list for sb_execute that matches RPC call order.
+
+    Each entry is a MagicMock with .data set to the result value.
+    """
+    if results is None:
+        results = _RPC_RESULTS_ORDER
+    return [_make_rpc_result(r) for r in results]
+
+
+def _mock_pipeline(mock_redis):
+    """Set up pipeline mock on an AsyncMock Redis client.
+
+    redis-py async pipeline() is a synchronous call (returns a Pipeline
+    object synchronously). Pipe methods like setex() are also sync.
+    Only execute() is a coroutine.
+    """
+    pipe = MagicMock()
+    pipe.setex = MagicMock(return_value=True)
+    pipe.execute = AsyncMock()
+    mock_redis.pipeline = MagicMock(return_value=pipe)
+    return pipe
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+class TestComputeAllMetrics:
+    """Tests for compute_all_metrics()."""
+
+    @pytest.mark.asyncio
+    async def test_computes_all_metrics_successfully(self):
+        """Should compute all 6 metrics from Supabase RPCs."""
+        mock_sb = MagicMock()
+        rpc_results = _build_rpc_side_effect()
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("supabase_client.sb_execute", new_callable=AsyncMock, side_effect=rpc_results):
+
+            from services.metrics_cache import compute_all_metrics
+            results = await compute_all_metrics()
+
+        assert "mrr_current" in results
+        assert results["mrr_current"]["mrr"] == 5200.0
+        assert results["mrr_current"]["subscriber_count"] == 14
+        assert results["churn_rate_30d"] == MOCK_CHURN
+        assert results["trial_to_paid_30d"] == MOCK_TTP30
+        assert results["trial_to_paid_90d"] == MOCK_TTP90
+        assert results["d7_retention"] == MOCK_D7
+        assert results["arpa"] == MOCK_ARPA
+        assert len(results) == 6
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_rpc_failure(self):
+        """Should return zeros when all RPCs fail."""
+        mock_sb = MagicMock()
+        mock_sb_execute = AsyncMock(side_effect=Exception("Supabase down"))
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("supabase_client.sb_execute", mock_sb_execute):
+
+            from services.metrics_cache import compute_all_metrics
+            results = await compute_all_metrics()
+
+        assert results["mrr_current"]["mrr"] == 0
+        assert results["mrr_current"]["subscriber_count"] == 0
+        assert results["churn_rate_30d"] == 0.0
+        assert results["trial_to_paid_30d"] == 0.0
+        assert results["trial_to_paid_90d"] == 0.0
+        assert results["d7_retention"] == 0.0
+        assert results["arpa"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_empty_mrr_data_returns_placeholder(self):
+        """Should use placeholder when MRR data is empty."""
+        mock_sb = MagicMock()
+        # First RPC (get_mrr) returns empty list; rest return None
+        side_effects = [_make_rpc_result([])] + _build_rpc_side_effect([None] * 5)
+
+        with patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("supabase_client.sb_execute", new_callable=AsyncMock, side_effect=side_effects):
+
+            from services.metrics_cache import compute_all_metrics
+            results = await compute_all_metrics()
+
+        assert results["mrr_current"]["mrr"] == 0
+        assert results["mrr_current"]["subscriber_count"] == 0
+        assert results["mrr_current"]["month"] == date.today().isoformat()
+
+
+class TestCacheMetrics:
+    """Tests for cache_metrics()."""
+
+    @pytest.mark.asyncio
+    async def test_caches_all_metrics(self):
+        """Should store all metrics in Redis with pipeline."""
+        mock_redis = AsyncMock()
+        pipe = _mock_pipeline(mock_redis)
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):
+            from services.metrics_cache import cache_metrics
+            await cache_metrics(MOCK_METRICS)
+
+        # Should have called setex for each metric
+        assert pipe.setex.call_count == 6
+        for key in MOCK_METRICS:
+            pipe.setex.assert_any_call(
+                f"metrics:revenue:{key}", 3600, json.dumps(MOCK_METRICS[key], default=str)
+            )
+        # Pipeline should have been executed
+        pipe.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_when_redis_unavailable(self):
+        """Should not raise when Redis is unavailable."""
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=None):
+            from services.metrics_cache import cache_metrics
+            # Should not raise
+            await cache_metrics(MOCK_METRICS)
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_redis_error(self):
+        """Should not raise when Redis operations fail."""
+        mock_redis = AsyncMock()
+        mock_redis.pipeline.side_effect = Exception("Pipeline error")
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):
+            from services.metrics_cache import cache_metrics
+            # Should not raise
+            await cache_metrics(MOCK_METRICS)
+
+
+class TestGetCachedMetrics:
+    """Tests for get_cached_metrics()."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_all_metrics(self):
+        """Should return cached metrics without recomputing."""
+        mock_redis = AsyncMock()
+        cached_values = {f"metrics:revenue:{k}": json.dumps(v, default=str) for k, v in MOCK_METRICS.items()}
+
+        async def mock_get(key):
+            return cached_values.get(key)
+
+        mock_redis.get = mock_get
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):
+            from services.metrics_cache import get_cached_metrics
+            results = await get_cached_metrics()
+
+        assert results == MOCK_METRICS
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_recomputes(self):
+        """Should recompute when a cache key is missing."""
+        mock_redis = AsyncMock()
+
+        # Only return cached value for one metric, miss all others
+        cached_mrr = json.dumps(MOCK_MRR_DATA[-1], default=str)
+        cache = {"metrics:revenue:mrr_current": cached_mrr}
+
+        async def mock_get(key):
+            return cache.get(key)
+
+        mock_redis.get = mock_get
+
+        # Mock Supabase for recomputation
+        mock_sb = MagicMock()
+        rpc_results = _build_rpc_side_effect()
+        pipe = _mock_pipeline(mock_redis)
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis), \
+             patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("supabase_client.sb_execute", new_callable=AsyncMock, side_effect=rpc_results):
+
+            from services.metrics_cache import get_cached_metrics
+            results = await get_cached_metrics()
+
+        # Should have returned all metrics (recomputed + cached)
+        assert len(results) == 6
+        assert results["mrr_current"]["mrr"] == 5200.0
+        assert results["churn_rate_30d"] == MOCK_CHURN
+
+        # Should have re-cached (setex called after recomputation)
+        assert pipe.setex.call_count >= 5  # At least 5 recomputed metrics cached
+
+    @pytest.mark.asyncio
+    async def test_computes_directly_when_redis_unavailable(self):
+        """Should compute directly when Redis is unavailable."""
+        mock_sb = MagicMock()
+        # Only first RPC needs data; rest can be None since test checks MRR
+        rpc_side = [_make_rpc_result(MOCK_MRR_DATA)] + _build_rpc_side_effect([None] * 5)
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=None), \
+             patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("supabase_client.sb_execute", new_callable=AsyncMock, side_effect=rpc_side):
+
+            from services.metrics_cache import get_cached_metrics
+            results = await get_cached_metrics()
+
+        assert len(results) == 6
+        assert results["mrr_current"]["mrr"] == 5200.0
+
+    @pytest.mark.asyncio
+    async def test_redis_exception_falls_back_to_compute(self):
+        """Should compute directly when Redis raises an error."""
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(side_effect=Exception("Redis error"))
+
+        mock_sb = MagicMock()
+        rpc_side = _build_rpc_side_effect([None] * 6)
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis), \
+             patch("supabase_client.get_supabase", return_value=mock_sb), \
+             patch("supabase_client.sb_execute", new_callable=AsyncMock, side_effect=rpc_side):
+
+            from services.metrics_cache import get_cached_metrics
+            results = await get_cached_metrics()
+
+        assert len(results) == 6  # Graceful degradation
+
+
+class TestInvalidateMetricsCache:
+    """Tests for invalidate_metrics_cache()."""
+
+    @pytest.mark.asyncio
+    async def test_invalidates_all_metric_keys(self):
+        """Should delete all metrics:revenue:* keys."""
+        mock_redis = AsyncMock()
+        mock_redis.keys = AsyncMock(return_value=[
+            "metrics:revenue:mrr_current",
+            "metrics:revenue:churn_rate_30d",
+            "metrics:revenue:arpa",
+        ])
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):
+            from services.metrics_cache import invalidate_metrics_cache
+            deleted = await invalidate_metrics_cache()
+
+        assert deleted == 3
+        mock_redis.keys.assert_awaited_once_with("metrics:revenue:*")
+        mock_redis.delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_keys_returns_zero(self):
+        """Should return 0 when no cache keys exist."""
+        mock_redis = AsyncMock()
+        mock_redis.keys = AsyncMock(return_value=[])
+
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):
+            from services.metrics_cache import invalidate_metrics_cache
+            deleted = await invalidate_metrics_cache()
+
+        assert deleted == 0
+        mock_redis.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_unavailable_returns_zero(self):
+        """Should return 0 when Redis is unavailable."""
+        with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=None):
+            from services.metrics_cache import invalidate_metrics_cache
+            deleted = await invalidate_metrics_cache()
+
+        assert deleted == 0
+
+
+class TestMetricsCron:
+    """Tests for metrics_cron.refresh_metrics_cache()."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_metrics_cache(self):
+        """Should compute and cache all metrics."""
+        with patch("services.metrics_cache.compute_all_metrics", new_callable=AsyncMock, return_value=MOCK_METRICS), \
+             patch("services.metrics_cache.cache_metrics", new_callable=AsyncMock) as mock_cache:
+
+            from services.metrics_cron import refresh_metrics_cache
+            result = await refresh_metrics_cache()
+
+        assert result["status"] == "ok"
+        assert result["metrics_count"] == 6
+        mock_cache.assert_awaited_once_with(MOCK_METRICS)
+
+
+class TestMetricsRefreshCronTask:
+    """Tests for jobs.cron.metrics_refresh."""
+
+    @pytest.mark.asyncio
+    async def test_run_metrics_refresh_once_success(self):
+        """Should run refresh and return status."""
+        with patch("services.metrics_cron.refresh_metrics_cache",
+                   new_callable=AsyncMock,
+                   return_value={"status": "ok", "metrics_count": 6}):
+
+            from jobs.cron.metrics_refresh import run_metrics_refresh_once
+            result = await run_metrics_refresh_once()
+
+        assert result["status"] == "ok"
+        assert result["metrics_count"] == 6
+
+    @pytest.mark.asyncio
+    async def test_run_metrics_refresh_once_cb_error(self):
+        """Should handle circuit breaker errors gracefully."""
+        class CircuitBreakerError(Exception):
+            pass
+
+        with patch("services.metrics_cron.refresh_metrics_cache",
+                   new_callable=AsyncMock,
+                   side_effect=CircuitBreakerError("CircuitBreaker is OPEN")):
+
+            from jobs.cron.metrics_refresh import run_metrics_refresh_once
+            result = await run_metrics_refresh_once()
+
+        assert result["status"] == "skipped"
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_run_metrics_refresh_once_generic_error(self):
+        """Should handle generic errors gracefully."""
+        with patch("services.metrics_cron.refresh_metrics_cache",
+                   new_callable=AsyncMock,
+                   side_effect=Exception("Generic error")):
+
+            from jobs.cron.metrics_refresh import run_metrics_refresh_once
+            result = await run_metrics_refresh_once()
+
+        assert result["status"] == "error"
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_start_metrics_refresh_task_returns_task(self):
+        """Should create and return an asyncio Task."""
+        from jobs.cron.metrics_refresh import start_metrics_refresh_task
+        task = await start_metrics_refresh_task()
+
+        assert task is not None
+        assert task.get_name() == "metrics_refresh"
+        # Cancel to clean up
+        task.cancel()
+
+    def test_registered_in_scheduler(self):
+        """Should be registered in the centralised cron scheduler."""
+        from jobs.cron.scheduler import register_all_cron_tasks
+        tasks = register_all_cron_tasks()
+        names = [t.__name__ for t in tasks]
+
+        assert "start_metrics_refresh_task" in names
+
+
+class TestMetricsConstants:
+    """Tests for module-level constants."""
+
+    def test_metrics_ttl_is_one_hour(self):
+        from services.metrics_cache import METRICS_TTL
+        assert METRICS_TTL == 3600
+
+    def test_metrics_prefix(self):
+        from services.metrics_cache import METRICS_PREFIX
+        assert METRICS_PREFIX == "metrics:revenue"
+
+    def test_metrics_list_has_six_items(self):
+        from services.metrics_cache import METRICS
+        assert len(METRICS) == 6
+        assert "mrr_current" in METRICS
+        assert "churn_rate_30d" in METRICS
+        assert "trial_to_paid_30d" in METRICS
+        assert "trial_to_paid_90d" in METRICS
+        assert "d7_retention" in METRICS
+        assert "arpa" in METRICS

--- a/supabase/migrations/20260606001248_add_metrics_cache_cron.down.sql
+++ b/supabase/migrations/20260606001248_add_metrics_cache_cron.down.sql
@@ -1,0 +1,10 @@
+-- ============================================================================
+-- Migration 20260606001248 (down): Remove metrics cache refresh cron job
+-- FOUNDER-002: Daily refresh of financial metrics cache
+-- ============================================================================
+
+-- 1. Unschedule the pg_cron job
+SELECT cron.unschedule('metrics-cache-refresh');
+
+-- 2. Drop the cron-trigger function
+DROP FUNCTION IF EXISTS public.refresh_metrics_cache_cron;

--- a/supabase/migrations/20260606001248_add_metrics_cache_cron.sql
+++ b/supabase/migrations/20260606001248_add_metrics_cache_cron.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE FUNCTION public.refresh_metrics_cache_cron()
 RETURNS text
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 BEGIN
   -- Attempt to trigger the backend via pg_net HTTP request.

--- a/supabase/migrations/20260606001248_add_metrics_cache_cron.sql
+++ b/supabase/migrations/20260606001248_add_metrics_cache_cron.sql
@@ -1,0 +1,86 @@
+-- ============================================================================
+-- Migration 20260606001248: Add metrics cache refresh cron job
+-- FOUNDER-002: Daily refresh of financial metrics cache
+-- Date: 2026-06-06
+-- ============================================================================
+--
+-- This migration schedules a pg_cron job that refreshes the metrics cache
+-- daily at 02:00 BRT (05:00 UTC). The cron acts as a safety net alongside
+-- the lifespan background loop in ``jobs/cron/metrics_refresh.py``.
+--
+-- The cron calls a PostgreSQL function that triggers the backend via pg_net.
+-- If pg_net is unavailable, metrics are still refreshed by the lifespan
+-- background loop on the next startup / 24h cycle.
+--
+-- ============================================================================
+-- pg_cron is already enabled by migration 022_retention_cleanup.sql.
+-- ============================================================================
+
+-- ============================================================================
+-- 1. Create the cron-trigger function
+-- ============================================================================
+-- This function is called by pg_cron and uses pg_net to make an HTTP POST
+-- request to the backend's admin metrics-cache endpoint.
+-- Falls back gracefully if pg_net is not available.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.refresh_metrics_cache_cron()
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- Attempt to trigger the backend via pg_net HTTP request.
+  -- If pg_net extension is not available, this is a no-op.
+  -- The actual metrics refresh runs via the lifespan background loop.
+  BEGIN
+    PERFORM net.http_post(
+      url := 'https://api.smartlic.tech/v1/admin/refresh-metrics-cache',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json'
+      )
+    );
+    RETURN 'triggered';
+  EXCEPTION WHEN OTHERS THEN
+    -- pg_net unavailable or request failed — metrics still refreshed
+    -- by lifespan background loop. Log notice for monitoring.
+    RAISE NOTICE 'pg_net HTTP request failed — metrics refresh handled by lifespan loop';
+    RETURN 'fallback';
+  END;
+END;
+$$;
+
+COMMENT ON FUNCTION public.refresh_metrics_cache_cron IS
+  'FOUNDER-002: Called by pg_cron daily at 02:00 BRT. Triggers backend metrics cache refresh via pg_net HTTP request. Falls back gracefully if pg_net is unavailable.';
+
+-- ============================================================================
+-- 2. Schedule the pg_cron job
+-- ============================================================================
+-- Schedule: 05:00 UTC = 02:00 BRT (Brazil daylight saving)
+-- ============================================================================
+
+SELECT cron.schedule(
+    'metrics-cache-refresh',                              -- job name
+    '0 5 * * *',                                          -- cron: 05:00 UTC daily
+    $$SELECT public.refresh_metrics_cache_cron()$$         -- SQL to execute
+);
+
+-- ============================================================================
+-- pg_cron Verification and Management
+-- ============================================================================
+--
+-- View scheduled jobs:
+--   SELECT * FROM cron.job WHERE jobname = 'metrics-cache-refresh';
+--
+-- View job run history:
+--   SELECT * FROM cron.job_run_details
+--   WHERE job_name = 'metrics-cache-refresh'
+--   ORDER BY start_time DESC LIMIT 10;
+--
+-- Unschedule a job (if needed):
+--   SELECT cron.unschedule('metrics-cache-refresh');
+--
+-- Manually trigger a job (for testing):
+--   SELECT public.refresh_metrics_cache_cron();
+--
+-- ============================================================================


### PR DESCRIPTION
## Context
FOUNDER-002: Cron diário + cache Redis para métricas financeiras. Computa métricas (MRR, churn, trial-to-paid, D7, ARPA) e armazena em Redis com TTL 1h. pg_cron dispara refresh diário às 02:00 BRT.

## Changes
- **metrics_cache.py**: serviço de cache com compute_all_metrics, cache_metrics (pipeline Redis), get_cached_metrics (cache-first com recompute on miss), invalidate_metrics_cache
- **metrics_cron.py**: wrapper refresh_metrics_cache()
- **metrics_refresh.py**: background loop seguindo padrão existente (inicialização + a cada 24h)
- **scheduler.py**: registro na lista centralizada de tarefas cron
- **Migration**: pg_cron schedule + função public.refresh_metrics_cache_cron()
- **Tests** (22): cache hit/miss, Redis unavailable, compute_all, invalidate, cron, scheduler

## Testing Plan
- [x] 22/22 tests passing
- [ ] Cache hit rate >95% em staging
- [ ] pg_cron job visível em SELECT * FROM cron.job

Closes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)