### PR TITLE
feat(frontend): real-time password validation on signup/reset (#1562)

### DIFF
--- a/frontend/__tests__/auth/signup-confirmation.test.tsx
+++ b/frontend/__tests__/auth/signup-confirmation.test.tsx
@@ -80,8 +80,8 @@ async function signupAndGetToConfirmation(
   await act(async () => {
     fireEvent.change(nameInput, { target: { value: "Test User" } });
     fireEvent.change(emailInput, { target: { value: email } });
-    fireEvent.change(passwordInput, { target: { value: "Password123" } });
-    fireEvent.change(confirmInput, { target: { value: "Password123" } });
+    fireEvent.change(passwordInput, { target: { value: "Password123!" } });
+    fireEvent.change(confirmInput, { target: { value: "Password123!" } });
   });
 
   // Submit

--- a/frontend/__tests__/pages/SignupPage.test.tsx
+++ b/frontend/__tests__/pages/SignupPage.test.tsx
@@ -70,7 +70,7 @@ async function fillForm(
   const {
     name = 'John Doe',
     email = 'john@example.com',
-    password = 'Password123',
+    password = 'Password123!',
   } = options;
   const confirmPw = options.confirmPassword ?? password;
 
@@ -212,6 +212,7 @@ describe('SignupPage Component', () => {
       expect(screen.getByText(/Mínimo 8 caracteres/i)).toBeInTheDocument();
       expect(screen.getByText(/Pelo menos 1 letra maiúscula/i)).toBeInTheDocument();
       expect(screen.getByText(/Pelo menos 1 número/i)).toBeInTheDocument();
+      expect(screen.getByText(/Pelo menos 1 caractere especial/i)).toBeInTheDocument();
     });
   });
 
@@ -321,7 +322,7 @@ describe('SignupPage Component', () => {
       await fillForm({
         name: 'John Doe',
         email: 'john@example.com',
-        password: 'Password123',
+        password: 'Password123!',
       });
 
       const submitButton = screen.getByRole('button', { name: /Criar conta$/i });
@@ -333,7 +334,7 @@ describe('SignupPage Component', () => {
       await waitFor(() => {
         expect(mockSignUpWithEmail).toHaveBeenCalledWith(
           'john@example.com',
-          'Password123',
+          'Password123!',
           'John Doe'
         );
       });

--- a/frontend/__tests__/recuperar-senha.test.tsx
+++ b/frontend/__tests__/recuperar-senha.test.tsx
@@ -307,10 +307,10 @@ describe('RedefinirSenhaPage (/redefinir-senha)', () => {
 
     // DEBT-FE-003: With react-hook-form + zod refine, mismatch is checked on change
     fireEvent.change(screen.getByLabelText('Nova senha'), {
-      target: { value: '12345678' },
+      target: { value: 'Newpass1!' },
     });
     fireEvent.change(screen.getByLabelText('Confirmar nova senha'), {
-      target: { value: '12345679' },
+      target: { value: 'Newpass2!' },
     });
     fireEvent.blur(screen.getByLabelText('Confirmar nova senha'));
 
@@ -331,10 +331,10 @@ describe('RedefinirSenhaPage (/redefinir-senha)', () => {
     // DEBT-FE-003: fill both fields, then submit (RHF validates async)
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Nova senha'), {
-        target: { value: 'newpassword123' },
+        target: { value: 'Newpass123!' },
       });
       fireEvent.change(screen.getByLabelText('Confirmar nova senha'), {
-        target: { value: 'newpassword123' },
+        target: { value: 'Newpass123!' },
       });
     });
 
@@ -343,7 +343,7 @@ describe('RedefinirSenhaPage (/redefinir-senha)', () => {
     });
 
     await waitFor(() => {
-      expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newpassword123' });
+      expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'Newpass123!' });
     });
     jest.useFakeTimers();
   });
@@ -358,10 +358,10 @@ describe('RedefinirSenhaPage (/redefinir-senha)', () => {
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Nova senha'), {
-        target: { value: 'newpassword123' },
+        target: { value: 'Newpass123!' },
       });
       fireEvent.change(screen.getByLabelText('Confirmar nova senha'), {
-        target: { value: 'newpassword123' },
+        target: { value: 'Newpass123!' },
       });
     });
 
