### PR TITLE
feat(frontend): active filter count badge on search customize button (#1564)

### DIFF
--- a/frontend/app/buscar/components/SearchCustomizePanel.tsx
+++ b/frontend/app/buscar/components/SearchCustomizePanel.tsx
@@ -75,6 +75,12 @@ export default function SearchCustomizePanel({
   compactSummary,
 }: SearchCustomizePanelProps) {
   const [subcontratacaoFilter, setSubcontratacaoFilter] = useState(false);
+  const activeFiltersCount =
+    (esferas.length > 0 && esferas.length < 3 ? 1 : 0) +
+    (municipios.length > 0 ? 1 : 0) +
+    (status !== "recebendo_proposta" ? 1 : 0) +
+    (modalidades.length > 0 ? 1 : 0) +
+    (valorMin !== null || valorMax !== null ? 1 : 0);
   return (
     <section className="mb-6 animate-fade-in-up stagger-3">
       <button
@@ -86,6 +92,14 @@ export default function SearchCustomizePanel({
       >
         <SlidersHorizontal className="w-5 h-5 text-ink-muted" strokeWidth={2} aria-hidden="true" />
         Personalizar análise
+        {activeFiltersCount > 0 && (
+          <span
+            className="inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold rounded-full bg-brand-blue text-white"
+            aria-label={`${activeFiltersCount} filtro${activeFiltersCount > 1 ? 's' : ''} ativo${activeFiltersCount > 1 ? 's' : ''}`}
+          >
+            {activeFiltersCount}
+          </span>
+        )}
         <ChevronDown className={`w-4 h-4 ml-auto transition-transform ${customizeOpen ? 'rotate-180' : ''}`} strokeWidth={2} aria-hidden="true" />
       </button>
 


### PR DESCRIPTION
## Summary

UX-314: Badge com contagem de filtros ativos no botao 'Personalizar busca'.

Adds a small badge (e.g., '3') next to the 'Personalizar analise' button label showing how many optional filters deviate from their defaults.

## What changed

- `frontend/app/buscar/components/SearchCustomizePanel.tsx`: Added `activeFiltersCount` computed from esferas, municipios, status, modalidades, and valor range props, rendered as a `bg-brand-blue` rounded-full badge when count > 0.

## Filter counting logic

| Filter | Active when |
|--------|-------------|
| Esferas | length between 1 and 2 (not all 3) |
| Municipios | length > 0 |
| Status | not the default \`recebendo_proposta\` |
| Modalidades | length > 0 |
| Valor range | valorMin !== null OR valorMax !== null |

## Testing

All 39 SearchForm tests pass (verified locally).

Closes #1564

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search customize panel now shows a blue badge on the toggle indicating the number of active filters (counts across multiple filter types, with correct singular/plural wording and ignoring a specific inactive status), giving immediate visual feedback about current filter selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->