### PR TITLE
feat(backend): implement DIGEST-004 — PATCH /conta/preferencias frequency toggle (#1413)

### DIFF
--- a/backend/routes/conta.py
+++ b/backend/routes/conta.py
@@ -22,10 +22,12 @@ from __future__ import annotations
 from typing import Optional
 
 import stripe
-from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field, field_validator
 
+from auth import require_auth
 from log_sanitizer import get_sanitized_logger, mask_user_id
+from pipeline.budget import _run_with_budget
 from services.trial_cancel_token import (
     TrialCancelTokenError,
     verify_cancel_trial_token,
@@ -289,4 +291,116 @@ async def cancel_trial_execute(payload: CancelTrialRequest) -> CancelTrialRespon
 
     return CancelTrialResponse(
         cancelled=True, access_until=trial_end_ts, already_cancelled=False
+    )
+
+
+# ============================================================================
+# DIGEST-004: Digest preference frequency toggle
+# ============================================================================
+
+_VALID_FREQUENCIES = frozenset({"daily", "weekly", "twice_weekly", "off", "none"})
+
+
+class PreferenciasRequest(BaseModel):
+    """Request body for PATCH /conta/preferencias — frequency toggle."""
+
+    frequency: str = Field(
+        ...,
+        description="Digest frequency: daily, weekly, twice_weekly, off, none",
+    )
+
+    @field_validator("frequency")
+    @classmethod
+    def _validate_frequency(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in _VALID_FREQUENCIES:
+            raise ValueError(
+                f"Frequência inválida: '{v}'. Opções: {', '.join(sorted(_VALID_FREQUENCIES))}"
+            )
+        return normalized
+
+
+class PreferenciasResponse(BaseModel):
+    """Response for PATCH /conta/preferencias — current digest preferences."""
+
+    frequency: str = Field(
+        ...,
+        description="Digest frequency (API namespace: off, not none)",
+    )
+    enabled: bool = Field(
+        default=True,
+        description="Whether the digest email is enabled",
+    )
+    last_digest_sent_at: str | None = Field(
+        default=None,
+        description="ISO 8601 timestamp of last sent digest",
+    )
+
+
+@router.patch("/preferencias", response_model=PreferenciasResponse)
+async def update_preferencias(
+    payload: PreferenciasRequest,
+    user: dict = Depends(require_auth),
+) -> PreferenciasResponse:
+    """DIGEST-004: Toggle the user's digest email frequency.
+
+    Accepts ``frequency`` field with one of:
+      - ``daily`` — every day at 07:00 BRT
+      - ``twice_weekly`` — Monday + Thursday at 07:00 BRT
+      - ``weekly`` — Monday at 07:00 BRT
+      - ``off`` / ``none`` — disable digest emails
+
+    Internally normalizes ``off`` → ``none`` for DB storage (DIGEST-001 naming).
+    Returns the API-facing value (``off``, never ``none``) on the response.
+    Uses upsert on ``user_id`` — creates a row if none exists.
+    Uses ``_run_with_budget`` for the DB write (RES-BE-001/015 compliance).
+    """
+    user_id = user["id"]
+    raw_frequency = payload.frequency
+
+    # DIGEST-001: normalize API value "off" → DB value "none"
+    db_frequency = "none" if raw_frequency in ("off", "none") else raw_frequency
+
+    sb = get_supabase()
+
+    try:
+        result = await _run_with_budget(
+            sb_execute(
+                sb.table("alert_preferences").upsert(
+                    {
+                        "user_id": user_id,
+                        "frequency": db_frequency,
+                    },
+                    on_conflict="user_id",
+                ),
+                category="write",
+            ),
+            budget=5.0,
+            phase="route",
+            source="conta.update_preferencias",
+        )
+    except Exception as exc:
+        logger.error(f"Failed to update digest preferences for {mask_user_id(user_id)}: {exc}")
+        raise HTTPException(
+            status_code=500,
+            detail="Erro ao salvar preferências de frequência.",
+        ) from exc
+
+    row = result.data[0] if result.data else {}
+
+    # DIGEST-001: normalize DB value "none" → API value "off"
+    api_frequency = row.get("frequency", db_frequency)
+    if api_frequency == "none":
+        api_frequency = "off"
+
+    logger.info(
+        "DIGEST-004: frequency updated user=%s frequency=%s",
+        mask_user_id(user_id),
+        api_frequency,
+    )
+
+    return PreferenciasResponse(
+        frequency=api_frequency,
+        enabled=row.get("enabled", True),
+        last_digest_sent_at=row.get("last_digest_sent_at"),
     )

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -11457,6 +11457,54 @@
         "title": "PorteEmpresa",
         "type": "string"
       },
+      "PreferenciasRequest": {
+        "description": "Request body for PATCH /conta/preferencias \u2014 frequency toggle.",
+        "properties": {
+          "frequency": {
+            "description": "Digest frequency: daily, weekly, twice_weekly, off, none",
+            "title": "Frequency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "frequency"
+        ],
+        "title": "PreferenciasRequest",
+        "type": "object"
+      },
+      "PreferenciasResponse": {
+        "description": "Response for PATCH /conta/preferencias \u2014 current digest preferences.",
+        "properties": {
+          "enabled": {
+            "default": true,
+            "description": "Whether the digest email is enabled",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "frequency": {
+            "description": "Digest frequency (API namespace: off, not none)",
+            "title": "Frequency",
+            "type": "string"
+          },
+          "last_digest_sent_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 timestamp of last sent digest",
+            "title": "Last Digest Sent At"
+          }
+        },
+        "required": [
+          "frequency"
+        ],
+        "title": "PreferenciasResponse",
+        "type": "object"
+      },
       "ProductsResponse": {
         "properties": {
           "products": {
@@ -23771,6 +23819,53 @@
           }
         },
         "summary": "Cancel Trial Execute",
+        "tags": [
+          "conta"
+        ]
+      }
+    },
+    "/v1/conta/preferencias": {
+      "patch": {
+        "description": "DIGEST-004: Toggle the user's digest email frequency.\n\nAccepts ``frequency`` field with one of:\n  - ``daily`` \u2014 every day at 07:00 BRT\n  - ``twice_weekly`` \u2014 Monday + Thursday at 07:00 BRT\n  - ``weekly`` \u2014 Monday at 07:00 BRT\n  - ``off`` / ``none`` \u2014 disable digest emails\n\nInternally normalizes ``off`` \u2192 ``none`` for DB storage (DIGEST-001 naming).\nReturns the API-facing value (``off``, never ``none``) on the response.\nUses upsert on ``user_id`` \u2014 creates a row if none exists.\nUses ``_run_with_budget`` for the DB write (RES-BE-001/015 compliance).",
+        "operationId": "update_preferencias_v1_conta_preferencias_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreferenciasRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreferenciasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Preferencias",
         "tags": [
           "conta"
         ]

--- a/backend/tests/test_conta_preferencias.py
+++ b/backend/tests/test_conta_preferencias.py
@@ -1,0 +1,225 @@
+"""Tests for DIGEST-004: PATCH /conta/preferencias frequency toggle.
+
+Tests the endpoint in routes/conta.py which allows authenticated users
+to toggle their digest email frequency.
+
+Design notes:
+- Endpoint uses admin client (get_supabase) — no RLS, explicit .eq("user_id")
+- Uses _run_with_budget() for DB write budget compliance
+- Follows same test patterns as test_alert_preferences.py
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from routes.conta import router
+from auth import require_auth
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+def _mock_user():
+    return {"id": "test-user-123", "email": "test@example.com"}
+
+
+@pytest.fixture
+def app():
+    """Create a test FastAPI app with conta router."""
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/v1")
+    return test_app
+
+
+@pytest.fixture
+def client(app):
+    """Create test client with auth override."""
+    app.dependency_overrides[require_auth] = lambda: _mock_user()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ============================================================================
+# PATCH /v1/conta/preferencias
+# ============================================================================
+
+class TestUpdatePreferencias:
+    """Test PATCH /conta/preferencias — frequency toggle."""
+
+    PATCH_PATH = "/v1/conta/preferencias"
+
+    def test_sets_daily_frequency(self, app, client):
+        """PATCH with 'daily' updates frequency and returns it."""
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "user_id": "test-user-123",
+            "frequency": "daily",
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "daily"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["frequency"] == "daily"
+        assert data["enabled"] is True
+        assert data["last_digest_sent_at"] is None
+
+    def test_sets_weekly_frequency(self, app, client):
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "frequency": "weekly",
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "weekly"})
+
+        assert response.status_code == 200
+        assert response.json()["frequency"] == "weekly"
+
+    def test_sets_twice_weekly_frequency(self, app, client):
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "frequency": "twice_weekly",
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "twice_weekly"})
+
+        assert response.status_code == 200
+        assert response.json()["frequency"] == "twice_weekly"
+
+    def test_sets_off_frequency__returns_off(self, app, client):
+        """DIGEST-001: API accepts 'off', normalizes to 'none' in DB, returns 'off'."""
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "frequency": "none",
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "off"})
+
+        assert response.status_code == 200
+        data = response.json()
+        # API contract: returns "off" (normalized from DB "none")
+        assert data["frequency"] == "off"
+        assert data["enabled"] is True
+
+        # Verify DB write used "none", not "off"
+        upsert_kwargs = mock_sb.table.return_value.upsert.call_args[0][0]
+        assert upsert_kwargs["frequency"] == "none"
+
+    def test_accepts_none_as_frequency(self, app, client):
+        """DIGEST-004: API accepts 'none' directly (synonym for off)."""
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "frequency": "none",
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "none"})
+
+        assert response.status_code == 200
+        # API normalizes "none" → "off" in response
+        assert response.json()["frequency"] == "off"
+
+    def test_rejects_invalid_frequency(self, app, client):
+        """PATCH with invalid frequency returns 422."""
+        mock_sb = MagicMock()
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "hourly"})
+
+        assert response.status_code == 422
+        error_detail = response.json()["detail"]
+        # Pydantic field_validator raises ValueError → 422 via FastAPI
+        assert any("Frequência" in str(e) for e in (
+            error_detail if isinstance(error_detail, list) else [error_detail]
+        ))
+
+    def test_handles_db_error(self, app, client):
+        """DB failure returns 500."""
+        mock_sb = MagicMock()
+        mock_sb.table.return_value.upsert.return_value.execute.side_effect = Exception("DB error")
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "daily"})
+
+        assert response.status_code == 500
+        data = response.json()
+        assert "Erro ao salvar" in data["detail"]
+
+    def test_requires_authentication(self, app):
+        """Without auth override, should fail with 401/403."""
+        app.dependency_overrides.clear()
+        client_no_auth = TestClient(app, raise_server_exceptions=False)
+        response = client_no_auth.patch(self.PATCH_PATH, json={"frequency": "daily"})
+        assert response.status_code in (401, 403)
+
+    def test_upsert_creates_row_if_not_exists(self, app, client):
+        """PATCH creates a new row when none exists (upsert)."""
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "user_id": "test-user-123",
+            "frequency": "daily",
+            "enabled": True,
+            "last_digest_sent_at": None,
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "daily"})
+
+        assert response.status_code == 200
+        assert response.json()["frequency"] == "daily"
+
+        # Verify upsert was called with the right on_conflict
+        upsert_call = mock_sb.table.return_value.upsert
+        assert upsert_call.call_count == 1
+        kwargs = upsert_call.call_args[1]
+        assert kwargs.get("on_conflict") == "user_id"
+
+    def test_response_shape_matches_schema(self, app, client):
+        """Response contains all expected fields."""
+        mock_sb = MagicMock()
+        result = MagicMock()
+        result.data = [{
+            "frequency": "daily",
+            "enabled": True,
+            "last_digest_sent_at": "2026-06-06T10:00:00+00:00",
+        }]
+        mock_sb.table.return_value.upsert.return_value.execute.return_value = result
+
+        with patch("routes.conta.get_supabase", return_value=mock_sb):
+            response = client.patch(self.PATCH_PATH, json={"frequency": "daily"})
+
+        assert response.status_code == 200
+        data = response.json()
+        # All three fields must be present
+        assert "frequency" in data
+        assert "enabled" in data
+        assert "last_digest_sent_at" in data
+        # last_digest_sent_at is preserved from DB
+        assert data["last_digest_sent_at"] == "2026-06-06T10:00:00+00:00"

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -3137,6 +3137,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/conta/preferencias": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Preferencias
+         * @description DIGEST-004: Toggle the user's digest email frequency.
+         *
+         *     Accepts ``frequency`` field with one of:
+         *       - ``daily`` — every day at 07:00 BRT
+         *       - ``twice_weekly`` — Monday + Thursday at 07:00 BRT
+         *       - ``weekly`` — Monday at 07:00 BRT
+         *       - ``off`` / ``none`` — disable digest emails
+         *
+         *     Internally normalizes ``off`` → ``none`` for DB storage (DIGEST-001 naming).
+         *     Returns the API-facing value (``off``, never ``none``) on the response.
+         *     Uses upsert on ``user_id`` — creates a row if none exists.
+         *     Uses ``_run_with_budget`` for the DB write (RES-BE-001/015 compliance).
+         */
+        patch: operations["update_preferencias_v1_conta_preferencias_patch"];
+        trace?: never;
+    };
     "/v1/contratos/orgao/{cnpj}/stats": {
         parameters: {
             query?: never;
@@ -10981,6 +11012,39 @@ export interface components {
          * @enum {string}
          */
         PorteEmpresa: "MEI" | "ME" | "EPP" | "MEDIO" | "GRANDE";
+        /**
+         * PreferenciasRequest
+         * @description Request body for PATCH /conta/preferencias — frequency toggle.
+         */
+        PreferenciasRequest: {
+            /**
+             * Frequency
+             * @description Digest frequency: daily, weekly, twice_weekly, off, none
+             */
+            frequency: string;
+        };
+        /**
+         * PreferenciasResponse
+         * @description Response for PATCH /conta/preferencias — current digest preferences.
+         */
+        PreferenciasResponse: {
+            /**
+             * Enabled
+             * @description Whether the digest email is enabled
+             * @default true
+             */
+            enabled: boolean;
+            /**
+             * Frequency
+             * @description Digest frequency (API namespace: off, not none)
+             */
+            frequency: string;
+            /**
+             * Last Digest Sent At
+             * @description ISO 8601 timestamp of last sent digest
+             */
+            last_digest_sent_at?: string | null;
+        };
         /** ProductsResponse */
         ProductsResponse: {
             /** Products */
@@ -17710,6 +17774,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CancelTrialResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_preferencias_v1_conta_preferencias_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PreferenciasRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PreferenciasResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

Implementa o endpoint `PATCH /v1/conta/preferencias` que permite usuários alternarem a frequência do digest (daily, weekly, twice_weekly, off, none).

Closes #1413

## O que foi feito

### Endpoint
- `PATCH /v1/conta/preferencias` — aceita JSON com campo `frequency`
- Validação via Pydantic field_validator: `daily`, `weekly`, `twice_weekly`, `off`, `none`
- Normalização DIGEST-001: API usa "off", DB usa "none"
- Upsert na tabela `alert_preferences` com `on_conflict="user_id"`
- Autenticação: `Depends(require_auth)` (JWT obrigatório)
- DB write protegido por `_run_with_budget()` (RES-BE-001/015 compliance)
- Retorna `PreferenciasResponse` com frequency, enabled, last_digest_sent_at

### Arquivos alterados

| Arquivo | Tipo |
|---------|------|
| `backend/routes/conta.py` | Adicionado endpoint PATCH /conta/preferencias + schemas |
| `backend/tests/test_conta_preferencias.py` | 10 testes para o novo endpoint |

### Testes (10)
- ✅ PATCH com frequency=daily, weekly, twice_weekly
- ✅ PATCH com frequency=off (normaliza "none" no DB, retorna "off")
- ✅ PATCH com frequency=none (sinônimo de off)
- ✅ PATCH com frequency inválida (422)
- ✅ PATCH sem autenticação (401/403)
- ✅ DB error retorna 500
- ✅ Upsert cria registro quando não existe
- ✅ Response shape corresponde ao schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)