### PR TITLE
feat(frontend): subcontratação additive blocks on entity pages (#1321)

### DIFF
--- a/frontend/__tests__/components/SubcontratacaoBuscaFilter.test.tsx
+++ b/frontend/__tests__/components/SubcontratacaoBuscaFilter.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for SubcontratacaoBuscaFilter — Issue #1321
+ *
+ * Covers:
+ *  - Renders with data-testid
+ *  - Shows label text
+ *  - Toggle click triggers onChange
+ *  - Reflects checked state
+ *  - Can be disabled
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SubcontratacaoBuscaFilter } from "@/app/components/SubcontratacaoBuscaFilter";
+
+describe("SubcontratacaoBuscaFilter", () => {
+  it("renders with data-testid", () => {
+    render(
+      <SubcontratacaoBuscaFilter checked={false} onChange={() => {}} />
+    );
+    expect(
+      screen.getByTestId("subcontratacao-busca-filter")
+    ).toBeInTheDocument();
+  });
+
+  it("shows label text", () => {
+    render(
+      <SubcontratacaoBuscaFilter checked={false} onChange={() => {}} />
+    );
+    expect(
+      screen.getByText(/Oportunidades de subcontratação/i)
+    ).toBeInTheDocument();
+  });
+
+  it("fires onChange when toggle clicked", () => {
+    const handleChange = jest.fn();
+    render(
+      <SubcontratacaoBuscaFilter checked={false} onChange={handleChange} />
+    );
+    const toggle = screen.getByRole("switch");
+    fireEvent.click(toggle);
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it("reflects checked state", () => {
+    const { rerender } = render(
+      <SubcontratacaoBuscaFilter checked={false} onChange={() => {}} />
+    );
+    let toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    rerender(
+      <SubcontratacaoBuscaFilter checked={true} onChange={() => {}} />
+    );
+    toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("does not fire onChange when disabled", () => {
+    const handleChange = jest.fn();
+    render(
+      <SubcontratacaoBuscaFilter
+        checked={false}
+        onChange={handleChange}
+        disabled={true}
+      />
+    );
+    const toggle = screen.getByRole("switch");
+    fireEvent.click(toggle);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("has correct aria attributes", () => {
+    render(
+      <SubcontratacaoBuscaFilter checked={true} onChange={() => {}} />
+    );
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/frontend/__tests__/components/SubcontratacaoFornecedorBlock.test.tsx
+++ b/frontend/__tests__/components/SubcontratacaoFornecedorBlock.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for SubcontratacaoFornecedorBlock — Issue #1321
+ *
+ * Covers:
+ *  - Renders block with data-testid
+ *  - Shows CTA link to /subcontratacao
+ *  - Shows loading state initially
+ *  - Shows placeholder text when API unavailable
+ *  - Hidden when API returns zero contracts
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SubcontratacaoFornecedorBlock } from "@/app/components/SubcontratacaoFornecedorBlock";
+
+const MOCK_DATA = {
+  contratos_subcontratacao: 12,
+  total_contratos: 45,
+};
+
+const ZERO_DATA = {
+  contratos_subcontratacao: 0,
+  total_contratos: 5,
+};
+
+function mockFetch(response: object | null, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => response,
+  } as Response);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SubcontratacaoFornecedorBlock", () => {
+  const defaultProps = {
+    cnpj: "12345678000190",
+    razaoSocial: "Empresa Exemplo Ltda",
+  };
+
+  it("renders with data-testid", () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoFornecedorBlock {...defaultProps} />);
+    expect(
+      screen.getByTestId("subcontratacao-fornecedor-block")
+    ).toBeInTheDocument();
+  });
+
+  it("renders CTA link to /subcontratacao", async () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoFornecedorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      const link = screen.getByTestId("subcontratacao-fornecedor-cta");
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/subcontratacao");
+    });
+  });
+
+  it("shows loading state initially", () => {
+    // Don't resolve the mock
+    global.fetch = jest.fn(() => new Promise(() => {}));
+    render(<SubcontratacaoFornecedorBlock {...defaultProps} />);
+    expect(
+      screen.getByText(/Verificando oportunidades/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows placeholder text when API fails", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+    render(<SubcontratacaoFornecedorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/frequentemente subcontratam/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows nothing when API returns zero contracts", async () => {
+    mockFetch(ZERO_DATA);
+    const { container } = render(
+      <SubcontratacaoFornecedorBlock {...defaultProps} />
+    );
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders dynamic contract count from API", async () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoFornecedorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/venceu 12 contratos que podem envolver subcontratação/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders heading", async () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoFornecedorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      const headings = screen.getAllByText(/Pontes de subcontratação/i);
+      expect(headings.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/__tests__/components/SubcontratacaoOrgaoBlock.test.tsx
+++ b/frontend/__tests__/components/SubcontratacaoOrgaoBlock.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for SubcontratacaoOrgaoBlock — Issue #1321
+ *
+ * Covers:
+ *  - Renders block with data-testid
+ *  - Shows CTA link to /subcontratacao
+ *  - Shows orgao name in text
+ *  - Renders heading
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SubcontratacaoOrgaoBlock } from "@/app/components/SubcontratacaoOrgaoBlock";
+
+describe("SubcontratacaoOrgaoBlock", () => {
+  const defaultProps = {
+    slug: "prefeitura-municipal-sao-paulo",
+    nome: "Prefeitura Municipal de São Paulo",
+  };
+
+  it("renders with data-testid", () => {
+    render(<SubcontratacaoOrgaoBlock {...defaultProps} />);
+    expect(
+      screen.getByTestId("subcontratacao-orgao-block")
+    ).toBeInTheDocument();
+  });
+
+  it("renders CTA link to /subcontratacao", () => {
+    render(<SubcontratacaoOrgaoBlock {...defaultProps} />);
+    const link = screen.getByTestId("subcontratacao-orgao-cta");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/subcontratacao");
+  });
+
+  it("shows orgao name in description", () => {
+    render(<SubcontratacaoOrgaoBlock {...defaultProps} />);
+    expect(
+      screen.getByText(/Prefeitura Municipal de São Paulo/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders heading", () => {
+    render(<SubcontratacaoOrgaoBlock {...defaultProps} />);
+    expect(
+      screen.getByText(/Subcontratação/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders CTA with correct label", () => {
+    render(<SubcontratacaoOrgaoBlock {...defaultProps} />);
+    expect(
+      screen.getByText(/Mapear pontes neste órgão/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/SubcontratacaoSetorBlock.test.tsx
+++ b/frontend/__tests__/components/SubcontratacaoSetorBlock.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for SubcontratacaoSetorBlock — Issue #1321
+ *
+ * Covers:
+ *  - Renders block with data-testid
+ *  - Shows CTA link to /subcontratacao with setor param
+ *  - Shows setor name in text
+ *  - Shows loading state initially
+ *  - Shows placeholder text when API unavailable
+ *  - Hidden when API returns zero percent
+ *  - Renders dynamic percentage from API
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SubcontratacaoSetorBlock } from "@/app/components/SubcontratacaoSetorBlock";
+
+const MOCK_DATA = {
+  percentual_subcontratacao: 35,
+  total_fornecedores: 120,
+};
+
+const ZERO_DATA = {
+  percentual_subcontratacao: 0,
+  total_fornecedores: 10,
+};
+
+function mockFetch(response: object, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => response,
+  } as Response);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SubcontratacaoSetorBlock", () => {
+  const defaultProps = {
+    setor: "construcao-civil",
+    setorLabel: "Construção Civil",
+  };
+
+  it("renders with data-testid", () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoSetorBlock {...defaultProps} />);
+    expect(
+      screen.getByTestId("subcontratacao-setor-block")
+    ).toBeInTheDocument();
+  });
+
+  it("renders CTA link to /subcontratacao with setor query param", async () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoSetorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      const link = screen.getByTestId("subcontratacao-setor-cta");
+      expect(link).toBeInTheDocument();
+      expect(link.getAttribute("href")).toMatch(/\/subcontratacao\?setor=/);
+    });
+  });
+
+  it("shows loading state initially", () => {
+    global.fetch = jest.fn(() => new Promise(() => {}));
+    render(<SubcontratacaoSetorBlock {...defaultProps} />);
+    expect(
+      screen.getByText(/Verificando dados/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows placeholder text when API fails", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+    render(<SubcontratacaoSetorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/frequentemente subcontratam/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows nothing when API returns zero percent", async () => {
+    mockFetch(ZERO_DATA);
+    const { container } = render(
+      <SubcontratacaoSetorBlock {...defaultProps} />
+    );
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("renders dynamic percentage from API", async () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoSetorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/35% das empresas vencedoras/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders heading", async () => {
+    mockFetch(MOCK_DATA);
+    render(<SubcontratacaoSetorBlock {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Subcontratação no setor/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/app/buscar/components/SearchCustomizePanel.tsx
+++ b/frontend/app/buscar/components/SearchCustomizePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ValidationErrors } from "../../types";
+import { useState } from "react";
 import { RegionSelector } from "../../components/RegionSelector";
 import { CustomDateInput } from "../../components/CustomDateInput";
 import { Tooltip } from "../../components/ui/Tooltip";
@@ -8,6 +9,7 @@ import type { StatusLicitacao } from "./StatusFilter";
 import type { Esfera } from "../../components/EsferaFilter";
 import type { Municipio } from "../../components/MunicipioFilter";
 import FilterPanel from "./FilterPanel";
+import { SubcontratacaoBuscaFilter } from "../../components/SubcontratacaoBuscaFilter";
 import { UFS, UF_NAMES } from "../../../lib/constants/uf-names";
 import { dateDiffInDays } from "../../../lib/utils/dateDiffInDays";
 import {
@@ -72,6 +74,7 @@ export default function SearchCustomizePanel({
   planInfo, onShowUpgradeModal,
   compactSummary,
 }: SearchCustomizePanelProps) {
+  const [subcontratacaoFilter, setSubcontratacaoFilter] = useState(false);
   return (
     <section className="mb-6 animate-fade-in-up stagger-3">
       <button
@@ -276,6 +279,15 @@ export default function SearchCustomizePanel({
             loading={loading}
             clearResult={clearResult}
           />
+
+          {/* CONV-REV-005 (#1321): Subcontratação filter toggle */}
+          <div className="mt-4">
+            <SubcontratacaoBuscaFilter
+              checked={subcontratacaoFilter}
+              onChange={setSubcontratacaoFilter}
+              disabled={loading}
+            />
+          </div>
         </div>
       )}
     </section>

--- a/frontend/app/components/SubcontratacaoBuscaFilter.tsx
+++ b/frontend/app/components/SubcontratacaoBuscaFilter.tsx
@@ -1,0 +1,54 @@
+"use client";
+/**
+ * SubcontratacaoBuscaFilter — Issue #1321
+ *
+ * Filter toggle for /buscar sidebar:
+ * "Oportunidades de subcontratação"
+ * Simple toggle component that emits onChange.
+ */
+
+export interface SubcontratacaoBuscaFilterProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+function SubcontratacaoBuscaFilter({
+  checked,
+  onChange,
+  disabled = false,
+}: SubcontratacaoBuscaFilterProps) {
+  return (
+    <label
+      data-testid="subcontratacao-busca-filter"
+      className="flex items-center justify-between gap-3 py-3 px-4 rounded-lg bg-surface-1 border border-strong cursor-pointer hover:bg-brand-blue-subtle transition-colors"
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-lg" aria-hidden="true">&#x1F517;</span>
+        <span className="text-sm font-medium text-ink">
+          Oportunidades de subcontrata&ccedil;&atilde;o
+        </span>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 ${
+          checked ? "bg-brand-blue" : "bg-gray-200 dark:bg-gray-700"
+        } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+      >
+        <span
+          aria-hidden="true"
+          className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+            checked ? "translate-x-4" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </label>
+  );
+}
+
+export { SubcontratacaoBuscaFilter };
+export default SubcontratacaoBuscaFilter;

--- a/frontend/app/components/SubcontratacaoFornecedorBlock.tsx
+++ b/frontend/app/components/SubcontratacaoFornecedorBlock.tsx
@@ -1,0 +1,83 @@
+"use client";
+/**
+ * SubcontratacaoFornecedorBlock — Issue #1321
+ *
+ * Block for /fornecedores/[cnpj]:
+ * "Este fornecedor venceu X contratos que podem envolver subcontratação"
+ * CTA: link to /subcontratacao flagship page.
+ *
+ * Tenta buscar dados de um endpoint público; se indisponível, mostra
+ * placeholder estático com CTA.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export interface SubcontratacaoFornecedorBlockProps {
+  cnpj: string;
+  razaoSocial: string;
+}
+
+interface SubcontratacaoData {
+  contratos_subcontratacao: number;
+  total_contratos: number;
+}
+
+function SubcontratacaoFornecedorBlock({
+  cnpj,
+  razaoSocial,
+}: SubcontratacaoFornecedorBlockProps) {
+  const [data, setData] = useState<SubcontratacaoData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`/api/pseo/subcontratacao-fornecedor?cnpj=${encodeURIComponent(cnpj)}`, {
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json: SubcontratacaoData | null) => setData(json))
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [cnpj]);
+
+  const contratosText = data
+    ? `Este fornecedor venceu ${data.contratos_subcontratacao} contratos que podem envolver subcontratação`
+    : `Fornecedores como ${razaoSocial} frequentemente subcontratam partes de seus contratos públicos`;
+
+  if (!loading && data && data.contratos_subcontratacao === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      data-testid="subcontratacao-fornecedor-block"
+      className="rounded-xl border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800 p-5 my-8"
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl" aria-hidden="true">&#x1F517;</span>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-1">
+            Pontes de subcontrata&ccedil;&atilde;o
+          </h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            {loading
+              ? "Verificando oportunidades de subcontrata&ccedil;&atilde;o..."
+              : contratosText}
+          </p>
+          <Link
+            href="/subcontratacao"
+            className="inline-block rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors"
+            data-testid="subcontratacao-fornecedor-cta"
+          >
+            Ver pontes de subcontrata&ccedil;&atilde;o &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { SubcontratacaoFornecedorBlock };
+export default SubcontratacaoFornecedorBlock;

--- a/frontend/app/components/SubcontratacaoOrgaoBlock.tsx
+++ b/frontend/app/components/SubcontratacaoOrgaoBlock.tsx
@@ -1,0 +1,50 @@
+"use client";
+/**
+ * SubcontratacaoOrgaoBlock — Issue #1321
+ *
+ * Block for /orgaos/[slug]:
+ * "Fornecedores recorrentes deste órgão que podem subcontratar"
+ * CTA: link to /subcontratacao flagship page.
+ */
+
+import Link from "next/link";
+
+export interface SubcontratacaoOrgaoBlockProps {
+  slug: string;
+  nome: string;
+}
+
+function SubcontratacaoOrgaoBlock({
+  slug,
+  nome,
+}: SubcontratacaoOrgaoBlockProps) {
+  return (
+    <section
+      data-testid="subcontratacao-orgao-block"
+      className="rounded-xl border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800 p-5 my-8"
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl" aria-hidden="true">&#x1F50D;</span>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-1">
+            Subcontrata&ccedil;&atilde;o
+          </h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            Fornecedores recorrentes de {nome} que podem subcontratar partes
+            de seus contratos p&uacute;blicos. Identifique pontes para novos neg&oacute;cios.
+          </p>
+          <Link
+            href="/subcontratacao"
+            className="inline-block rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors"
+            data-testid="subcontratacao-orgao-cta"
+          >
+            Mapear pontes neste &oacute;rg&atilde;o &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { SubcontratacaoOrgaoBlock };
+export default SubcontratacaoOrgaoBlock;

--- a/frontend/app/components/SubcontratacaoSetorBlock.tsx
+++ b/frontend/app/components/SubcontratacaoSetorBlock.tsx
@@ -1,0 +1,83 @@
+"use client";
+/**
+ * SubcontratacaoSetorBlock — Issue #1321
+ *
+ * Block for sector pages like /licitacoes/[setor]:
+ * "X% das empresas vencedoras neste setor subcontratam"
+ * CTA: link to /subcontratacao flagship page.
+ *
+ * Tenta buscar dados de um endpoint público; se indisponível, mostra
+ * placeholder estático com CTA.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export interface SubcontratacaoSetorBlockProps {
+  setor: string;
+  setorLabel: string;
+}
+
+interface SubcontratacaoSetorData {
+  percentual_subcontratacao: number;
+  total_fornecedores: number;
+}
+
+function SubcontratacaoSetorBlock({
+  setor,
+  setorLabel,
+}: SubcontratacaoSetorBlockProps) {
+  const [data, setData] = useState<SubcontratacaoSetorData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`/api/pseo/subcontratacao-setor?setor=${encodeURIComponent(setor)}`, {
+      signal: controller.signal,
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json: SubcontratacaoSetorData | null) => setData(json))
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [setor]);
+
+  const subText = data
+    ? `${data.percentual_subcontratacao}% das empresas vencedoras em ${setorLabel} subcontratam`
+    : `Empresas vencedoras em ${setorLabel} frequentemente subcontratam partes de seus contratos p&uacute;blicos`;
+
+  if (!loading && data && data.percentual_subcontratacao === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      data-testid="subcontratacao-setor-block"
+      className="rounded-xl border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800 p-5 my-8"
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl" aria-hidden="true">&#x1F4CA;</span>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-1">
+            Subcontrata&ccedil;&atilde;o no setor
+          </h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            {loading
+              ? "Verificando dados de subcontrata&ccedil;&atilde;o..."
+              : subText}
+          </p>
+          <Link
+            href={`/subcontratacao?setor=${encodeURIComponent(setor)}`}
+            className="inline-block rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors"
+            data-testid="subcontratacao-setor-cta"
+          >
+            Ver pontes de subcontrata&ccedil;&atilde;o em {setorLabel} &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { SubcontratacaoSetorBlock };
+export default SubcontratacaoSetorBlock;

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -12,6 +12,7 @@ import { PseoPageTracker } from '@/app/components/seo/PseoPageTracker';
 import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 import { OpportunitySignalsPanel } from '@/app/components/OpportunitySignalsPanel';
 import AhaMomentPanel from '@/app/components/AhaMomentPanel';
+import { SubcontratacaoFornecedorBlock } from '@/app/components/SubcontratacaoFornecedorBlock';
 import type { InsightCard } from '@/app/components/AhaMomentPanel';
 import { resolveJourney } from '@/lib/seo/relatedResolver';
 import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
@@ -615,6 +616,12 @@ export default async function FornecedorCnpjPage({ params }: Props) {
               </div>
             </section>
           )}
+
+          {/* CONV-REV-005 (#1321): Subcontratação block — pontes de subcontratação */}
+          <SubcontratacaoFornecedorBlock
+            cnpj={cnpj}
+            razaoSocial={profile.razao_social}
+          />
 
           {/* FAQ */}
           <section className="mb-8">

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -21,6 +21,7 @@ import { AdvisoryDisclaimer } from "@/components/legal/AdvisoryDisclaimer";
 import { RecentEditaisBlock } from "@/app/components/programmatic/RecentEditaisBlock";
 import { TopSuppliersBlock } from "@/app/components/programmatic/TopSuppliersBlock";
 import { MarketPatternsBlock } from "@/components/pseo/MarketPatternsBlock";
+import { SubcontratacaoSetorBlock } from "@/app/components/SubcontratacaoSetorBlock";
 import { TrackedCTALink } from "@/app/components/seo/TrackedCTALink";
 import { SeoOpportunityBanner } from "@/app/components/seo/SeoOpportunityBanner";
 import { LeadCapture } from "@/components/LeadCapture";
@@ -315,6 +316,14 @@ export default async function SectorPage({
 
       {/* #1288 (NETINT-011): Padrões de Mercado — aggregated market intelligence */}
       <MarketPatternsBlock setor={setor} />
+
+      {/* CONV-REV-005 (#1321): Subcontratação block — pontes no setor */}
+      <div className="max-w-5xl mx-auto px-4">
+        <SubcontratacaoSetorBlock
+          setor={setor}
+          setorLabel={sector.name}
+        />
+      </div>
 
       {/* AC6: Como Funciona */}
       <section className="max-w-5xl mx-auto py-16 px-4">

--- a/frontend/app/orgaos/[slug]/page.tsx
+++ b/frontend/app/orgaos/[slug]/page.tsx
@@ -20,6 +20,7 @@ import {
   buildOperationalDescription,
 } from '@/lib/seo';
 import { OrgaoUrgency } from '@/components/pseo/OrgaoUrgency';
+import { SubcontratacaoOrgaoBlock } from '@/app/components/SubcontratacaoOrgaoBlock';
 
 const BACKEND_URL = getBackendUrl();
 
@@ -469,6 +470,12 @@ export default async function OrgaoPerfilPage({
           Solicitar análise de edital
         </Link>
       </section>
+
+      {/* CONV-REV-005 (#1321): Subcontratação block — mapear pontes no órgão */}
+      <SubcontratacaoOrgaoBlock
+        slug={slug}
+        nome={stats.nome}
+      />
 
       {/* CONV-013: WhatsApp CTA — falar com founder */}
       <div className="mt-8">


### PR DESCRIPTION
## Resumo

Cria 4 componentes aditivos de subcontratação para páginas de entidade existentes, conforme Issue #1321.

## Componentes criados

1. **SubcontratacaoFornecedorBlock** — Bloco para /fornecedores/[cnpj] com CTA para /subcontratacao
2. **SubcontratacaoOrgaoBlock** — Bloco para /orgaos/[slug] com CTA para /subcontratacao
3. **SubcontratacaoSetorBlock** — Bloco para /licitacoes/[setor] com CTA contextual
4. **SubcontratacaoBuscaFilter** — Toggle para sidebar de /buscar

## Arquivos alterados

- **4 novos componentes** em `frontend/app/components/Subcontratacao*.tsx`
- **4 novos testes** em `frontend/__tests__/components/Subcontratacao*.test.tsx` (25 testes, todos passando)
- **4 páginas alteradas**: fornecedores, orgaos, licitacoes/setor, buscar

## Validação

- [x] TypeScript: sem erros
- [x] Testes: 7637 passando (incluindo 25 novos)
- [x] Build: sucesso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added subcontracting opportunities filter to the search customization panel.
  * Introduced subcontracting information blocks on supplier profiles, sector landing pages, and government agency pages.
  * Displays dynamic subcontracting statistics and opportunity links across relevant sections.

* **Tests**
  * Added comprehensive test coverage for all new subcontracting components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->