### PR TITLE
fix(frontend): FIX-LP-001 — fix bento grid 27 UFs card alignment

### DIFF
--- a/frontend/app/components/ValuePropSection.tsx
+++ b/frontend/app/components/ValuePropSection.tsx
@@ -35,10 +35,22 @@ export default function ValuePropSection() {
     'zeroWaste',
   ];
 
+  // Asymmetric bento sizes for visual hierarchy (FIX-LP-001):
+  //   timeSaved (Foco)         → large (2x2) — hero card top-left
+  //   relevanceRate (87%)      → medium (2x1)
+  //   nationalCoverage (27 UFs)→ full (4x1) — full-width, no empty column
+  //   zeroWaste (Foco)         → medium (2x1)
+  const propSizes: Record<keyof typeof valueProps, 'large' | 'medium' | 'full'> = {
+    timeSaved: 'large',
+    relevanceRate: 'medium',
+    nationalCoverage: 'full',
+    zeroWaste: 'medium',
+  };
+
   const props = propOrder.map((key) => ({
     ...valueProps[key],
     icon: propIcons[key],
-    size: 'medium' as const,
+    size: propSizes[key],
   }));
 
   return (


### PR DESCRIPTION
## Summary
Corrige o grid bento da landing page: card "27 UFs" agora ocupa largura total (full-width), eliminando espaço vazio na coluna.

## Mudanças
- `frontend/app/components/ValuePropSection.tsx`: grid assimétrico
  - timeSaved: 2x2 (hero)
  - relevanceRate: 2x1
  - **nationalCoverage: 4x1 (full-width)** ← fix
  - zeroWaste: 2x1

## Responsivo
- Mobile (375px): cards empilhados 1 coluna
- Tablet (768px): grid 2 colunas
- Desktop (1024px+): grid assimétrico 4 colunas

## Verificação
- TypeScript: sem erros

## Closes
Closes FIX-LP-001

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)