### PR TITLE
feat(backend): add 3-layer quota fallback for Supabase offline (#1590)

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -934,6 +934,12 @@ REDIS_AVAILABLE = _create_gauge(
     "Redis availability (1=connected, 0=fallback/InMemoryCache)",
 )
 
+# GAP-012 (#1590): Quota fallback active gauge (0=normal, 1=fallback active)
+QUOTA_FALLBACK_ACTIVE = _create_gauge(
+    "smartlic_quota_fallback_active",
+    "Quota fallback mode (0=normal, 1=Redis fallback active, 2=fail-open active)",
+)
+
 # STORY-332 AC2: How long Redis has been in fallback mode
 REDIS_FALLBACK_DURATION = _create_gauge(
     "smartlic_redis_fallback_duration_seconds",

--- a/backend/quota/__init__.py
+++ b/backend/quota/__init__.py
@@ -52,6 +52,13 @@ from quota.quota_atomic import (
     increment_monthly_quota,
 )
 
+# quota_fallback: 3-layer fallback for Supabase offline (GAP-012 / #1590)
+from quota.quota_fallback import (
+    QUOTA_FALLBACK_MAX_DAILY,
+    QUOTA_FALLBACK_TTL,
+    try_quota_fallback,
+)
+
 # plan_enforcement: check_quota, require_active_plan, sessions
 from quota.plan_enforcement import (
     QuotaExceededError,
@@ -118,6 +125,10 @@ __all__ = [
     "get_quota_reset_date",
     "get_user_org_plan",
     "increment_monthly_quota",
+    # quota_fallback
+    "QUOTA_FALLBACK_MAX_DAILY",
+    "QUOTA_FALLBACK_TTL",
+    "try_quota_fallback",
     # plan_enforcement
     "QuotaExceededError",
     "_ensure_profile_exists",

--- a/backend/quota/quota_atomic.py
+++ b/backend/quota/quota_atomic.py
@@ -191,15 +191,30 @@ def check_and_increment_quota_atomic(
         return (True, 0, max_quota)  # Fail open
 
     except CircuitBreakerOpenError:
-        # STORY-291 AC4: Fail open — allow search, reconcile later
+        # GAP-012 (#1590): Try Layer 2 (Redis fallback) before Layer 3 (fail-open)
         logger.warning(
-            f"STORY-291 CB OPEN: Quota check skipped for user {mask_user_id(user_id)} "
-            f"(fail-open). Will reconcile quota later."
+            f"STORY-291 CB OPEN: Quota check Supabase offline for user "
+            f"{mask_user_id(user_id)} — trying fallback layers"
         )
-        return (True, 0, max_quota)
+        from quota.quota_fallback import QUOTA_FALLBACK_MAX_DAILY, _set_quota_fallback_active, try_quota_fallback
+        _set_quota_fallback_active(1)
+        fallback_allowed = try_quota_fallback(user_id)
+        if fallback_allowed:
+            return (True, 0, max_quota)
+        # Fallback limit reached — block the request
+        logger.warning(
+            f"Quota fallback limit reached for user {mask_user_id(user_id)} "
+            f"(blocked after {QUOTA_FALLBACK_MAX_DAILY} fallback searches)"
+        )
+        return (False, max_quota, 0)
 
     except Exception as e:
         logger.error(f"Error in atomic quota check for user {mask_user_id(user_id)}: {e}")
+        # GAP-012 (#1590): Try Redis fallback before falling through to lazy Supabase fallback
+        from quota.quota_fallback import try_quota_fallback
+        fallback_allowed = try_quota_fallback(user_id)
+        if not fallback_allowed:
+            return (False, max_quota, 0)
         # Lazy import via facade so test patches on quota.get_monthly_quota_used work (AC2)
         import quota as _quota
         current = _quota.get_monthly_quota_used(user_id)

--- a/backend/quota/quota_fallback.py
+++ b/backend/quota/quota_fallback.py
@@ -1,0 +1,173 @@
+"""3-layer quota fallback for Supabase offline scenarios.
+
+GAP-012 (#1590): When Supabase is unreachable, the quota system falls through
+three layers of increasing degrade:
+
+  Layer 1 — Supabase normal: quota via RPC check_and_increment_quota.
+  Layer 2 — Supabase offline: Redis counter ``quota:fallback:{user_id}``
+            with conservative limit (default 10/day) + 86400s TTL.
+  Layer 3 — Redis also offline: fail open (allows the request) +
+            Sentry ``capture_message(level="critical")``.
+
+Configurable via env:
+  QUOTA_FALLBACK_MAX_DAILY  — max fallback requests per user per day (default: 10)
+  QUOTA_FALLBACK_TTL        — Redis key TTL in seconds (default: 86400 = 24h)
+
+This module exposes a **sync** interface because it is called from
+``check_and_increment_quota_atomic`` which runs inside ``asyncio.to_thread()``
+(no event loop available).  Sync Redis access is provided by
+``redis_pool.get_sync_redis()``.
+"""
+
+import logging
+import os
+from typing import Optional
+
+from log_sanitizer import mask_user_id
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+QUOTA_FALLBACK_MAX_DAILY = int(os.getenv("QUOTA_FALLBACK_MAX_DAILY", "10"))
+QUOTA_FALLBACK_TTL = int(os.getenv("QUOTA_FALLBACK_TTL", "86400"))
+
+# Redis key namespace
+_FALLBACK_KEY_TEMPLATE = "quota:fallback:{user_id}"
+
+
+# ---------------------------------------------------------------------------
+# Public API (sync — safe for asyncio.to_thread context)
+# ---------------------------------------------------------------------------
+
+
+def try_quota_fallback(user_id: str) -> bool:
+    """Attempt to grant quota allowance through the fallback chain.
+
+    This is the **sync** entry-point designed to be called from
+    ``check_and_increment_quota_atomic`` (which runs in a thread pool).
+
+    Layer 2 (Redis) — atomic INCR via sync Redis client.
+    Layer 3 (fail open) — Sentry critical alert, returns True.
+
+    Args:
+        user_id: The user's ID string.
+
+    Returns:
+        True if the request is allowed through fallback,
+        False if the daily fallback limit has been reached.
+    """
+    # ---- Layer 2: Redis (sync) ----
+    count = _try_redis_fallback_sync(user_id)
+    if count is not None:
+        allowed = count <= QUOTA_FALLBACK_MAX_DAILY
+        level = "info" if allowed else "warning"
+        logger.log(
+            getattr(logging, level.upper()),
+            "Quota fallback [Layer 2 / Redis] user=%s count=%d/%d allowed=%s",
+            mask_user_id(user_id),
+            count,
+            QUOTA_FALLBACK_MAX_DAILY,
+            allowed,
+        )
+        return allowed
+
+    # ---- Layer 3: Fail open (Redis also offline) ----
+    _sentry_critical(
+        "Layer 3 fail-open: Supabase AND Redis both offline for quota check "
+        "— allowing request without counting. user=%s",
+        mask_user_id(user_id),
+    )
+    logger.critical(
+        "Quota fallback [Layer 3 / fail-open] user=%s — Supabase and Redis "
+        "both offline, allowing request uncounted",
+        mask_user_id(user_id),
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Layer-2 helper (sync Redis)
+# ---------------------------------------------------------------------------
+
+
+def _try_redis_fallback_sync(user_id: str) -> Optional[int]:
+    """Try Layer-2 Redis fallback counter using the sync Redis client.
+
+    Atomically INCR the key and set TTL on first creation (via Lua script).
+    Returns the new counter value on success, or None if Redis is unavailable.
+
+    Uses ``redis_pool.get_sync_redis()`` — safe for thread-pool context.
+    """
+    try:
+        from redis_pool import get_sync_redis
+
+        redis = get_sync_redis()
+        if redis is None:
+            return None  # Redis unavailable — escalate to Layer 3
+
+        key = _FALLBACK_KEY_TEMPLATE.format(user_id=user_id)
+
+        # Lua script: INCR atomically + set EXPIRE only if not already set.
+        script = """
+            local count = redis.call("INCR", KEYS[1])
+            local ttl = redis.call("TTL", KEYS[1])
+            if ttl == -1 then
+                redis.call("EXPIRE", KEYS[1], ARGV[1])
+            end
+            return count
+        """
+        count = redis.eval(script, 1, key, QUOTA_FALLBACK_TTL)
+        return int(count)
+
+    except Exception as exc:
+        logger.warning(
+            "Redis fallback counter failed for user %s: %s",
+            mask_user_id(user_id),
+            exc,
+        )
+        return None  # Escalate to Layer 3
+
+
+# ---------------------------------------------------------------------------
+# Layer-3 helper
+# ---------------------------------------------------------------------------
+
+
+def _sentry_critical(message: str, *args) -> None:
+    """Send a CRITICAL-level message to Sentry (fail-safe)."""
+    try:
+        import sentry_sdk
+
+        sentry_sdk.capture_message(message % args if args else message, level="critical")
+    except Exception:
+        pass  # Sentry itself may not be configured — never throw here
+
+
+# ---------------------------------------------------------------------------
+# Metric helper (shared with quota_atomic)
+# ---------------------------------------------------------------------------
+
+
+def _set_quota_fallback_active(value: int) -> None:
+    """Update the QUOTA_FALLBACK_ACTIVE Prometheus gauge (no-op if unavailable)."""
+    try:
+        from metrics import QUOTA_FALLBACK_ACTIVE
+
+        QUOTA_FALLBACK_ACTIVE.set(value)
+    except Exception:
+        pass  # Graceful degradation when metrics are not configured
+
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "QUOTA_FALLBACK_MAX_DAILY",
+    "QUOTA_FALLBACK_TTL",
+    "_set_quota_fallback_active",
+    "try_quota_fallback",
+]

--- a/backend/tests/test_quota_fallback.py
+++ b/backend/tests/test_quota_fallback.py
@@ -1,0 +1,286 @@
+"""Tests for 3-layer quota fallback (GAP-012 / #1590).
+
+Tests:
+  1. try_quota_fallback with Redis available — respects max daily limit.
+  2. try_quota_fallback with Redis unavailable — fail open (Layer 3).
+  3. try_quota_fallback counts correctly up to QUOTA_FALLBACK_MAX_DAILY.
+  4. Integration with check_and_increment_quota_atomic on CircuitBreakerOpenError.
+  5. QUOTA_FALLBACK_ACTIVE gauge is updated.
+
+All tests mock the sync Redis client to avoid real Redis dependency.
+IMPORTANT: Patches target the import-origin module, not the local namespace,
+because quota_fallback uses lazy ``from redis_pool import get_sync_redis``.
+"""
+
+import importlib
+import os
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_redis():
+    """Return a MagicMock that behaves like a sync Redis client."""
+    r = MagicMock()
+    r.eval.return_value = 1
+    return r
+
+
+@pytest.fixture
+def mock_redis_unavailable():
+    """Patch redis_pool.get_sync_redis to return None (Redis offline)."""
+    with patch("redis_pool.get_sync_redis", return_value=None):
+        yield
+
+
+@pytest.fixture
+def mock_redis_available(mock_redis):
+    """Patch redis_pool.get_sync_redis to return a working mock."""
+    with patch("redis_pool.get_sync_redis", return_value=mock_redis):
+        yield mock_redis
+
+
+# ============================================================================
+# Tests for try_quota_fallback (core function)
+# ============================================================================
+
+
+class TestTryQuotaFallback:
+    """Direct tests for quota_fallback.try_quota_fallback()."""
+
+    def test_redis_available_first_call_allowed(self, mock_redis_available):
+        """First call should be allowed (INCR=1 <= 10)."""
+        from quota.quota_fallback import try_quota_fallback
+
+        result = try_quota_fallback("user-123")
+        assert result is True
+
+    def test_redis_available_under_limit(self, mock_redis_available):
+        """Calls up to QUOTA_FALLBACK_MAX_DAILY should be allowed."""
+        from quota.quota_fallback import try_quota_fallback, QUOTA_FALLBACK_MAX_DAILY
+
+        for count in range(1, QUOTA_FALLBACK_MAX_DAILY + 1):
+            mock_redis_available.eval.return_value = count
+            result = try_quota_fallback("user-123")
+            assert result is True, f"Call #{count} should be allowed"
+
+    def test_redis_available_over_limit_blocked(self, mock_redis_available):
+        """Call #11 should be blocked (exceeds QUOTA_FALLBACK_MAX_DAILY=10)."""
+        from quota.quota_fallback import try_quota_fallback, QUOTA_FALLBACK_MAX_DAILY
+
+        mock_redis_available.eval.return_value = QUOTA_FALLBACK_MAX_DAILY + 1
+        result = try_quota_fallback("user-123")
+        assert result is False
+
+    def test_redis_unavailable_fail_open(self, mock_redis_unavailable):
+        """When Redis is unavailable, Layer 3 fail-open should allow."""
+        from quota.quota_fallback import try_quota_fallback
+
+        result = try_quota_fallback("user-123")
+        assert result is True  # Fail open
+
+    def test_redis_eval_error_falls_to_layer3(self, mock_redis_available):
+        """When Redis eval() raises, should fall through to Layer 3."""
+        from quota.quota_fallback import try_quota_fallback
+
+        mock_redis_available.eval.side_effect = RuntimeError("Redis connection lost")
+        result = try_quota_fallback("user-123")
+        assert result is True  # Fail open
+
+    def test_redis_key_includes_user_id(self, mock_redis_available):
+        """Redis key should follow the pattern quota:fallback:{user_id}."""
+        from quota.quota_fallback import try_quota_fallback
+
+        try_quota_fallback("test-user-xyz")
+        call_args = mock_redis_available.eval.call_args
+        assert call_args is not None
+        # eval(script, num_keys, key, TTL)
+        key_arg = call_args[0][2]
+        assert "quota:fallback:" in key_arg
+        assert "test-user-xyz" in key_arg
+
+    def test_redis_ttl_set_in_eval(self, mock_redis_available):
+        """The TTL should be passed as the fourth argument to eval."""
+        from quota.quota_fallback import try_quota_fallback, QUOTA_FALLBACK_TTL
+
+        try_quota_fallback("user-ttl-test")
+        call_args = mock_redis_available.eval.call_args
+        ttl_arg = call_args[0][3]
+        assert ttl_arg == QUOTA_FALLBACK_TTL
+
+
+# ============================================================================
+# Tests for integration with check_and_increment_quota_atomic
+# ============================================================================
+
+
+class TestCheckAndIncrementQuotaIntegration:
+    """Ensure the fallback is called when CircuitBreakerOpenError is raised."""
+
+    def test_cb_open_calls_fallback_allowed(self):
+        """CircuitBreakerOpenError should delegate to try_quota_fallback."""
+        from supabase_client import CircuitBreakerOpenError
+        from quota.quota_atomic import check_and_increment_quota_atomic
+
+        with patch(
+            "supabase_client.supabase_cb.call_sync",
+            side_effect=CircuitBreakerOpenError("Supabase CB open"),
+        ):
+            with patch("redis_pool.get_sync_redis") as mock_get_redis:
+                mock_redis = MagicMock()
+                mock_redis.eval.return_value = 1
+                mock_get_redis.return_value = mock_redis
+
+                allowed, new_count, remaining = check_and_increment_quota_atomic(
+                    "user-123", 100
+                )
+                assert allowed is True
+                assert remaining == 100  # max_quota passed through
+
+    def test_cb_open_calls_fallback_blocked(self):
+        """When fallback limit is exceeded, CB open should block."""
+        from supabase_client import CircuitBreakerOpenError
+        from quota.quota_atomic import check_and_increment_quota_atomic
+        from quota.quota_fallback import QUOTA_FALLBACK_MAX_DAILY
+
+        with patch(
+            "supabase_client.supabase_cb.call_sync",
+            side_effect=CircuitBreakerOpenError("Supabase CB open"),
+        ):
+            with patch("redis_pool.get_sync_redis") as mock_get_redis:
+                mock_redis = MagicMock()
+                mock_redis.eval.return_value = QUOTA_FALLBACK_MAX_DAILY + 1
+                mock_get_redis.return_value = mock_redis
+
+                allowed, new_count, remaining = check_and_increment_quota_atomic(
+                    "user-123", 100
+                )
+                assert allowed is False
+                assert remaining == 0
+
+    def test_cb_open_redis_unavailable_fail_open(self):
+        """When both Supabase CB open AND Redis unavailable -> fail open."""
+        from supabase_client import CircuitBreakerOpenError
+        from quota.quota_atomic import check_and_increment_quota_atomic
+
+        with patch(
+            "supabase_client.supabase_cb.call_sync",
+            side_effect=CircuitBreakerOpenError("Supabase CB open"),
+        ):
+            with patch("redis_pool.get_sync_redis", return_value=None):
+                allowed, new_count, remaining = check_and_increment_quota_atomic(
+                    "user-123", 100
+                )
+                assert allowed is True  # Layer 3 fail-open
+                assert remaining == 100
+
+    def test_generic_exception_calls_fallback_allowed(self):
+        """Generic Exception in quota check should also use fallback."""
+        from quota.quota_atomic import check_and_increment_quota_atomic
+
+        with patch(
+            "supabase_client.supabase_cb.call_sync",
+            side_effect=RuntimeError("Supabase connection error"),
+        ):
+            with patch("redis_pool.get_sync_redis") as mock_get_redis:
+                mock_redis = MagicMock()
+                mock_redis.eval.return_value = 1
+                mock_get_redis.return_value = mock_redis
+                with patch(
+                    "quota.quota_atomic.get_monthly_quota_used", return_value=0
+                ):
+                    with patch(
+                        "quota.quota_atomic.increment_monthly_quota", return_value=1
+                    ):
+                        allowed, new_count, remaining = (
+                            check_and_increment_quota_atomic("user-123", 100)
+                        )
+                        assert allowed is True
+
+    def test_generic_exception_fallback_blocked(self):
+        """Generic Exception + fallback exceeded should block."""
+        from quota.quota_atomic import check_and_increment_quota_atomic
+        from quota.quota_fallback import QUOTA_FALLBACK_MAX_DAILY
+
+        with patch(
+            "supabase_client.supabase_cb.call_sync",
+            side_effect=RuntimeError("Supabase connection error"),
+        ):
+            with patch("redis_pool.get_sync_redis") as mock_get_redis:
+                mock_redis = MagicMock()
+                mock_redis.eval.return_value = QUOTA_FALLBACK_MAX_DAILY + 1
+                mock_get_redis.return_value = mock_redis
+
+                allowed, new_count, remaining = check_and_increment_quota_atomic(
+                    "user-123", 100
+                )
+                assert allowed is False
+
+
+# ============================================================================
+# Tests for QUOTA_FALLBACK_ACTIVE gauge
+# ============================================================================
+
+
+class TestQuotaFallbackMetric:
+    """QUOTA_FALLBACK_ACTIVE gauge updates correctly."""
+
+    def test_metric_set_on_cb_open(self):
+        """QUOTA_FALLBACK_ACTIVE should be set to 1 on CB open."""
+        mock_gauge = MagicMock()
+        from supabase_client import CircuitBreakerOpenError
+        from quota.quota_atomic import check_and_increment_quota_atomic
+
+        with patch(
+            "supabase_client.supabase_cb.call_sync",
+            side_effect=CircuitBreakerOpenError("Supabase CB open"),
+        ):
+            with patch("redis_pool.get_sync_redis", return_value=None):
+                with patch(
+                    "metrics.QUOTA_FALLBACK_ACTIVE", mock_gauge
+                ):
+                    check_and_increment_quota_atomic("user-metric", 100)
+                    mock_gauge.set.assert_called_with(1)
+
+
+# ============================================================================
+# Tests for configuration defaults
+# ============================================================================
+
+
+class TestQuotaFallbackConfig:
+    """Default env var configuration for quota fallback."""
+
+    def test_default_max_daily(self):
+        """QUOTA_FALLBACK_MAX_DAILY should default to 10."""
+        from quota.quota_fallback import QUOTA_FALLBACK_MAX_DAILY
+
+        assert QUOTA_FALLBACK_MAX_DAILY == 10
+
+    def test_default_ttl(self):
+        """QUOTA_FALLBACK_TTL should default to 86400 (24h)."""
+        from quota.quota_fallback import QUOTA_FALLBACK_TTL
+
+        assert QUOTA_FALLBACK_TTL == 86400
+
+    @patch.dict(os.environ, {"QUOTA_FALLBACK_MAX_DAILY": "5"})
+    def test_custom_max_daily(self):
+        """QUOTA_FALLBACK_MAX_DAILY should be configurable via env var."""
+        from quota import quota_fallback
+
+        importlib.reload(quota_fallback)
+        assert quota_fallback.QUOTA_FALLBACK_MAX_DAILY == 5
+
+    @patch.dict(os.environ, {"QUOTA_FALLBACK_TTL": "43200"})
+    def test_custom_ttl(self):
+        """QUOTA_FALLBACK_TTL should be configurable via env var."""
+        from quota import quota_fallback
+
+        importlib.reload(quota_fallback)
+        assert quota_fallback.QUOTA_FALLBACK_TTL == 43200


### PR DESCRIPTION
## Context

Quando o Supabase fica offline, o sistema de quota quebrava com CircuitBreakerOpenError e entrava em fail-open incondicional (Layer 3), permitindo requisicoes ilimitadas sem contagem — sem visibilidade para operadores. GAP-012 (#1590) introduz um fallback intermediario via Redis com limite conservador de 10 requisicoes/dia por usuario, reduzindo o risco de abuso durante indisponibilidade do Supabase.

## Changes

- backend/quota/quota_fallback.py — novo modulo com a logica de fallback em 3 camadas (Supabase, Redis, fail-open)
- backend/quota/quota_atomic.py — integracao nos handlers de excecao (CircuitBreakerOpenError e Exception generico) para tentar Layer 2 antes de cair para Layer 3
- backend/quota/__init__.py — re-export dos novos simbolos (try_quota_fallback, QUOTA_FALLBACK_MAX_DAILY, QUOTA_FALLBACK_TTL)
- backend/metrics.py — nova gauge QUOTA_FALLBACK_ACTIVE (0=normal, 1=Redis fallback ativo, 2=fail-open ativo)
- backend/tests/test_quota_fallback.py — 17 testes unitarios + integracao cobrindo todas as camadas e cenarios de falha

## Testing Plan

- [x] Unit tests passing (17 tests em test_quota_fallback.py)
- [ ] Integration tests passing (if applicable)
- [x] Manual validation performed on: simulacao local de Supabase offline (mock RPC raise) + Redis offline (redis_pool retornando None)
- [x] No regressions detected

### Evidence

```
cd backend && pytest tests/test_quota_fallback.py -v
```

## Risks & Rollback

**Risks:**
- Baixo — fail open no ultimo layer (Redis offline -> permite requisicao). Sentry CRITICAL alerta operadores. Limite conservador de 10/dia por usuario no Layer 2.

**Rollback plan:**
- Revert commit. Modulo quota_fallback.py e autocontido, sem migracao de schema. Basta reverter para restaurar comportamento anterior (fail-open direto).

## Closes

Closes #1590

---

## Checklist (Nao remover)

- [x] PR title follows Conventional Commits format
- [x] All acceptance criteria from the issue are met
- [x] Code is formatted (backend: ruff format, frontend: npm run lint)
- [x] No sensitive data (API keys, passwords) in code
- [x] Documentation updated (if public APIs changed)
- [x] Tests added/updated for new functionality
- [x] CI checks are passing locally
- [x] Zero test failures
- [x] API contract — verified