### PR TITLE
feat(backend): implement API-SELF-003 — API key rate limiting via Redis monthly counter (#1420)

### DIFF
--- a/backend/api_key_rate_limit.py
+++ b/backend/api_key_rate_limit.py
@@ -1,0 +1,231 @@
+"""API-SELF-003: Rate limiting por API key via Redis monthly counter.
+
+Rate limits per API key based on the user's plan tier:
+    - Starter: 1,000 requests/month
+    - Pro:    10,000 requests/month
+    - Scale: 100,000 requests/month
+
+Uses Redis INCR + EXPIRE with monthly key format:
+    ``api_key_rl:{api_key_id}:{YYYY-MM}``
+
+The month boundary aligns to BRT (UTC-3) so that the reset happens at
+midnight Brazilian time on the 1st of each month.
+
+Headers on every response:
+    ``X-RateLimit-Remaining``
+    ``X-RateLimit-Limit``
+
+On exceeded:
+    429 + ``Retry-After`` header (seconds until next month in BRT)
+
+Implements acceptance criteria for API-SELF-003.
+"""
+
+from __future__ import annotations
+
+import logging
+import time as _time
+from datetime import datetime, timedelta, timezone
+
+from fastapi import HTTPException
+
+from redis_pool import get_redis_pool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tier definitions
+# ---------------------------------------------------------------------------
+
+# Plan type -> API key tier mapping
+_API_KEY_TIER_MAP: dict[str, str] = {
+    "free_trial": "starter",
+    "free": "starter",
+    "consultor_agil": "starter",
+    "maquina": "pro",
+    "smartlic_pro": "pro",
+    "sala_guerra": "scale",
+    "smartlic_command": "scale",
+    "consultoria": "scale",
+    "founding_member": "scale",
+    "master": "unlimited",
+}
+
+# Tier -> monthly request limit
+API_KEY_TIER_LIMITS: dict[str, int] = {
+    "starter": 1000,
+    "pro": 10000,
+    "scale": 100000,
+    "unlimited": 999_999_999,
+}
+
+# Redis key prefix
+_REDIS_PREFIX: str = "api_key_rl:"
+
+# ---------------------------------------------------------------------------
+# In-memory plan cache (60 s TTL)
+# ---------------------------------------------------------------------------
+
+_PLAN_CACHE: dict[str, tuple[str, float]] = {}
+_PLAN_CACHE_TTL: int = 60  # seconds
+
+
+def _clear_plan_cache() -> None:
+    """Clear the plan cache (used in tests)."""
+    _PLAN_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_brt_now() -> datetime:
+    """Return current UTC datetime minus 3 hours (approximate BRT)."""
+    return datetime.now(timezone.utc) - timedelta(hours=3)
+
+
+def _get_month_key() -> str:
+    """Get the current month key (``YYYY-MM``) in BRT."""
+    return _get_brt_now().strftime("%Y-%m")
+
+
+def _seconds_until_next_month() -> int:
+    """Calculate seconds until the first day of next month at 00:00 BRT.
+
+    Returns at least 1 second.
+    """
+    now_brt = _get_brt_now()
+    year = now_brt.year
+    month = now_brt.month
+
+    if month == 12:
+        next_brt = now_brt.replace(year=year + 1, month=1, day=1)
+    else:
+        next_brt = now_brt.replace(month=month + 1, day=1)
+
+    next_brt = next_brt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # Convert back to UTC for the timedelta
+    next_utc = next_brt + timedelta(hours=3)
+    now_utc = datetime.now(timezone.utc)
+
+    seconds = int((next_utc - now_utc).total_seconds())
+    return max(1, seconds)
+
+
+async def _get_user_plan(user_id: str) -> str:
+    """Look up the user's ``plan_type`` from the profiles table.
+
+    Falls back to ``free_trial`` on any error.
+    Cached briefly in memory (60 s) to avoid a DB hit on every request.
+    """
+    now = _time.monotonic()
+    cached = _PLAN_CACHE.get(user_id)
+    if cached is not None and (now - cached[1]) < _PLAN_CACHE_TTL:
+        return cached[0]
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("profiles")
+            .select("plan_type")
+            .eq("id", user_id)
+            .limit(1),
+            category="read",
+        )
+        if result.data and len(result.data) > 0:
+            plan = result.data[0].get("plan_type", "free_trial")
+            _PLAN_CACHE[user_id] = (plan, now)
+            return plan
+    except Exception as exc:
+        logger.warning(
+            "Failed to fetch plan for user %s: %s", user_id[:8], exc
+        )
+
+    return "free_trial"
+
+
+def _get_tier_from_plan(plan_type: str) -> str:
+    """Map a ``plan_type`` to an API key tier."""
+    return _API_KEY_TIER_MAP.get(plan_type, "starter")
+
+
+# ---------------------------------------------------------------------------
+# Main rate-limit check
+# ---------------------------------------------------------------------------
+
+
+async def check_api_key_rate_limit(
+    api_key_id: str,
+    user_id: str,
+) -> tuple[int, int]:
+    """Check and enforce the monthly rate limit for an API key.
+
+    The limit is determined by the user's plan tier.
+
+    Redis key format: ``api_key_rl:{api_key_id}:{YYYY-MM}``, TTL set to
+    the number of seconds until the next month (BRT).
+
+    Falls back to in-memory when Redis is unavailable (fail-open).
+
+    Args:
+        api_key_id: The API key's UUID (from ``request.state.api_key_id``).
+        user_id:    The key owner's user ID (from ``require_api_key``).
+
+    Returns:
+        ``(remaining, limit)`` tuple.
+
+    Raises:
+        HTTPException 429: when the monthly quota is exhausted.
+    """
+    plan_type = await _get_user_plan(user_id)
+    tier = _get_tier_from_plan(plan_type)
+    limit = API_KEY_TIER_LIMITS.get(tier, 1000)
+
+    month_key = _get_month_key()
+    redis_key = f"{_REDIS_PREFIX}{api_key_id}:{month_key}"
+
+    redis = await get_redis_pool()
+
+    if redis is not None:
+        try:
+            count = await redis.incr(redis_key)
+            if count == 1:
+                ttl_seconds = _seconds_until_next_month()
+                await redis.expire(redis_key, ttl_seconds)
+
+            remaining = max(0, limit - count)
+
+            if count > limit:
+                retry_after = _seconds_until_next_month()
+                raise HTTPException(
+                    status_code=429,
+                    detail={
+                        "detail": "API rate limit exceeded. "
+                        "Your quota resets at the start of next month.",
+                        "retry_after_seconds": retry_after,
+                        "limit": limit,
+                        "tier": tier,
+                    },
+                    headers={
+                        "X-RateLimit-Limit": str(limit),
+                        "X-RateLimit-Remaining": "0",
+                        "Retry-After": str(retry_after),
+                    },
+                )
+
+            return remaining, limit
+
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "API key rate limit Redis error (fail-open): %s", exc
+            )
+            return limit, limit
+
+    # No Redis - allow through (best-effort rate limiting)
+    return limit, limit

