### PR TITLE
feat(frontend): CONV-007-1 — 4 landing pages de intenção (#1401)

### DIFF
--- a/frontend/__tests__/IntentLandingPage.test.tsx
+++ b/frontend/__tests__/IntentLandingPage.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Tests for IntentLandingPage — CONV-007-1
+ *
+ * Covers:
+ * - 4 clusters render correctly
+ * - Custom steps render
+ * - CTAs have correct hrefs
+ * - Mobile responsiveness (CSS classes)
+ * - JSON-LD structured data presence
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import IntentLandingPage from '../app/components/IntentLandingPage';
+import type { IntentCluster } from '../app/components/conversion/IntentRouter';
+
+const baseProps = {
+  cluster: 'comercial' as IntentCluster,
+  headline: 'Test Headline',
+  subtitle: 'Test Subtitle',
+  steps: [
+    { title: 'Step 1', description: 'Description 1' },
+    { title: 'Step 2', description: 'Description 2' },
+    { title: 'Step 3', description: 'Description 3' },
+  ],
+  socialProofText: 'Social proof text',
+  ctaPrimary: { text: 'Primary CTA', href: '/primary' },
+  ctaSecondary: { text: 'Secondary CTA', href: '/secondary' },
+  pageTitle: 'Test Page Title',
+  pageDescription: 'Test page description',
+};
+
+describe('IntentLandingPage', () => {
+  describe('cluster rendering', () => {
+    it.each([
+      ['comercial', 'Encontre editais para sua empresa'],
+      ['investigativa', 'Dados de licitação para seus clientes'],
+      ['juridica', 'Fundamentação jurídica para licitações'],
+      ['subcontratacao', 'Seja subcontratado em licitações'],
+    ] as [IntentCluster, string][])(
+      'renders %s cluster with correct headline',
+      (cluster, headline) => {
+        render(
+          <IntentLandingPage {...baseProps} cluster={cluster} headline={headline} />,
+        );
+        const h1 = screen.getByRole('heading', { level: 1, name: headline });
+        expect(h1).toBeInTheDocument();
+      },
+    );
+  });
+
+  describe('steps', () => {
+    it('renders heading "Como funciona"', () => {
+      render(<IntentLandingPage {...baseProps} />);
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'Como funciona' }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders all 3 custom step titles', () => {
+      const steps = [
+        { title: 'Alpha step', description: 'Alpha desc' },
+        { title: 'Beta step', description: 'Beta desc' },
+        { title: 'Gamma step', description: 'Gamma desc' },
+      ];
+      render(<IntentLandingPage {...baseProps} steps={steps} />);
+
+      for (const step of steps) {
+        expect(
+          screen.getByRole('heading', { level: 3, name: step.title }),
+        ).toBeInTheDocument();
+      }
+    });
+
+    it('renders step descriptions', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      for (const step of baseProps.steps) {
+        expect(screen.getByText(step.description)).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('CTAs', () => {
+    it('renders primary CTA with correct href', () => {
+      render(
+        <IntentLandingPage
+          {...baseProps}
+          ctaPrimary={{ text: 'Sign Up Now', href: '/signup?test=1' }}
+        />,
+      );
+
+      // CTA appears in hero and final section — check all have same href
+      const primaryLinks = screen.getAllByRole('link', {
+        name: 'Sign Up Now',
+      });
+      expect(primaryLinks.length).toBeGreaterThan(0);
+      primaryLinks.forEach((link) => {
+        expect(link).toHaveAttribute('href', '/signup?test=1');
+      });
+    });
+
+    it('renders secondary CTA with correct href', () => {
+      render(
+        <IntentLandingPage
+          {...baseProps}
+          ctaSecondary={{ text: 'Learn More', href: '/about' }}
+        />,
+      );
+
+      // Secondary CTA appears in hero and final section
+      const secondaryLinks = screen.getAllByRole('link', {
+        name: 'Learn More',
+      });
+      expect(secondaryLinks.length).toBeGreaterThan(0);
+      secondaryLinks.forEach((link) => {
+        expect(link).toHaveAttribute('href', '/about');
+      });
+    });
+
+    it('renders primary CTA in the hero section', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      // The primary CTA should appear as a link (button-like anchor)
+      const primaryLinks = screen.getAllByRole('link', {
+        name: baseProps.ctaPrimary.text,
+      });
+      expect(primaryLinks.length).toBeGreaterThan(0);
+    });
+
+    it('renders secondary CTA in the hero and final section', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      // Secondary CTA link text appears in both hero and final CTA sections
+      const secondaryLinks = screen.getAllByRole('link', {
+        name: baseProps.ctaSecondary.text,
+      });
+      expect(secondaryLinks.length).toBe(2); // Hero + final CTA
+    });
+
+    it('renders primary CTA in both hero and final section', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      const primaryLinks = screen.getAllByRole('link', {
+        name: baseProps.ctaPrimary.text,
+      });
+      expect(primaryLinks.length).toBe(2); // Hero + final CTA
+    });
+  });
+
+  describe('social proof', () => {
+    it('renders social proof text', () => {
+      const proofText = 'Trusted by 1000+ companies';
+      render(
+        <IntentLandingPage {...baseProps} socialProofText={proofText} />,
+      );
+
+      expect(screen.getByText(proofText)).toBeInTheDocument();
+    });
+  });
+
+  describe('JSON-LD structured data', () => {
+    function getJsonLdScript(): HTMLScriptElement | null {
+      const scripts = document.querySelectorAll(
+        'script[type="application/ld+json"]',
+      );
+      for (const script of scripts) {
+        try {
+          const data = JSON.parse(script.innerHTML);
+          if (data['@type'] === 'WebPage') return script as HTMLScriptElement;
+        } catch {
+          // skip invalid JSON
+        }
+      }
+      return null;
+    }
+
+    it('includes a JSON-LD script with WebPage type', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      const script = getJsonLdScript();
+      expect(script).not.toBeNull();
+    });
+
+    it('includes correct WebPage schema data', () => {
+      const pageTitle = 'Custom Page Title for SEO';
+      const pageDescription = 'Custom description for SEO testing';
+
+      render(
+        <IntentLandingPage
+          {...baseProps}
+          pageTitle={pageTitle}
+          pageDescription={pageDescription}
+        />,
+      );
+
+      const script = getJsonLdScript();
+      expect(script).not.toBeNull();
+
+      const data = JSON.parse(script!.innerHTML);
+      expect(data['@type']).toBe('WebPage');
+      expect(data.name).toBe(pageTitle);
+      expect(data.description).toBe(pageDescription);
+    });
+
+    it('includes SmartLic organization as provider', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      const script = getJsonLdScript();
+      expect(script).not.toBeNull();
+
+      const data = JSON.parse(script!.innerHTML);
+      expect(data.provider).toBeDefined();
+      expect(data.provider['@type']).toBe('Organization');
+      expect(data.provider.name).toBe('SmartLic');
+      expect(data.provider.url).toBe('https://smartlic.tech');
+    });
+
+    it('sets inLanguage to pt-BR', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      const script = getJsonLdScript();
+      const data = JSON.parse(script!.innerHTML);
+      expect(data.inLanguage).toBe('pt-BR');
+    });
+  });
+
+  describe('responsive design', () => {
+    it('uses responsive hero layout classes', () => {
+      const { container } = render(<IntentLandingPage {...baseProps} />);
+
+      // Hero section has flex-col on mobile, sm:flex-row on desktop
+      const ctaContainers = container.querySelectorAll(
+        '.flex.flex-col.sm\\:flex-row',
+      );
+      expect(ctaContainers.length).toBeGreaterThan(0);
+    });
+
+    it('uses full-width CTAs on mobile (w-full sm:w-auto)', () => {
+      const { container } = render(<IntentLandingPage {...baseProps} />);
+
+      const mobileCtas = container.querySelectorAll('.w-full.sm\\:w-auto');
+      expect(mobileCtas.length).toBeGreaterThan(0);
+    });
+
+    it('renders steps in a responsive grid (grid sm:grid-cols-3)', () => {
+      const { container } = render(<IntentLandingPage {...baseProps} />);
+
+      const grid = container.querySelector('.grid.sm\\:grid-cols-3');
+      expect(grid).not.toBeNull();
+    });
+
+    it('includes responsive text sizes on heading', () => {
+      const { container } = render(<IntentLandingPage {...baseProps} />);
+
+      const h1 = container.querySelector('h1');
+      expect(h1).not.toBeNull();
+      expect(h1!.className).toContain('sm:text-4xl');
+      expect(h1!.className).toContain('lg:text-5xl');
+    });
+  });
+
+  describe('subtitle', () => {
+    it('renders subtitle text', () => {
+      const subtitle = 'Test subtitle text';
+      render(
+        <IntentLandingPage {...baseProps} subtitle={subtitle} />,
+      );
+      expect(screen.getByText(subtitle)).toBeInTheDocument();
+    });
+  });
+
+  describe('semantic HTML', () => {
+    it('uses <main> semantic element', () => {
+      const { container } = render(<IntentLandingPage {...baseProps} />);
+
+      const main = container.querySelector('main');
+      expect(main).not.toBeNull();
+    });
+
+    it('uses section elements with aria-labels', () => {
+      render(<IntentLandingPage {...baseProps} />);
+
+      expect(
+        screen.getByRole('region', { name: 'Hero' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('region', { name: 'Como funciona' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('region', { name: 'Credibilidade' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('region', { name: 'Chamada para acao' }),
+      ).toBeInTheDocument();
+    });
+
+    it('uses correct heading hierarchy (h1 → h2 → h3)', () => {
+      const { container } = render(<IntentLandingPage {...baseProps} />);
+
+      const headings = container.querySelectorAll('h1, h2, h3');
+      expect(headings.length).toBeGreaterThan(0);
+
+      // Check h1 exists
+      expect(container.querySelector('h1')).not.toBeNull();
+      // Check h2 exists (Como funciona)
+      expect(container.querySelector('h2')).not.toBeNull();
+      // Check h3 elements exist (step titles)
+      expect(container.querySelectorAll('h3').length).toBe(
+        baseProps.steps.length,
+      );
+    });
+  });
+});

--- a/frontend/app/components/IntentLandingPage.tsx
+++ b/frontend/app/components/IntentLandingPage.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+import type { IntentCluster } from '@/app/components/conversion/IntentRouter';
+
+export interface Step {
+  title: string;
+  description: string;
+}
+
+export interface CtaAction {
+  text: string;
+  href: string;
+}
+
+export interface IntentLandingPageProps {
+  /** Intent cluster used for tracking and visual theming */
+  cluster: IntentCluster;
+  /** Hero headline (h1) */
+  headline: string;
+  /** Hero subtitle */
+  subtitle: string;
+  /** 3 how-it-works steps */
+  steps: Step[];
+  /** Social proof / credibility text */
+  socialProofText: string;
+  /** Primary CTA button config */
+  ctaPrimary: CtaAction;
+  /** Secondary CTA link config */
+  ctaSecondary: CtaAction;
+  /** Page title for JSON-LD structured data */
+  pageTitle: string;
+  /** Page description for JSON-LD structured data */
+  pageDescription: string;
+}
+
+/**
+ * Reusable landing page component for intent-based conversion pages.
+ *
+ * Renders a hero, how-it-works steps, social proof, and dual-CTAs.
+ * Includes JSON-LD structured data for SEO.
+ * Matches the SmartLic design language (blue/green, rounded corners, shadows).
+ */
+export default function IntentLandingPage({
+  cluster,
+  headline,
+  subtitle,
+  steps,
+  socialProofText,
+  ctaPrimary,
+  ctaSecondary,
+  pageTitle,
+  pageDescription,
+}: IntentLandingPageProps) {
+  const schema = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: pageTitle,
+      description: pageDescription,
+      provider: {
+        '@type': 'Organization',
+        name: 'SmartLic',
+        url: 'https://smartlic.tech',
+      },
+      inLanguage: 'pt-BR',
+    }),
+    [pageTitle, pageDescription],
+  );
+
+  return (
+    <>
+      {/* JSON-LD structured data for SEO */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+
+      <main>
+        {/* ── Hero Section ────────────────────────────────────────────── */}
+        <section
+          aria-label="Hero"
+          className="relative bg-gradient-to-br from-brand-navy to-brand-blue text-white py-20 px-4"
+        >
+          <div className="max-w-4xl mx-auto text-center">
+            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold leading-tight mb-6">
+              {headline}
+            </h1>
+            <p className="text-lg sm:text-xl text-white/80 max-w-2xl mx-auto mb-8">
+              {subtitle}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <Link
+                href={ctaPrimary.href}
+                className="inline-block bg-green-600 hover:bg-green-700 text-white font-semibold px-8 py-4 rounded-xl transition-all hover:scale-[1.02] active:scale-[0.98] shadow-lg focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-navy w-full sm:w-auto text-center"
+              >
+                {ctaPrimary.text}
+              </Link>
+              <Link
+                href={ctaSecondary.href}
+                className="inline-block text-white/80 hover:text-white font-medium px-6 py-4 underline underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-navy rounded"
+              >
+                {ctaSecondary.text}
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* ── How It Works Section ────────────────────────────────────── */}
+        <section aria-label="Como funciona" className="py-16 px-4 bg-canvas">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl sm:text-3xl font-bold text-center text-ink mb-12">
+              Como funciona
+            </h2>
+            <div className="grid sm:grid-cols-3 gap-8">
+              {steps.map((step, index) => (
+                <article key={index} className="text-center">
+                  <div
+                    className="w-12 h-12 bg-brand-blue/10 rounded-full flex items-center justify-center mx-auto mb-4"
+                    aria-hidden="true"
+                  >
+                    <span className="text-brand-blue font-bold text-lg">
+                      {index + 1}
+                    </span>
+                  </div>
+                  <h3 className="font-bold text-lg text-ink mb-2">
+                    {step.title}
+                  </h3>
+                  <p className="text-ink-secondary text-sm leading-relaxed">
+                    {step.description}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Social Proof Section ────────────────────────────────────── */}
+        <section aria-label="Credibilidade" className="py-16 px-4 bg-surface-1 border-y border-[var(--border)]">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="bg-canvas rounded-2xl p-8 shadow-sm border border-[var(--border)]">
+              <p className="text-lg text-ink-secondary leading-relaxed">
+                {socialProofText}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Final CTA Section ────────────────────────────────────────── */}
+        <section aria-label="Chamada para acao" className="py-20 px-4 bg-canvas">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <Link
+                href={ctaPrimary.href}
+                className="inline-block bg-green-600 hover:bg-green-700 text-white font-bold px-10 py-4 rounded-xl text-lg transition-all hover:scale-[1.02] active:scale-[0.98] shadow-lg focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 w-full sm:w-auto text-center"
+              >
+                {ctaPrimary.text}
+              </Link>
+              <Link
+                href={ctaSecondary.href}
+                className="inline-block text-brand-blue hover:text-brand-blue-hover font-medium px-6 py-4 underline underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 rounded"
+              >
+                {ctaSecondary.text}
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/frontend/app/para-advogados/page.tsx
+++ b/frontend/app/para-advogados/page.tsx
@@ -1,0 +1,71 @@
+/**
+ * Intent Landing Page: /para-advogados
+ *
+ * CONV-007-1: Landing page de intenção jurídica — conecta advogados e
+ * profissionais do direito licitatório à plataforma SmartLic. Cluster: juridica.
+ *
+ * Server component. Metadata + JSON-LD via IntentLandingPage.
+ */
+import type { Metadata } from 'next';
+import LandingNavbar from '@/app/components/landing/LandingNavbar';
+import Footer from '@/app/components/Footer';
+import IntentLandingPage from '@/app/components/IntentLandingPage';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Para Advogados — Impugnação de editais com dados | SmartLic',
+  description:
+    'Acesse editais completos, jurisprudência e análise detalhada para embasar seus recursos e impugnações.',
+  alternates: {
+    canonical: 'https://smartlic.tech/para-advogados',
+  },
+  openGraph: {
+    title: 'Para Advogados — Impugnação de editais com dados | SmartLic',
+    description:
+      'Acesse editais completos, jurisprudência e análise detalhada para embasar recursos e impugnações.',
+    url: 'https://smartlic.tech/para-advogados',
+    type: 'website',
+    locale: 'pt_BR',
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function ParaAdvogadosPage() {
+  return (
+    <>
+      <LandingNavbar />
+      <IntentLandingPage
+        cluster="juridica"
+        headline="Fundamentação jurídica para licitações"
+        subtitle="Acesse editais completos, jurisprudência e análise detalhada para embasar seus recursos e impugnações."
+        steps={[
+          {
+            title: 'Busque o edital',
+            description:
+              'Encontre o edital completo que você precisa analisar. Busca inteligente nas bases oficiais com dados estruturados.',
+          },
+          {
+            title: 'Analise cláusulas e jurisprudência',
+            description:
+              'Examine cada cláusula com dados de jurisprudência relacionada. Identifique pontos passíveis de impugnação.',
+          },
+          {
+            title: 'Prepare sua impugnação ou recurso',
+            description:
+              'Use os dados do sistema para fundamentar seus recursos com argumentos sólidos e jurisprudência atualizada.',
+          },
+        ]}
+        socialProofText="Base de conhecimento jurídico com milhares de editais e decisões. Dados oficiais para embasar sua atuação."
+        ctaPrimary={{
+          text: 'Começar trial grátis',
+          href: '/signup?source=intent-juridica',
+        }}
+        ctaSecondary={{ text: 'Ver base legal', href: '/compliance' }}
+        pageTitle="Para Advogados — Impugnação de editais com dados | SmartLic"
+        pageDescription="Acesse editais completos, jurisprudência e análise detalhada para embasar seus recursos e impugnações."
+      />
+      <Footer />
+    </>
+  );
+}

--- a/frontend/app/para-consultorias/page.tsx
+++ b/frontend/app/para-consultorias/page.tsx
@@ -1,0 +1,71 @@
+/**
+ * Intent Landing Page: /para-consultorias
+ *
+ * CONV-007-1: Landing page de intenção investigativa — conecta consultorias
+ * e assessorias à plataforma SmartLic. Cluster: investigativa.
+ *
+ * Server component. Metadata + JSON-LD via IntentLandingPage.
+ */
+import type { Metadata } from 'next';
+import LandingNavbar from '@/app/components/landing/LandingNavbar';
+import Footer from '@/app/components/Footer';
+import IntentLandingPage from '@/app/components/IntentLandingPage';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Para Consultorias — Dados de licitação para seus clientes | SmartLic',
+  description:
+    'Relatórios detalhados e análises setoriais para consultorias e assessorias de licitação. Acesse dados históricos e tendências do mercado público.',
+  alternates: {
+    canonical: 'https://smartlic.tech/para-consultorias',
+  },
+  openGraph: {
+    title: 'Para Consultorias — Dados de licitação para seus clientes | SmartLic',
+    description:
+      'Relatórios detalhados e análises setoriais para consultorias e assessorias de licitação.',
+    url: 'https://smartlic.tech/para-consultorias',
+    type: 'website',
+    locale: 'pt_BR',
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function ParaConsultoriasPage() {
+  return (
+    <>
+      <LandingNavbar />
+      <IntentLandingPage
+        cluster="investigativa"
+        headline="Dados de licitação para seus clientes"
+        subtitle="Relatórios detalhados e análises setoriais para consultorias e assessorias. Dados reais das fontes oficiais."
+        steps={[
+          {
+            title: 'Escolha o setor do cliente',
+            description:
+              'Selecione entre 20 setores da economia. O sistema busca editais, contratos e fornecedores do segmento desejado.',
+          },
+          {
+            title: 'Acesse dados históricos e tendências',
+            description:
+              'Analise histórico de concorrências, compare preços e mapeie tendências do mercado público com dados reais.',
+          },
+          {
+            title: 'Gere relatórios profissionais',
+            description:
+              'Exporte relatórios em Excel e PDF com análise setorial completa. Relatórios prontos para entregar ao cliente.',
+          },
+        ]}
+        socialProofText="+10 mil relatórios gerados para consultorias em todo Brasil. Dados consolidados das principais fontes oficiais."
+        ctaPrimary={{
+          text: 'Comprar relatório avulso',
+          href: '/checkout?sku=relatorio-setorial',
+        }}
+        ctaSecondary={{ text: 'Explorar dados abertos', href: '/observatorio' }}
+        pageTitle="Para Consultorias — Dados de licitação para seus clientes | SmartLic"
+        pageDescription="Relatórios detalhados e análises setoriais para consultorias e assessorias de licitação. Acesse dados históricos e tendências do mercado público."
+      />
+      <Footer />
+    </>
+  );
+}

--- a/frontend/app/para-empresas/page.tsx
+++ b/frontend/app/para-empresas/page.tsx
@@ -1,0 +1,68 @@
+/**
+ * Intent Landing Page: /para-empresas
+ *
+ * CONV-007-1: Landing page de intenção comercial — conecta empresas B2G
+ * à plataforma SmartLic. Cluster: comercial.
+ *
+ * Server component. Metadata + JSON-LD via IntentLandingPage.
+ */
+import type { Metadata } from 'next';
+import LandingNavbar from '@/app/components/landing/LandingNavbar';
+import Footer from '@/app/components/Footer';
+import IntentLandingPage from '@/app/components/IntentLandingPage';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Para Empresas — Encontre editais para sua empresa | SmartLic',
+  description:
+    'Descubra editais classificados por setor com análise de viabilidade. Aumente suas chances de vencer licitações.',
+  alternates: {
+    canonical: 'https://smartlic.tech/para-empresas',
+  },
+  openGraph: {
+    title: 'Para Empresas — Encontre editais para sua empresa | SmartLic',
+    description:
+      'Descubra editais classificados por setor com análise de viabilidade. Aumente suas chances de vencer licitações.',
+    url: 'https://smartlic.tech/para-empresas',
+    type: 'website',
+    locale: 'pt_BR',
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function ParaEmpresasPage() {
+  return (
+    <>
+      <LandingNavbar />
+      <IntentLandingPage
+        cluster="comercial"
+        headline="Encontre editais para sua empresa"
+        subtitle="IA classifica automaticamente licitações do seu setor. Economize horas de pesquisa manual."
+        steps={[
+          {
+            title: 'Defina seu setor',
+            description:
+              'Selecione seu ramo de atuação entre 20 setores. O sistema entende seu nicho e busca editais compatíveis.',
+          },
+          {
+            title: 'Receba editais classificados',
+            description:
+              'IA analisa e classifica cada edital com análise de viabilidade em 4 fatores. Você só vê o que importa.',
+          },
+          {
+            title: 'Organize seu pipeline',
+            description:
+              'Arraste editais no kanban e foque no que importa. Acompanhe propostas em andamento com alertas inteligentes.',
+          },
+        ]}
+        socialProofText="+1.5 milhão de editais monitorados para empresas de todos os portes. Dados reais das fontes oficiais (PNCP, PCP, ComprasGov)."
+        ctaPrimary={{ text: 'Começar trial grátis', href: '/signup?source=intent-comercial' }}
+        ctaSecondary={{ text: 'Ver exemplos de resultados', href: '/buscar' }}
+        pageTitle="Para Empresas — Encontre editais para sua empresa | SmartLic"
+        pageDescription="Descubra editais classificados por setor com análise de viabilidade. Aumente suas chances de vencer licitações."
+      />
+      <Footer />
+    </>
+  );
+}

--- a/frontend/app/para-fornecedores/page.tsx
+++ b/frontend/app/para-fornecedores/page.tsx
@@ -1,0 +1,73 @@
+/**
+ * Intent Landing Page: /para-fornecedores
+ *
+ * CONV-007-1: Landing page de intenção de subcontratação — conecta
+ * fornecedores terceiros a oportunidades em licitações. Cluster: subcontratacao.
+ *
+ * Server component. Metadata + JSON-LD via IntentLandingPage.
+ */
+import type { Metadata } from 'next';
+import LandingNavbar from '@/app/components/landing/LandingNavbar';
+import Footer from '@/app/components/Footer';
+import IntentLandingPage from '@/app/components/IntentLandingPage';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title:
+    'Para Fornecedores — Seja subcontratado em licitações | SmartLic',
+  description:
+    'Identifique consórcios, subcontratações e oportunidades para sua empresa atuar como fornecedor terceiro em licitações públicas.',
+  alternates: {
+    canonical: 'https://smartlic.tech/para-fornecedores',
+  },
+  openGraph: {
+    title:
+      'Para Fornecedores — Seja subcontratado em licitações | SmartLic',
+    description:
+      'Identifique consórcios, subcontratações e oportunidades para sua empresa atuar como fornecedor terceiro em licitações.',
+    url: 'https://smartlic.tech/para-fornecedores',
+    type: 'website',
+    locale: 'pt_BR',
+  },
+  robots: { index: true, follow: true },
+};
+
+export default function ParaFornecedoresPage() {
+  return (
+    <>
+      <LandingNavbar />
+      <IntentLandingPage
+        cluster="subcontratacao"
+        headline="Seja subcontratado em licitações"
+        subtitle="Identifique consórcios, subcontratações e oportunidades para sua empresa atuar como fornecedor terceiro."
+        steps={[
+          {
+            title: 'Identifique oportunidades',
+            description:
+              'Descubra empresas que venceram licitações e buscam fornecedores terceiros para atender contratos públicos.',
+          },
+          {
+            title: 'Conecte-se com vencedores',
+            description:
+              'Mapeie as empresas vencedoras de licitações no seu setor. Entenda as necessidades de cada contrato.',
+          },
+          {
+            title: 'Feche parcerias',
+            description:
+              'Ofereça seus produtos ou serviços como subcontratado. Receba alertas de novas oportunidades de parceria.',
+          },
+        ]}
+        socialProofText="Milhares de pontes de subcontratação mapeadas entre fornecedores e vencedores de licitações em todo Brasil."
+        ctaPrimary={{
+          text: 'Mapear pontes de subcontratação',
+          href: '/subcontratacao',
+        }}
+        ctaSecondary={{ text: 'Ver editais recentes', href: '/licitacoes' }}
+        pageTitle="Para Fornecedores — Seja subcontratado em licitações | SmartLic"
+        pageDescription="Identifique consórcios, subcontratações e oportunidades para sua empresa atuar como fornecedor terceiro em licitações."
+      />
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Implementa 4 landing pages segmentadas por intenção de busca com template compartilhado.

### Componentes
- **IntentLandingPage** — componente reutilizável com hero section, 3-step "Como funciona", social proof, CTA duplo, JSON-LD estruturado. Mobile responsive.
- **4 páginas** — `/para-empresas`, `/para-consultorias`, `/para-advogados`, `/para-fornecedores`

### Paginas
| Rota | Cluster | Headline |
|------|---------|----------|
| `/para-empresas` | Comercial | Encontre editais para sua empresa |
| `/para-consultorias` | Investigativa | Dados de licitacao para seus clientes |
| `/para-advogados` | Juridica | Fundamentacao juridica para licitacoes |
| `/para-fornecedores` | Subcontratacao | Seja subcontratado em licitacoes |

### Testes
- **25/25 passando** — 4 cluster render, steps, CTAs, social proof, JSON-LD, responsive design, semantic HTML

### Dependencias
- Stacked on #1511 (IntentRouter — importa `IntentCluster` type)

### Issue
Closes #1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
