### PR TITLE
feat(frontend): cancel plan confirmation modal (#1567)

### DIFF
--- a/frontend/__tests__/account/cancel-subscription-flow.test.tsx
+++ b/frontend/__tests__/account/cancel-subscription-flow.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Tests for 4-step cancel subscription flow (UX-308).
  * Covers: AC1 (reason selection), AC2 (retention flow), AC3 (discount offer),
- * AC4 (pause offer), AC5 (confirmation checkbox), AC6 (feedback form).
+ * AC4 (pause offer), AC5 (confirmation text input), AC6 (feedback form).
  */
 import React from "react";
 import {
@@ -48,6 +48,11 @@ function mockFetchFeedback() {
     ok: true,
     json: async () => ({ success: true, message: "Obrigado!" }),
   });
+}
+
+function typeCANCELAR() {
+  const input = screen.getByTestId("cancel-confirm-input");
+  fireEvent.change(input, { target: { value: "CANCELAR" } });
 }
 
 describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
@@ -222,26 +227,32 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
       ).toBeInTheDocument();
     });
 
-    it("shows confirmation checkbox", () => {
+    it("shows confirmation text input for typing CANCELAR", () => {
       render(<CancelSubscriptionModal {...defaultProps} />);
       navigateToConfirm();
 
       expect(
-        screen.getByText(
-          /Entendo que perderei acesso aos benefícios/
-        )
+        screen.getByTestId("cancel-confirm-input")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Digite/)
       ).toBeInTheDocument();
     });
 
-    it("disables confirm button until checkbox is checked", () => {
+    it("disables confirm button until CANCELAR is typed", () => {
       render(<CancelSubscriptionModal {...defaultProps} />);
       navigateToConfirm();
 
       const confirmBtn = screen.getByRole("button", { name: "Confirmar cancelamento" });
       expect(confirmBtn).toBeDisabled();
 
-      const checkbox = screen.getByRole("checkbox");
-      fireEvent.click(checkbox);
+      const input = screen.getByTestId("cancel-confirm-input");
+      // Lowercase not accepted
+      fireEvent.change(input, { target: { value: "cancelar" } });
+      expect(confirmBtn).toBeDisabled();
+
+      // Exact uppercase match enables button
+      fireEvent.change(input, { target: { value: "CANCELAR" } });
       expect(confirmBtn).not.toBeDisabled();
     });
 
@@ -250,8 +261,7 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
 
       render(<CancelSubscriptionModal {...defaultProps} />);
       navigateToConfirm();
-
-      fireEvent.click(screen.getByRole("checkbox"));
+      typeCANCELAR();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -286,8 +296,7 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
 
       render(<CancelSubscriptionModal {...defaultProps} />);
       navigateToConfirm();
-
-      fireEvent.click(screen.getByRole("checkbox"));
+      typeCANCELAR();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -311,8 +320,7 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
 
       render(<CancelSubscriptionModal {...defaultProps} />);
       navigateToConfirm();
-
-      fireEvent.click(screen.getByRole("checkbox"));
+      typeCANCELAR();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -342,8 +350,7 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
       fireEvent.click(screen.getByText("Está caro para mim"));
       fireEvent.click(screen.getByText("Continuar"));
       fireEvent.click(screen.getByText("Continuar cancelamento"));
-
-      fireEvent.click(screen.getByRole("checkbox"));
+      typeCANCELAR();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -366,7 +373,7 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
 
       fireEvent.click(screen.getByText("Outro motivo"));
       fireEvent.click(screen.getByText("Continuar"));
-      fireEvent.click(screen.getByRole("checkbox"));
+      typeCANCELAR();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -515,8 +522,8 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
       ).toBeInTheDocument();
       fireEvent.click(screen.getByText("Continuar cancelamento"));
 
-      // Step 3: Check checkbox and confirm
-      fireEvent.click(screen.getByRole("checkbox"));
+      // Step 3: Type CANCELAR and confirm
+      typeCANCELAR();
       global.fetch = mockFetchCancel();
 
       await act(async () => {
@@ -562,8 +569,8 @@ describe("CancelSubscriptionModal — UX-308 4-Step Flow", () => {
       ).toBeInTheDocument();
       fireEvent.click(screen.getByText("Continuar cancelamento"));
 
-      // Step 3
-      fireEvent.click(screen.getByRole("checkbox"));
+      // Step 3: Type CANCELAR and confirm
+      typeCANCELAR();
       global.fetch = mockFetchCancel();
 
       await act(async () => {

--- a/frontend/__tests__/account/cancel-subscription.test.tsx
+++ b/frontend/__tests__/account/cancel-subscription.test.tsx
@@ -63,6 +63,26 @@ describe("CancelSubscriptionModal", () => {
     expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("shows text input requiring CANCELAR on confirm step", () => {
+    render(<CancelSubscriptionModal {...defaultProps} />);
+    fireEvent.click(screen.getByText("Outro motivo"));
+    fireEvent.click(screen.getByText("Continuar"));
+
+    expect(screen.getByTestId("cancel-confirm-input")).toBeInTheDocument();
+
+    const confirmBtn = screen.getByRole("button", { name: "Confirmar cancelamento" });
+    expect(confirmBtn).toBeDisabled();
+
+    // Partial match still disabled
+    const input = screen.getByTestId("cancel-confirm-input");
+    fireEvent.change(input, { target: { value: "cancel" } });
+    expect(confirmBtn).toBeDisabled();
+
+    // Exact match enables
+    fireEvent.change(input, { target: { value: "CANCELAR" } });
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
   it("calls API and onCancelled on successful cancellation", async () => {
     const mockEndsAt = "2026-03-15T00:00:00Z";
     global.fetch = jest.fn().mockResolvedValueOnce({
@@ -72,10 +92,12 @@ describe("CancelSubscriptionModal", () => {
 
     render(<CancelSubscriptionModal {...defaultProps} />);
 
-    // Navigate: reason → confirm → cancel
+    // Navigate: reason → confirm → type CANCELAR → cancel
     fireEvent.click(screen.getByText("Outro motivo"));
     fireEvent.click(screen.getByText("Continuar"));
-    fireEvent.click(screen.getByRole("checkbox"));
+
+    const input = screen.getByTestId("cancel-confirm-input");
+    fireEvent.change(input, { target: { value: "CANCELAR" } });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -100,10 +122,12 @@ describe("CancelSubscriptionModal", () => {
 
     render(<CancelSubscriptionModal {...defaultProps} />);
 
-    // Navigate: reason → confirm → cancel
+    // Navigate: reason → confirm → type CANCELAR → cancel
     fireEvent.click(screen.getByText("Outro motivo"));
     fireEvent.click(screen.getByText("Continuar"));
-    fireEvent.click(screen.getByRole("checkbox"));
+
+    const input = screen.getByTestId("cancel-confirm-input");
+    fireEvent.change(input, { target: { value: "CANCELAR" } });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -126,10 +150,12 @@ describe("CancelSubscriptionModal", () => {
 
     render(<CancelSubscriptionModal {...defaultProps} />);
 
-    // Navigate: reason → confirm → cancel
+    // Navigate: reason → confirm → type CANCELAR → cancel
     fireEvent.click(screen.getByText("Outro motivo"));
     fireEvent.click(screen.getByText("Continuar"));
-    fireEvent.click(screen.getByRole("checkbox"));
+
+    const input = screen.getByTestId("cancel-confirm-input");
+    fireEvent.change(input, { target: { value: "CANCELAR" } });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));

--- a/frontend/components/account/CancelSubscriptionModal.tsx
+++ b/frontend/components/account/CancelSubscriptionModal.tsx
@@ -4,6 +4,22 @@ import { useState, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import FocusTrap from "focus-trap-react";
 
+// ---------------------------------------------------------------------------
+// Tracking
+// ---------------------------------------------------------------------------
+function trackEvent(name: string, props?: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  const mp = (
+    window as unknown as { mixpanel?: { track: (e: string, p?: Record<string, unknown>) => void } }
+  ).mixpanel;
+  if (!mp) return;
+  try {
+    mp.track(name, props ?? {});
+  } catch {
+    // best-effort
+  }
+}
+
 type CancelReason =
   | "too_expensive"
   | "not_using"
@@ -43,7 +59,7 @@ export function CancelSubscriptionModal({
 }: CancelSubscriptionModalProps) {
   const [step, setStep] = useState<Step>("reason");
   const [reason, setReason] = useState<CancelReason | null>(null);
-  const [confirmed, setConfirmed] = useState(false);
+  const [confirmationText, setConfirmationText] = useState("");
   const [cancelling, setCancelling] = useState(false);
   const [submittingFeedback, setSubmittingFeedback] = useState(false);
   const [feedback, setFeedback] = useState("");
@@ -68,7 +84,7 @@ export function CancelSubscriptionModal({
   const resetAndClose = () => {
     setStep("reason");
     setReason(null);
-    setConfirmed(false);
+    setConfirmationText("");
     setCancelling(false);
     setSubmittingFeedback(false);
     setFeedback("");
@@ -93,6 +109,9 @@ export function CancelSubscriptionModal({
   const handleCancel = async () => {
     setCancelling(true);
     setError(null);
+
+    trackEvent("plan_cancel_confirmed", { reason });
+
     try {
       const res = await fetch("/api/subscriptions/cancel", {
         method: "POST",
@@ -381,17 +400,27 @@ export function CancelSubscriptionModal({
               ))}
             </ul>
 
-            <label className="flex items-start gap-3 p-3 rounded-input border border-[var(--border)] mb-4 cursor-pointer">
+            <div className="mb-4">
+              <label
+                htmlFor="cancel-confirm-input"
+                className="block text-sm font-medium text-[var(--ink)] mb-2"
+              >
+                Digite <span className="font-bold tracking-wider text-[var(--error)]">CANCELAR</span> para confirmar
+              </label>
               <input
-                type="checkbox"
-                checked={confirmed}
-                onChange={(e) => setConfirmed(e.target.checked)}
-                className="mt-0.5 accent-[var(--error)]"
+                id="cancel-confirm-input"
+                type="text"
+                autoComplete="off"
+                value={confirmationText}
+                onChange={(e) => setConfirmationText(e.target.value)}
+                placeholder="Digite CANCELAR para confirmar"
+                className="w-full p-3 rounded-input border border-[var(--border)] bg-[var(--surface-0)]
+                           text-sm text-[var(--ink)] placeholder:text-[var(--ink-muted)]
+                           focus:outline-none focus:ring-2 focus:ring-[var(--error)]
+                           uppercase tracking-widest text-center font-bold"
+                data-testid="cancel-confirm-input"
               />
-              <span className="text-sm text-[var(--ink)]">
-                Entendo que perderei acesso aos benefícios ao final do período atual
-              </span>
-            </label>
+            </div>
 
             {error && (
               <div className="mb-4 p-3 bg-[var(--error-subtle)] text-[var(--error)] rounded-input text-sm">
@@ -402,7 +431,7 @@ export function CancelSubscriptionModal({
             <div className="flex gap-3">
               <button
                 onClick={() => {
-                  setConfirmed(false);
+                  setConfirmationText("");
                   setError(null);
                   if (reason === "too_expensive" || reason === "not_using") {
                     setStep("retention");
@@ -419,7 +448,7 @@ export function CancelSubscriptionModal({
               </button>
               <button
                 onClick={handleCancel}
-                disabled={!confirmed || cancelling}
+                disabled={confirmationText !== "CANCELAR" || cancelling}
                 className="flex-1 px-4 py-2.5 rounded-button bg-[var(--error)] text-white
                            hover:opacity-90 transition-opacity text-sm
                            disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary

UX-308: Add confirmation modal before cancelling plan subscription. Replaces the checkbox confirmation with a type-to-confirm pattern requiring the user to type CANCELAR before the cancel button is enabled.

## Changes

- **CancelSubscriptionModal.tsx**: Replaced checkbox with text input requiring exact `CANCELAR` match
- Added mixpanel tracking event `plan_cancel_confirmed` with reason metadata
- Red destructive styling on confirm input
- Updated both test files to reflect type-to-confirm flow

## Testing

- Tested manually via code inspection
- Updated unit tests in both `cancel-subscription-flow.test.tsx` and `cancel-subscription.test.tsx`
- Tests verify: lowercase 'cancelar' rejected, exact 'CANCELAR' enables button, API call on confirm

## Notes

- Jest has a known environment issue (`jest-circus` hangs) in this WSL environment, preventing full test suite execution. Code changes verified structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)