### PR TITLE
feat(frontend): /obrigado thank-you page for digital product checkout (#1337)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,3 +446,4 @@ frontend/e2e-tests/billing/fixtures/*.secret.yaml
 # Squads aiox-* local downgrade sentinels (feat/squads-integration)
 squads/*/.disabled
 .reversa/
+node_modules_broken/

--- a/backend/routes/checkout.py
+++ b/backend/routes/checkout.py
@@ -32,6 +32,7 @@ from schemas.checkout import (
     ApiSubscriptionCheckoutResponse,
     CheckoutRequest,
     CheckoutResponse,
+    CheckoutSessionStatusResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -414,4 +415,95 @@ async def create_api_subscription_checkout(
     return ApiSubscriptionCheckoutResponse(
         checkout_url=session.url,
         session_id=session.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1337: Session status lookup for /obrigado thank-you page
+# ---------------------------------------------------------------------------
+
+
+@router.get("/session/{session_id}", response_model=CheckoutSessionStatusResponse)
+async def get_checkout_session_status(session_id: str):
+    """Return the status of a one-time digital product purchase.
+
+    The /obrigado thank-you page calls this endpoint after the user is
+    redirected back from Stripe Checkout.  The endpoint looks up the
+    purchase by ``stripe_checkout_session_id`` in the
+    ``intel_report_purchases`` table and resolves the product name from
+    ``digital_products`` when applicable.
+
+    No auth required — the session_id is a Stripe-generated unique
+    identifier known only to the user who initiated the checkout.
+    """
+    try:
+        sb = get_supabase()
+    except Exception as exc:
+        logger.warning("checkout: failed to get supabase client: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Erro temporario ao conectar com o banco de dados.",
+        ) from exc
+
+    # Lookup purchase by stripe_checkout_session_id
+    try:
+        result = await sb_execute(
+            sb.table("intel_report_purchases")
+            .select("*")
+            .eq("stripe_checkout_session_id", session_id)
+            .limit(1)
+        )
+    except Exception as exc:
+        logger.warning(
+            "checkout: purchase lookup failed for session=%s: %s",
+            session_id[:8] if session_id else "?",
+            exc,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Erro temporario ao consultar compra. Tente novamente.",
+        ) from exc
+
+    if not result.data:
+        raise HTTPException(
+            status_code=404,
+            detail="Compra nao encontrada para esta sessao.",
+        )
+
+    purchase = result.data[0]
+    status = purchase.get("status", "pending")
+    sku = purchase.get("entity_key")  # For digital_product rows, entity_key = product_sku
+    pdf_url = purchase.get("pdf_url")
+    created_at = purchase.get("created_at")
+
+    # Resolve product name from digital_products table (best-effort)
+    product_name: str | None = None
+    if sku:
+        try:
+            prod_result = await sb_execute(
+                sb.table("digital_products")
+                .select("name")
+                .eq("sku", sku)
+                .limit(1)
+            )
+            if prod_result.data:
+                product_name = prod_result.data[0].get("name")
+        except Exception:
+            logger.debug(
+                "checkout: product name lookup failed for sku=%s (non-blocking)", sku
+            )
+
+    logger.info(
+        "checkout: session status checked — session=%s status=%s sku=%s",
+        session_id[:8] if session_id else "?",
+        status,
+        sku,
+    )
+
+    return CheckoutSessionStatusResponse(
+        status=status,
+        product_name=product_name,
+        sku=sku,
+        pdf_url=pdf_url,
+        created_at=created_at,
     )

--- a/backend/routes/checkout.py
+++ b/backend/routes/checkout.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException
 
 from auth import require_auth
+from log_sanitizer import sanitize
 from rate_limiter import require_rate_limit
 from supabase_client import get_supabase, sb_execute
 
@@ -456,7 +457,7 @@ async def get_checkout_session_status(session_id: str):
     except Exception as exc:
         logger.warning(
             "checkout: purchase lookup failed for session=%s: %s",
-            session_id[:8] if session_id else "?",
+            sanitize(session_id, context="stripe_session"),
             exc,
         )
         raise HTTPException(
@@ -471,7 +472,7 @@ async def get_checkout_session_status(session_id: str):
         )
 
     purchase = result.data[0]
-    status = purchase.get("status", "pending")
+    status = purchase.get("status") or "pending"
     sku = purchase.get("entity_key")  # For digital_product rows, entity_key = product_sku
     pdf_url = purchase.get("pdf_url")
     created_at = purchase.get("created_at")
@@ -495,7 +496,7 @@ async def get_checkout_session_status(session_id: str):
 
     logger.info(
         "checkout: session status checked — session=%s status=%s sku=%s",
-        session_id[:8] if session_id else "?",
+        sanitize(session_id, context="stripe_session"),
         status,
         sku,
     )

--- a/backend/schemas/checkout.py
+++ b/backend/schemas/checkout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -31,3 +31,17 @@ class ApiSubscriptionCheckoutResponse(BaseModel):
 
     checkout_url: str
     session_id: str
+
+
+class CheckoutSessionStatusResponse(BaseModel):
+    """Response for GET /api/checkout/session/{session_id}.
+
+    Returns the status of a one-time digital product purchase after
+    the user is redirected back from Stripe to the /obrigado page.
+    """
+
+    status: str  # "pending" | "generating" | "ready" | "failed" | "completed"
+    product_name: Optional[str] = None
+    sku: Optional[str] = None
+    pdf_url: Optional[str] = None
+    created_at: Optional[str] = None

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -3293,6 +3293,64 @@
         "title": "CheckoutResponse",
         "type": "object"
       },
+      "CheckoutSessionStatusResponse": {
+        "description": "Response for GET /api/checkout/session/{session_id}.\n\nReturns the status of a one-time digital product purchase after\nthe user is redirected back from Stripe to the /obrigado page.",
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "pdf_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pdf Url"
+          },
+          "product_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Product Name"
+          },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "CheckoutSessionStatusResponse",
+        "type": "object"
+      },
       "CidadeSectorStats": {
         "properties": {
           "avg_value": {
@@ -18055,6 +18113,49 @@
           }
         ],
         "summary": "Create One Time Checkout",
+        "tags": [
+          "checkout"
+        ]
+      }
+    },
+    "/api/checkout/session/{session_id}": {
+      "get": {
+        "description": "Return the status of a one-time digital product purchase.\n\nThe /obrigado thank-you page calls this endpoint after the user is\nredirected back from Stripe Checkout.  The endpoint looks up the\npurchase by ``stripe_checkout_session_id`` in the\n``intel_report_purchases`` table and resolves the product name from\n``digital_products`` when applicable.\n\nNo auth required \u2014 the session_id is a Stripe-generated unique\nidentifier known only to the user who initiated the checkout.",
+        "operationId": "get_checkout_session_status_api_checkout_session__session_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckoutSessionStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Checkout Session Status",
         "tags": [
           "checkout"
         ]

--- a/backend/tests/test_checkout.py
+++ b/backend/tests/test_checkout.py
@@ -400,3 +400,125 @@ class TestRateLimit:
                 json={"sku": "relatorio-oportunidade"},
             )
             assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# #1337: GET /api/checkout/session/{session_id}
+# ---------------------------------------------------------------------------
+
+
+class TestCheckoutSessionStatus:
+    """GET /api/checkout/session/{session_id} behavior."""
+
+    MOCK_PURCHASE = {
+        "id": "purchase-abc-123",
+        "user_id": "user-abc-123",
+        "product_type": "digital_product",
+        "entity_key": "relatorio-oportunidade",
+        "status": "completed",
+        "stripe_checkout_session_id": "cs_test_session123",
+        "pdf_url": None,
+        "created_at": "2026-06-07T00:00:00Z",
+    }
+
+    MOCK_PURCHASE_READY = {
+        **MOCK_PURCHASE,
+        "status": "ready",
+        "pdf_url": "https://storage.example.com/report.pdf",
+    }
+
+    MOCK_PRODUCT_NAME = {"name": "Relatorio de Oportunidade Setorial"}
+
+    @pytest.fixture
+    def client(self):
+        """TestClient with app that overrides rate limit but not auth."""
+        from routes.checkout import router as checkout_router
+
+        app = FastAPI()
+        app.dependency_overrides[checkout_rate_limit] = lambda: None
+        app.include_router(checkout_router)
+        return TestClient(app)
+
+    def _mock_supabase_purchase(
+        self, mock_get_supabase, purchases: list[dict], product_names: list[dict] | None = None
+    ) -> None:
+        """Configure supabase mock for purchase + optional product name lookups."""
+        mock_sb = MagicMock()
+        mock_query = MagicMock()
+        mock_sb.table.return_value = mock_query
+        mock_query.select.return_value = mock_query
+        mock_query.eq.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+
+        # First eq call filters by stripe_checkout_session_id (purchase lookup),
+        # second eq call filters by sku (product name lookup).
+        # We use side_effect to return different data based on table name.
+        original_table = mock_sb.table
+
+        def table_side_effect(table_name: str):
+            if table_name == "intel_report_purchases":
+                return mock_query
+            elif table_name == "digital_products" and product_names is not None:
+                prod_query = MagicMock()
+                prod_query.select.return_value = prod_query
+                prod_query.eq.return_value = prod_query
+                prod_query.limit.return_value = prod_query
+                prod_query.execute.return_value = MagicMock(data=product_names)
+                return prod_query
+            return mock_query
+
+        mock_sb.table.side_effect = table_side_effect
+        mock_query.execute.return_value = MagicMock(data=purchases)
+        mock_get_supabase.return_value = mock_sb
+
+    @patch("routes.checkout.get_supabase")
+    def test_valid_session_returns_status(self, mock_get_supabase, client):
+        """Valid session_id should return 200 with purchase status."""
+        self._mock_supabase_purchase(mock_get_supabase, [self.MOCK_PURCHASE], [self.MOCK_PRODUCT_NAME])
+
+        resp = client.get("/api/checkout/session/cs_test_session123")
+
+        assert resp.status_code == 200, resp.json()
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert data["product_name"] == "Relatorio de Oportunidade Setorial"
+        assert data["sku"] == "relatorio-oportunidade"
+        assert data["pdf_url"] is None
+
+    @patch("routes.checkout.get_supabase")
+    def test_ready_purchase_includes_pdf_url(self, mock_get_supabase, client):
+        """Ready purchase should include pdf_url in response."""
+        self._mock_supabase_purchase(mock_get_supabase, [self.MOCK_PURCHASE_READY], [self.MOCK_PRODUCT_NAME])
+
+        resp = client.get("/api/checkout/session/cs_test_session123")
+
+        assert resp.status_code == 200, resp.json()
+        data = resp.json()
+        assert data["status"] == "ready"
+        assert data["pdf_url"] == "https://storage.example.com/report.pdf"
+
+    @patch("routes.checkout.get_supabase")
+    def test_invalid_session_returns_404(self, mock_get_supabase, client):
+        """Non-existent session_id should return 404."""
+        self._mock_supabase_purchase(mock_get_supabase, [])
+
+        resp = client.get("/api/checkout/session/cs_test_invalid")
+
+        assert resp.status_code == 404
+        assert "nao encontrada" in resp.json()["detail"].lower()
+
+    @patch("routes.checkout.get_supabase")
+    def test_supabase_error_returns_503(self, mock_get_supabase, client):
+        """Transient Supabase error should return 503."""
+        mock_sb = MagicMock()
+        mock_query = MagicMock()
+        mock_sb.table.return_value = mock_query
+        mock_query.select.return_value = mock_query
+        mock_query.eq.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.execute.side_effect = Exception("Connection refused")
+        mock_get_supabase.return_value = mock_sb
+
+        resp = client.get("/api/checkout/session/cs_test_session123")
+
+        assert resp.status_code == 503

--- a/frontend/__tests__/obrigado/ObrigadoClient.test.tsx
+++ b/frontend/__tests__/obrigado/ObrigadoClient.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * Tests for ObrigadoClient component (#1337).
+ *
+ * Covers:
+ * - Loading state (initial render, no session_id)
+ * - Session status fetch (success)
+ * - Product name display
+ * - Error state (network failure)
+ * - Not found state (404)
+ * - Processing state
+ * - Ready/completed state
+ * - Navigation links
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import ObrigadoClient from "../../app/obrigado/ObrigadoClient";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseSearchParams = jest.fn();
+const mockUseRouter = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockUseSearchParams(),
+  useRouter: () => mockUseRouter(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const mockFetch = jest.fn();
+const mockMixpanelTrack = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  globalThis.fetch = mockFetch;
+  (window as any).mixpanel = { track: mockMixpanelTrack };
+});
+
+afterEach(() => {
+  (window as any).mixpanel = undefined;
+});
+
+function mockSearchParams(params: Record<string, string>) {
+  const urlSearchParams = new URLSearchParams(params);
+  mockUseSearchParams.mockReturnValue(urlSearchParams);
+}
+
+function mockFetchResponse(
+  status: number,
+  data: Record<string, unknown> | null,
+) {
+  mockFetch.mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ObrigadoClient", () => {
+  describe("Loading state", () => {
+    it('shows "Verificando pagamento..." on initial render', () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+      mockSearchParams({ session_id: "cs_test_abc123" });
+
+      render(<ObrigadoClient />);
+
+      expect(screen.getByText("Verificando pagamento...")).toBeInTheDocument();
+    });
+
+    it("shows not-found state when session_id is missing", () => {
+      mockSearchParams({});
+
+      render(<ObrigadoClient />);
+
+      expect(
+        screen.getByText("Nenhuma sessão de pagamento encontrada."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Session fetch", () => {
+    it("fetches session status on mount", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "completed",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/checkout/session/cs_test_abc123",
+        );
+      });
+    });
+
+    it("displays product name when available", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "completed",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Relatório de Licitações"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows "Pagamento confirmado!" on success', async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "completed",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText("Pagamento confirmado!").length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it("handles 404 gracefully", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(404, null);
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/pode levar alguns instantes/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("handles network error gracefully", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Não foi possível verificar o status/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows processing message for generating status", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "generating",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Seu relatório está sendo gerado."),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows ready message for ready status", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "ready",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: "https://storage.example.com/report.pdf",
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Seu relatório está pronto para download!"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows download link when pdf_url is available", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "ready",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: "https://storage.example.com/report.pdf",
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Baixar relatório")).toBeInTheDocument();
+      });
+    });
+
+    it("handles failed status gracefully", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "failed",
+        sku: "relatorio-licitacoes",
+        product_name: "Relatório de Licitações",
+        pdf_url: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/ocorreu um erro ao gerar o relatório/i),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Navigation links", () => {
+    it('renders "Ir para busca" link', async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "completed",
+        product_name: null,
+        sku: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Ir para busca")).toBeInTheDocument();
+      });
+    });
+
+    it('renders "Ver minhas compras" link', async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "completed",
+        product_name: null,
+        sku: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Ver minhas compras")).toBeInTheDocument();
+      });
+    });
+
+    it("renders support email link", async () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+      mockFetchResponse(200, {
+        status: "completed",
+        product_name: null,
+        sku: null,
+      });
+
+      render(<ObrigadoClient />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("tiago@confenge.com.br"),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Tracking events", () => {
+    it("tracks page view on mount", () => {
+      mockSearchParams({ session_id: "cs_test_abc123" });
+
+      render(<ObrigadoClient />);
+
+      expect(mockMixpanelTrack).toHaveBeenCalledWith(
+        "obrigado_page_viewed",
+        expect.objectContaining({ session_id: "cs_test_abc123" }),
+      );
+    });
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -80,6 +80,35 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/checkout/session/{session_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Checkout Session Status
+         * @description Return the status of a one-time digital product purchase.
+         *
+         *     The /obrigado thank-you page calls this endpoint after the user is
+         *     redirected back from Stripe Checkout.  The endpoint looks up the
+         *     purchase by ``stripe_checkout_session_id`` in the
+         *     ``intel_report_purchases`` table and resolves the product name from
+         *     ``digital_products`` when applicable.
+         *
+         *     No auth required — the session_id is a Stripe-generated unique
+         *     identifier known only to the user who initiated the checkout.
+         */
+        get: operations["get_checkout_session_status_api_checkout_session__session_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/email/click/{tracking_id}": {
         parameters: {
             query?: never;
@@ -7754,6 +7783,25 @@ export interface components {
             /** Checkout Url */
             checkout_url: string;
         };
+        /**
+         * CheckoutSessionStatusResponse
+         * @description Response for GET /api/checkout/session/{session_id}.
+         *
+         *     Returns the status of a one-time digital product purchase after
+         *     the user is redirected back from Stripe to the /obrigado page.
+         */
+        CheckoutSessionStatusResponse: {
+            /** Created At */
+            created_at?: string | null;
+            /** Pdf Url */
+            pdf_url?: string | null;
+            /** Product Name */
+            product_name?: string | null;
+            /** Sku */
+            sku?: string | null;
+            /** Status */
+            status: string;
+        };
         /** CidadeSectorStats */
         CidadeSectorStats: {
             /** Avg Value */
@@ -14368,6 +14416,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CheckoutResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_checkout_session_status_api_checkout_session__session_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckoutSessionStatusResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/app/obrigado/ObrigadoClient.tsx
+++ b/frontend/app/obrigado/ObrigadoClient.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { CheckCircle, Loader2, AlertCircle, PartyPopper } from "lucide-react";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type FetchState = "loading" | "success" | "not_found" | "error";
+
+interface SessionStatus {
+  status: string; // "pending" | "generating" | "ready" | "failed" | "completed"
+  product_name?: string | null;
+  sku?: string | null;
+  pdf_url?: string | null;
+  created_at?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  const mp = (
+    window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }
+  ).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // best-effort
+  }
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "pending":
+    case "generating":
+      return "Seu relatório está sendo gerado.";
+    case "ready":
+      return "Seu relatório está pronto para download!";
+    case "completed":
+      return "Pagamento confirmado! Seu produto está disponível.";
+    case "failed":
+      return "Ocorreu um erro no processamento. Entre em contato com o suporte.";
+    default:
+      return "Pagamento confirmado!";
+  }
+}
+
+function statusIcon(status: string): React.ReactNode {
+  switch (status) {
+    case "pending":
+    case "generating":
+      return <Loader2 className="w-8 h-8 text-[var(--brand-blue)] animate-spin" />;
+    case "ready":
+    case "completed":
+      return <CheckCircle className="w-8 h-8 text-[var(--success)]" />;
+    case "failed":
+      return <AlertCircle className="w-8 h-8 text-red-500" />;
+    default:
+      return <CheckCircle className="w-8 h-8 text-[var(--success)]" />;
+  }
+}
+
+function statusBgClass(status: string): string {
+  switch (status) {
+    case "pending":
+    case "generating":
+      return "bg-blue-50";
+    case "ready":
+    case "completed":
+      return "bg-emerald-50";
+    case "failed":
+      return "bg-red-50";
+    default:
+      return "bg-emerald-50";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function ObrigadoClient() {
+  const searchParams = useSearchParams();
+  const [sessionStatus, setSessionStatus] = useState<SessionStatus | null>(null);
+  const [fetchState, setFetchState] = useState<FetchState>("loading");
+  const [statusMessage, setStatusMessage] = useState("");
+
+  const sessionId = searchParams.get("session_id");
+
+  // Track page view
+  useEffect(() => {
+    trackEvent("obrigado_page_viewed", { session_id: sessionId });
+  }, [sessionId]);
+
+  // Fetch session status
+  useEffect(() => {
+    if (!sessionId) {
+      setFetchState("not_found");
+      setStatusMessage("Nenhuma sessão de pagamento encontrada.");
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch(`/api/checkout/session/${encodeURIComponent(sessionId)}`);
+
+        if (!res.ok) {
+          if (res.status === 404) {
+            if (!cancelled) {
+              setFetchState("not_found");
+              setStatusMessage("Compra não encontrada. Pode levar alguns instantes para o pagamento ser processado.");
+            }
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        const data: SessionStatus = await res.json();
+
+        if (cancelled) return;
+
+        setSessionStatus(data);
+        setFetchState("success");
+        setStatusMessage(statusLabel(data.status));
+
+        // Track success
+        trackEvent("obrigado_session_loaded", {
+          session_id: sessionId,
+          status: data.status,
+          sku: data.sku,
+        });
+
+        // Show toast on success states
+        if (data.status === "ready" || data.status === "completed") {
+          toast.success("Pagamento confirmado com sucesso!", {
+            duration: 5000,
+            icon: <PartyPopper className="w-5 h-5" />,
+          });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setFetchState("error");
+          setStatusMessage(
+            "Não foi possível verificar o status da compra. Tente novamente em instantes."
+          );
+        }
+      }
+    };
+
+    fetchStatus();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const isProcessing =
+    sessionStatus?.status === "pending" || sessionStatus?.status === "generating";
+  const isReady =
+    sessionStatus?.status === "ready" || sessionStatus?.status === "completed";
+  const isFailed = sessionStatus?.status === "failed";
+
+  return (
+    <div className="min-h-screen bg-[var(--canvas)] flex items-center justify-center px-4">
+      <div className="max-w-lg w-full text-center">
+        <div className="bg-[var(--surface-0)] border border-[var(--border)] rounded-card p-8 shadow-lg">
+          {/* Status Icon */}
+          <div
+            className={`w-16 h-16 mx-auto mb-6 rounded-full flex items-center justify-center ${statusBgClass(sessionStatus?.status || "completed")}`}
+          >
+            {fetchState === "loading" ? (
+              <Loader2 className="w-8 h-8 text-[var(--brand-blue)] animate-spin" />
+            ) : (
+              statusIcon(sessionStatus?.status || "completed")
+            )}
+          </div>
+
+          {/* Title */}
+          {fetchState === "loading" ? (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Verificando pagamento...
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-4">
+                Estamos confirmando sua compra. Isso leva apenas alguns segundos.
+              </p>
+              <div className="flex items-center justify-center gap-2 text-sm text-[var(--ink-muted)]">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Verificando...
+              </div>
+            </>
+          ) : fetchState === "not_found" ? (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Pagamento em processamento
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-4">{statusMessage}</p>
+              <div className="p-4 bg-[var(--surface-1)] rounded-input text-left mb-4">
+                <p className="text-sm text-[var(--ink-secondary)]">
+                  Se você pagou com boleto ou PIX, a confirmação pode levar alguns minutos.
+                  Você receberá um email assim que a compra for confirmada.
+                </p>
+              </div>
+            </>
+          ) : fetchState === "error" ? (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Algo deu errado
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-4">{statusMessage}</p>
+              <div className="p-4 bg-[var(--surface-1)] rounded-input text-left mb-4">
+                <p className="text-sm text-[var(--ink-secondary)]">
+                  Seu pagamento foi processado pelo Stripe. Se o problema persistir,
+                  entre em contato pelo email{" "}
+                  <a
+                    href="mailto:tiago@confenge.com.br"
+                    className="text-[var(--brand-blue)] underline"
+                  >
+                    tiago@confenge.com.br
+                  </a>
+                  .
+                </p>
+              </div>
+            </>
+          ) : isProcessing ? (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Pagamento confirmado!
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-2">{statusMessage}</p>
+              <p className="text-sm text-[var(--ink-muted)] mb-4">
+                Você receberá um email assim que o relatório estiver pronto.
+              </p>
+              {sessionStatus?.sku && (
+                <div className="p-3 bg-[var(--surface-1)] rounded-input mb-4">
+                  <p className="text-sm font-medium text-[var(--ink)]">
+                    {sessionStatus.product_name || sessionStatus.sku}
+                  </p>
+                  <p className="text-xs text-[var(--ink-muted)] mt-1">
+                    Em processamento...
+                  </p>
+                </div>
+              )}
+            </>
+          ) : isReady ? (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Pagamento confirmado!
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-4">{statusMessage}</p>
+
+              {sessionStatus?.sku && (
+                <div className="p-3 bg-emerald-50 border border-emerald-200 rounded-input mb-4">
+                  <p className="text-sm font-medium text-emerald-800">
+                    {sessionStatus.product_name || sessionStatus.sku}
+                  </p>
+                  {sessionStatus.pdf_url ? (
+                    <a
+                      href={sessionStatus.pdf_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-block text-sm font-medium text-[var(--brand-blue)] underline hover:text-[var(--brand-blue-hover)]"
+                    >
+                      Baixar relatório
+                    </a>
+                  ) : (
+                    <p className="text-xs text-emerald-600 mt-1">
+                      Disponível para download
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {!sessionStatus?.sku && (
+                <p className="text-lg text-[var(--ink-secondary)] mb-4">
+                  Obrigado pela confiança!
+                </p>
+              )}
+            </>
+          ) : isFailed ? (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Erro no processamento
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-4">{statusMessage}</p>
+              <div className="p-4 bg-[var(--surface-1)] rounded-input text-left mb-4">
+                <p className="text-sm text-[var(--ink-secondary)]">
+                  Seu pagamento foi processado, mas ocorreu um erro ao gerar o relatório.
+                  Entre em contato pelo email{" "}
+                  <a
+                    href="mailto:tiago@confenge.com.br"
+                    className="text-[var(--brand-blue)] underline"
+                  >
+                    tiago@confenge.com.br
+                  </a>{" "}
+                  para resolvermos o problema.
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <h1 className="text-2xl font-display font-bold text-[var(--ink)] mb-2">
+                Pagamento confirmado!
+              </h1>
+              <p className="text-[var(--ink-secondary)] mb-4">
+                Obrigado pela confiança!
+              </p>
+            </>
+          )}
+
+          {/* Action buttons */}
+          <div className="space-y-3 mt-6">
+            <Link
+              href="/buscar"
+              className="block w-full py-3 bg-[var(--brand-navy)] text-white rounded-button font-semibold hover:bg-[var(--brand-blue)] transition-colors"
+            >
+              Ir para busca
+            </Link>
+            <Link
+              href="/conta"
+              className="block w-full py-3 border border-[var(--border)] text-[var(--ink)] rounded-button font-semibold hover:bg-[var(--surface-1)] transition-colors"
+            >
+              Ver minhas compras
+            </Link>
+          </div>
+
+          {/* Support footer */}
+          <p className="mt-6 text-xs text-[var(--ink-muted)]">
+            Dúvidas? Escreva para{" "}
+            <a
+              href="mailto:tiago@confenge.com.br"
+              className="text-[var(--brand-blue)] underline"
+            >
+              tiago@confenge.com.br
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/obrigado/ObrigadoClient.tsx
+++ b/frontend/app/obrigado/ObrigadoClient.tsx
@@ -5,20 +5,14 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { CheckCircle, Loader2, AlertCircle, PartyPopper } from "lucide-react";
 import { toast } from "sonner";
+import type { components } from "../api-types.generated";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 type FetchState = "loading" | "success" | "not_found" | "error";
-
-interface SessionStatus {
-  status: string; // "pending" | "generating" | "ready" | "failed" | "completed"
-  product_name?: string | null;
-  sku?: string | null;
-  pdf_url?: string | null;
-  created_at?: string | null;
-}
+type SessionStatus = components["schemas"]["CheckoutSessionStatusResponse"];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -170,18 +164,29 @@ export default function ObrigadoClient() {
     sessionStatus?.status === "ready" || sessionStatus?.status === "completed";
   const isFailed = sessionStatus?.status === "failed";
 
+  // Derive visual status from fetchState to avoid showing green success
+  // when sessionStatus is null in error/not_found states (CodeRabbit fix).
+  const visualStatus: string =
+    fetchState === "loading"
+      ? "loading"
+      : fetchState === "not_found"
+        ? "pending"
+        : fetchState === "error"
+          ? "failed"
+          : sessionStatus?.status ?? "completed";
+
   return (
     <div className="min-h-screen bg-[var(--canvas)] flex items-center justify-center px-4">
       <div className="max-w-lg w-full text-center">
         <div className="bg-[var(--surface-0)] border border-[var(--border)] rounded-card p-8 shadow-lg">
           {/* Status Icon */}
           <div
-            className={`w-16 h-16 mx-auto mb-6 rounded-full flex items-center justify-center ${statusBgClass(sessionStatus?.status || "completed")}`}
+            className={`w-16 h-16 mx-auto mb-6 rounded-full flex items-center justify-center ${statusBgClass(visualStatus)}`}
           >
             {fetchState === "loading" ? (
               <Loader2 className="w-8 h-8 text-[var(--brand-blue)] animate-spin" />
             ) : (
-              statusIcon(sessionStatus?.status || "completed")
+              statusIcon(visualStatus)
             )}
           </div>
 

--- a/frontend/app/obrigado/page.tsx
+++ b/frontend/app/obrigado/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from "react";
+import { Metadata } from "next";
+import ObrigadoClient from "./ObrigadoClient";
+
+/**
+ * Thank-you page after a successful one-time digital product checkout.
+ *
+ * Server Component shell: exports metadata and wraps the dynamic content
+ * in Suspense (required because ObrigadoClient reads useSearchParams).
+ * The actual session status polling and UI are handled by ObrigadoClient ("use client").
+ */
+export const metadata: Metadata = {
+  title: "Pagamento Confirmado",
+  description: "Seu pagamento foi confirmado com sucesso.",
+  robots: { index: false, follow: false },
+};
+
+export default function ObrigadoPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-[var(--canvas)] flex items-center justify-center">
+        <div className="animate-pulse text-[var(--ink-muted)]">Carregando...</div>
+      </div>
+    }>
+      <ObrigadoClient />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary

Creates thank-you/confirmation page at /obrigado for digital product purchases.

### Changes
- New /obrigado page with session status check
- Client component with loading, success, and error states
- Backend GET /api/checkout/session/{session_id} endpoint
- Backend tests for the new endpoint
- Frontend tests for the client component
- Matches existing design patterns from /planos/obrigado

### Testing
- [x] Backend tests pass (14/14)
- [ ] Frontend tests (WSL2 environment limitation - verified TypeScript compilation)
- [x] TypeScript strict (no errors for new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a thank-you page and client that polls checkout session status, shows processing/ready/completed/failed states, displays product name and a downloadable PDF when available, triggers success toasts, and includes navigation/support links and page tracking.
* **API**
  * Added a public endpoint to fetch one-time checkout session status.
* **Tests**
  * Added comprehensive tests covering session status responses and thank-you page UI states.
* **Chores**
  * Updated .gitignore to ignore an additional directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->