### PR TITLE
feat(frontend): add consistent navigation to /conta page (#1559)

### DIFF
--- a/frontend/app/conta/layout.tsx
+++ b/frontend/app/conta/layout.tsx
@@ -9,6 +9,11 @@ import { ErrorBoundary } from "../../components/ErrorBoundary";
 
 /**
  * DEBT-011 FE-001 AC3: Shared sidebar layout for /conta sub-routes.
+ *
+ * UX-306: Consistent header/navigation via NavigationShell (root layout)
+ * and PageHeader. Outer wrapper uses flex-1 instead of min-h-screen to
+ * integrate properly within NavigationShell's flex column layout —
+ * prevents overflow with footer and BottomNav.
  */
 
 const NAV_ITEMS = [
@@ -42,7 +47,7 @@ export default function ContaLayout({ children }: { children: React.ReactNode })
   const pathname = usePathname();
 
   return (
-    <div className="min-h-screen bg-[var(--canvas)]">
+    <div className="bg-[var(--canvas)] flex-1">
       <PageHeader title="Minha Conta" />
 
       <div className="max-w-4xl mx-auto px-4 py-6">


### PR DESCRIPTION
## Summary

UX-306: The /conta page already had NavigationShell wrapping via the root layout, but its layout wrapper used `min-h-screen` which conflicted with NavigationShell's own `flex min-h-screen` container, causing the page content area to overflow past the footer and BottomNav.

## Change

Changed the outer wrapper in `ContaLayout` from `min-h-screen bg-[var(--canvas)]` to `bg-[var(--canvas)] flex-1` so the layout integrates properly within NavigationShell's flex column — `flex-1` fills the available space without forcing 100vh overflow.

## Validation
- TypeScript: ✅ (tsc --noEmit)
- Tests: ✅ (23/23, 2 suites — NavigationShell + conta)
- Build: ✅ (4206 pages generated)

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)