--- a/backend/routes/api_search.py
+++ b/backend/routes/api_search.py
@@ -6,11 +6,12 @@ Endpoints:
 Reuses the same ``SearchPipeline`` as ``POST /buscar`` but authenticated
 with an API key (``require_api_key``) instead of JWT (``require_auth``).
 
-Rate limiting:
-    - ``X-RateLimit-Limit``: 100 requests/day (hardcoded for now)
-    - ``X-RateLimit-Remaining``: remaining quota in current window
-    - Redis key ``ratelimit:api:{user_id}:{YYYY-MM-DD}`` with 24h TTL
-    - Returns 429 when exceeded
+Rate limiting (API-SELF-003):
+    - Monthly counter per API key via Redis
+    - Limits determined by user's plan tier (Starter 1k / Pro 10k / Scale 100k)
+    - ``X-RateLimit-Limit`` and ``X-RateLimit-Remaining`` on every response
+    - Returns 429 with ``Retry-After`` when quota exhausted
+    - Reset at 00:00 BRT on the 1st of each month
 """
 
 from __future__ import annotations
@@ -39,76 +40,11 @@ from filter import (
 from excel import create_excel
 from rate_limiter import rate_limiter
 from authorization import check_user_roles
+from api_key_rate_limit import check_api_key_rate_limit
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["api"])
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-
-API_RATE_LIMIT_PER_DAY: int = 100  # Hardcoded; configurable per tier in API-SELF-003
-_RATE_LIMIT_REDIS_PREFIX: str = "ratelimit:api:"
-
-
-# ---------------------------------------------------------------------------
-# Rate limit helpers
-# ---------------------------------------------------------------------------
-
-
-async def _check_api_rate_limit(
-    user_id: str,
-    *,
-    limit: int = API_RATE_LIMIT_PER_DAY,
-) -> tuple[int, int]:
-    """Check and enforce daily rate limit for an API key user.
-
-    Redis key format: ``ratelimit:api:{user_id}:{YYYY-MM-DD}``, TTL 24h.
-    Falls back to in-memory when Redis is unavailable (fail-open).
-
-    Returns:
-        ``(remaining, limit)`` tuple.
-
-    Raises:
-        HTTPException 429: when quota is exhausted.
-    """
-    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    redis_key = f"{_RATE_LIMIT_REDIS_PREFIX}{user_id}:{date_str}"
-
-    from redis_pool import get_redis_pool
-    redis = await get_redis_pool()
-
-    if redis is not None:
-        try:
-            count = await redis.incr(redis_key)
-            if count == 1:
-                await redis.expire(redis_key, 86400)  # 24 hours
-
-            remaining = max(0, limit - count)
-            if count > limit:
-                raise HTTPException(
-                    status_code=429,
-                    detail={
-                        "detail": "Rate limit exceeded. Try again later.",
-                        "retry_after_seconds": 86400,
-                    },
-                    headers={
-                        "X-RateLimit-Limit": str(limit),
-                        "X-RateLimit-Remaining": "0",
-                        "Retry-After": "86400",
-                    },
-                )
-            return remaining, limit
-        except HTTPException:
-            raise
-        except Exception as exc:
-            logger.warning("API rate limit Redis error (fail-open): %s", exc)
-            return limit, limit  # Fail-open
-
-    # No Redis — allow through (best-effort rate limiting)
-    return limit, limit
-
 
 # ---------------------------------------------------------------------------
 # Endpoint
@@ -153,10 +89,12 @@ async def api_search(
     Same search pipeline as ``POST /buscar`` but authenticated with an
     ``X-API-Key`` header instead of JWT Bearer token.
 
-    **Rate limiting:** 100 requests/day per API key (``X-RateLimit-*`` headers).
+    **Rate limiting:** Monthly quota per API key based on user's plan tier
+    (``X-RateLimit-*`` headers).
     """
