### PR TITLE
fix(ci): replace supabase init --yes with --force flag

### DIFF
--- a/.github/workflows/migration-validate.yml
+++ b/.github/workflows/migration-validate.yml
@@ -66,7 +66,7 @@ jobs:
           # step which handles multi-statement files natively.
           mkdir -p /tmp/supabase-test
           cd /tmp/supabase-test
-          supabase init --yes
+          supabase init --force
 
           # Free disk space and prune dangling images before pulling fresh ones
           docker system prune -af --volumes 2>/dev/null || true


### PR DESCRIPTION
## Summary

Supabase CLI v2.15.8 removed the `--yes` flag. The `--force` flag is the correct replacement.

This fixes the **Validate Migration Sequence** check failing on all PRs touching `supabase/migrations/` (currently affecting PRs #1601, #1602, #1604, and possibly others).

## Changes
- `.github/workflows/migration-validate.yml`: `supabase init --yes` → `supabase init --force`

## Testing Plan
- Manual CI validation on affected PRs after merge