### PR TITLE
fix(backend): update sector ID 'transporte' → 'transporte_servicos' in integration test

### DIFF
--- a/backend/tests/snapshots/api_contracts/pcp_record_schema.json
+++ b/backend/tests/snapshots/api_contracts/pcp_record_schema.json
@@ -78,16 +78,16 @@
     ]
   },
   "sample_record": {
-    "codigoLicitacao": 483796,
+    "codigoLicitacao": 479821,
     "numeroLicitacao": null,
-    "identificacao": "09",
-    "numero": "09/2026",
-    "resumo": "Contratação de empresa especializada na prestação de serviços de locação, montagem, operação técnica e desmontagem de estrutura de sonorização, iluminação e suporte cênico, destinados à realização de evento festivo escolar promovido pela Associação de...",
-    "razaoSocial": "Associação de Apoio da Escola Municipal de 1º Grau Pouso Alegre",
-    "nomeUnidade": "Associação de Apoio da Escola Municipal de 1º Grau Pouso Alegre",
+    "identificacao": "069",
+    "numero": "022/2026",
+    "resumo": "Constitui o objeto da presente licitação a contratação de seguro para veículos diversos pertencentes a frota do Município e Edificação do Corpo de Bombeiros Militar do Estado de Santa, localizado em Mondaí/SC, conforme especificações e quantitativos...",
+    "razaoSocial": "Município de Mondaí",
+    "nomeUnidade": "MUNICÍPIO DE MONDAI",
     "status": {
-      "codigo": 11,
-      "descricao": "Cancelado"
+      "codigo": 9,
+      "descricao": "Sessão Pública Iniciada"
     },
     "situacao": {
       "codigo": 0,
@@ -102,32 +102,32 @@
       "tipoRealizacao": "Eletrônico",
       "tipoJulgamento": "Menor Preço"
     },
-    "codigoSituacaoEdital": 3,
+    "codigoSituacaoEdital": 1,
     "codigoTratamentoDiferenciado": 1,
     "codigoSituacaoCadastroLicitacao": 2,
-    "dataHoraInicioLances": "2026-06-04T17:01:00Z",
-    "dataHoraInicioPropostas": "2026-05-28T17:00:00Z",
-    "dataHoraFinalPropostas": "2026-06-04T17:00:00Z",
+    "dataHoraInicioLances": "2026-06-05T17:16:00Z",
+    "dataHoraInicioPropostas": "2026-05-22T17:15:00Z",
+    "dataHoraFinalPropostas": "2026-06-05T17:15:00Z",
     "dataHoraFinalLances": null,
-    "dataHoraPublicacao": "2026-05-28T16:57:00Z",
+    "dataHoraPublicacao": "2026-05-22T14:14:00Z",
     "isPublicado": false,
     "unidadeCompradora": {
-      "codigoUnidadeCompradora": 7352,
-      "nomeUnidadeCompradora": "Associação de Apoio da Escola Municipal de 1º Grau Pouso Alegre",
-      "codigoComprador": 4222,
+      "codigoUnidadeCompradora": 2149,
+      "nomeUnidadeCompradora": "MUNICÍPIO DE MONDAI",
+      "codigoComprador": 1360,
       "nomeComprador": null,
-      "cidade": "Paraíso do Tocantins",
+      "cidade": "Mondaí",
       "codigoMunicipioIbge": null,
-      "uf": "TO"
+      "uf": "SC"
     },
     "comprador": null,
-    "urlReferencia": "/to/associacao-de-apoio-da-escola-municipal-de-1o-grau-pouso-alegre-4222/pe-09-2026-2026-483796",
+    "urlReferencia": "/sc/municipio-de-mondai-1360/pe-022-2026-2026-479821",
     "statusProcessoPublico": {
-      "codigo": 11,
-      "descricao": "Cancelado"
+      "codigo": 9,
+      "descricao": "Sessão Pública Iniciada"
     },
     "isExclusivoME": false,
     "isBeneficoLocal": false
   },
-  "captured_at": "2026-06-04T17:43:10.797161+00:00"
+  "captured_at": "2026-06-07T13:40:45.396674+00:00"
 }

--- a/backend/tests/snapshots/api_contracts/pcp_response_toplevel.json
+++ b/backend/tests/snapshots/api_contracts/pcp_response_toplevel.json
@@ -18,5 +18,5 @@
     "previousPage": "NoneType",
     "total": "int"
   },
-  "captured_at": "2026-06-04T17:43:09.537362+00:00"
+  "captured_at": "2026-06-07T13:40:43.010833+00:00"
 }

--- a/backend/tests/test_integration_new_sectors.py
+++ b/backend/tests/test_integration_new_sectors.py
@@ -299,7 +299,7 @@ class TestTransporteIntegration:
     """Validate Transporte e Veículos sector keywords against real PNCP data."""
 
     def test_transporte_finds_matches(self, pncp_records):
-        result = run_sector_against_api("transporte", pncp_records)
+        result = run_sector_against_api("transporte_servicos", pncp_records)
         print(f"\n{'='*60}")
         print("TRANSPORTE SECTOR RESULTS")
         print(f"{'='*60}")
@@ -319,7 +319,7 @@ class TestTransporteIntegration:
 
     def test_transporte_excludes_non_vehicle(self, pncp_records):
         """Check that non-vehicle uses of keywords are excluded."""
-        sector = get_sector("transporte")
+        sector = get_sector("transporte_servicos")
         false_positives = []
         for rec in pncp_records:
             objeto = rec.get("objetoCompra", "")
@@ -346,7 +346,7 @@ class TestTransporteIntegration:
         )
 
     def test_transporte_keyword_coverage(self, pncp_records):
-        sector = get_sector("transporte")
+        sector = get_sector("transporte_servicos")
         keyword_hits = Counter()
         for rec in pncp_records:
             objeto = rec.get("objetoCompra", "")


### PR DESCRIPTION
## Summary

Fix `TestTransporteIntegration` — sector ID `'transporte'` was renamed to `'transporte_servicos'` in `sectors_data.yaml` but 3 test references still used the old ID, causing `KeyError`.

## Changes

- `test_integration_new_sectors.py`: Update 3 references from `"transporte"` → `"transporte_servicos"`
- Contract snapshots auto-updated from test run

## Validation

- `test_transporte_finds_matches`: ✅ PASSED
- Full backend suite: ✅ 11813 passed, 0 failures
- Module coverage: ✅ All thresholds passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)