### PR TITLE
feat(frontend): CONV-005b-3 — Digital product preview + checkout components (#1336)

### DIFF
--- a/frontend/__tests__/checkout/CheckoutButton.test.tsx
+++ b/frontend/__tests__/checkout/CheckoutButton.test.tsx
@@ -1,0 +1,408 @@
+/**
+ * Tests for CheckoutButton component (CONV-005b-3).
+ *
+ * Covers:
+ * - Default label with formatted price
+ * - Custom label override
+ * - Click handler calls fetch and redirects
+ * - Loading state with spinner
+ * - Error handling
+ * - Disabled state
+ * - Variant styles (inline, card, banner)
+ * - Accessibility
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CheckoutButton } from "../../app/components/checkout/CheckoutButton";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_PRODUCT = {
+  sku: "relatorio-licitacoes",
+  name: "Relatorio de Licitacoes",
+  description: "Analise completa",
+  price_brl: 14700,
+  preview_config: {},
+  delivery_config: {},
+};
+
+const MOCK_CHECKOUT_RESPONSE = {
+  checkout_url: "https://checkout.stripe.com/pay/test-session-id",
+};
+
+const DEFAULT_CONTEXT = {
+  entity_type: "fornecedor",
+  entity_id: "12345678000195",
+};
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = mockFetch;
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_CHECKOUT_RESPONSE),
+  });
+
+  delete (window as any).location;
+  window.location = { href: "" } as any;
+
+  (window as any).mixpanel = { track: jest.fn() };
+});
+
+afterEach(() => {
+  (window as any).mixpanel = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CheckoutButton", () => {
+  describe("Label rendering", () => {
+    it("renders default label with formatted price", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(
+        screen.getByText(/Comprar por/),
+      ).toBeInTheDocument();
+    });
+
+    it("renders custom label when provided", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          label="Quero este relatorio"
+        />,
+      );
+
+      expect(
+        screen.getByText("Quero este relatorio"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders with button tag", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      const button = screen.getByTestId("checkout-button");
+      expect(button.tagName).toBe("BUTTON");
+    });
+  });
+
+  describe("Click behavior", () => {
+    it("calls checkout API on click", async () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/checkout/digital-product",
+          expect.objectContaining({
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      });
+    });
+
+    it("sends SKU and context in request body", async () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/checkout/digital-product",
+          expect.objectContaining({
+            body: expect.stringContaining("relatorio-licitacoes"),
+          }),
+        );
+      });
+    });
+
+    it("redirects to Stripe checkout URL on success", async () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(window.location.href).toBe(
+          "https://checkout.stripe.com/pay/test-session-id",
+        );
+      });
+    });
+
+    it("calls onClick prop when provided", async () => {
+      const onClick = jest.fn();
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          onClick={onClick}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("calls onComplete prop on successful redirect", async () => {
+      const onComplete = jest.fn();
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          onComplete={onComplete}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("Loading state", () => {
+    it("shows spinner and Aguarde... text while loading", async () => {
+      // Keep fetch pending
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Aguarde.../)).toBeInTheDocument();
+      });
+    });
+
+    it("disables button while loading", async () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("checkout-button")).toBeDisabled();
+      });
+    });
+  });
+
+  describe("Error handling", () => {
+    it("shows error from backend detail on failed checkout", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({ detail: "Produto nao encontrado" }),
+      });
+
+      const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(alertMock).toHaveBeenCalledWith("Produto nao encontrado");
+      });
+
+      alertMock.mockRestore();
+    });
+
+    it("shows default error on network failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(alertMock).toHaveBeenCalledWith("Network failure");
+      });
+
+      alertMock.mockRestore();
+    });
+
+    it("re-enables button after error", async () => {
+      mockFetch.mockRejectedValue(new Error("fail"));
+
+      const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+      await waitFor(() => expect(alertMock).toHaveBeenCalled());
+
+      expect(screen.getByTestId("checkout-button")).not.toBeDisabled();
+      alertMock.mockRestore();
+    });
+  });
+
+  describe("Disabled state", () => {
+    it("renders disabled when disabled prop is true", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          disabled={true}
+        />,
+      );
+
+      expect(screen.getByTestId("checkout-button")).toBeDisabled();
+    });
+
+    it("does not call fetch when disabled", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          disabled={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Variant styles", () => {
+    it("renders with card variant (default)", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      const button = screen.getByTestId("checkout-button");
+      expect(button.className).toContain("rounded-xl");
+    });
+
+    it("renders with inline variant", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          variant="inline"
+        />,
+      );
+
+      const button = screen.getByTestId("checkout-button");
+      expect(button.className).toContain("rounded-lg");
+    });
+
+    it("renders with banner variant", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          variant="banner"
+        />,
+      );
+
+      const button = screen.getByTestId("checkout-button");
+      expect(button.className).toContain("bg-white");
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("button has data-testid for programmatic access", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.getByTestId("checkout-button")).toBeInTheDocument();
+    });
+
+    it("disabled button has aria-disabled semantics via CSS", () => {
+      render(
+        <CheckoutButton
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          disabled={true}
+        />,
+      );
+
+      const button = screen.getByTestId("checkout-button");
+      expect(button).toBeDisabled();
+      expect(button.className).toContain("disabled:opacity-60");
+    });
+  });
+});

--- a/frontend/__tests__/checkout/CheckoutModal.test.tsx
+++ b/frontend/__tests__/checkout/CheckoutModal.test.tsx
@@ -1,0 +1,606 @@
+/**
+ * Tests for CheckoutModal component (CONV-005b-3).
+ *
+ * Covers:
+ * - Modal visibility (open/closed)
+ * - Product summary display
+ * - Checkout button interaction
+ * - Loading state
+ * - Error state
+ * - Success state
+ * - Close button and Escape key
+ * - Body scroll lock
+ * - Accessibility
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CheckoutModal } from "../../app/components/checkout/CheckoutModal";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_PRODUCT = {
+  sku: "relatorio-licitacoes",
+  name: "Relatorio de Licitacoes",
+  description: "Analise completa de licitacoes por setor e UF",
+  price_brl: 14700,
+  preview_config: { free_items: 3, total_items: 8 },
+  delivery_config: {},
+};
+
+const MOCK_CHECKOUT_RESPONSE = {
+  checkout_url: "https://checkout.stripe.com/pay/test-session-id",
+};
+
+const DEFAULT_CONTEXT = {
+  entity_type: "fornecedor",
+  entity_id: "12345678000195",
+  setor: "limpeza",
+  uf: "SP",
+};
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const mockFetch = jest.fn();
+const mockOnClose = jest.fn();
+const mockOnComplete = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = mockFetch;
+
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_CHECKOUT_RESPONSE),
+  });
+
+  delete (window as any).location;
+  window.location = { href: "" } as any;
+
+  (window as any).mixpanel = { track: jest.fn() };
+});
+
+afterEach(() => {
+  (window as any).mixpanel = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CheckoutModal", () => {
+  describe("Visibility", () => {
+    it("renders when isOpen is true", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(
+        screen.getByRole("dialog", { name: /Finalizar compra/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render when isOpen is false", () => {
+      render(
+        <CheckoutModal
+          isOpen={false}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Product summary", () => {
+    it("displays the product name", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.getByText("Relatorio de Licitacoes")).toBeInTheDocument();
+    });
+
+    it("displays the product description", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(
+        screen.getByText("Analise completa de licitacoes por setor e UF"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays the formatted price", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      // R$147,00 appears in both summary and button text
+      const priceElements = screen.getAllByText(/147,00/);
+      expect(priceElements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("displays context info when provided", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.getByText(/fornecedor/)).toBeInTheDocument();
+      expect(screen.getByText(/12345678000195/)).toBeInTheDocument();
+    });
+
+    it("shows payment method info", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(
+        screen.getByText(/cartao, boleto ou PIX/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Close behavior", () => {
+    it("calls onClose when close button is clicked", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText(/Fechar modal/i));
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when Escape key is pressed", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Checkout flow", () => {
+    it("calls the checkout API when confirm is clicked", async () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/checkout/digital-product",
+          expect.objectContaining({
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: expect.stringContaining("relatorio-licitacoes"),
+          }),
+        );
+      });
+    });
+
+    it("calls onComplete on successful checkout", async () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+          onComplete={mockOnComplete}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(mockOnComplete).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("redirects to Stripe checkout URL on success", async () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(window.location.href).toBe(
+          "https://checkout.stripe.com/pay/test-session-id",
+        );
+      });
+    });
+
+    it("shows loading state while checkout is processing", async () => {
+      // Keep fetch pending
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Processando.../)).toBeInTheDocument();
+      });
+    });
+
+    it("disables close button during loading", async () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Fechar modal/i)).toBeDisabled();
+      });
+    });
+  });
+
+  describe("Error state", () => {
+    it("shows error message when checkout API fails", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({ detail: "Produto indisponivel no momento." }),
+      });
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Produto indisponivel no momento."),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows default error message when API returns non-JSON", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error("not json")),
+      });
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Nao foi possivel iniciar o checkout/),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows generic error on network failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Network failure")).toBeInTheDocument();
+      });
+    });
+
+    it("allows retry after error (button is re-enabled)", async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error("Network failure"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(MOCK_CHECKOUT_RESPONSE),
+        });
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      // First attempt — fails
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+      await waitFor(() => {
+        expect(screen.getByText("Network failure")).toBeInTheDocument();
+      });
+
+      // Button should be re-enabled
+      expect(screen.getByTestId("checkout-modal-confirm")).not.toBeDisabled();
+    });
+  });
+
+  describe("Body scroll lock", () => {
+    it("locks body scroll when open", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    it("restores body scroll when closed via isOpen=false", () => {
+      const { rerender } = render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      rerender(
+        <CheckoutModal
+          isOpen={false}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(document.body.style.overflow).toBe("");
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has role=dialog and aria-modal=true", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("has aria-labelledby pointing to the title", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      const dialog = screen.getByRole("dialog");
+      const titleId = dialog.getAttribute("aria-labelledby");
+
+      expect(titleId).toBe("checkout-modal-title");
+
+      const title = document.getElementById(titleId!);
+      expect(title).toHaveTextContent("Finalizar compra");
+    });
+
+    it("close button has accessible label", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      const closeButton = screen.getByLabelText(/Fechar modal/i);
+      expect(closeButton.tagName).toBe("BUTTON");
+    });
+
+    it("confirm button has test id for programmatic access", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.getByTestId("checkout-modal-confirm")).toBeInTheDocument();
+    });
+  });
+
+  describe("Confidence footer", () => {
+    it("shows secure payment message", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.getByText(/Pagamento 100% seguro/)).toBeInTheDocument();
+    });
+
+    it("shows 30-day guarantee message", () => {
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(screen.getByText(/Garantia 30 dias/)).toBeInTheDocument();
+    });
+  });
+
+  describe("Tracking events", () => {
+    it("tracks modal view on open", () => {
+      const mockTrack = jest.fn();
+      (window as any).mixpanel = { track: mockTrack };
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        "product_checkout_modal_viewed",
+        expect.objectContaining({ sku: "relatorio-licitacoes" }),
+      );
+    });
+
+    it("tracks checkout start when confirm is clicked", async () => {
+      const mockTrack = jest.fn();
+      (window as any).mixpanel = { track: mockTrack };
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalledWith(
+          "product_checkout_started",
+          expect.objectContaining({ sku: "relatorio-licitacoes" }),
+        );
+      });
+    });
+
+    it("tracks redirect event on successful checkout", async () => {
+      const mockTrack = jest.fn();
+      (window as any).mixpanel = { track: mockTrack };
+
+      render(
+        <CheckoutModal
+          isOpen={true}
+          onClose={mockOnClose}
+          product={MOCK_PRODUCT}
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("checkout-modal-confirm"));
+
+      await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalledWith(
+          "product_checkout_redirected",
+          expect.objectContaining({ sku: "relatorio-licitacoes" }),
+        );
+      });
+    });
+  });
+});

--- a/frontend/__tests__/checkout/DigitalProductPreview.test.tsx
+++ b/frontend/__tests__/checkout/DigitalProductPreview.test.tsx
@@ -1,0 +1,476 @@
+/**
+ * Tests for DigitalProductPreview component (CONV-005b-3).
+ *
+ * Covers:
+ * - Loading skeleton render
+ * - Error state with retry
+ * - Product data fetch and display (card, inline, banner variants)
+ * - Preview items (free + premium/blurred)
+ * - Checkout button render
+ * - Modal open/close via button
+ * - Tracking events (mixpanel)
+ * - Accessibility
+ * - Mobile responsive classes
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DigitalProductPreview } from "../../app/components/checkout/DigitalProductPreview";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_PRODUCT = {
+  sku: "relatorio-licitacoes",
+  name: "Relatorio de Licitacoes",
+  description: "Analise completa de licitacoes por setor e UF",
+  price_brl: 14700, // R$147,00
+  preview_config: {
+    free_items: 3,
+    total_items: 8,
+  },
+  delivery_config: {},
+};
+
+const MOCK_PRODUCTS_RESPONSE = {
+  products: [MOCK_PRODUCT],
+};
+
+const MOCK_CHECKOUT_RESPONSE = {
+  checkout_url: "https://checkout.stripe.com/pay/test-session-id",
+};
+
+const DEFAULT_CONTEXT = {
+  entity_type: "fornecedor",
+  entity_id: "12345678000195",
+  setor: "limpeza",
+  uf: "SP",
+};
+
+// ---------------------------------------------------------------------------
+// Mock fetch
+// ---------------------------------------------------------------------------
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = mockFetch;
+
+  // Default: products endpoint succeeds
+  mockFetch.mockImplementation((url: string) => {
+    if (url === "/api/products") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_PRODUCTS_RESPONSE),
+      });
+    }
+    if (url === "/api/checkout/digital-product") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_CHECKOUT_RESPONSE),
+      });
+    }
+    return Promise.resolve({ ok: false, status: 404 });
+  });
+
+  // Mock window.location.href
+  delete (window as any).location;
+  window.location = { href: "" } as any;
+
+  // Mock mixpanel
+  (window as any).mixpanel = {
+    track: jest.fn(),
+  };
+});
+
+afterEach(() => {
+  (window as any).mixpanel = undefined;
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DigitalProductPreview", () => {
+  describe("Loading state", () => {
+    it("renders a skeleton when fetch is in progress", () => {
+      // Keep fetch pending by never resolving
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      expect(
+        screen.getByTestId("digital-product-preview-loading"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Error state", () => {
+    it("renders error alert when fetch fails", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-error"),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/Produto indisponivel/)).toBeInTheDocument();
+    });
+
+    it("renders error when product SKU not found", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ products: [] }),
+      });
+
+      render(
+        <DigitalProductPreview
+          sku="inexistent-sku"
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-error"),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/inexistent-sku/)).toBeInTheDocument();
+    });
+
+    it("calls refetch when retry button is clicked", async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error("Network failure"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(MOCK_PRODUCTS_RESPONSE),
+        });
+
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-error"),
+        ).toBeInTheDocument();
+      });
+
+      // Click retry
+      fireEvent.click(screen.getByText("Tentar novamente"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Relatorio de Licitacoes")).toBeInTheDocument();
+      });
+
+      // Should have called fetch twice (initial + retry)
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Card variant (default)", () => {
+    it("renders product name, description and price", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-card"),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Relatorio de Licitacoes")).toBeInTheDocument();
+      expect(
+        screen.getByText("Analise completa de licitacoes por setor e UF"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays the formatted price", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        const priceElements = screen.getAllByText(/147/);
+        expect(priceElements.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it("shows free preview items without blur", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        // First 3 items should be free (no blur)
+        const freeItems = screen.queryAllByTestId((id) =>
+          id.startsWith("preview-item-free-"),
+        );
+        expect(freeItems.length).toBe(3);
+      });
+    });
+
+    it("shows premium preview items with blur", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        const premiumItems = screen.queryAllByTestId((id) =>
+          id.startsWith("preview-item-premium-"),
+        );
+        // Total 8, free 3, premium 5
+        expect(premiumItems.length).toBe(5);
+      });
+    });
+
+    it("renders the checkout button", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("checkout-button")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/Comprar por/)).toBeInTheDocument();
+    });
+
+    it('shows "pagamento unico" text', async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("pagamento unico")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Inline variant", () => {
+    it("renders with inline layout classes", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="inline"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-inline"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders product info in inline mode", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="inline"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Relatorio de Licitacoes")).toBeInTheDocument();
+        expect(screen.getByTestId("checkout-button")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Banner variant", () => {
+    it("renders with banner test id", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="banner"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-banner"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders the checkout button in banner mode", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="banner"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("checkout-button")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Checkout button interaction", () => {
+    it("opens the checkout modal when buy button is clicked", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("checkout-button")).toBeInTheDocument();
+      });
+
+      // Click the checkout button
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      // Modal should appear
+      await waitFor(() => {
+        expect(
+          screen.getByRole("dialog", { name: /Finalizar compra/i }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Tracking", () => {
+    it("tracks product_preview_viewed after product loads", async () => {
+      const mockTrack = jest.fn();
+      (window as any).mixpanel = { track: mockTrack };
+
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalledWith(
+          "product_preview_viewed",
+          expect.objectContaining({
+            sku: "relatorio-licitacoes",
+            price_brl: 14700,
+            source_template: "card",
+          }),
+        );
+      });
+    });
+
+    it("tracks product_checkout_started when buy is clicked", async () => {
+      const mockTrack = jest.fn();
+      (window as any).mixpanel = { track: mockTrack };
+
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("checkout-button")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId("checkout-button"));
+
+      await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalledWith(
+          "product_checkout_started",
+          expect.objectContaining({
+            sku: "relatorio-licitacoes",
+            source_template: "card",
+          }),
+        );
+      });
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("preview section has an accessible label", async () => {
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+          variant="card"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText("Previa do produto"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("error state uses role=alert", async () => {
+      mockFetch.mockRejectedValue(new Error("fail"));
+
+      render(
+        <DigitalProductPreview
+          sku="relatorio-licitacoes"
+          context={DEFAULT_CONTEXT}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("digital-product-preview-error"),
+        ).toHaveAttribute("role", "alert");
+      });
+    });
+  });
+});

--- a/frontend/app/api/checkout/digital-product/route.ts
+++ b/frontend/app/api/checkout/digital-product/route.ts
@@ -1,0 +1,14 @@
+/**
+ * Digital product checkout proxy — POST /api/checkout/one-time
+ * Authenticated. Returns { checkout_url } from backend.
+ * Frontend redirects user to checkout_url (Stripe Checkout).
+ * CONV-005b-3: Used by CheckoutModal to initiate digital product purchase.
+ */
+import { createProxyRoute } from "../../../../lib/create-proxy-route";
+
+export const { POST } = createProxyRoute({
+  backendPath: "/api/checkout/one-time",
+  methods: ["POST"],
+  requireAuth: true,
+  errorMessage: "Não foi possível iniciar o checkout do produto digital.",
+});

--- a/frontend/app/api/products/route.ts
+++ b/frontend/app/api/products/route.ts
@@ -1,0 +1,14 @@
+/**
+ * Products listing proxy — GET /v1/products
+ * Public (no auth required). Returns list of active digital products.
+ * CONV-005b-3: Used by DigitalProductPreview to fetch product data by SKU.
+ */
+import { createProxyRoute } from "../../../lib/create-proxy-route";
+
+export const { GET } = createProxyRoute({
+  backendPath: "/v1/products",
+  methods: ["GET"],
+  requireAuth: false,
+  fetchCache: { revalidate: 300 },
+  errorMessage: "Erro ao carregar produtos.",
+});

--- a/frontend/app/components/checkout/CheckoutButton.tsx
+++ b/frontend/app/components/checkout/CheckoutButton.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import type { components } from "../../api-types.generated";
+import type { DigitalProductContext, PreviewVariant } from "./DigitalProductPreview";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type DigitalProductOut = components["schemas"]["DigitalProductOut"];
+
+export interface CheckoutButtonProps {
+  /** Product data to display in the button label and pass to checkout. */
+  product: DigitalProductOut;
+  /** Context metadata forwarded to the checkout endpoint. */
+  context: DigitalProductContext;
+  /** Visual variant matching the parent preview. */
+  variant?: PreviewVariant;
+  /** Optional click handler fired before the modal opens. */
+  onClick?: () => void;
+  /** Optional callback fired after successful checkout (Stripe redirect). */
+  onComplete?: () => void;
+  /** Disable the button (e.g., while loading in parent). */
+  disabled?: boolean;
+  /** Override label text. Defaults to "Comprar por R$XX". */
+  label?: string;
+  /** Class name override. */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Price formatting
+// ---------------------------------------------------------------------------
+
+function formatBRL(cents: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+// ---------------------------------------------------------------------------
+// Variant-specific styles
+// ---------------------------------------------------------------------------
+
+const baseStyles =
+  "inline-flex items-center justify-center font-semibold transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed";
+
+const variantStyles: Record<PreviewVariant, string> = {
+  inline:
+    "w-full rounded-lg bg-brand-navy px-5 py-2.5 text-sm text-white hover:bg-brand-blue-hover focus:ring-brand-navy",
+  card:
+    "w-full rounded-xl bg-brand-navy px-6 py-3 text-base text-white hover:bg-brand-blue-hover hover:-translate-y-0.5 hover:shadow-lg focus:ring-brand-navy",
+  banner:
+    "rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-brand-navy hover:bg-white/90 focus:ring-white",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CheckoutButton({
+  product,
+  context,
+  variant = "card",
+  onClick,
+  onComplete,
+  disabled = false,
+  label,
+  className = "",
+}: CheckoutButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const defaultLabel = `Comprar por ${formatBRL(product.price_brl)}`;
+  const buttonLabel = label ?? defaultLabel;
+
+  const handleClick = async () => {
+    if (loading || disabled) return;
+
+    setLoading(true);
+    try {
+      onClick?.();
+
+      // Stripe Checkout redirect via backend
+      const res = await fetch("/api/checkout/digital-product", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sku: product.sku,
+          context: {
+            entity_type: context.entity_type ?? "",
+            entity_id: context.entity_id ?? "",
+            ...(context.setor ? { setor: context.setor } : {}),
+            ...(context.uf ? { uf: context.uf } : {}),
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        // Try to extract error detail from backend
+        let detail = "Nao foi possivel iniciar o checkout.";
+        try {
+          const errData = await res.json();
+          if (typeof errData?.detail === "string") {
+            detail = errData.detail;
+          }
+        } catch {
+          // keep default
+        }
+        throw new Error(detail);
+      }
+
+      const data = (await res.json()) as { checkout_url: string };
+      onComplete?.();
+
+      // Redirect to Stripe Checkout
+      window.location.href = data.checkout_url;
+    } catch (err) {
+      setLoading(false);
+      alert(
+        err instanceof Error
+          ? err.message
+          : "Erro ao iniciar checkout. Tente novamente.",
+      );
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={loading || disabled}
+      data-testid="checkout-button"
+      className={`${baseStyles} ${variantStyles[variant]} ${className}`}
+    >
+      {loading ? (
+        <span className="flex items-center gap-2">
+          <svg
+            className="animate-spin h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+          Aguarde...
+        </span>
+      ) : (
+        buttonLabel
+      )}
+    </button>
+  );
+}

--- a/frontend/app/components/checkout/CheckoutModal.tsx
+++ b/frontend/app/components/checkout/CheckoutModal.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { components } from "../../api-types.generated";
+import type { DigitalProductContext } from "./DigitalProductPreview";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type DigitalProductOut = components["schemas"]["DigitalProductOut"];
+
+export interface CheckoutModalProps {
+  /** Whether the modal is visible. */
+  isOpen: boolean;
+  /** Called when the user dismisses the modal. */
+  onClose: () => void;
+  /** Product being purchased. */
+  product: DigitalProductOut;
+  /** Context metadata forwarded to the checkout endpoint. */
+  context: DigitalProductContext;
+  /** Optional callback fired after successful checkout initiation (Stripe redirect). */
+  onComplete?: () => void;
+}
+
+type CheckoutStatus = "idle" | "loading" | "error" | "success" | "redirecting";
+
+// ---------------------------------------------------------------------------
+// Price formatting
+// ---------------------------------------------------------------------------
+
+function formatBRL(cents: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 2,
+  }).format(cents / 100);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  const mp = (
+    window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }
+  ).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CheckoutModal({
+  isOpen,
+  onClose,
+  product,
+  context,
+  onComplete,
+}: CheckoutModalProps) {
+  const [status, setStatus] = useState<CheckoutStatus>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Lock body scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  // Track modal view
+  useEffect(() => {
+    if (isOpen) {
+      trackEvent("product_checkout_modal_viewed", {
+        sku: product.sku,
+        price_brl: product.price_brl,
+        ...context,
+      });
+    }
+  }, [isOpen, product.sku, product.price_brl, context]);
+
+  // Handle Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Focus trap — focus first interactive element
+  useEffect(() => {
+    if (!isOpen) return;
+    const timer = setTimeout(() => {
+      const firstFocusable = document.querySelector<HTMLElement>(
+        '[data-checkout-modal] button, [data-checkout-modal] a, [data-checkout-modal] input',
+      );
+      firstFocusable?.focus();
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  const handleStartCheckout = useCallback(async () => {
+    if (status === "loading") return;
+
+    setStatus("loading");
+    setErrorMsg(null);
+
+    trackEvent("product_checkout_started", {
+      sku: product.sku,
+      price_brl: product.price_brl,
+      ...context,
+    });
+
+    try {
+      const res = await fetch("/api/checkout/digital-product", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sku: product.sku,
+          context: {
+            entity_type: context.entity_type ?? "",
+            entity_id: context.entity_id ?? "",
+            ...(context.setor ? { setor: context.setor } : {}),
+            ...(context.uf ? { uf: context.uf } : {}),
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        let detail = "Nao foi possivel iniciar o checkout.";
+        try {
+          const errData = await res.json();
+          if (typeof errData?.detail === "string") {
+            detail = errData.detail;
+          }
+        } catch {
+          // keep default
+        }
+        throw new Error(detail);
+      }
+
+      const data = (await res.json()) as { checkout_url: string };
+      setStatus("redirecting");
+      onComplete?.();
+
+      trackEvent("product_checkout_redirected", {
+        sku: product.sku,
+        price_brl: product.price_brl,
+      });
+
+      // Redirect to Stripe Checkout
+      window.location.href = data.checkout_url;
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(
+        err instanceof Error
+          ? err.message
+          : "Erro ao iniciar checkout. Tente novamente.",
+      );
+    }
+  }, [status, product.sku, product.price_brl, context, onComplete]);
+
+  if (!isOpen) return null;
+
+  // ---------- Success state ----------
+  if (status === "success") {
+    return (
+      <div
+        data-checkout-modal
+        className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="checkout-modal-success-title"
+      >
+        <div className="max-w-md w-full rounded-2xl bg-[var(--surface-0)] p-8 shadow-xl">
+          <div className="text-center">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100">
+              <svg
+                className="h-8 w-8 text-emerald-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h2
+              id="checkout-modal-success-title"
+              className="text-xl font-bold text-[var(--ink)]"
+            >
+              Compra confirmada!
+            </h2>
+            <p className="mt-2 text-sm text-[var(--ink-secondary)]">
+              Seu pagamento foi processado com sucesso. Voce recebera as
+              instrucoes de acesso por email.
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="mt-6 w-full rounded-xl bg-brand-navy px-6 py-3 font-semibold text-white hover:bg-brand-blue-hover transition-colors focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2"
+            >
+              Continuar
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------- Main modal ----------
+  return (
+    <div
+      data-checkout-modal
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="checkout-modal-title"
+    >
+      <div className="max-w-md w-full rounded-2xl bg-[var(--surface-0)] p-6 shadow-xl max-h-[90vh] overflow-y-auto">
+        {/* Close button */}
+        <div className="flex items-center justify-between mb-6">
+          <h2 id="checkout-modal-title" className="text-lg font-bold text-[var(--ink)]">
+            Finalizar compra
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={status === "loading" || status === "redirecting"}
+            className="p-1.5 rounded-full text-[var(--ink-muted)] hover:text-[var(--ink)] hover:bg-[var(--surface-1)] transition-colors focus:outline-none focus:ring-2 focus:ring-brand-navy"
+            aria-label="Fechar modal"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Product summary */}
+        <div className="rounded-xl bg-[var(--surface-1)] p-4 mb-6">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-[var(--ink)]">{product.name}</p>
+              {product.description && (
+                <p className="mt-1 text-sm text-[var(--ink-secondary)]">
+                  {product.description}
+                </p>
+              )}
+            </div>
+            <span className="shrink-0 text-lg font-bold text-brand-navy">
+              {formatBRL(product.price_brl)}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-[var(--ink-muted)]">
+            Pagamento unico via Stripe (cartao, boleto ou PIX)
+          </p>
+        </div>
+
+        {/* Context info */}
+        {context.entity_type && context.entity_id && (
+          <div className="mb-4 text-xs text-[var(--ink-muted)]">
+            Produto para: {context.entity_type} {context.entity_id}
+            {context.setor && ` / ${context.setor}`}
+            {context.uf && ` / ${context.uf}`}
+          </div>
+        )}
+
+        {/* Error state */}
+        {status === "error" && errorMsg && (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-800"
+          >
+            {errorMsg}
+          </div>
+        )}
+
+        {/* Confirm button */}
+        <button
+          type="button"
+          onClick={handleStartCheckout}
+          disabled={status === "loading" || status === "redirecting"}
+          data-testid="checkout-modal-confirm"
+          className="w-full rounded-xl bg-brand-navy px-6 py-3.5 font-semibold text-white text-base hover:bg-brand-blue-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2"
+        >
+          {status === "loading" || status === "redirecting" ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg
+                className="animate-spin h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              {status === "redirecting"
+                ? "Redirecionando para pagamento..."
+                : "Processando..."}
+            </span>
+          ) : (
+            `Confirmar compra — ${formatBRL(product.price_brl)}`
+          )}
+        </button>
+
+        {/* Confidence footer */}
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-4 text-xs text-[var(--ink-muted)]">
+          <span className="flex items-center gap-1">
+            <svg className="w-3.5 h-3.5 text-emerald-500" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            </svg>
+            Pagamento 100% seguro
+          </span>
+          <span className="flex items-center gap-1">
+            <svg className="w-3.5 h-3.5 text-blue-500" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+              <path fillRule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5C18.577 6.44 19 8.027 19 9.7c0 5.009-3.667 9.132-8.44 9.878a.75.75 0 01-.12.002.75.75 0 01-.12-.002C5.667 18.832 2 14.709 2 9.7c0-1.673.423-3.26 1.166-4.701zM10 5a1 1 0 011 1v3.586l2.207 2.207a1 1 0 01-1.414 1.414l-2.5-2.5A1 1 0 019 10V6a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            Garantia 30 dias
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/checkout/DigitalProductPreview.tsx
+++ b/frontend/app/components/checkout/DigitalProductPreview.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { components } from "../../api-types.generated";
+import { CheckoutButton } from "./CheckoutButton";
+import { CheckoutModal } from "./CheckoutModal";
+import { GlassCard } from "../ui/GlassCard";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type DigitalProductOut = components["schemas"]["DigitalProductOut"];
+type ProductsResponse = components["schemas"]["ProductsResponse"];
+
+export interface DigitalProductContext {
+  /** Entity type hosting the preview — "fornecedor", "orgao", "setor", etc. */
+  entity_type?: string;
+  /** Entity identifier (CNPJ, slug, sector_id, etc.) */
+  entity_id?: string;
+  /** Optional sector ID for context-aware filtering */
+  setor?: string;
+  /** Optional UF for location-aware filtering */
+  uf?: string;
+}
+
+export type PreviewVariant = "inline" | "card" | "banner";
+
+export interface DigitalProductPreviewProps {
+  /** Product SKU to display and offer for purchase. */
+  sku: string;
+  /** Context metadata forwarded to the checkout endpoint. */
+  context: DigitalProductContext;
+  /** Visual variant: inline (entity pages), card (catalog), banner (blog). */
+  variant?: PreviewVariant;
+  /** Optional override for inline variant: inline elements are skipped inside
+   *  a wrapping card; set `noWrapper={true}` if the parent already provides one. */
+  noWrapper?: boolean;
+  /** Class name override for the outermost container. */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Price formatting
+// ---------------------------------------------------------------------------
+
+function formatBRL(cents: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+// ---------------------------------------------------------------------------
+// Preview items generator (configurable via preview_config)
+// ---------------------------------------------------------------------------
+
+interface PreviewItem {
+  id: string;
+  label: string;
+  value: string;
+  premium: boolean;
+}
+
+function generatePreviewItems(
+  previewConfig: Record<string, unknown>,
+): PreviewItem[] {
+  const freeItems = (previewConfig.free_items as number) ?? 3;
+  const totalItems = (previewConfig.total_items as number) ?? 8;
+  const labels = (previewConfig.item_labels as string[]) ?? [
+    "Secretaria de Educação",
+    "Secretaria de Saúde",
+    "Prefeitura Municipal",
+    "Governo do Estado",
+    "Ministério Público",
+    "Câmara Municipal",
+    "Defensoria Pública",
+    "Tribunal de Justiça",
+  ];
+
+  const items: PreviewItem[] = [];
+  for (let i = 0; i < Math.min(totalItems, labels.length); i++) {
+    const estimatedValue = (i + 1) * 150000;
+    items.push({
+      id: `preview-${i}`,
+      label: labels[i],
+      value: new Intl.NumberFormat("pt-BR", {
+        style: "currency",
+        currency: "BRL",
+        maximumFractionDigits: 0,
+      }).format(estimatedValue),
+      premium: i >= freeItems,
+    });
+  }
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Product fetch hook
+// ---------------------------------------------------------------------------
+
+type LoadState = "idle" | "loading" | "loaded" | "error";
+
+function useProduct(sku: string) {
+  const [product, setProduct] = useState<DigitalProductOut | null>(null);
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const fetchProduct = useCallback(async () => {
+    if (!sku) return;
+    setLoadState("loading");
+    setLoadError(null);
+    try {
+      const res = await fetch("/api/products");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as ProductsResponse;
+      const found = (data.products ?? []).find((p) => p.sku === sku);
+      if (!found) {
+        throw new Error(`Produto "${sku}" nao encontrado.`);
+      }
+      setProduct(found);
+      setLoadState("loaded");
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Erro ao carregar produto.";
+      setLoadError(msg);
+      setLoadState("error");
+    }
+  }, [sku]);
+
+  useEffect(() => {
+    fetchProduct();
+  }, [fetchProduct]);
+
+  return { product, loadState, loadError, refetch: fetchProduct };
+}
+
+// ---------------------------------------------------------------------------
+// Variant styles
+// ---------------------------------------------------------------------------
+
+const variantStyles: Record<
+  PreviewVariant,
+  {
+    container: string;
+    heading: string;
+    description: string;
+    price: string;
+  }
+> = {
+  inline: {
+    container:
+      "rounded-xl border border-[var(--border)] bg-[var(--surface-0)] p-5",
+    heading: "text-lg font-semibold text-[var(--ink)]",
+    description: "text-sm text-[var(--ink-secondary)] mt-1",
+    price: "text-2xl font-bold text-[var(--ink)]",
+  },
+  card: {
+    container:
+      "rounded-2xl border border-[var(--border)] bg-[var(--surface-0)] p-6 shadow-sm hover:shadow-md transition-shadow",
+    heading: "text-xl font-bold text-[var(--ink)]",
+    description: "text-sm text-[var(--ink-secondary)] mt-2",
+    price: "text-3xl font-bold text-[var(--ink)]",
+  },
+  banner: {
+    container:
+      "rounded-xl bg-gradient-to-r from-[var(--brand-navy)] to-[var(--brand-blue)] p-6 text-white",
+    heading: "text-xl font-bold text-white",
+    description: "text-sm text-white/80 mt-1",
+    price: "text-3xl font-bold text-white",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DigitalProductPreview({
+  sku,
+  context,
+  variant = "card",
+  noWrapper = false,
+  className = "",
+}: DigitalProductPreviewProps) {
+  const { product, loadState, loadError, refetch } = useProduct(sku);
+  const [showModal, setShowModal] = useState(false);
+
+  // --- Tracking helpers (defined above early returns so hooks order is stable) ---
+  const trackEventInternal = (name: string, extra?: Record<string, unknown>) => {
+    if (typeof window === "undefined") return;
+    const mp = (
+      window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }
+    ).mixpanel;
+    if (!mp) return;
+    try {
+      mp.track(name, {
+        ...(product ? { sku: product.sku, price_brl: product.price_brl } : {}),
+        ...context,
+        ...extra,
+      });
+    } catch {
+      // best-effort
+    }
+  };
+
+  // Track view when product data is loaded (fires once)
+  const hasTrackedView = useRef(false);
+  useEffect(() => {
+    if (product && !hasTrackedView.current) {
+      hasTrackedView.current = true;
+      trackEventInternal("product_preview_viewed", { source_template: variant });
+    }
+  });
+
+  // --- Loading state ---
+  if (loadState === "loading") {
+    return (
+      <div
+        className={`animate-pulse ${variantStyles[variant].container} ${className}`}
+        data-testid="digital-product-preview-loading"
+      >
+        <div className="h-5 w-2/3 rounded bg-[var(--surface-1)]" />
+        <div className="mt-2 h-4 w-full rounded bg-[var(--surface-1)]" />
+        <div className="mt-4 h-8 w-1/3 rounded bg-[var(--surface-1)]" />
+      </div>
+    );
+  }
+
+  // --- Error state ---
+  if (loadState === "error") {
+    return (
+      <div
+        className={`rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800 ${className}`}
+        role="alert"
+        data-testid="digital-product-preview-error"
+      >
+        <p className="font-medium">Produto indisponivel</p>
+        <p className="mt-1 text-red-600">{loadError}</p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="mt-2 text-sm font-medium text-red-700 underline hover:text-red-900"
+        >
+          Tentar novamente
+        </button>
+      </div>
+    );
+  }
+
+  // --- Empty / not found ---
+  if (!product) {
+    return null;
+  }
+
+  const previewItems = generatePreviewItems(
+    (product.preview_config as Record<string, unknown>) ?? {},
+  );
+  const styles = variantStyles[variant];
+  const isBanner = variant === "banner";
+
+  const handleCheckoutStart = () => {
+    trackEventInternal("product_checkout_started", { source_template: variant });
+    setShowModal(true);
+  };
+
+  const handleCheckoutComplete = () => {
+    trackEventInternal("product_checkout_completed", { source_template: variant });
+  };
+
+  // ------------------------------------------------------------------
+  // Preview items section
+  // ------------------------------------------------------------------
+
+  const previewSection = (
+    <section aria-label="Previa do produto" className="space-y-1.5">
+      {previewItems.map((item) => (
+        <div
+          key={item.id}
+          data-testid={`preview-item-${item.premium ? "premium" : "free"}-${item.id}`}
+          className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm ${
+            item.premium
+              ? "relative overflow-hidden blur-sm select-none"
+              : "bg-[var(--surface-1)]"
+          }`}
+        >
+          <span
+            className={
+              item.premium ? "text-[var(--ink-muted)]" : "text-[var(--ink)]"
+            }
+          >
+            {item.label}
+          </span>
+          <span
+            className={
+              item.premium
+                ? "text-[var(--ink-muted)]"
+                : "font-medium text-[var(--ink)]"
+            }
+          >
+            {item.value}
+          </span>
+          {item.premium && (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <span className="rounded bg-[var(--surface-0)]/80 px-2 py-0.5 text-xs font-medium text-[var(--ink-muted)]">
+                Premium
+              </span>
+            </div>
+          )}
+        </div>
+      ))}
+    </section>
+  );
+
+  // ---------- Banner variant ----------
+  if (isBanner) {
+    return (
+      <>
+        <div
+          className={`flex items-center justify-between gap-4 ${styles.container} ${className}`}
+          data-testid="digital-product-preview-banner"
+        >
+          <div className="flex-1 min-w-0">
+            <h3 className={styles.heading}>{product.name}</h3>
+            {product.description && (
+              <p className={styles.description}>{product.description}</p>
+            )}
+            <p className="mt-1 text-sm text-white/60">
+              {previewItems.length} itens analisados —{" "}
+              {previewItems.filter((i) => i.premium).length} exclusivos
+            </p>
+          </div>
+          <div className="flex items-center gap-4 shrink-0">
+            <span className={styles.price}>
+              {formatBRL(product.price_brl)}
+            </span>
+            <CheckoutButton
+              product={product}
+              context={context}
+              variant="banner"
+              onClick={handleCheckoutStart}
+              onComplete={handleCheckoutComplete}
+            />
+          </div>
+        </div>
+
+        <CheckoutModal
+          isOpen={showModal}
+          onClose={() => setShowModal(false)}
+          product={product}
+          context={context}
+          onComplete={handleCheckoutComplete}
+        />
+      </>
+    );
+  }
+
+  // ---------- Inline / Card variants ----------
+  const content = (
+    <div
+      className={`${styles.container} ${className}`}
+      data-testid={`digital-product-preview-${variant}`}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className={styles.heading}>{product.name}</h3>
+          {product.description && (
+            <p className={styles.description}>{product.description}</p>
+          )}
+        </div>
+        <span className="shrink-0 text-right">
+          <span className={styles.price}>
+            {formatBRL(product.price_brl)}
+          </span>
+          <span className="block text-xs text-[var(--ink-muted)]">
+            pagamento unico
+          </span>
+        </span>
+      </div>
+
+      {/* Preview items */}
+      <div className="mt-4">{previewSection}</div>
+
+      {/* CTA */}
+      <div className="mt-4">
+        <CheckoutButton
+          product={product}
+          context={context}
+          variant={variant}
+          onClick={handleCheckoutStart}
+          onComplete={handleCheckoutComplete}
+        />
+      </div>
+
+      {/* Metadata */}
+      <div className="mt-3 flex items-center gap-4 text-xs text-[var(--ink-muted)]">
+        <span>{previewItems.length} itens no total</span>
+        <span>Estimativa atualizada</span>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {noWrapper ? content : variant === "card" ? <GlassCard hoverable={false}>{content}</GlassCard> : content}
+      <CheckoutModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        product={product}
+        context={context}
+        onComplete={handleCheckoutComplete}
+      />
+    </>
+  );
+}

--- a/frontend/app/components/checkout/index.ts
+++ b/frontend/app/components/checkout/index.ts
@@ -1,0 +1,21 @@
+/**
+ * CONV-005b-3: Checkout component barrel export.
+ *
+ * Re-exports all checkout components for clean imports:
+ * ```ts
+ * import { DigitalProductPreview, CheckoutModal, CheckoutButton } from "@/app/components/checkout";
+ * ```
+ */
+
+export { DigitalProductPreview } from "./DigitalProductPreview";
+export type {
+  DigitalProductPreviewProps,
+  DigitalProductContext,
+  PreviewVariant,
+} from "./DigitalProductPreview";
+
+export { CheckoutModal } from "./CheckoutModal";
+export type { CheckoutModalProps } from "./CheckoutModal";
+
+export { CheckoutButton } from "./CheckoutButton";
+export type { CheckoutButtonProps } from "./CheckoutButton";


### PR DESCRIPTION
## Summary

Implementa #1336 — Preview configurável por produto digital + modal de checkout com Stripe.

## Changes

**3 componentes de checkout:**
- **DigitalProductPreview.tsx** — Card de preview com variantes (inline/card/banner), fetch por SKU, preview items (N free + blurred premium)
- **CheckoutModal.tsx** — Modal de pagamento com resumo do produto, Stripe Checkout redirect, loading/error states
- **CheckoutButton.tsx** — CTA com preço formatado, 3 variantes visuais, loading spinner

**API proxies:**
- GET /api/products — catálogo público (cache 5min)
- POST /api/checkout/one-time — authenticated

**68 testes** — 3 suites: preview (loading/error/variants/tracking), modal (visibility/checkout flow/scroll lock/Escape), button (label/click/loading/disabled)

## Tracking Mixpanel
product_preview_viewed → product_checkout_started → product_checkout_redirected/completed

## Validation
- TypeScript: ✅
- Testes: ✅ 68 passing
- Backend #1335 já done
- Acessibilidade: Escape dismiss, body scroll lock, data-testid

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)