### PR TITLE
feat(frontend): 4 intent cluster landing pages with shared layout (#1316)

### DIFF
--- a/frontend/__tests__/intencao/IntentLandingLayout.test.tsx
+++ b/frontend/__tests__/intencao/IntentLandingLayout.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for IntentLandingLayout — CONV-007-2 / #1316
+ *
+ * Covers:
+ * - Renders children
+ * - Renders main element
+ * - Renders LandingNavbar
+ * - Renders Footer
+ */
+// Mock AuthProvider before any imports (required by LandingNavbar -> NavbarAuthCTA)
+jest.mock('../../app/components/AuthProvider', () => {
+  const React = require('react');
+  return {
+    useAuth: () => ({ user: null, session: null, loading: false }),
+    AuthProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import IntentLandingLayout from '../../app/intencao/IntentLandingLayout';
+
+describe('IntentLandingLayout', () => {
+  it('renders children content', () => {
+    render(
+      <IntentLandingLayout>
+        <p data-testid="child-content">Test content</p>
+      </IntentLandingLayout>,
+    );
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('renders main semantic element', () => {
+    const { container } = render(
+      <IntentLandingLayout>
+        <p>Content</p>
+      </IntentLandingLayout>,
+    );
+    const main = container.querySelector('main#main-content');
+    expect(main).not.toBeNull();
+  });
+
+  it('renders the Logo link in the navbar', () => {
+    render(
+      <IntentLandingLayout>
+        <p>Content</p>
+      </IntentLandingLayout>,
+    );
+    const logoLink = screen.getByRole('link', { name: /smartlic/i });
+    expect(logoLink).toBeInTheDocument();
+    expect(logoLink).toHaveAttribute('href', '/');
+  });
+
+  it('renders the Footer with site-footer id', () => {
+    const { container } = render(
+      <IntentLandingLayout>
+        <p>Content</p>
+      </IntentLandingLayout>,
+    );
+    const footer = container.querySelector('#site-footer');
+    expect(footer).not.toBeNull();
+  });
+
+  it('renders Hero and Como funciona when used with a page', () => {
+    render(
+      <IntentLandingLayout>
+        <p>Page content</p>
+      </IntentLandingLayout>,
+    );
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/intencao/intent-pages.test.tsx
+++ b/frontend/__tests__/intencao/intent-pages.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Tests for 4 intent cluster landing pages — CONV-007-2 / #1316, #1401
+ *
+ * Covers:
+ * - Each page renders its specific headline
+ * - Each page renders primary and secondary CTAs
+ * - Each page renders step titles and descriptions
+ * - Mobile responsiveness (CSS classes)
+ * - JSON-LD structured data presence
+ */
+// Mock AuthProvider before any imports (required by LandingNavbar -> NavbarAuthCTA)
+jest.mock('../../app/components/AuthProvider', () => {
+  const React = require('react');
+  return {
+    useAuth: () => ({ user: null, session: null, loading: false }),
+    AuthProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ComercialPage from '../../app/intencao/comercial/page';
+import InvestigativaPage from '../../app/intencao/investigativa/page';
+import JuridicaPage from '../../app/intencao/juridica/page';
+import SubcontratacaoPage from '../../app/intencao/subcontratacao/page';
+
+describe('ComercialPage', () => {
+  it('renders the headline', () => {
+    render(<ComercialPage />);
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /venda para o governo com inteligência/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders primary CTA in both hero and final section', () => {
+    render(<ComercialPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /relatório de fornecedor.*r\$67/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/checkout?sku=relatorio-fornecedor');
+    });
+  });
+
+  it('renders secondary CTA', () => {
+    render(<ComercialPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /monitoramento de editais/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/signup?source=intent-comercial');
+    });
+  });
+
+  it('renders 3 step titles with data points', () => {
+    render(<ComercialPage />);
+    expect(
+      screen.getByText('2 milhões de contratos monitorados'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('27 estados com cobertura nacional'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('15+ setores classificados por IA'),
+    ).toBeInTheDocument();
+  });
+
+  it('includes JSON-LD structured data', () => {
+    render(<ComercialPage />);
+    const scripts = document.querySelectorAll(
+      'script[type="application/ld+json"]',
+    );
+    expect(scripts.length).toBeGreaterThan(0);
+  });
+});
+
+describe('InvestigativaPage', () => {
+  it('renders the headline', () => {
+    render(<InvestigativaPage />);
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /pesquise licitações com profundidade/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders primary CTA', () => {
+    render(<InvestigativaPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /mapa de oportunidades.*r\$47/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/checkout?sku=mapa-oportunidades');
+    });
+  });
+
+  it('renders secondary CTA', () => {
+    render(<InvestigativaPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /relatório setorial/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/checkout?sku=relatorio-setorial');
+    });
+  });
+
+  it('renders 3 step titles with data points', () => {
+    render(<InvestigativaPage />);
+    expect(
+      screen.getByText('50 mil+ órgãos públicos mapeados'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('R$ 1 bilhão+ em contratos analisados'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Relatórios setoriais completos'),
+    ).toBeInTheDocument();
+  });
+
+  it('includes JSON-LD structured data', () => {
+    render(<InvestigativaPage />);
+    const scripts = document.querySelectorAll(
+      'script[type="application/ld+json"]',
+    );
+    expect(scripts.length).toBeGreaterThan(0);
+  });
+});
+
+describe('JuridicaPage', () => {
+  it('renders the headline', () => {
+    render(<JuridicaPage />);
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /fundamentação jurídica para licitações/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders primary CTA (lead capture)', () => {
+    render(<JuridicaPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /diagnóstico gratuito/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/signup?source=intent-juridica');
+    });
+  });
+
+  it('renders secondary CTA (consultoria)', () => {
+    render(<JuridicaPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /falar com consultoria/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/contato');
+    });
+  });
+
+  it('renders 3 step titles with data points', () => {
+    render(<JuridicaPage />);
+    expect(
+      screen.getByText('100% da legislação federal disponível'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Editais completos com análise jurídica'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Diagnóstico personalizado gratuito'),
+    ).toBeInTheDocument();
+  });
+
+  it('includes JSON-LD structured data', () => {
+    render(<JuridicaPage />);
+    const scripts = document.querySelectorAll(
+      'script[type="application/ld+json"]',
+    );
+    expect(scripts.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SubcontratacaoPage', () => {
+  it('renders the headline', () => {
+    render(<SubcontratacaoPage />);
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /encontre parceiros de licitação/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders primary CTA', () => {
+    render(<SubcontratacaoPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /matching.*relatório.*r\$97/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute(
+        'href',
+        '/checkout?sku=relatorio-subcontratacao',
+      );
+    });
+  });
+
+  it('renders secondary CTA', () => {
+    render(<SubcontratacaoPage />);
+    const ctas = screen.getAllByRole('link', {
+      name: /ver editais recentes/i,
+    });
+    expect(ctas.length).toBe(2);
+    ctas.forEach((cta) => {
+      expect(cta).toHaveAttribute('href', '/licitacoes');
+    });
+  });
+
+  it('renders 3 step titles with data points', () => {
+    render(<SubcontratacaoPage />);
+    expect(
+      screen.getByText('5 mil+ empresas parceiras cadastradas'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('27 estados com oportunidades'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Match inteligente com vencedores'),
+    ).toBeInTheDocument();
+  });
+
+  it('includes JSON-LD structured data', () => {
+    render(<SubcontratacaoPage />);
+    const scripts = document.querySelectorAll(
+      'script[type="application/ld+json"]',
+    );
+    expect(scripts.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Shared layout patterns', () => {
+  it.each([
+    ['Comercial', ComercialPage],
+    ['Investigativa', InvestigativaPage],
+    ['Juridica', JuridicaPage],
+    ['Subcontratacao', SubcontratacaoPage],
+  ])('%s page has responsive hero layout', (_name, PageComponent) => {
+    const { container } = render(<PageComponent />);
+    const ctaContainers = container.querySelectorAll('.flex.flex-col');
+    expect(ctaContainers.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['Comercial', ComercialPage],
+    ['Investigativa', InvestigativaPage],
+    ['Juridica', JuridicaPage],
+    ['Subcontratacao', SubcontratacaoPage],
+  ])('%s page uses semantic main element', (_name, PageComponent) => {
+    const { container } = render(<PageComponent />);
+    const main = container.querySelector('main');
+    expect(main).not.toBeNull();
+  });
+
+  it.each([
+    ['Comercial', ComercialPage],
+    ['Investigativa', InvestigativaPage],
+    ['Juridica', JuridicaPage],
+    ['Subcontratacao', SubcontratacaoPage],
+  ])('%s page renders "Como funciona" section', (_name, PageComponent) => {
+    render(<PageComponent />);
+    expect(
+      screen.getByRole('heading', { level: 2, name: /como funciona/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/app/intencao/IntentLandingLayout.tsx
+++ b/frontend/app/intencao/IntentLandingLayout.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import B2GIntelTheme from '../components/landing/B2GIntelTheme';
+import LandingNavbar from '../components/landing/LandingNavbar';
+import Footer from '../components/Footer';
+
+interface IntentLandingLayoutProps {
+  children: ReactNode;
+}
+
+/**
+ * Shared layout component for intent cluster landing pages (/intencao/*).
+ *
+ * Provides B2GIntelTheme, LandingNavbar, and Footer for visual consistency
+ * across all 4 intent cluster landing pages (comercial, investigativa,
+ * juridica, subcontratacao).
+ *
+ * @example
+ * ```tsx
+ * <IntentLandingLayout>
+ *   <YourPageContent />
+ * </IntentLandingLayout>
+ * ```
+ */
+export default function IntentLandingLayout({
+  children,
+}: IntentLandingLayoutProps) {
+  return (
+    <B2GIntelTheme>
+      <LandingNavbar />
+      <main id="main-content" className="min-h-screen">
+        {children}
+      </main>
+      <Footer />
+    </B2GIntelTheme>
+  );
+}

--- a/frontend/app/intencao/comercial/page.tsx
+++ b/frontend/app/intencao/comercial/page.tsx
@@ -1,0 +1,56 @@
+/**
+ * Intent landing page — Comercial (fornecedor/CNPJ)
+ *
+ * Route: /intencao/comercial
+ * Users arrive via IntentRouter (#1511) when searching for fornecedores,
+ * CNPJs, or commercial opportunities in public bidding.
+ */
+import type { Metadata } from 'next';
+import IntentLandingPage from '../../components/IntentLandingPage';
+import IntentLandingLayout from '../IntentLandingLayout';
+
+export const metadata: Metadata = {
+  title: 'Inteligência Comercial B2G — SmartLic',
+  description:
+    'Encontre fornecedores, analise concorrentes e descubra quem vence licitações públicas. Plataforma de inteligência B2G com dados oficiais do governo.',
+};
+
+export default function ComercialPage() {
+  return (
+    <IntentLandingLayout>
+      <IntentLandingPage
+        cluster="comercial"
+        headline="Venda para o governo com inteligência"
+        subtitle="Encontre fornecedores, analise concorrentes, descubra quem vence licitações públicas"
+        steps={[
+          {
+            title: '2 milhões de contratos monitorados',
+            description:
+              'Busque por CNPJ ou setor e acesse dados completos de fornecedores que já vendem para o governo em todo o Brasil.',
+          },
+          {
+            title: '27 estados com cobertura nacional',
+            description:
+              'Compare preços, margens e histórico de contratações em qualquer região do país com dados atualizados diariamente.',
+          },
+          {
+            title: '15+ setores classificados por IA',
+            description:
+              'Receba alertas de oportunidades filtradas automaticamente para o seu segmento de atuação.',
+          },
+        ]}
+        socialProofText="Empresas que usam o SmartLic aumentam em até 3x suas chances de vencer licitações públicas. Mais de 2 mil usuários ativos em todo o Brasil monitoram oportunidades com nossa plataforma."
+        ctaPrimary={{
+          text: 'Relatório de fornecedor — R$67',
+          href: '/checkout?sku=relatorio-fornecedor',
+        }}
+        ctaSecondary={{
+          text: 'Monitoramento de editais →',
+          href: '/signup?source=intent-comercial',
+        }}
+        pageTitle="Inteligência Comercial B2G — SmartLic"
+        pageDescription="Encontre fornecedores, analise concorrentes e descubra quem vence licitações públicas. Plataforma de inteligência B2G com dados oficiais do governo."
+      />
+    </IntentLandingLayout>
+  );
+}

--- a/frontend/app/intencao/investigativa/page.tsx
+++ b/frontend/app/intencao/investigativa/page.tsx
@@ -1,0 +1,56 @@
+/**
+ * Intent landing page — Investigativa (orgao/contrato)
+ *
+ * Route: /intencao/investigativa
+ * Users arrive via IntentRouter (#1511) when searching for orgaos
+ * compradores, contratos publicos, or deep market research.
+ */
+import type { Metadata } from 'next';
+import IntentLandingPage from '../../components/IntentLandingPage';
+import IntentLandingLayout from '../IntentLandingLayout';
+
+export const metadata: Metadata = {
+  title: 'Pesquisa de Licitações e Mercado Público — SmartLic',
+  description:
+    'Mapeie órgãos compradores, analise contratos, encontre oportunidades de pesquisa com dados oficiais do governo.',
+};
+
+export default function InvestigativaPage() {
+  return (
+    <IntentLandingLayout>
+      <IntentLandingPage
+        cluster="investigativa"
+        headline="Pesquise licitações com profundidade"
+        subtitle="Mapeie órgãos compradores, analise contratos, encontre oportunidades de pesquisa"
+        steps={[
+          {
+            title: '50 mil+ órgãos públicos mapeados',
+            description:
+              'Selecione órgãos, municípios ou esferas governamentais e acesse todo o histórico de contratações e gastos públicos.',
+          },
+          {
+            title: 'R$ 1 bilhão+ em contratos analisados',
+            description:
+              'Identifique tendências de compra, sazonalidades e padrões de gasto por setor, região e modalidade.',
+          },
+          {
+            title: 'Relatórios setoriais completos',
+            description:
+              'Gere diagnósticos detalhados com dados consolidados, gráficos e insights estratégicos para sua pesquisa.',
+          },
+        ]}
+        socialProofText="SmartLic processa mais de 2 milhões de contratos públicos com atualização diária, permitindo pesquisas profundas e análises de mercado em todo o Brasil."
+        ctaPrimary={{
+          text: 'Mapa de oportunidades — R$47',
+          href: '/checkout?sku=mapa-oportunidades',
+        }}
+        ctaSecondary={{
+          text: 'Relatório setorial →',
+          href: '/checkout?sku=relatorio-setorial',
+        }}
+        pageTitle="Pesquisa de Licitações e Mercado Público — SmartLic"
+        pageDescription="Mapeie órgãos compradores, analise contratos, encontre oportunidades de pesquisa com dados oficiais do governo."
+      />
+    </IntentLandingLayout>
+  );
+}

--- a/frontend/app/intencao/juridica/page.tsx
+++ b/frontend/app/intencao/juridica/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * Intent landing page — Juridica (legal questions / Lei 14.133)
+ *
+ * Route: /intencao/juridica
+ * Users arrive via IntentRouter (#1511) when searching for legal aspects
+ * of public bidding, Lei 14.133, impugnacoes, and compliance.
+ *
+ * CTA is lead capture (Diagnostico + Consultoria), not direct checkout.
+ */
+import type { Metadata } from 'next';
+import IntentLandingPage from '../../components/IntentLandingPage';
+import IntentLandingLayout from '../IntentLandingLayout';
+
+export const metadata: Metadata = {
+  title: 'Assessoria Jurídica em Licitações — SmartLic',
+  description:
+    'Entenda a Lei 14.133, evite impugnações, prepare sua empresa para licitar com segurança jurídica.',
+};
+
+export default function JuridicaPage() {
+  return (
+    <IntentLandingLayout>
+      <IntentLandingPage
+        cluster="juridica"
+        headline="Fundamentação jurídica para licitações"
+        subtitle="Entenda a Lei 14.133, prepare sua empresa para licitar, evite impugnações e recursos"
+        steps={[
+          {
+            title: '100% da legislação federal disponível',
+            description:
+              'Consulte a Lei 14.133, decretos regulamentadores e portarias atualizadas em um só lugar, com busca inteligente.',
+          },
+          {
+            title: 'Editais completos com análise jurídica',
+            description:
+              'Acesse editais integrais com cláusulas destacadas e alertas para pontos críticos de habilitação e documentação.',
+          },
+          {
+            title: 'Diagnóstico personalizado gratuito',
+            description:
+              'Receba uma avaliação gratuita da situação da sua empresa frente aos requisitos legais das licitações públicas.',
+          },
+        ]}
+        socialProofText="Mais de 100 mil editais analisados com suporte jurídico. Advogados e consultores de todo o Brasil utilizam o SmartLic para embasar recursos e impugnações."
+        ctaPrimary={{
+          text: 'Diagnóstico gratuito →',
+          href: '/signup?source=intent-juridica',
+        }}
+        ctaSecondary={{
+          text: 'Falar com consultoria',
+          href: '/contato',
+        }}
+        pageTitle="Assessoria Jurídica em Licitações — SmartLic"
+        pageDescription="Entenda a Lei 14.133, evite impugnações, prepare sua empresa para licitar com segurança jurídica."
+      />
+    </IntentLandingLayout>
+  );
+}

--- a/frontend/app/intencao/subcontratacao/page.tsx
+++ b/frontend/app/intencao/subcontratacao/page.tsx
@@ -1,0 +1,56 @@
+/**
+ * Intent landing page — Subcontratacao (subcontracting/partnership)
+ *
+ * Route: /intencao/subcontratacao
+ * Users arrive via IntentRouter (#1511) when searching for subcontracting,
+ * consorcios, or partnership opportunities in public bidding.
+ */
+import type { Metadata } from 'next';
+import IntentLandingPage from '../../components/IntentLandingPage';
+import IntentLandingLayout from '../IntentLandingLayout';
+
+export const metadata: Metadata = {
+  title: 'Subcontratação em Licitações — SmartLic',
+  description:
+    'Seja subcontratado por vencedores de licitação, forme consórcios e expanda suas oportunidades no mercado público.',
+};
+
+export default function SubcontratacaoPage() {
+  return (
+    <IntentLandingLayout>
+      <IntentLandingPage
+        cluster="subcontratacao"
+        headline="Encontre parceiros de licitação"
+        subtitle="Seja subcontratado por vencedores de licitação, forme consórcios e expanda suas oportunidades"
+        steps={[
+          {
+            title: '5 mil+ empresas parceiras cadastradas',
+            description:
+              'Cadastre sua empresa e seja encontrado por vencedores de licitação que precisam de subcontratados qualificados.',
+          },
+          {
+            title: '27 estados com oportunidades',
+            description:
+              'Descubra editais que preveem subcontratação obrigatória em todas as regiões do Brasil.',
+          },
+          {
+            title: 'Match inteligente com vencedores',
+            description:
+              'Nosso algoritmo conecta sua empresa a fornecedores que venceram licitações e precisam de parceiros para execução.',
+          },
+        ]}
+        socialProofText="Empresas subcontratadas faturam em média R$ 150 mil por contrato. O SmartLic conecta fornecedores a vencedores de licitação em todo o Brasil."
+        ctaPrimary={{
+          text: 'Matching + Relatório — R$97',
+          href: '/checkout?sku=relatorio-subcontratacao',
+        }}
+        ctaSecondary={{
+          text: 'Ver editais recentes →',
+          href: '/licitacoes',
+        }}
+        pageTitle="Subcontratação em Licitações — SmartLic"
+        pageDescription="Seja subcontratado por vencedores de licitação, forme consórcios e expanda suas oportunidades no mercado público."
+      />
+    </IntentLandingLayout>
+  );
+}


### PR DESCRIPTION
## Summary

Creates 4 intent cluster landing pages for intent-based routing, integrating with the IntentRouter (#1511).

### Changes
- New /intencao/comercial, /intencao/investigativa, /intencao/juridica, /intencao/subcontratacao
- Shared IntentLandingLayout component for visual consistency
- Each page has intent-specific hero, stats, and CTA
- Tests for layout and pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new landing pages—Commercial, Investigative, Legal, and Subcontracting—each with targeted marketing content, call-to-action links, multi-step conversion flows, customer testimonials, and optimized metadata for search engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->