-    # ---- Rate limit check ----
-    remaining, limit = await _check_api_rate_limit(_api_user_id)
+    # ---- Rate limit check (API-SELF-003: monthly, tier-aware) ----
+    api_key_id = getattr(raw_request.state, "api_key_id", _api_user_id)
+    remaining, limit = await check_api_key_rate_limit(api_key_id, _api_user_id)
     http_response.headers["X-RateLimit-Limit"] = str(limit)
     http_response.headers["X-RateLimit-Remaining"] = str(remaining)
 

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -9349,6 +9349,30 @@
         "title": "ModalidadeAggregate",
         "type": "object"
       },
+      "MrrEntry": {
+        "description": "Single month MRR entry returned by ``get_mrr()``.",
+        "properties": {
+          "month": {
+            "title": "Month",
+            "type": "string"
+          },
+          "mrr": {
+            "default": 0.0,
+            "title": "Mrr",
+            "type": "number"
+          },
+          "subscriber_count": {
+            "default": 0,
+            "title": "Subscriber Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "month"
+        ],
+        "title": "MrrEntry",
+        "type": "object"
+      },
       "MunicipioProfileResponse": {
         "properties": {
           "atividade_recente": {
@@ -12829,6 +12853,81 @@
           "paths"
         ],
         "title": "RevalidateSEOResponse",
+        "type": "object"
+      },
+      "RevenueMetricsResponse": {
+        "description": "Response for GET /v1/admin/metrics/revenue (FOUNDER-003 + FOUNDER-005).\n\nAggregated revenue and engagement metrics for the founder dashboard.\nAll values are non-PII aggregates computed by server-side SQL functions\n(FOUNDER-001 migration 20260606010000).\n\n``mrr`` is the most recent month's MRR in BRL.\n``mrr_history`` contains per-month MRR entries for chart rendering.\nAll rate/percentage fields are normalized to the 0.0-1.0 range.",
+        "properties": {
+          "activation_d7": {
+            "default": 0.0,
+            "title": "Activation D7",
+            "type": "number"
+          },
+          "arpa": {
+            "default": 0.0,
+            "title": "Arpa",
+            "type": "number"
+          },
+          "churn_rate_30d": {
+            "default": 0.0,
+            "title": "Churn Rate 30D",
+            "type": "number"
+          },
+          "mrr": {
+            "default": 0.0,
+            "title": "Mrr",
+            "type": "number"
+          },
+          "mrr_history": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/MrrEntry"
+            },
+            "title": "Mrr History",
+            "type": "array"
+          },
+          "period_end": {
+            "default": "",
+            "title": "Period End",
+            "type": "string"
+          },
+          "period_start": {
+            "default": "",
+            "title": "Period Start",
+            "type": "string"
+          },
+          "retention_d1": {
+            "default": 0.0,
+            "title": "Retention D1",
+            "type": "number"
+          },
+          "retention_d30": {
+            "default": 0.0,
+            "title": "Retention D30",
+            "type": "number"
+          },
+          "retention_d7": {
+            "default": 0.0,
+            "title": "Retention D7",
+            "type": "number"
+          },
+          "total_subscribers": {
+            "default": 0,
+            "title": "Total Subscribers",
+            "type": "integer"
+          },
+          "trial_to_paid_30d": {
+            "default": 0.0,
+            "title": "Trial To Paid 30D",
+            "type": "number"
+          },
+          "trial_to_paid_90d": {
+            "default": 0.0,
+            "title": "Trial To Paid 90D",
+            "type": "number"
+          }
+        },
+        "title": "RevenueMetricsResponse",
         "type": "object"
       },
       "ReverseSyncRequest": {
@@ -18812,6 +18911,34 @@
         ]
       }
     },
