### PR TITLE
feat(backend): implement FOUNDER-005 — Mixpanel founder_metrics_viewed + audit log (#1422)

### DIFF
--- a/backend/audit.py
+++ b/backend/audit.py
@@ -48,6 +48,7 @@ VALID_EVENT_TYPES: Set[str] = {
     "admin.user_delete",
     "admin.plan_assign",
     "admin.feature_flag_change",
+    "admin.founder_metrics_viewed",
     "billing.checkout",
     "billing.subscription_change",
     "data.search",

--- a/backend/routes/admin_metrics.py
+++ b/backend/routes/admin_metrics.py
@@ -1,0 +1,214 @@
+"""Admin metrics routes for the founder dashboard (FOUNDER-003/005).
+
+Provides admin-only endpoints that aggregate financial and engagement metrics
+from server-side SQL functions. Includes Mixpanel tracking and audit logging
+for all accesses.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from admin import require_admin
+from analytics_events import track_event
+from audit import audit_logger
+from schemas.admin import RevenueMetricsResponse, MrrEntry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/metrics", tags=["admin", "metrics"])
+
+
+def _parse_mrr_rows(rows: list[dict[str, Any]] | None) -> list[MrrEntry]:
+    """Parse raw RPC result rows into MrrEntry models."""
+    if not rows:
+        return []
+    entries = []
+    for row in rows:
+        month = str(row.get("month", ""))
+        mrr_val = float(row.get("mrr", 0) or 0)
+        sub_count = int(row.get("subscriber_count", 0) or 0)
+        entries.append(MrrEntry(month=month, mrr=mrr_val, subscriber_count=sub_count))
+    return entries
+
+
+async def _call_rpc(rpc_name: str, params: dict[str, Any] | None = None) -> Any:
+    """Execute a Supabase RPC and return the parsed result.
+
+    Args:
+        rpc_name: Name of the SQL function to call (e.g. 'get_mrr').
+        params: Optional dict of parameters to pass to the RPC.
+
+    Returns:
+        Parsed result data from the RPC.
+
+    Raises:
+        HTTPException(502): If the Supabase call fails.
+    """
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        if params:
+            result = await sb_execute(
+                sb.rpc(rpc_name, params),
+                category="read",
+            )
+        else:
+            result = await sb_execute(
+                sb.rpc(rpc_name),
+                category="read",
+            )
+        return result.data
+    except Exception as e:
+        logger.error("FOUNDER-003: RPC %s failed: %s", rpc_name, e)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Erro ao consultar indicador: {rpc_name}",
+        )
+
+
+async def _get_total_subscribers() -> int:
+    """Count currently active paid subscribers (non-free, non-trial plans).
+
+    Returns:
+        Number of active paid subscribers.
+    """
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("user_subscriptions")
+            .select("id", count="exact")
+            .eq("is_active", True)
+            .in_("subscription_status", ["active", "trialing"])
+            .not_.in_("plan_id", [
+                "free", "free_trial", "pack_5", "pack_10", "pack_20", "master",
+            ]),
+            category="read",
+        )
+        return result.count or 0
+    except Exception as e:
+        logger.warning("FOUNDER-003: total_subscribers query failed: %s", e)
+        return 0
+
+
+@router.get("/founder", response_model=RevenueMetricsResponse)
+async def get_founder_metrics(
+    admin: dict = Depends(require_admin),
+) -> RevenueMetricsResponse:
+    """FOUNDER-003/005: Return aggregated founder dashboard metrics.
+
+    Fetches MRR, churn rate, trial-to-paid conversion, D7 retention, ARPA,
+    and total active paid subscribers. All values are non-PII aggregates.
+
+    Fires a Mixpanel ``founder_metrics_viewed`` event with a snapshot of the
+    aggregated metrics (no PII) and logs an audit event.
+
+    Permission check is handled by ``Depends(require_admin)`` — non-admin
+    users receive 403 Forbidden.
+    """
+    start_time = time.monotonic()
+
+    # Fetch all metrics in parallel for performance
+    import asyncio
+
+    now = datetime.now(timezone.utc)
+    mrr_start = (now - timedelta(days=365)).strftime("%Y-%m-%d")
+    mrr_end = now.strftime("%Y-%m-%d")
+
+    mrr_future = _call_rpc("get_mrr", {"start_date": mrr_start, "end_date": mrr_end})
+    churn_future = _call_rpc("get_churn_rate_30d")
+    trial_30d_future = _call_rpc("get_trial_to_paid_30d")
+    trial_90d_future = _call_rpc("get_trial_to_paid_90d")
+    retention_future = _call_rpc("get_d7_retention")
+    arpa_future = _call_rpc("get_arpa")
+    subscribers_future = _get_total_subscribers()
+
+    mrr_data, churn_data, trial_30d_data, trial_90d_data, retention_data, arpa_data, total_subscribers = (
+        await asyncio.gather(
+            mrr_future, churn_future, trial_30d_future,
+            trial_90d_future, retention_future, arpa_future,
+            subscribers_future,
+        )
+    )
+
+    lookup_duration_ms = round((time.monotonic() - start_time) * 1000, 1)
+
+    # Parse MRR rows
+    mrr_entries = _parse_mrr_rows(mrr_data if isinstance(mrr_data, list) else [])
+
+    # Parse scalar metrics (RPC returns single value or [{value}])
+    def _parse_scalar(raw: Any) -> float:
+        if raw is None:
+            return 0.0
+        if isinstance(raw, list):
+            if len(raw) == 0:
+                return 0.0
+            # Some RPCs return [{"get_churn_rate_30d": 5.0}]
+            if isinstance(raw[0], dict):
+                return float(list(raw[0].values())[0] if raw[0] else 0)
+            return float(raw[0]) if raw[0] is not None else 0.0
+        if isinstance(raw, dict):
+            return float(list(raw.values())[0] if raw else 0)
+        return float(raw or 0)
+
+    churn_rate = _parse_scalar(churn_data)
+    trial_to_paid_30d = _parse_scalar(trial_30d_data)
+    trial_to_paid_90d = _parse_scalar(trial_90d_data)
+    d7_retention = _parse_scalar(retention_data)
+    arpa = _parse_scalar(arpa_data)
+
+    response = RevenueMetricsResponse(
+        mrr=mrr_entries,
+        churn_rate_30d=churn_rate,
+        trial_to_paid_30d=trial_to_paid_30d,
+        trial_to_paid_90d=trial_to_paid_90d,
+        d7_retention=d7_retention,
+        arpa=arpa,
+        total_subscribers=total_subscribers,
+        lookup_duration_ms=lookup_duration_ms,
+    )
+
+    # --- FOUNDER-005: Mixpanel tracking (fire-and-forget, never raises) ---
+    try:
+        track_event("founder_metrics_viewed", {
+            "user_id": admin.get("sub", admin.get("id", "unknown")),
+            "mrr": response.mrr[-1].mrr if response.mrr else 0,
+            "churn_rate_30d": response.churn_rate_30d,
+            "trial_to_paid_30d": response.trial_to_paid_30d,
+            "trial_to_paid_90d": response.trial_to_paid_90d,
+            "d7_retention": response.d7_retention,
+            "arpa": response.arpa,
+            "total_subscribers": response.total_subscribers,
+            "lookup_duration_ms": response.lookup_duration_ms,
+        })
+    except Exception:
+        logger.warning("FOUNDER-005: track_event failed (fire-and-forget)", exc_info=True)
+
+    # --- FOUNDER-005: Audit log (admin who accessed the dashboard) ---
+    try:
+        await audit_logger.log(
+            event_type="admin.founder_metrics_viewed",
+            actor_id=str(admin.get("sub", admin.get("id", ""))),
+            details={
+                "total_subscribers": response.total_subscribers,
+                "churn_rate_30d": response.churn_rate_30d,
+                "lookup_duration_ms": response.lookup_duration_ms,
+            },
+        )
+    except ValueError:
+        # Fallback: if event type was not registered (rare race), log via logger
+        logger.info(
+            "admin.founder_metrics_viewed actor=%s subscribers=%d",
+            str(admin.get("sub", admin.get("id", "")))[:8],
+            response.total_subscribers,
+        )
+    except Exception:
+        logger.warning("Failed to log audit event for founder_metrics_viewed", exc_info=True)
+
+    return response

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -236,3 +236,31 @@ class UserSegmentsResponse(BaseModel):
     transitions_last_week: list
     power_users: list
     queried_at: str
+
+
+# ---------------------------------------------------------------------------
+# FOUNDER-001/003/005: Founder Metrics Dashboard
+# ---------------------------------------------------------------------------
+
+
+class MrrEntry(BaseModel):
+    """Single month MRR entry returned by get_mrr()."""
+    month: str  # ISO date string, e.g. "2026-06-01"
+    mrr: float
+    subscriber_count: int
+
+
+class RevenueMetricsResponse(BaseModel):
+    """Response for GET /admin/metrics/founder (FOUNDER-003/005).
+
+    Aggregated revenue and engagement metrics for the founder dashboard.
+    All values are non-PII aggregates computed by server-side SQL functions.
+    """
+    mrr: list[MrrEntry]
+    churn_rate_30d: float
+    trial_to_paid_30d: float
+    trial_to_paid_90d: float
+    d7_retention: float
+    arpa: float
+    total_subscribers: int
+    lookup_duration_ms: float

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -36,6 +36,7 @@ from routes.admin_calibration import router as admin_calibration_router
 from routes.survey import router as survey_router
 from routes.admin_billing_sync import router as admin_billing_sync_router
 from routes.admin_founding import router as admin_founding_router
+from routes.admin_metrics import router as admin_metrics_router
 from routes.auth_check import router as auth_check_router
 from routes.bid_analysis import router as bid_analysis_router
 from routes.slo import router as slo_router
@@ -167,6 +168,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(admin_calibration_router)
     app.include_router(admin_billing_sync_router)
     app.include_router(admin_founding_router)
+    app.include_router(admin_metrics_router)
     app.include_router(slo_router)
 
     # Issue #1002: founders availability — self-prefixed at /api/founders/*

--- a/backend/tests/test_admin_metrics.py
+++ b/backend/tests/test_admin_metrics.py
@@ -1,0 +1,338 @@
+"""Tests for FOUNDER-003/005: admin metrics dashboard + Mixpanel tracking.
+
+Validates:
+- 403 for non-admin users (require_admin gate)
+- Correct response shape for admin users
+- Mixpanel event fired with correct aggregated properties (no PII)
+- Mixpanel failure does NOT break the response (fire-and-forget)
+- No PII in the response snapshot
+- Audit log event fires on access
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth import require_auth
+from rate_limiter import require_rate_limit
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FAKE_ADMIN = {
+    "id": "admin-123-uuid",
+    "sub": "admin-123-uuid",
+    "email": "admin@smartlic.tech",
+    "role": "authenticated",
+}
+
+FAKE_NON_ADMIN = {
+    "id": "user-456-uuid",
+    "sub": "user-456-uuid",
+    "email": "user@example.com",
+    "role": "authenticated",
+}
+
+# Mock RPC data
+MOCK_MRR_DATA = [
+    {"month": "2026-05-01", "mrr": 15000.00, "subscriber_count": 12},
+    {"month": "2026-06-01", "mrr": 18250.00, "subscriber_count": 15},
+]
+
+MOCK_CHURN_DATA = [{"get_churn_rate_30d": 3.5}]
+MOCK_TRIAL_30D_DATA = [{"get_trial_to_paid_30d": 12.0}]
+MOCK_TRIAL_90D_DATA = [{"get_trial_to_paid_90d": 18.5}]
+MOCK_RETENTION_DATA = [{"get_d7_retention": 45.0}]
+MOCK_ARPA_DATA = [{"get_arpa": 1216.67}]
+MOCK_SUBSCRIBERS_COUNT = 15
+
+
+def _rpc_side_effect(name, params=None):
+    """Side effect for _call_rpc mock — dispatches by RPC name."""
+    if name == "get_mrr":
+        return MOCK_MRR_DATA
+    elif name == "get_churn_rate_30d":
+        return MOCK_CHURN_DATA
+    elif name == "get_trial_to_paid_30d":
+        return MOCK_TRIAL_30D_DATA
+    elif name == "get_trial_to_paid_90d":
+        return MOCK_TRIAL_90D_DATA
+    elif name == "get_d7_retention":
+        return MOCK_RETENTION_DATA
+    elif name == "get_arpa":
+        return MOCK_ARPA_DATA
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _setup_admin_router():
+    """Register the admin_metrics router with dependency overrides.
+
+    Each test gets a fresh app so overrides don't leak between tests.
+    """
+    from routes.admin_metrics import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    # Bypass rate limiter in tests
+    app.dependency_overrides[require_rate_limit(60, 60)] = lambda: None
+    app.dependency_overrides[require_rate_limit(20, 60)] = lambda: None
+
+    yield app
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def _admin_auth(_setup_admin_router):
+    """Set up admin authentication overrides on the app."""
+    import admin
+    app = _setup_admin_router
+    app.dependency_overrides[require_auth] = lambda: FAKE_ADMIN
+    app.dependency_overrides[admin.require_admin] = lambda: FAKE_ADMIN
+    return app
+
+
+@pytest.fixture
+def _mock_all_rpcs():
+    """Mock all _call_rpc calls to return standard test data."""
+    with patch("routes.admin_metrics._call_rpc") as mock_rpc:
+        mock_rpc.side_effect = _rpc_side_effect
+        yield mock_rpc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionGate:
+    """FOUNDER-005 AC2: Permission check — 401/403 for non-admin."""
+
+    def test_non_admin_gets_403(self, _setup_admin_router):
+        """Non-admin user must receive 403 Forbidden."""
+        import admin
+        app = _setup_admin_router
+        app.dependency_overrides[require_auth] = lambda: FAKE_NON_ADMIN
+
+        async def _fail_non_admin(_user=None):
+            from fastapi import HTTPException
+            raise HTTPException(status_code=403, detail="Acesso restrito a administradores")
+
+        app.dependency_overrides[admin.require_admin] = _fail_non_admin
+
+        client = TestClient(app)
+        response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 403
+        assert "restrito" in response.json().get("detail", "").lower()
+
+    def test_admin_gets_200(self, _setup_admin_router):
+        """Admin user must receive 200 OK with valid metrics."""
+        import admin
+        app = _setup_admin_router
+        app.dependency_overrides[require_auth] = lambda: FAKE_ADMIN
+        app.dependency_overrides[admin.require_admin] = lambda: FAKE_ADMIN
+
+        with patch("routes.admin_metrics._call_rpc") as mock_rpc:
+            mock_rpc.side_effect = _rpc_side_effect
+            with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+                mock_subs.return_value = 15
+
+                client = TestClient(app)
+                response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+
+
+class TestMetricsStructure:
+    """FOUNDER-003/005: Response shape validation."""
+
+    def test_response_contains_all_fields(self, _admin_auth, _mock_all_rpcs):
+        """Response must include all expected metric fields."""
+        with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+            mock_subs.return_value = 15
+
+            client = TestClient(_admin_auth)
+            response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "mrr" in data
+        assert "churn_rate_30d" in data
+        assert "trial_to_paid_30d" in data
+        assert "trial_to_paid_90d" in data
+        assert "d7_retention" in data
+        assert "arpa" in data
+        assert "total_subscribers" in data
+        assert "lookup_duration_ms" in data
+
+        assert len(data["mrr"]) == 2
+        assert data["mrr"][0]["month"] == "2026-05-01"
+        assert data["mrr"][0]["mrr"] == 15000.0
+        assert data["mrr"][0]["subscriber_count"] == 12
+
+        assert data["churn_rate_30d"] == 3.5
+        assert data["trial_to_paid_30d"] == 12.0
+        assert data["trial_to_paid_90d"] == 18.5
+        assert data["d7_retention"] == 45.0
+        assert data["arpa"] == 1216.67
+        assert data["total_subscribers"] == 15
+        assert data["lookup_duration_ms"] > 0
+
+    def test_no_pii_in_response(self, _admin_auth, _mock_all_rpcs):
+        """Response must NOT contain PII (email, name, etc.)."""
+        with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+            mock_subs.return_value = 15
+
+            client = TestClient(_admin_auth)
+            response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+        data = response.json()
+        body_str = str(data).lower()
+
+        assert "@" not in body_str
+        assert "admin-123-uuid" not in body_str
+        assert "admin@smartlic.tech" not in body_str
+
+
+class TestMixpanelTracking:
+    """FOUNDER-005 AC1: Mixpanel founder_metrics_viewed event."""
+
+    def test_mixpanel_event_fired(self, _admin_auth, _mock_all_rpcs):
+        """Mixpanel track_event must be called with founder_metrics_viewed."""
+        with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+            mock_subs.return_value = 15
+
+            with patch("routes.admin_metrics.track_event") as mock_track:
+                client = TestClient(_admin_auth)
+                response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+        mock_track.assert_called_once()
+
+        call_args = mock_track.call_args
+        assert call_args[0][0] == "founder_metrics_viewed"
+
+        props = call_args[0][1]
+        assert "user_id" in props
+        assert props["user_id"] == FAKE_ADMIN["sub"]
+        assert props["mrr"] == 18250.0  # Latest month MRR
+        assert props["churn_rate_30d"] == 3.5
+        assert props["trial_to_paid_30d"] == 12.0
+        assert props["trial_to_paid_90d"] == 18.5
+        assert props["d7_retention"] == 45.0
+        assert props["arpa"] == 1216.67
+        assert props["total_subscribers"] == 15
+
+        # No PII in properties
+        assert "email" not in props
+        assert "name" not in props
+
+    def test_mixpanel_failure_does_not_break(self, _admin_auth, _mock_all_rpcs):
+        """Mixpanel failure must NOT prevent 200 response (fire-and-forget).
+
+        The route wraps ``track_event`` in try/except so that even if the
+        analytics call raises unexpectedly, the response is still 200.
+        """
+        with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+            mock_subs.return_value = 15
+
+            with patch("routes.admin_metrics.track_event") as mock_track:
+                mock_track.side_effect = Exception("Mixpanel connection error")
+
+                client = TestClient(_admin_auth)
+                response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_subscribers"] == 15
+
+
+class TestAuditLog:
+    """FOUNDER-005 AC3: Audit log on founder metrics access."""
+
+    def test_audit_log_fired(self, _admin_auth, _mock_all_rpcs):
+        """Audit log must be called with correct event type."""
+        with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+            mock_subs.return_value = 15
+
+            with patch("routes.admin_metrics.audit_logger") as mock_audit:
+                mock_audit.log = AsyncMock()
+
+                client = TestClient(_admin_auth)
+                response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+        mock_audit.log.assert_called_once()
+        call_kwargs = mock_audit.log.call_args.kwargs
+        assert call_kwargs["event_type"] == "admin.founder_metrics_viewed"
+        assert call_kwargs["actor_id"] == FAKE_ADMIN["sub"]
+
+        details = call_kwargs.get("details", {})
+        assert details["total_subscribers"] == 15
+        assert "email" not in str(details).lower()
+
+    def test_audit_log_failure_does_not_break(self, _admin_auth, _mock_all_rpcs):
+        """Audit log failure must NOT prevent 200 response."""
+        with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+            mock_subs.return_value = 15
+
+            with patch("routes.admin_metrics.audit_logger") as mock_audit:
+                mock_audit.log = AsyncMock(side_effect=Exception("DB error"))
+
+                client = TestClient(_admin_auth)
+                response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+
+
+class TestEdgeCases:
+    """Edge case handling for founder metrics."""
+
+    def test_empty_mrr_returns_empty_list(self, _admin_auth):
+        """Empty MRR data should return [] for mrr field."""
+        with patch("routes.admin_metrics._call_rpc") as mock_rpc:
+            def side_effect(name, params=None):
+                if name == "get_mrr":
+                    return []
+                return _rpc_side_effect(name, params)
+            mock_rpc.side_effect = side_effect
+
+            with patch("routes.admin_metrics._get_total_subscribers") as mock_subs:
+                mock_subs.return_value = 0
+
+                client = TestClient(_admin_auth)
+                response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mrr"] == []
+        assert data["total_subscribers"] == 0
+
+    def test_rpc_failure_returns_502(self, _admin_auth):
+        """RPC failure should return 502 Bad Gateway."""
+        from fastapi import HTTPException
+
+        async def _failing_rpc(name, params=None):
+            raise HTTPException(
+                status_code=502,
+                detail=f"Erro ao consultar indicador: {name}",
+            )
+
+        with patch("routes.admin_metrics._call_rpc", side_effect=_failing_rpc):
+            client = TestClient(_admin_auth)
+            response = client.get("/admin/metrics/founder")
+
+        assert response.status_code == 502

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -80,6 +80,9 @@ class TestValidEventTypes:
         # STORY-BTS-010a feature flag registry: added admin.feature_flag_change
         # for auditable flag lifecycle changes (2026-04-19).
         "admin.feature_flag_change",
+        # FOUNDER-005 (#1422): added admin.founder_metrics_viewed for founder
+        # dashboard access audit trail (2026-06-06).
+        "admin.founder_metrics_viewed",
         "billing.checkout",
         "billing.subscription_change",
         "data.search",


### PR DESCRIPTION
## Summary

Implementa tracking Mixpanel para visualizacao do dashboard founder com snapshot agregado (sem PII) + audit trail no Supabase.

## Changes

### New files
- **`backend/routes/admin_metrics.py`**: GET /admin/metrics/founder endpoint com agregacao de MRR, churn, trial-to-paid, D7 retention, ARPA e total_subscribers
- **`backend/tests/test_admin_metrics.py`**: 10 testes cobrindo permission gate, response shape, Mixpanel event, fire-and-forget resilience, PII-free snapshot, audit log e edge cases

### Modified files
- **`backend/schemas/admin.py`**: RevenueMetricsResponse + MrrEntry schemas
- **`backend/audit.py`**: admin.founder_metrics_viewed adicionado a VALID_EVENT_TYPES
- **`backend/startup/routes.py`**: admin_metrics router registrado
- **`backend/tests/test_audit.py`**: EXPECTED_TYPES atualizado com novo event type

## Key Implementation Details

- **Mixpanel**: `track_event("founder_metrics_viewed", {...})` com snapshot agregado (mrr, churn_rate_30d, trial_to_paid_30d, trial_to_paid_90d, d7_retention, arpa, total_subscribers) — **sem PII**
- **Permission check**: `Depends(require_admin)` retorna 403 para non-admin
- **Fire-and-forget**: Mixpanel tracking e audit log sao wrapped em try/except — nunca bloqueiam a resposta
- **Audit log**: `admin.founder_metrics_viewed` registrado via `audit_logger.log()` com actor_id e detalhes

## Testing

- 10 tests passing (test_admin_metrics.py)
- 19 tests passing (test_audit.py — existing + updated)
- Testes cobrem: admin/non-admin gate, estrutura da resposta, Mixpanel event properties, fire-and-forget, ausencia de PII, audit log, MRR vazio, RPC failure

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)