### PR TITLE
feat(frontend): welcoming empty state for /historico (#1560)

### DIFF
--- a/frontend/__tests__/empty-states.test.tsx
+++ b/frontend/__tests__/empty-states.test.tsx
@@ -285,23 +285,23 @@ describe("Historico empty state (AC4-AC6)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("empty-state")).toBeInTheDocument();
     }, { timeout: 3000 });
-    // EmptyState renders the Histórico de Análises title
+    // EmptyState renders the "Nenhuma busca salva ainda" title
     const emptyStateEl = screen.getByTestId("empty-state");
-    expect(emptyStateEl.textContent).toMatch(/Hist.*rico de An.*lises/);
+    expect(emptyStateEl.textContent).toMatch(/Nenhuma busca salva/);
   });
 
-  it("AC5: mentions revisiting doesn't cost a new analysis", async () => {
+  it("AC5: mentions searches are saved automatically", async () => {
     render(<HistoricoPage />);
 
     await waitFor(() => {
       expect(screen.getByTestId("empty-state")).toBeInTheDocument();
     }, { timeout: 3000 });
-    // Description mentions revisiting without spending a new analysis
+    // Description mentions automatic saving
     const emptyStateEl = screen.getByTestId("empty-state");
-    expect(emptyStateEl.textContent).toMatch(/nova an.*lise/);
+    expect(emptyStateEl.textContent).toMatch(/salvas automaticamente/);
   });
 
-  it("AC6: CTA 'Fazer primeira análise' links to /buscar", async () => {
+  it("AC6: CTA 'Fazer primeira busca' links to /buscar", async () => {
     render(<HistoricoPage />);
 
     await waitFor(() => {

--- a/frontend/__tests__/pages/HistoricoPage.test.tsx
+++ b/frontend/__tests__/pages/HistoricoPage.test.tsx
@@ -210,7 +210,7 @@ describe('HistoricoPage Component', () => {
 
       render(<HistoricoPage />);
 
-      const searchLink = screen.getByRole('link', { name: /Fazer primeira análise/i });
+      const searchLink = screen.getByRole('link', { name: /Fazer primeira busca/i });
       expect(searchLink).toBeInTheDocument();
       expect(searchLink).toHaveAttribute('href', '/buscar');
     });

--- a/frontend/__tests__/pages/HistoricoUX354.test.tsx
+++ b/frontend/__tests__/pages/HistoricoUX354.test.tsx
@@ -401,7 +401,7 @@ describe('UX-354: Histórico Unicode, Sector Slugs, English Errors', () => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
     });
     // Verify the CTA link text is rendered
-    expect(screen.getByText(/Fazer primeira análise/i)).toBeInTheDocument();
+    expect(screen.getByText(/Fazer primeira busca/i)).toBeInTheDocument();
   });
 
   test('AC8: UF display works correctly', async () => {

--- a/frontend/app/historico/page.tsx
+++ b/frontend/app/historico/page.tsx
@@ -366,9 +366,9 @@ export default function HistoricoPage() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
               </svg>
             }
-            title="Histórico de Análises"
-            description="Cada análise que você faz fica salva aqui. Você pode revisitar resultados anteriores sem gastar uma nova análise."
-            ctaLabel="Fazer primeira análise"
+            title="Nenhuma busca salva ainda"
+            description="Suas buscas são salvas automaticamente."
+            ctaLabel="Fazer primeira busca"
             ctaHref="/buscar"
           />
         ) : (


### PR DESCRIPTION
## Summary

UX-313: When user has zero saved searches, /historico now shows a welcoming empty state instead of a generic one.

## Changes

- **Title:** Changed from "Histórico de Análises" to "Nenhuma busca salva ainda"
- **Description:** Changed from generic text to "Suas buscas são salvas automaticamente."
- **CTA:** Changed from "Fazer primeira análise" to "Fazer primeira busca" (links to /buscar)
- **Tests:** Updated all test assertions to match the new copy

## Files Changed

- `frontend/app/historico/page.tsx` — Updated EmptyState props
- `frontend/__tests__/pages/HistoricoPage.test.tsx` — Updated CTA text regex
- `frontend/__tests__/pages/HistoricoUX354.test.tsx` — Updated CTA text regex
- `frontend/__tests__/empty-states.test.tsx` — Updated AC4 (title), AC5 (description), AC6 (CTA label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated empty-state test cases to reflect new UI messaging and labels.

* **UI Updates**
  * Updated empty state title to "Nenhuma busca salva".
  * Changed call-to-action label from "Fazer primeira análise" to "Fazer primeira busca".
  * Modified empty state description to clarify searches are saved automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->