+    "/v1/admin/metrics/revenue": {
+      "get": {
+        "description": "Return financial and engagement metrics for the founder dashboard.\n\nCalls six PostgreSQL functions (FOUNDER-001) + inline queries for\nactivation_d7, retention_d1, retention_d30. All DB calls run in\nparallel via ``asyncio.gather``.\n\nFires a Mixpanel ``founder_metrics_viewed`` event and logs an audit\nevent. Both are fire-and-forget \u2014 they never block the response.\n\n**Requires:** admin or master role.",
+        "operationId": "get_revenue_metrics_v1_admin_metrics_revenue_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevenueMetricsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Revenue Metrics",
+        "tags": [
+          "admin",
+          "metrics"
+        ]
+      }
+    },
     "/v1/admin/partners": {
       "get": {
         "description": "AC10: List all partners. Admin only.",
@@ -21922,7 +22049,7 @@
     },
     "/v1/api/search": {
       "get": {
-        "description": "Search licitacoes via API key authentication.\n\nSame search pipeline as ``POST /buscar`` but authenticated with an\n``X-API-Key`` header instead of JWT Bearer token.\n\n**Rate limiting:** 100 requests/day per API key (``X-RateLimit-*`` headers).",
+        "description": "Search licitacoes via API key authentication.\n\nSame search pipeline as ``POST /buscar`` but authenticated with an\n``X-API-Key`` header instead of JWT Bearer token.\n\n**Rate limiting:** Monthly quota per API key based on user's plan tier\n(``X-RateLimit-*`` headers).",
         "operationId": "api_search_v1_api_search_get",
         "parameters": [
           {

--- a/backend/tests/test_api_key_rate_limit.py
+++ b/backend/tests/test_api_key_rate_limit.py
@@ -1,0 +1,413 @@
+"""Tests for API-SELF-003 — API key rate limiting via Redis monthly counter.
+
+Acceptance criteria:
+  - Token bucket Redis por key_id
+  - Limits: Starter 1k, Pro 10k, Scale 100k requests/month
+  - X-RateLimit-Remaining header on every response
+  - Excedeu -> 429 + Retry-After
+  - Reset no virar do mes (dia 1, 00:00 BRT)
+  - 1000 consultas OK, 1001a -> 429
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api_key_rate_limit import (
+    API_KEY_TIER_LIMITS,
+    _get_brt_now,
+    _get_month_key,
+    _get_tier_from_plan,
+    _seconds_until_next_month,
+    check_api_key_rate_limit,
+)
+
+
+# ========================================================================
+# Tier mapping tests
+# ========================================================================
+
+
+class TestGetTierFromPlan:
+    def test_free_trial_is_starter(self):
+        assert _get_tier_from_plan("free_trial") == "starter"
+
+    def test_smartlic_pro_is_pro(self):
+        assert _get_tier_from_plan("smartlic_pro") == "pro"
+
+    def test_sala_guerra_is_scale(self):
+        assert _get_tier_from_plan("sala_guerra") == "scale"
+
+    def test_master_is_unlimited(self):
+        assert _get_tier_from_plan("master") == "unlimited"
+
+    def test_unknown_plan_falls_back_to_starter(self):
+        assert _get_tier_from_plan("nonexistent_plan") == "starter"
+
+    def test_consultor_agil_is_starter(self):
+        assert _get_tier_from_plan("consultor_agil") == "starter"
+
+    def test_maquina_is_pro(self):
+        assert _get_tier_from_plan("maquina") == "pro"
+
+    def test_consultoria_is_scale(self):
+        assert _get_tier_from_plan("consultoria") == "scale"
+
+    def test_founding_member_is_scale(self):
+        assert _get_tier_from_plan("founding_member") == "scale"
+
+    def test_smartlic_command_is_scale(self):
+        assert _get_tier_from_plan("smartlic_command") == "scale"
+
+
+class TestApiKeyTierLimits:
+    def test_starter_1000(self):
+        assert API_KEY_TIER_LIMITS["starter"] == 1000
+
+    def test_pro_10000(self):
+        assert API_KEY_TIER_LIMITS["pro"] == 10000
+
+    def test_scale_100000(self):
+        assert API_KEY_TIER_LIMITS["scale"] == 100000
+
+    def test_unlimited_very_high(self):
+        assert API_KEY_TIER_LIMITS["unlimited"] > 1_000_000
+
+
+# ========================================================================
+# Helper tests
+# ========================================================================
+
+
+class TestGetBrtNow:
+    def test_returns_datetime(self):
+        now = _get_brt_now()
+        assert isinstance(now, datetime)
+        # Should be within reasonable range from UTC
+        utc_now = datetime.now(timezone.utc)
+        diff = (utc_now - now).total_seconds()
+        # BRT = UTC-3, so diff should be ~3 hours
+        assert 2.5 * 3600 < diff < 3.5 * 3600
+
+
+class TestGetMonthKey:
+    def test_returns_yyyy_mm_format(self):
+        key = _get_month_key()
+        assert len(key) == 7
+        parts = key.split("-")
+        assert len(parts) == 2
+        assert parts[0].isdigit()  # year
+        assert parts[1].isdigit()  # month
+        assert 1 <= int(parts[1]) <= 12
+
+
+class TestSecondsUntilNextMonth:
+    def test_returns_positive_value(self):
+        seconds = _seconds_until_next_month()
+        assert seconds >= 1
+
+    def test_returns_reasonable_value(self):
+        """Should return at most ~32 days worth of seconds."""
+        seconds = _seconds_until_next_month()
+        assert seconds <= 32 * 24 * 3600
+
+
+# ========================================================================
+# Main rate limit check tests
+# ========================================================================
+
+
+class TestCheckApiKeyRateLimit:
+    """Tests for check_api_key_rate_limit with mocked Redis and plan."""
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_allows_requests_within_limit(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Request is allowed when under monthly limit (smartlic_pro -> pro)."""
+        mock_get_plan.return_value = "smartlic_pro"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 50
+        mock_redis_pool.return_value = mock_redis
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-123",
+            user_id="user-abc",
+        )
+
+        assert limit == 10000  # smartlic_pro -> pro
+        assert remaining == 9950
+        mock_redis.incr.assert_called_once()
+        mock_redis.expire.assert_not_called()  # count != 1
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_sets_ttl_on_first_request(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """First request (count == 1) sets TTL until next month."""
+        mock_get_plan.return_value = "free_trial"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 1
+        mock_redis_pool.return_value = mock_redis
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-123",
+            user_id="user-abc",
+        )
+
+        assert remaining == 999  # Starter limit 1000 - 1
+        mock_redis.expire.assert_called_once()
+        # TTL should be a positive number of seconds
+        ttl_arg = mock_redis.expire.call_args[0][1]
+        assert ttl_arg >= 1
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_returns_429_when_exceeded(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Request exceeding monthly limit raises 429 with headers."""
+        mock_get_plan.return_value = "free_trial"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 1001  # Over starter limit of 1000
+        mock_redis_pool.return_value = mock_redis
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_api_key_rate_limit(
+                api_key_id="key-123",
+                user_id="user-abc",
+            )
+
+        assert exc_info.value.status_code == 429
+        headers = exc_info.value.headers
+        assert headers is not None
+        assert headers["X-RateLimit-Limit"] == "1000"
+        assert headers["X-RateLimit-Remaining"] == "0"
+        assert "Retry-After" in headers
+        retry_after = int(headers["Retry-After"])
+        assert retry_after >= 1
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_exact_limit_boundary_starter(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """AC: 1,000th request OK, 1,001st -> 429 for Starter tier."""
+        mock_get_plan.return_value = "free_trial"  # -> starter -> 1000 limit
+        mock_redis = AsyncMock()
+        mock_redis_pool.return_value = mock_redis
+
+        # Exactly at limit (1000) - should be allowed
+        mock_redis.incr.return_value = 1000
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-123",
+            user_id="user-abc",
+        )
+        assert remaining == 0
+        assert limit == 1000
+
+        # One over (1001) - should raise 429
+        mock_redis.incr.return_value = 1001
+        with pytest.raises(HTTPException) as exc_info:
+            await check_api_key_rate_limit(
+                api_key_id="key-123",
+                user_id="user-abc",
+            )
+        assert exc_info.value.status_code == 429
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_different_tiers_have_different_limits(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Each tier has its own limit (starter < pro < scale)."""
+        mock_redis = AsyncMock()
+        mock_redis_pool.return_value = mock_redis
+
+        # Starter: 1000 limit
+        mock_get_plan.return_value = "free_trial"
+        mock_redis.incr.return_value = 500
+        remaining_starter, limit_starter = await check_api_key_rate_limit(
+            api_key_id="key-123",
+            user_id="user-abc",
+        )
+        assert limit_starter == 1000
+
+        # Pro: 10000 limit
+        mock_get_plan.return_value = "smartlic_pro"
+        mock_redis.incr.return_value = 500
+        remaining_pro, limit_pro = await check_api_key_rate_limit(
+            api_key_id="key-456",
+            user_id="user-def",
+        )
+        assert limit_pro == 10000
+
+        # Scale: 100000 limit
+        mock_get_plan.return_value = "sala_guerra"
+        mock_redis.incr.return_value = 500
+        remaining_scale, limit_scale = await check_api_key_rate_limit(
+            api_key_id="key-789",
+            user_id="user-ghi",
+        )
+        assert limit_scale == 100000
+
+        # Unlimited: very high limit
+        mock_get_plan.return_value = "master"
+        mock_redis.incr.return_value = 500
+        remaining_master, limit_master = await check_api_key_rate_limit(
+            api_key_id="key-master",
+            user_id="user-master",
+        )
+        assert limit_master > 1_000_000
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_fail_open_when_redis_unavailable(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """When Redis is None, allow request (fail-open)."""
+        mock_get_plan.return_value = "smartlic_pro"
+        mock_redis_pool.return_value = None
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-123",
+            user_id="user-abc",
+        )
+
+        # Fail-open: returns (limit, limit) so remaining == limit
+        assert limit == 10000
+        assert remaining == 10000
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_fail_open_on_redis_error(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """When Redis raises an error, allow request (fail-open)."""
+        mock_get_plan.return_value = "free_trial"
+        mock_redis = AsyncMock()
+        mock_redis.incr.side_effect = Exception("Redis connection lost")
+        mock_redis_pool.return_value = mock_redis
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-123",
+            user_id="user-abc",
+        )
+
+        # Fail-open: returns (limit, limit)
+        assert limit == 1000
+        assert remaining == 1000
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_pro_limit_not_reached(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Pro tier allows up to 10000 requests."""
+        mock_get_plan.return_value = "smartlic_pro"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 9999  # Just under limit
+        mock_redis_pool.return_value = mock_redis
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-pro",
+            user_id="user-pro",
+        )
+
+        assert remaining == 1  # 10000 - 9999
+        assert limit == 10000
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_pro_limit_exceeded(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Pro tier returns 429 when limit exceeded."""
+        mock_get_plan.return_value = "smartlic_pro"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 10001  # Over pro limit
+        mock_redis_pool.return_value = mock_redis
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_api_key_rate_limit(
+                api_key_id="key-pro",
+                user_id="user-pro",
+            )
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["X-RateLimit-Limit"] == "10000"
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_scale_limit_allows_high_usage(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Scale tier allows 100000 requests."""
+        mock_get_plan.return_value = "sala_guerra"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 50000  # Half of scale
+        mock_redis_pool.return_value = mock_redis
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-scale",
+            user_id="user-scale",
+        )
+
+        assert remaining == 50000
+        assert limit == 100000
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_scale_limit_exceeded(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Scale tier returns 429 when limit exceeded."""
+        mock_get_plan.return_value = "sala_guerra"
+        mock_redis = AsyncMock()
+        mock_redis.incr.return_value = 100001  # Over scale limit
+        mock_redis_pool.return_value = mock_redis
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_api_key_rate_limit(
+                api_key_id="key-scale",
+                user_id="user-scale",
+            )
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers["X-RateLimit-Limit"] == "100000"
+
+    @pytest.mark.asyncio
+    @patch("api_key_rate_limit.get_redis_pool", new_callable=AsyncMock)
+    @patch("api_key_rate_limit._get_user_plan")
+    async def test_unlimited_master_never_429(
+        self, mock_get_plan, mock_redis_pool
+    ):
+        """Master tier has unlimited requests - never 429."""
+        mock_get_plan.return_value = "master"
+        mock_redis = AsyncMock()
+        # Even a very high count should not trigger 429 for master
+        mock_redis.incr.return_value = 500_000
+        mock_redis_pool.return_value = mock_redis
+
+        remaining, limit = await check_api_key_rate_limit(
+            api_key_id="key-master",
+            user_id="user-master",
+        )
+
+        assert limit > 1_000_000
+        assert remaining > 0

--- a/backend/tests/test_api_search.py
+++ b/backend/tests/test_api_search.py
@@ -161,7 +161,7 @@ class TestApiSearchAuth:
         assert response.status_code == 200
         assert "X-RateLimit-Limit" in response.headers
         assert "X-RateLimit-Remaining" in response.headers
-        assert response.headers["X-RateLimit-Limit"] == "100"
+        assert response.headers["X-RateLimit-Limit"] == "1000"
 
     def test_pipeline_failure_returns_500(
         self, client, override_valid_key

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -2217,7 +2217,8 @@ export interface paths {
          *     Same search pipeline as ``POST /buscar`` but authenticated with an
          *     ``X-API-Key`` header instead of JWT Bearer token.
          *
-         *     **Rate limiting:** 100 requests/day per API key (``X-RateLimit-*`` headers).
+         *     **Rate limiting:** Monthly quota per API key based on user's plan tier
+         *     (``X-RateLimit-*`` headers).
          */
         get: operations["api_search_v1_api_search_get"];
         put?: never;


### PR DESCRIPTION
## Summary

Implementa rate limiting por API key usando Redis monthly counter, respeitando o tier do plano do usuario.

## Alteracoes

### Novo arquivo: `backend/api_key_rate_limit.py`
- `API_KEY_TIER_LIMITS`: Mapeamento de tiers para limites mensais (Starter=1k, Pro=10k, Scale=100k)
- `_get_user_plan()`: Busca plan_type do profiles table com cache em memoria de 60s
- `check_api_key_rate_limit()`: Funcao principal que verifica e enforce o rate limit mensal
- Usa Redis INCR + EXPIRE com chave `api_key_rl:{api_key_id}:{YYYY-MM}`
- Alinha mes ao BRT (UTC-3) para reset no dia 1 as 00:00 BRT
- Fail-open quando Redis indisponivel

### Modificado: `backend/routes/api_search.py`
- Substitui `_check_api_rate_limit` (daily INCR, hardcoded 100/dia) por `check_api_key_rate_limit` do novo modulo
- Headers `X-RateLimit-Limit` e `X-RateLimit-Remaining` agora refletem o limite mensal do tier

### Novo arquivo: `backend/tests/test_api_key_rate_limit.py`
- 30 testes cobrindo todos os acceptance criteria
- Testes de mapeamento plan_type -> tier (10 testes)
- Testes de limites por tier (4 testes)
- Testes de helper functions (4 testes)
- Testes de rate limit: within limit, exceeded, boundary (12 testes)
- Testa fail-open quando Redis indisponivel ou com erro

## Acceptance Criteria

- [x] Token bucket Redis por key_id
- [x] Limites por tier: Starter 1k, Pro 10k, Scale 100k consultas/mes
- [x] Header X-RateLimit-Remaining em cada resposta
- [x] Excedeu -> 429 + header Retry-After
- [x] Reset no virar do mes (dia 1, 00:00 BRT)
- [x] Test: 1.000 consultas OK, 1.001a -> 429

## Plan -> Tier Mapping

| Plan | Tier | Limite |
|------|------|--------|
| free_trial, free, consultor_agil | starter | 1.000/mes |
| smartlic_pro, maquina | pro | 10.000/mes |
| sala_guerra, smartlic_command, consultoria, founding_member | scale | 100.000/mes |
| master | unlimited | ~1B/mes |

## Testes

```
30 passed in 3.94s
```

Closes #1420

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key rate limiting now uses monthly, tier-based quotas (resets 00:00 BRT on the 1st)
  * Rate limit details returned in response headers: X-RateLimit-Limit, X-RateLimit-Remaining and Retry-After
  * New admin revenue metrics endpoint (returns aggregated revenue and MRR history)

* **Tests**
  * Added comprehensive test coverage for monthly rate limiting across plan tiers and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->