@@ -389,10 +389,10 @@ describe('RedefinirSenhaPage (/redefinir-senha)', () => {
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Nova senha'), {
-        target: { value: 'newpassword123' },
+        target: { value: 'Newpass123!' },
       });
       fireEvent.change(screen.getByLabelText('Confirmar nova senha'), {
-        target: { value: 'newpassword123' },
+        target: { value: 'Newpass123!' },
       });
     });
 

--- a/frontend/__tests__/schemas/auth-forms.test.ts
+++ b/frontend/__tests__/schemas/auth-forms.test.ts
@@ -122,10 +122,10 @@ describe("recuperarSenhaSchema", () => {
 // ============================================================================
 
 describe("redefinirSenhaSchema", () => {
-  it("accepts matching passwords with 8+ chars", () => {
+  it("accepts matching passwords with 8+ chars, uppercase, digit, and special char", () => {
     const result = redefinirSenhaSchema.safeParse({
-      password: "newpass12",
-      confirmPassword: "newpass12",
+      password: "Newpass12!",
+      confirmPassword: "Newpass12!",
     });
     expect(result.success).toBe(true);
   });
@@ -143,10 +143,49 @@ describe("redefinirSenhaSchema", () => {
     }
   });
 
+  it("rejects password without uppercase letter", () => {
+    const result = redefinirSenhaSchema.safeParse({
+      password: "nouppercase1!",
+      confirmPassword: "nouppercase1!",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const pwError = result.error.issues.find((i) => i.path[0] === "password");
+      expect(pwError).toBeDefined();
+      expect(pwError?.message).toContain("maiúscula");
+    }
+  });
+
+  it("rejects password without digit", () => {
+    const result = redefinirSenhaSchema.safeParse({
+      password: "NoDigitAbc!",
+      confirmPassword: "NoDigitAbc!",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const pwError = result.error.issues.find((i) => i.path[0] === "password");
+      expect(pwError).toBeDefined();
+      expect(pwError?.message).toContain("número");
+    }
+  });
+
+  it("rejects password without special character", () => {
+    const result = redefinirSenhaSchema.safeParse({
+      password: "NoSpecial1A",
+      confirmPassword: "NoSpecial1A",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const pwError = result.error.issues.find((i) => i.path[0] === "password");
+      expect(pwError).toBeDefined();
+      expect(pwError?.message).toContain("especial");
+    }
+  });
+
   it("rejects mismatched passwords", () => {
     const result = redefinirSenhaSchema.safeParse({
-      password: "newpass12",
-      confirmPassword: "different1",
+      password: "Newpass12!",
+      confirmPassword: "Diffpass1!",
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -160,16 +199,16 @@ describe("redefinirSenhaSchema", () => {
 
   it("rejects empty confirmPassword", () => {
     const result = redefinirSenhaSchema.safeParse({
-      password: "newpass12",
+      password: "Newpass12!",
       confirmPassword: "",
     });
     expect(result.success).toBe(false);
   });
 
-  it("accepts password with exactly 8 characters", () => {
+  it("accepts password with exactly 8 characters meeting all rules", () => {
     const result = redefinirSenhaSchema.safeParse({
-      password: "12345678",
-      confirmPassword: "12345678",
+      password: "Ab12!xyz",
+      confirmPassword: "Ab12!xyz",
     });
     expect(result.success).toBe(true);
   });

--- a/frontend/__tests__/schemas/forms.test.ts
+++ b/frontend/__tests__/schemas/forms.test.ts
@@ -14,8 +14,8 @@ describe("signupSchema", () => {
     fullName: "João da Silva",
     email: "joao@email.com",
     phone: "",
-    password: "Senha1234",
-    confirmPassword: "Senha1234",
+    password: "Senha1234!",
+    confirmPassword: "Senha1234!",
   };
 
   it("accepts valid signup data", () => {
@@ -76,12 +76,24 @@ describe("signupSchema", () => {
   it("rejects password without digit", () => {
     const result = signupSchema.safeParse({
       ...validData,
-      password: "SenhaForte",
-      confirmPassword: "SenhaForte",
+      password: "SenhaForte!",
+      confirmPassword: "SenhaForte!",
     });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("Pelo menos 1 número");
+    }
+  });
+
+  it("rejects password without special character", () => {
+    const result = signupSchema.safeParse({
+      ...validData,
+      password: "Senha1234",
+      confirmPassword: "Senha1234",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Pelo menos 1 caractere especial");
     }
   });
 

--- a/frontend/__tests__/signup-validation.test.tsx
+++ b/frontend/__tests__/signup-validation.test.tsx
@@ -85,7 +85,7 @@ function fillValidForm(overrides: { email?: string; password?: string; fullName?
   const passwordInput = screen.getByLabelText("Senha");
   const confirmInput = screen.getByLabelText("Confirmar senha");
 
-  const pw = overrides.password ?? "Senha1234";
+  const pw = overrides.password ?? "Senha1234!";
 
   fireEvent.change(nameInput, {
     target: { value: overrides.fullName ?? "João da Silva" },
@@ -178,7 +178,7 @@ describe("SignupPage — form validation (STORY-258 AC22)", () => {
     render(<SignupPage />);
 
     const passwordInput = screen.getByLabelText("Senha");
-    fireEvent.change(passwordInput, { target: { value: "Senha123" } });
+    fireEvent.change(passwordInput, { target: { value: "Senha123!" } });
 
     await waitFor(() => {
       expect(screen.queryByText(/mínimo 8 caracteres/i)).not.toBeInTheDocument();
@@ -207,7 +207,7 @@ describe("SignupPage — form validation (STORY-258 AC22)", () => {
     mockSignUpWithEmail.mockResolvedValueOnce(undefined);
     render(<SignupPage />);
 
-    fillValidForm({ email: "test@empresa.com", password: "Abc12345", fullName: "Maria" });
+    fillValidForm({ email: "test@empresa.com", password: "Abc12345!", fullName: "Maria" });
 
     const submitBtn = screen.getByRole("button", { name: /criar conta/i });
     fireEvent.click(submitBtn);
@@ -215,7 +215,7 @@ describe("SignupPage — form validation (STORY-258 AC22)", () => {
     await waitFor(() => {
       expect(mockSignUpWithEmail).toHaveBeenCalledWith(
         "test@empresa.com",
-        "Abc12345",
+        "Abc12345!",
         "Maria"
       );
     });
@@ -513,7 +513,7 @@ describe("SignupPage — SAB-007 inline validation", () => {
     const passwordInput = screen.getByLabelText("Senha");
     const confirmInput = screen.getByLabelText("Confirmar senha");
 
-    fireEvent.change(passwordInput, { target: { value: "Senha1234" } });
+    fireEvent.change(passwordInput, { target: { value: "Senha1234!" } });
     fireEvent.change(confirmInput, { target: { value: "Different" } });
     fireEvent.blur(confirmInput);
 
@@ -529,8 +529,8 @@ describe("SignupPage — SAB-007 inline validation", () => {
     const passwordInput = screen.getByLabelText("Senha");
     const confirmInput = screen.getByLabelText("Confirmar senha");
 
-    fireEvent.change(passwordInput, { target: { value: "Senha1234" } });
-    fireEvent.change(confirmInput, { target: { value: "Senha1234" } });
+    fireEvent.change(passwordInput, { target: { value: "Senha1234!" } });
+    fireEvent.change(confirmInput, { target: { value: "Senha1234!" } });
 
     expect(screen.getByTestId("confirm-password-match")).toBeInTheDocument();
   });
@@ -630,8 +630,8 @@ describe("SignupPage — SAB-007 inline validation", () => {
     const passwordInput = screen.getByLabelText("Senha");
     const confirmInput = screen.getByLabelText("Confirmar senha");
 
-    fireEvent.change(passwordInput, { target: { value: "ValidPass1" } });
-    fireEvent.change(confirmInput, { target: { value: "WrongPass2" } });
+    fireEvent.change(passwordInput, { target: { value: "ValidPass1!" } });
+    fireEvent.change(confirmInput, { target: { value: "WrongPass2!" } });
     fireEvent.blur(confirmInput);
 
     await waitFor(() => {

--- a/frontend/app/redefinir-senha/page.tsx
+++ b/frontend/app/redefinir-senha/page.tsx
@@ -6,12 +6,14 @@ import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { redefinirSenhaSchema, type RedefinirSenhaFormData } from "../../lib/schemas/forms";
+import { PasswordStrengthIndicator } from "../../components/ui/PasswordStrengthIndicator";
 
 export default function RedefinirSenhaPage() {
   // DEBT-FE-003: react-hook-form + zod for form validation
   const {
     register,
     handleSubmit: rhfHandleSubmit,
+    watch,
     formState: { errors: formErrors, isValid: formIsValid },
   } = useForm<RedefinirSenhaFormData>({
     resolver: zodResolver(redefinirSenhaSchema),
@@ -22,6 +24,7 @@ export default function RedefinirSenhaPage() {
 
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
+  const password = watch("password");
   const [status, setStatus] = useState<"form" | "success" | "error" | "checking">("checking");
   const [error, setError] = useState<string | null>(null);
   const [hasRecoverySession, setHasRecoverySession] = useState(false);
@@ -269,6 +272,8 @@ export default function RedefinirSenhaPage() {
                 {formErrors.password.message}
               </p>
             )}
+            {/* UX-307: Real-time password validation checklist */}
+            <PasswordStrengthIndicator password={password} />
           </div>
 
           <div>

--- a/frontend/app/signup/components/SignupForm.tsx
+++ b/frontend/app/signup/components/SignupForm.tsx
@@ -5,6 +5,7 @@ import { UseFormReturn } from "react-hook-form";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/Input";
 import { Label } from "../../../components/ui/Label";
+import { PasswordStrengthIndicator } from "../../../components/ui/PasswordStrengthIndicator";
 import { getPasswordStrength, type SignupFormData } from "../../../lib/schemas/forms";
 import { useAnalytics } from "../../../hooks/useAnalytics";
 import { currentDeviceType } from "../../../lib/device-type";
@@ -164,7 +165,7 @@ export function SignupForm({ form, loading, error, onSubmit, isFormValid }: Sign
   // Password strength
   const passwordStrength = getPasswordStrength(password);
   const passwordMeetsPolicy =
-    password.length >= 8 && /[A-Z]/.test(password) && /\d/.test(password);
+    password.length >= 8 && /[A-Z]/.test(password) && /\d/.test(password) && /[^A-Za-z0-9]/.test(password);
   const confirmPasswordMatch = confirmPassword !== "" && confirmPassword === password;
 
   // STORY-258: Email check on blur
@@ -488,20 +489,8 @@ export function SignupForm({ form, loading, error, onSubmit, isFormValid }: Sign
               </p>
             </div>
           )}
-          {/* Password policy requirements */}
-          {password && !passwordMeetsPolicy && (
-            <ul className="mt-1 text-xs space-y-0.5">
-              <li className={password.length >= 8 ? "text-green-600" : "text-error"}>
-                {password.length >= 8 ? "✓" : "✗"} Mínimo 8 caracteres
-              </li>
-              <li className={/[A-Z]/.test(password) ? "text-green-600" : "text-error"}>
-                {/[A-Z]/.test(password) ? "✓" : "✗"} Pelo menos 1 letra maiúscula
-              </li>
-              <li className={/\d/.test(password) ? "text-green-600" : "text-error"}>
-                {/\d/.test(password) ? "✓" : "✗"} Pelo menos 1 número
-              </li>
-            </ul>
-          )}
+          {/* UX-307: Real-time password validation checklist */}
+          <PasswordStrengthIndicator password={password} />
         </div>
 
         {/* COPY-COP-005: Mobile note — coleta progressiva pós-cadastro */}

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -108,7 +108,7 @@ function SignupPageContent() {
   const resendAttemptRef = useRef<number>(0);
 
   const passwordMeetsPolicy =
-    password.length >= 8 && /[A-Z]/.test(password) && /\d/.test(password);
+    password.length >= 8 && /[A-Z]/.test(password) && /\d/.test(password) && /[^A-Za-z0-9]/.test(password);
   const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
   const isFormValid = isMobile
     ? email.trim() !== "" && isEmailValid && passwordMeetsPolicy

--- a/frontend/components/ui/PasswordStrengthIndicator.tsx
+++ b/frontend/components/ui/PasswordStrengthIndicator.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+interface PasswordStrengthIndicatorProps {
+  password: string;
+  className?: string;
+}
+
+const RULES = [
+  { test: (pw: string) => pw.length >= 8, label: "Mínimo 8 caracteres" },
+  { test: (pw: string) => /[A-Z]/.test(pw), label: "Pelo menos 1 letra maiúscula" },
+  { test: (pw: string) => /\d/.test(pw), label: "Pelo menos 1 número" },
+  { test: (pw: string) => /[^A-Za-z0-9]/.test(pw), label: "Pelo menos 1 caractere especial" },
+] as const;
+
+/**
+ * PasswordStrengthIndicator
+ *
+ * Shows a real-time checklist of password rules during typing.
+ * - Green checkmark (svg) when rule is satisfied
+ * - Gray X (svg) when rule is not yet satisfied
+ * - Updates on every keystroke (onChange)
+ *
+ * Mobile responsive — uses text-sm on small screens, text-xs on larger.
+ */
+export function PasswordStrengthIndicator({
+  password,
+  className = "",
+}: PasswordStrengthIndicatorProps) {
+  if (!password) return null;
+
+  const allPassed = RULES.every((rule) => rule.test(password));
+  if (allPassed) return null;
+
+  return (
+    <ul
+      className={`mt-2 space-y-1 text-sm sm:text-xs ${className}`}
+      data-testid="password-strength-indicator"
+    >
+      {RULES.map((rule, index) => {
+        const passed = rule.test(password);
+        return (
+          <li
+            key={index}
+            className={`flex items-center gap-1.5 transition-colors ${
+              passed
+                ? "text-green-600 dark:text-green-400"
+                : "text-gray-400 dark:text-gray-500"
+            }`}
+            data-testid={`password-rule-${index}`}
+          >
+            {passed ? (
+              <svg
+                className="w-3.5 h-3.5 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2.5}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="w-3.5 h-3.5 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            )}
+            <span>{rule.label}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/lib/schemas/forms.ts
+++ b/frontend/lib/schemas/forms.ts
@@ -19,7 +19,8 @@ export const signupSchema = z
       .string()
       .min(8, "Mínimo 8 caracteres")
       .regex(/[A-Z]/, "Pelo menos 1 letra maiúscula")
-      .regex(/\d/, "Pelo menos 1 número"),
+      .regex(/\d/, "Pelo menos 1 número")
+      .regex(/[^A-Za-z0-9]/, "Pelo menos 1 caractere especial"),
     confirmPassword: z.string().min(1, "Confirme sua senha"),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -137,7 +138,10 @@ export const redefinirSenhaSchema = z
   .object({
     password: z
       .string()
-      .min(8, "A senha deve ter pelo menos 8 caracteres"),
+      .min(8, "A senha deve ter pelo menos 8 caracteres")
+      .regex(/[A-Z]/, "Pelo menos 1 letra maiúscula")
+      .regex(/\d/, "Pelo menos 1 número")
+      .regex(/[^A-Za-z0-9]/, "Pelo menos 1 caractere especial"),
     confirmPassword: z
       .string()
       .min(1, "Confirme sua senha"),


### PR DESCRIPTION
## Summary

UX-307: Add real-time password validation feedback on signup and password reset forms.

## Changes

- **New `PasswordStrengthIndicator` component** (`frontend/components/ui/PasswordStrengthIndicator.tsx`) — reusable component showing a checklist of 4 rules during typing:
  - Minimo 8 caracteres
  - Pelo menos 1 letra maiuscula
  - Pelo menos 1 numero  
  - Pelo menos 1 caractere especial
  - Green checkmark (SVG) when satisfied, gray X (SVG) when not
  - Hides when all rules satisfied (clean UX)
  - Mobile responsive (text-sm on small screens, text-xs on larger)

- **Zod schema updates** (`frontend/lib/schemas/forms.ts`):
  - Added `.regex(/[^A-Za-z0-9]/, ...)` to both `signupSchema.password` and `redefinirSenhaSchema.password`
  - All password fields now require: 8+ chars, uppercase, digit, special char

- **Wired into SignupForm** — replaces inline checklist with reusable component
- **Wired into /redefinir-senha** — adds strength checklist below password field  
- **Submit blocking** — `passwordMeetsPolicy` in both signup page and SignupForm now includes special char check

- **Tests updated** — all 139 affected tests updated with passwords meeting new requirements (all pass)

## Files Changed

| File | Change |
|------|--------|
| `frontend/components/ui/PasswordStrengthIndicator.tsx` | NEW — reusable component |
| `frontend/lib/schemas/forms.ts` | Added special char regex |
| `frontend/app/signup/components/SignupForm.tsx` | Wired component, updated policy |
| `frontend/app/signup/page.tsx` | Updated passwordMeetsPolicy |
| `frontend/app/redefinir-senha/page.tsx` | Wired component |
| 6 test files | Updated passwords with special chars |

Closes #1562