### PR TITLE
feat(frontend): integrate QuotaBadge into sidebar and bottom nav (#1561)

### DIFF
--- a/frontend/components/BottomNav.tsx
+++ b/frontend/components/BottomNav.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "../app/components/AuthProvider";
 import { usePlan } from "../hooks/usePlan";
+import { QuotaBadge } from "../app/components/QuotaBadge";
 import {
   Search,
   LayoutDashboard,
@@ -262,6 +263,11 @@ export function BottomNav() {
                   <span>Admin</span>
                 </Link>
               )}
+
+              {/* Quota indicator — UX-312 */}
+              <div className="px-4 py-1">
+                <QuotaBadge />
+              </div>
 
               <div className="border-t border-[var(--border)] my-2" />
 

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Menu,
   Shield,
 } from "lucide-react";
+import { QuotaBadge } from "../app/components/QuotaBadge";
 
 const STORAGE_KEY = "smartlic-sidebar-collapsed";
 
@@ -141,6 +142,11 @@ export function Sidebar() {
       <div className="border-t border-[var(--border)] py-3 px-2 space-y-1">
         {SECONDARY_NAV.map(renderNavItem)}
         {isAdmin && renderNavItem({ href: "/admin", label: "Admin", icon: <Shield className="w-5 h-5" aria-hidden="true" /> })}
+
+        {/* Quota Indicator — UX-312 */}
+        <div className={`${collapsed ? "flex justify-center" : "px-3"}`}>
+          <QuotaBadge />
+        </div>
 
         {/* Sign Out */}
         <button


### PR DESCRIPTION
## Summary

UX-312: Integrate the existing QuotaBadge component into the navigation chrome so users can see remaining analyses at a glance.

### Changes

- **Sidebar**: Added QuotaBadge in the secondary navigation section, between the admin link and sign-out button. Adapts layout when collapsed (centered).
- **BottomNav**: Added QuotaBadge in the mobile drawer, below the secondary nav items and above the divider.

The QuotaBadge component already existed at `frontend/app/components/QuotaBadge.tsx` with support for:
- Surface styling (normal credits remaining)
- Warning styling (1 credit remaining)
- Error styling (0 credits — links to /planos)
- Purple styling (admin badge)
- Brand styling (unlimited plan badge)
- Cancelamento agendado badge
- SVG icons and friendly plan names

### Validation
- TypeScript check: PASS
- All affected tests: 120/120 passed
  - QuotaBadge: 21/21
  - QuotaCounter: 29/29
  - Sidebar: 19/19
  - BottomNav: 20/20
  - NavigationShell: 31/31

Closes #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)