### PR TITLE
feat(backend): limit concurrent searches per user to 3 (#1584)

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -254,6 +254,13 @@ RATE_LIMIT_HITS = _create_counter(
     labelnames=["endpoint", "caller_type"],
 )
 
+# GAP-006 / #1584: Concurrent search limit exceeded per user (429 returned)
+SEARCH_CONCURRENCY_REJECTED = _create_counter(
+    "smartlic_search_concurrency_rejected_total",
+    "GAP-006: Concurrent search limit exceeded per user (429 returned)",
+    labelnames=["user_tier"],
+)
+
 # OBS-001: Tiered rate limit decisions (bot vs human, allow vs throttle)
 RATE_LIMIT_DECISIONS_TOTAL = _create_counter(
     "smartlic_rate_limit_decisions_total",

--- a/backend/routes/search/__init__.py
+++ b/backend/routes/search/__init__.py
@@ -432,6 +432,9 @@ async def buscar_licitacoes(
             _slot_acquired = await acquire_search_slot(user["id"], request.search_id)
             if not _slot_acquired:
                 from config import MAX_CONCURRENT_SEARCHES
+                # GAP-006 / #1584: Increment concurrent search rejection metric
+                from metrics import SEARCH_CONCURRENCY_REJECTED
+                SEARCH_CONCURRENCY_REJECTED.labels(user_tier=user.get("role", "unknown")).inc()
                 await tracker.emit_error(
                     f"Limite de {MAX_CONCURRENT_SEARCHES} análises simultâneas atingido. "
                     f"Aguarde uma análise terminar."
@@ -440,6 +443,7 @@ async def buscar_licitacoes(
                 raise HTTPException(
                     status_code=429,
                     detail=f"Limite de {MAX_CONCURRENT_SEARCHES} análises simultâneas atingido.",
+                    headers={"Retry-After": "30"},
                 )
 
             # STORY-363 AC2: Try ARQ Worker first (true decoupling from HTTP)

--- a/backend/tests/test_story363_arq_search.py
+++ b/backend/tests/test_story363_arq_search.py
@@ -371,6 +371,40 @@ class TestAC14ConcurrentSearchLimiting:
                 response = client.post("/v1/buscar", json=VALID_SEARCH_BODY)
 
             assert response.status_code == 429
+            # GAP-006 / #1584: Verify Retry-After header
+            assert response.headers.get("Retry-After") == "30"
+        finally:
+            app.dependency_overrides.pop(require_auth, None)
+
+    def test_post_concurrent_limit_increments_metric(self):
+        """GAP-006: SEARCH_CONCURRENCY_REJECTED metric is incremented on 429."""
+        from fastapi.testclient import TestClient
+        from main import app
+        from auth import require_auth
+        from metrics import SEARCH_CONCURRENCY_REJECTED
+
+        mock_user = {"id": "user-363-metric", "email": "metric@test.com"}
+        app.dependency_overrides[require_auth] = lambda: mock_user
+
+        before = SEARCH_CONCURRENCY_REJECTED.labels(user_tier="unknown")._value.get()
+
+        try:
+            with patch("config.get_feature_flag", return_value=True), \
+                 patch("routes.search.check_user_roles", new_callable=AsyncMock, return_value=(False, False)), \
+                 patch("routes.search.create_tracker", new_callable=AsyncMock, return_value=_make_mock_tracker()), \
+                 patch("routes.search.create_state_machine", new_callable=AsyncMock, return_value=_make_mock_state_machine()), \
+                 patch("quota.require_active_plan", new_callable=AsyncMock), \
+                 patch("quota.check_quota", return_value=MagicMock(allowed=True, error_message="", capabilities={"max_requests_per_month": 1000})), \
+                 patch("quota.check_and_increment_quota_atomic", return_value=(True, 1, 999)), \
+                 patch("job_queue.acquire_search_slot", new_callable=AsyncMock, return_value=False), \
+                 patch("routes.search.remove_tracker", new_callable=AsyncMock):
+
+                client = TestClient(app, raise_server_exceptions=False)
+                response = client.post("/v1/buscar", json=VALID_SEARCH_BODY)
+
+            assert response.status_code == 429
+            after = SEARCH_CONCURRENCY_REJECTED.labels(user_tier="unknown")._value.get()
+            assert after == before + 1, "SEARCH_CONCURRENCY_REJECTED should have been incremented"
         finally:
             app.dependency_overrides.pop(require_auth, None)
 


### PR DESCRIPTION
## Context

Adiciona observabilidade e melhoria de UX ao limite de buscas simultâneas por usuário (STORY-363 AC14). Sem métricas, não é possível monitorar rejeições por concorrência no Prometheus, e sem header `Retry-After` o cliente não tem orientação de quando tentar novamente.

## Changes

- Adiciona contador Prometheus `SEARCH_CONCURRENCY_REJECTED` com label `user_tier` em `metrics.py`
- Adiciona header `Retry-After: 30` na resposta 429 em `routes/search/__init__.py`
- Incrementa o contador antes de lançar a exceção 429 quando o limite é excedido
- Adiciona teste para verificar header `Retry-After` na resposta 429
- Adiciona teste para verificar incremento da métrica `SEARCH_CONCURRENCY_REJECTED`

## Testing Plan

- [x] Unit tests passing
- [ ] Integration tests passing (if applicable)
- [ ] Manual validation performed on: [describe scenario]
- [x] No regressions detected

### Evidence

```bash
cd backend && pytest tests/ -k "concurrent" -v
```

## Risks & Rollback

**Risks:**
Nenhum — apenas adiciona métricas e header HTTP, sem alteração de lógica de controle.

**Rollback plan:**
Revert commit. Apenas backend, sem migração de schema.

## Closes

Closes #1584

---

## Checklist (Não remover)

- [x] PR title follows Conventional Commits format
- [x] All acceptance criteria from the issue are met
- [x] Code is formatted (backend: `ruff format`, frontend: `npm run lint`)
- [x] No sensitive data (API keys, passwords) in code
- [x] Documentation updated (if public APIs changed)
- [x] Tests added/updated for new functionality
- [x] CI checks are passing locally
- [x] **Zero test failures**
- [x] **API contract** — verified