### PR TITLE
feat(frontend): CONV-010-2 — AutonomousLandingShell + data-to-proposal mapping (#1509)

### DIFF
--- a/frontend/__tests__/AutonomousLandingShell.test.tsx
+++ b/frontend/__tests__/AutonomousLandingShell.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for AutonomousLandingShell component — CONV-010-2 (#1509)
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AutonomousLandingShell from '../app/components/conversion/AutonomousLandingShell';
+import type { EntityType } from '../app/components/conversion/AutonomousLandingShell';
+
+// Mock framer-motion to avoid animation issues in tests.
+// Strips framer-motion-specific props that React doesn't recognize on DOM elements.
+const MOTION_PROPS = new Set([
+  'variants', 'initial', 'animate', 'exit', 'whileInView',
+  'whileHover', 'whileTap', 'whileFocus', 'whileDrag',
+  'viewport', 'transition', 'layout', 'layoutId',
+]);
+function stripMotionProps(props: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (!MOTION_PROPS.has(key)) clean[key] = props[key];
+  }
+  return clean;
+}
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+      React.createElement('div', stripMotionProps(props as Record<string, unknown>), children),
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+describe('AutonomousLandingShell', () => {
+  const baseProps = {
+    entityType: 'fornecedor' as EntityType,
+    entityName: 'Empresa Exemplo Ltda',
+    entityData: { total_contratos: 42 },
+    valueProp: 'Análise concorrencial com IA',
+    insights: [
+      { label: 'Contratos', value: '42', icon: 'chart' as const },
+      { label: 'Estados', value: '5', icon: 'building' as const },
+    ],
+    ctaVariant: 'trial' as const,
+  };
+
+  beforeEach(() => {
+    // Mock mixpanel
+    Object.defineProperty(window, 'mixpanel', {
+      value: { track: jest.fn() },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders ValuePropositionAboveFold with correct entity name and value prop', () => {
+    render(<AutonomousLandingShell {...baseProps} />);
+
+    expect(
+      screen.getByText('Quer vencer mais licitações como Empresa Exemplo Ltda?'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Análise concorrencial com IA')).toBeInTheDocument();
+  });
+
+  it('renders AhaMomentPanel with insights', () => {
+    render(<AutonomousLandingShell {...baseProps} />);
+
+    expect(screen.getByText('Contratos')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Estados')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders CTAContextual with correct variant', () => {
+    render(<AutonomousLandingShell {...baseProps} />);
+
+    const ctaLink = screen.getByTestId('cta-contextual');
+    expect(ctaLink).toBeInTheDocument();
+    expect(ctaLink).toHaveTextContent(/Testar grátis/);
+  });
+
+  it('fires Mixpanel event on mount', () => {
+    const trackSpy = jest.fn();
+    Object.defineProperty(window, 'mixpanel', {
+      value: { track: trackSpy },
+      writable: true,
+      configurable: true,
+    });
+
+    render(<AutonomousLandingShell {...baseProps} />);
+
+    expect(trackSpy).toHaveBeenCalledWith('landing_autonomous_view', {
+      entityType: 'fornecedor',
+      entityName: 'Empresa Exemplo Ltda',
+    });
+  });
+
+  it('renders supporting detail when provided', () => {
+    render(
+      <AutonomousLandingShell
+        {...baseProps}
+        supportingDetail="Suporte adicional para sua análise"
+      />,
+    );
+
+    expect(
+      screen.getByText('Suporte adicional para sua análise'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders CTA text override when provided', () => {
+    render(
+      <AutonomousLandingShell
+        {...baseProps}
+        ctaText="Comprar agora"
+      />,
+    );
+
+    const ctaLink = screen.getByTestId('cta-contextual');
+    expect(ctaLink).toHaveTextContent('Comprar agora');
+  });
+
+  it('renders correctly for different entity types', () => {
+    const entityTypes: Array<{
+      type: EntityType;
+      name: string;
+      headline: string;
+    }> = [
+      { type: 'orgao', name: 'Prefeitura de SP', headline: 'Quer vender para Prefeitura de SP?' },
+      { type: 'setor', name: 'TI', headline: 'Oportunidades no setor — TI' },
+      { type: 'municipio', name: 'São Paulo', headline: 'Licitações em São Paulo — acompanhe em tempo real' },
+      { type: 'contrato', name: 'Contrato ABC', headline: 'Análise completa do contrato — Contrato ABC' },
+    ];
+
+    entityTypes.forEach(({ type, name, headline }) => {
+      const { unmount } = render(
+        <AutonomousLandingShell
+          entityType={type}
+          entityName={name}
+          entityData={{}}
+          valueProp={`Valor para ${type}`}
+          insights={[{ label: 'Item', value: '1', icon: 'target' }]}
+          ctaVariant="search"
+        />,
+      );
+
+      expect(screen.getByText(headline)).toBeInTheDocument();
+      unmount();
+    });
+  });
+
+  it('renders main element with accessible aria-label', () => {
+    render(<AutonomousLandingShell {...baseProps} />);
+
+    const main = screen.getByRole('main');
+    expect(main).toBeInTheDocument();
+    expect(main).toHaveAttribute(
+      'aria-label',
+      'Página autônoma — Empresa Exemplo Ltda',
+    );
+  });
+});

--- a/frontend/__tests__/data-to-proposal.test.ts
+++ b/frontend/__tests__/data-to-proposal.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for data-to-proposal mapping utility — CONV-010-2 (#1509)
+ */
+
+import { mapEntityToProposal } from '../app/components/conversion/data-to-proposal';
+
+describe('mapEntityToProposal', () => {
+  describe('fornecedor', () => {
+    it('maps fornecedor data correctly', () => {
+      const result = mapEntityToProposal('fornecedor', 'ABC Ltda', {
+        total_contratos: 42,
+        valor_total: 2500000,
+        ufs_atuantes: 'SP, RJ, MG',
+      });
+
+      expect(result.valueProp).toBe(
+        'Quer vencer mais licitações como ABC Ltda?',
+      );
+      expect(result.supportingDetail).toContain('concorrencial');
+      expect(result.insights).toHaveLength(3);
+
+      // Check first insight
+      expect(result.insights[0]).toMatchObject({
+        label: 'Contratos Ganhos',
+        value: '42',
+        icon: 'chart',
+      });
+
+      // Check value extraction with fallback
+      expect(result.insights[1].value).toBe('2500000');
+    });
+
+    it('uses fallback values when data is missing', () => {
+      const result = mapEntityToProposal('fornecedor', 'ABC Ltda', {});
+
+      result.insights.forEach((insight) => {
+        expect(insight.value).toBe('—');
+      });
+    });
+  });
+
+  describe('orgao', () => {
+    it('maps orgao data correctly', () => {
+      const result = mapEntityToProposal('orgao', 'Prefeitura de SP', {
+        total_licitacoes: 15,
+        contratos_ativos: 8,
+        valor_total_estimado: 5000000,
+      });
+
+      expect(result.valueProp).toBe(
+        'Quer vender para Prefeitura de SP?',
+      );
+      expect(result.insights).toHaveLength(3);
+      expect(result.insights[0].label).toBe('Editais Abertos');
+      expect(result.insights[0].value).toBe('15');
+    });
+  });
+
+  describe('cnpj', () => {
+    it('maps cnpj data correctly', () => {
+      const result = mapEntityToProposal('cnpj', '12.345.678/0001-90', {
+        participacoes: 25,
+        contratos_obtidos: 10,
+        presenca_geografica: 'SP, RJ',
+      });
+
+      expect(result.valueProp).toContain('Dados completos do CNPJ');
+      expect(result.insights).toHaveLength(3);
+      expect(result.insights[0].label).toBe('Participações');
+      expect(result.insights[0].value).toBe('25');
+    });
+  });
+
+  describe('setor', () => {
+    it('maps setor data correctly', () => {
+      const result = mapEntityToProposal('setor', 'Tecnologia da Informação', {
+        total_oportunidades: 120,
+        principais_orgaos: 'Ministérios, Prefeituras',
+        valor_medio: 350000,
+      });
+
+      expect(result.valueProp).toBe(
+        'Atue em Tecnologia da Informação com inteligência',
+      );
+      expect(result.insights).toHaveLength(3);
+      expect(result.insights[0].label).toBe('Editais no Setor');
+      expect(result.insights[0].value).toBe('120');
+    });
+  });
+
+  describe('municipio', () => {
+    it('maps municipio data correctly', () => {
+      const result = mapEntityToProposal('municipio', 'São Paulo', {
+        total_editais: 200,
+        setores_principais: 'Saúde, Educação',
+        volume_contratacoes: 'R$ 50M',
+      });
+
+      expect(result.valueProp).toBe('Licitações em São Paulo');
+      expect(result.insights).toHaveLength(3);
+      expect(result.insights[0].label).toBe('Editais Municipais');
+    });
+  });
+
+  describe('contrato', () => {
+    it('maps contrato data correctly', () => {
+      const result = mapEntityToProposal('contrato', 'Contrato 001/2025', {
+        renovacoes_previstas: 3,
+        concorrentes_ativos: 5,
+        valor_similar: 'R$ 2.5M',
+      });
+
+      expect(result.valueProp).toContain('Contratos como este em');
+      expect(result.insights).toHaveLength(3);
+      expect(result.insights[0].label).toBe('Renovações');
+      expect(result.insights[0].value).toBe('3');
+    });
+  });
+
+  describe('fallback', () => {
+    it('returns fallback for unknown entityType', () => {
+      const result = mapEntityToProposal('unknown', 'Entidade', {});
+
+      expect(result.valueProp).toBe('Análise inteligente para Entidade');
+      expect(result.insights).toHaveLength(1);
+      expect(result.insights[0].label).toBe('Oportunidades');
+    });
+  });
+});

--- a/frontend/app/components/conversion/AhaMomentPanel.tsx
+++ b/frontend/app/components/conversion/AhaMomentPanel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+/**
+ * AhaMomentPanel — CONV-004
+ *
+ * An insight/revelation panel that shows key data points about an entity
+ * to create an "aha moment". Renders a grid of insight cards (2-4) with
+ * icon, label, large value, and optional subtext.
+ *
+ * Responsive: 2-column grid on mobile, 4-column on desktop.
+ * Uses Framer Motion for fade-in animation.
+ */
+
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export type InsightIcon = 'chart' | 'money' | 'building' | 'target';
+
+export interface InsightCard {
+  label: string;
+  value: string;
+  subtext?: string;
+  icon?: InsightIcon;
+}
+
+export interface AhaMomentPanelProps {
+  /** Entity type for scoped analytics */
+  entityType: string;
+  /** Array of insight cards (2-4 cards) */
+  insights: InsightCard[];
+}
+
+const ICON_MAP: Record<InsightIcon, string> = {
+  chart: '📊',
+  money: '💰',
+  building: '🏛️',
+  target: '🎯',
+};
+
+const containerVariants = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.12,
+    },
+  },
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: 'easeOut' as const },
+  },
+};
+
+export default function AhaMomentPanel({
+  entityType,
+  insights,
+}: AhaMomentPanelProps) {
+  if (insights.length === 0) return null;
+
+  return (
+    <section aria-label="Insights" className="my-8">
+      <motion.div
+        className="grid grid-cols-2 gap-4 md:grid-cols-4"
+        variants={containerVariants}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.2 }}
+      >
+        {insights.map((insight, index) => (
+          <motion.div
+            key={`insight-${entityType}-${index}`}
+            variants={cardVariants}
+            className="rounded-xl border border-gray-200 bg-white p-4 text-center shadow-sm"
+            data-testid={`insight-card-${index}`}
+          >
+            {insight.icon && (
+              <span
+                className="mb-2 inline-block text-3xl"
+                role="img"
+                aria-hidden="true"
+              >
+                {ICON_MAP[insight.icon]}
+              </span>
+            )}
+            <p className="text-2xl font-bold text-gray-900">{insight.value}</p>
+            <p className="mt-1 text-sm font-medium text-gray-500">
+              {insight.label}
+            </p>
+            {insight.subtext && (
+              <p className="mt-1 text-xs text-gray-400">{insight.subtext}</p>
+            )}
+          </motion.div>
+        ))}
+      </motion.div>
+    </section>
+  );
+}

--- a/frontend/app/components/conversion/AutonomousLandingShell.tsx
+++ b/frontend/app/components/conversion/AutonomousLandingShell.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+/**
+ * AutonomousLandingShell — CONV-010-2 (#1509)
+ *
+ * A wrapper component that converts entity pages into autonomous landing pages.
+ * Composes three slots:
+ *   1. headline -> ValuePropositionAboveFold (hero banner)
+ *   2. insight-cards -> AhaMomentPanel (insight grid)
+ *   3. cta-block -> CTAContextual (CTA button)
+ *
+ * Fires Mixpanel event `landing_autonomous_view` on mount.
+ *
+ * Mobile responsive via Tailwind breakpoints.
+ */
+
+import React, { useEffect } from 'react';
+import ValuePropositionAboveFold from './ValuePropositionAboveFold';
+import AhaMomentPanel from './AhaMomentPanel';
+import type { InsightCard } from './AhaMomentPanel';
+import CTAContextual from './CTAContextual';
+import type { CTAVariant } from './CTAContextual';
+
+export type EntityType =
+  | 'fornecedor'
+  | 'orgao'
+  | 'cnpj'
+  | 'setor'
+  | 'municipio'
+  | 'contrato';
+
+export interface AutonomousLandingShellProps {
+  /** Entity type driving template selection */
+  entityType: EntityType;
+  /** Entity name for personalization */
+  entityName: string;
+  /** Entity-specific data used for proposal generation */
+  entityData: Record<string, unknown>;
+  /** Value proposition text */
+  valueProp: string;
+  /** Supporting detail (optional) */
+  supportingDetail?: string;
+  /** Insights for AhaMomentPanel */
+  insights: Array<{
+    label: string;
+    value: string;
+    subtext?: string;
+    icon?: 'chart' | 'money' | 'building' | 'target';
+  }>;
+  /** CTA variant */
+  ctaVariant: CTAVariant;
+  /** Override CTA text */
+  ctaText?: string;
+}
+
+/**
+ * AutonomousLandingShell
+ *
+ * Converts any entity page into an autonomous landing page by composing
+ * ValuePropositionAboveFold, AhaMomentPanel, and CTAContextual.
+ *
+ * @example
+ * <AutonomousLandingShell
+ *   entityType="fornecedor"
+ *   entityName="Empresa ABC Ltda"
+ *   entityData={{ total_contratos: 42 }}
+ *   valueProp="Análise concorrencial com inteligência artificial"
+ *   insights={[{ label: "Contratos", value: "42", icon: "chart" }]}
+ *   ctaVariant="trial"
+ * />
+ */
+export default function AutonomousLandingShell({
+  entityType,
+  entityName,
+  entityData,
+  valueProp,
+  supportingDetail,
+  insights,
+  ctaVariant,
+  ctaText,
+}: AutonomousLandingShellProps) {
+  // Fire Mixpanel event on mount
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.mixpanel) {
+      window.mixpanel.track('landing_autonomous_view', {
+        entityType,
+        entityName,
+      });
+    }
+  }, [entityType, entityName]);
+
+  return (
+    <main aria-label={`Página autônoma — ${entityName}`} className="min-h-screen">
+      {/* Headline slot: ValuePropositionAboveFold */}
+      <ValuePropositionAboveFold
+        entityType={entityType}
+        entityName={entityName}
+        valueProp={valueProp}
+        supportingDetail={supportingDetail}
+      />
+
+      {/* Content container for insight-cards and cta-block */}
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
+        {/* Insight-cards slot: AhaMomentPanel */}
+        <AhaMomentPanel
+          entityType={entityType}
+          insights={insights}
+        />
+
+        {/* Spacer before CTA */}
+        <div className="my-8 border-t border-gray-100" />
+
+        {/* CTA-block slot: CTAContextual */}
+        <CTAContextual
+          variant={ctaVariant}
+          entityType={entityType}
+          entityName={entityName}
+          ctaText={ctaText}
+        />
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/components/conversion/CTAContextual.tsx
+++ b/frontend/app/components/conversion/CTAContextual.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+/**
+ * CTAContextual — CONV-002
+ *
+ * A contextual CTA button/block that adapts to the page context.
+ * Variants map to default text/link combinations:
+ *   - trial: "Testar grátis por 7 dias" -> /signup?source=entity_{entityType}
+ *   - report: "Comprar relatório completo" -> /checkout?sku=relatorio-{entityType}
+ *   - search: "Buscar editais agora" -> /buscar
+ *
+ * Tracks click via Mixpanel: cta_contextual_click with { variant, entityType, entityName }.
+ */
+
+import React, { useCallback } from 'react';
+import Link from 'next/link';
+
+export type CTAVariant = 'trial' | 'report' | 'search';
+
+export interface CTAContextualProps {
+  /** CTA variant */
+  variant: CTAVariant;
+  /** Entity context for tracking */
+  entityType: string;
+  /** Entity name for personalization */
+  entityName: string;
+  /** Override CTA text */
+  ctaText?: string;
+  /** Override CTA link */
+  ctaLink?: string;
+}
+
+interface VariantConfig {
+  defaultText: string;
+  defaultHref: (entityType: string) => string;
+  showSecondary?: boolean;
+}
+
+const VARIANT_CONFIG: Record<CTAVariant, VariantConfig> = {
+  trial: {
+    defaultText: 'Testar grátis por 7 dias',
+    defaultHref: (entityType: string) =>
+      `/signup?source=entity_${entityType}`,
+    showSecondary: true,
+  },
+  report: {
+    defaultText: 'Comprar relatório completo',
+    defaultHref: (entityType: string) =>
+      `/checkout?sku=relatorio-${entityType}`,
+  },
+  search: {
+    defaultText: 'Buscar editais agora',
+    defaultHref: () => '/buscar',
+  },
+};
+
+export default function CTAContextual({
+  variant,
+  entityType,
+  entityName,
+  ctaText,
+  ctaLink,
+}: CTAContextualProps) {
+  const config = VARIANT_CONFIG[variant];
+  const text = ctaText ?? config.defaultText;
+  const href = ctaLink ?? config.defaultHref(entityType);
+
+  const handleClick = useCallback(() => {
+    if (typeof window !== 'undefined' && window.mixpanel) {
+      window.mixpanel.track('cta_contextual_click', {
+        variant,
+        entityType,
+        entityName,
+      });
+    }
+  }, [variant, entityType, entityName]);
+
+  return (
+    <div className="my-8 text-center">
+      <Link
+        href={href}
+        onClick={handleClick}
+        data-testid="cta-contextual"
+        className="inline-block w-full rounded-xl bg-green-600 px-8 py-3 text-center font-bold text-white shadow-lg transition-colors hover:bg-green-700 sm:w-auto"
+      >
+        {text}
+      </Link>
+      {config.showSecondary && (
+        <p className="mt-2 text-sm text-gray-500">
+          Sem compromisso. Cancele quando quiser.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/conversion/ValuePropositionAboveFold.tsx
+++ b/frontend/app/components/conversion/ValuePropositionAboveFold.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * ValuePropositionAboveFold — CONV-001
+ *
+ * Hero-section component that sits above the fold on entity pages.
+ * Renders a gradient banner with a personalized headline based on entity type,
+ * value proposition text, and optional supporting detail line.
+ *
+ * Responsive: full-width on mobile, max-width centered on desktop.
+ */
+
+import React from 'react';
+
+export type EntityType =
+  | 'fornecedor'
+  | 'orgao'
+  | 'cnpj'
+  | 'setor'
+  | 'municipio'
+  | 'contrato';
+
+export interface ValuePropositionAboveFoldProps {
+  /** Page entity type */
+  entityType: EntityType;
+  /** Entity name to personalize the headline */
+  entityName: string;
+  /** Specific value proposition text */
+  valueProp: string;
+  /** Supporting detail line */
+  supportingDetail?: string;
+}
+
+const HEADLINES: Record<EntityType, string> = {
+  fornecedor: 'Quer vencer mais licitações como {name}?',
+  orgao: 'Quer vender para {name}?',
+  cnpj: 'Quer vencer mais licitações como {name}?',
+  setor: 'Oportunidades no setor — {name}',
+  municipio: 'Licitações em {name} — acompanhe em tempo real',
+  contrato: 'Análise completa do contrato — {name}',
+};
+
+function interpolateHeadline(entityType: EntityType, entityName: string): string {
+  const template = HEADLINES[entityType];
+  return template.replace('{name}', entityName);
+}
+
+export default function ValuePropositionAboveFold({
+  entityType,
+  entityName,
+  valueProp,
+  supportingDetail,
+}: ValuePropositionAboveFoldProps) {
+  const headline = interpolateHeadline(entityType, entityName);
+
+  return (
+    <section
+      aria-label="Proposta de valor"
+      className="bg-gradient-to-br from-blue-700 via-blue-600 to-indigo-700"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col items-center px-4 py-16 text-center text-white sm:px-6 sm:py-24">
+        <h1 className="text-4xl font-extrabold leading-tight tracking-tighter sm:text-5xl lg:text-6xl">
+          {headline}
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg text-blue-100 sm:text-xl">
+          {valueProp}
+        </p>
+        {supportingDetail && (
+          <p className="mt-3 max-w-xl text-sm text-blue-200 sm:text-base">
+            {supportingDetail}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/components/conversion/data-to-proposal.ts
+++ b/frontend/app/components/conversion/data-to-proposal.ts
@@ -1,0 +1,322 @@
+/**
+ * data-to-proposal.ts — CONV-010-2 (#1509)
+ *
+ * Maps entity data to proposal content based on entityType.
+ * Provides value proposition text, supporting details, and insight cards
+ * derived from the raw entity data object.
+ */
+
+import type { InsightIcon } from './AhaMomentPanel';
+
+export interface ProposalContent {
+  valueProp: string;
+  supportingDetail?: string;
+  insights: Array<{
+    label: string;
+    value: string;
+    subtext?: string;
+    icon?: InsightIcon;
+  }>;
+}
+
+/**
+ * Extract a string value from a nested object using an accessor path.
+ * Falls back to a default value if the path is not found.
+ */
+function extractValue(
+  data: Record<string, unknown>,
+  path: string,
+  defaultValue: string,
+): string {
+  const parts = path.split('.');
+  let current: unknown = data;
+  for (const part of parts) {
+    if (current === null || current === undefined) return defaultValue;
+    if (typeof current !== 'object') return defaultValue;
+    current = (current as Record<string, unknown>)[part];
+  }
+  if (current === null || current === undefined) return defaultValue;
+  return String(current);
+}
+
+/**
+ * Format a number to Brazilian locale.
+ */
+function formatNumber(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const num = Number(value);
+  if (Number.isNaN(num)) return String(value);
+  return num.toLocaleString('pt-BR');
+}
+
+/**
+ * Format a number as BRL currency.
+ */
+function formatCurrency(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const num = Number(value);
+  if (Number.isNaN(num)) return String(value);
+  return num.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    maximumFractionDigits: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mapping functions per entity type
+// ---------------------------------------------------------------------------
+
+function mapFornecedor(
+  entityName: string,
+  data: Record<string, unknown>,
+): ProposalContent {
+  const contratos = extractValue(data, 'total_contratos', '—');
+  const valorTotal = extractValue(data, 'valor_total', '—');
+  const ufs = extractValue(data, 'ufs_atuantes', '—');
+
+  return {
+    valueProp: `Quer vencer mais licitações como ${entityName}?`,
+    supportingDetail: `Análise concorrencial com precificação inteligente e alertas de novos editais no seu setor.`,
+    insights: [
+      {
+        label: 'Contratos Ganhos',
+        value: contratos,
+        icon: 'chart',
+        subtext: 'Total de contratos registrados',
+      },
+      {
+        label: 'Ticket Médio',
+        value: valorTotal,
+        icon: 'money',
+        subtext: 'Valor total contratado',
+      },
+      {
+        label: 'Atuação',
+        value: ufs,
+        icon: 'building',
+        subtext: 'Estados onde atua',
+      },
+    ],
+  };
+}
+
+function mapOrgao(
+  entityName: string,
+  data: Record<string, unknown>,
+): ProposalContent {
+  const editais = extractValue(data, 'total_licitacoes', '—');
+  const contratosAtivos = extractValue(data, 'contratos_ativos', '—');
+  const valorTotal = extractValue(data, 'valor_total_estimado', '—');
+
+  return {
+    valueProp: `Quer vender para ${entityName}?`,
+    supportingDetail: `Editais abertos, contratos anteriores e contatos diretos do órgão público.`,
+    insights: [
+      {
+        label: 'Editais Abertos',
+        value: editais,
+        icon: 'target',
+        subtext: 'Oportunidades em aberto',
+      },
+      {
+        label: 'Contratos Ativos',
+        value: contratosAtivos,
+        icon: 'chart',
+        subtext: 'Contratos vigentes',
+      },
+      {
+        label: 'Valor Total',
+        value: valorTotal,
+        icon: 'money',
+        subtext: 'Total contratado pelo órgão',
+      },
+    ],
+  };
+}
+
+function mapCnpj(
+  entityName: string,
+  data: Record<string, unknown>,
+): ProposalContent {
+  const participacoes = extractValue(data, 'participacoes', '—');
+  const contratos = extractValue(data, 'contratos_obtidos', '—');
+  const geografia = extractValue(data, 'presenca_geografica', '—');
+
+  return {
+    valueProp: `Dados completos do CNPJ ${entityName}`,
+    supportingDetail: `Histórico completo de participações em licitações e contratos obtidos.`,
+    insights: [
+      {
+        label: 'Participações',
+        value: participacoes,
+        icon: 'chart',
+        subtext: 'Em licitações públicas',
+      },
+      {
+        label: 'Contratos',
+        value: contratos,
+        icon: 'money',
+        subtext: 'Contratos obtidos',
+      },
+      {
+        label: 'Presença',
+        value: geografia,
+        icon: 'building',
+        subtext: 'Presença geográfica',
+      },
+    ],
+  };
+}
+
+function mapSetor(
+  entityName: string,
+  data: Record<string, unknown>,
+): ProposalContent {
+  const editais = extractValue(data, 'total_oportunidades', '—');
+  const orgaos = extractValue(data, 'principais_orgaos', '—');
+  const valorMedio = extractValue(data, 'valor_medio', '—');
+
+  return {
+    valueProp: `Atue em ${entityName} com inteligência`,
+    supportingDetail: `Oportunidades mapeadas, concorrentes identificados e preços de referência do setor.`,
+    insights: [
+      {
+        label: 'Editais no Setor',
+        value: editais,
+        icon: 'target',
+        subtext: 'Oportunidades disponíveis',
+      },
+      {
+        label: 'Principais Órgãos',
+        value: orgaos,
+        icon: 'building',
+        subtext: 'Compradores do setor',
+      },
+      {
+        label: 'Valor Médio',
+        value: valorMedio,
+        icon: 'money',
+        subtext: 'Ticket médio por edital',
+      },
+    ],
+  };
+}
+
+function mapMunicipio(
+  entityName: string,
+  data: Record<string, unknown>,
+): ProposalContent {
+  const editais = extractValue(data, 'total_editais', '—');
+  const setores = extractValue(data, 'setores_principais', '—');
+  const volume = extractValue(data, 'volume_contratacoes', '—');
+
+  return {
+    valueProp: `Licitações em ${entityName}`,
+    supportingDetail: `Editais municipais, principais setores e volume de contratações da prefeitura.`,
+    insights: [
+      {
+        label: 'Editais Municipais',
+        value: editais,
+        icon: 'target',
+        subtext: 'Oportunidades no município',
+      },
+      {
+        label: 'Setores',
+        value: setores,
+        icon: 'chart',
+        subtext: 'Principais setores',
+      },
+      {
+        label: 'Volume',
+        value: volume,
+        icon: 'money',
+        subtext: 'Volume de contratações',
+      },
+    ],
+  };
+}
+
+function mapContrato(
+  entityName: string,
+  data: Record<string, unknown>,
+): ProposalContent {
+  const renovacoes = extractValue(data, 'renovacoes_previstas', '—');
+  const concorrentes = extractValue(data, 'concorrentes_ativos', '—');
+  const valorSimilar = extractValue(data, 'valor_similar', '—');
+
+  return {
+    valueProp: `Contratos como este em ${entityName}`,
+    supportingDetail: `Renovações previstas, concorrentes ativos e contratos de valor similar.`,
+    insights: [
+      {
+        label: 'Renovações',
+        value: renovacoes,
+        icon: 'target',
+        subtext: 'Renovações previstas',
+      },
+      {
+        label: 'Concorrentes',
+        value: concorrentes,
+        icon: 'building',
+        subtext: 'Concorrentes ativos',
+      },
+      {
+        label: 'Valor Similar',
+        value: valorSimilar,
+        icon: 'money',
+        subtext: 'Contratos de valor similar',
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Map entity data to proposal content based on entityType.
+ *
+ * @param entityType - The type of entity page
+ * @param entityName - Display name of the entity
+ * @param entityData - Raw entity data object
+ * @returns ProposalContent with valueProp, supportingDetail, and insights
+ *
+ * @example
+ * const proposal = mapEntityToProposal('fornecedor', 'Empresa ABC', { total_contratos: 42 });
+ * // => { valueProp: 'Quer vencer mais licitações como Empresa ABC?', ... }
+ */
+export function mapEntityToProposal(
+  entityType: string,
+  entityName: string,
+  entityData: Record<string, unknown>,
+): ProposalContent {
+  switch (entityType) {
+    case 'fornecedor':
+      return mapFornecedor(entityName, entityData);
+    case 'orgao':
+      return mapOrgao(entityName, entityData);
+    case 'cnpj':
+      return mapCnpj(entityName, entityData);
+    case 'setor':
+      return mapSetor(entityName, entityData);
+    case 'municipio':
+      return mapMunicipio(entityName, entityData);
+    case 'contrato':
+      return mapContrato(entityName, entityData);
+    default:
+      // Fallback for unknown entity types
+      return {
+        valueProp: `Análise inteligente para ${entityName}`,
+        supportingDetail: 'Dados e insights para licitações públicas.',
+        insights: [
+          {
+            label: 'Oportunidades',
+            value: 'Consulte',
+            icon: 'target',
+          },
+        ],
+      };
+  }
+}


### PR DESCRIPTION
## Summary

Implements **AutonomousLandingShell** — a wrapper that converts entity pages into autonomous landing pages with 3 composable slots: headline (ValuePropositionAboveFold), insight-cards (AhaMomentPanel), and cta-block (CTAContextual). Also adds the **data-to-proposal** mapping utility for generating context-aware proposal content from entity data.

### Files created

| File | Description |
|------|-------------|
| `frontend/app/components/conversion/AutonomousLandingShell.tsx` | Shell with 3 slots, Mixpanel view event (`landing_autonomous_view`), responsive layout |
| `frontend/app/components/conversion/data-to-proposal.ts` | Maps entity data to proposal content for 6 types + fallback |
| `frontend/app/components/conversion/ValuePropositionAboveFold.tsx` | Hero banner with gradient, headline interpolation per entity type |
| `frontend/app/components/conversion/CTAContextual.tsx` | CTA button (trial/report/search) with Mixpanel click tracking |
| `frontend/app/components/conversion/AhaMomentPanel.tsx` | Insight grid with Framer Motion stagger animation |
| `frontend/__tests__/AutonomousLandingShell.test.tsx` | 8 tests: render, Mixpanel, entity variants, a11y |
| `frontend/__tests__/data-to-proposal.test.ts` | 8 tests: all 6 entity types + fallback |

### Verification
- TypeScript: clean (0 errors)
- Tests: 16/16 passing
- All components use `"use client"` directive
- Framer Motion properly mocked in tests

Closes #1509