### PR TITLE
feat(backend): admin route for Command plan provisioning — GAP-002 Fase 1 (#1579)

### DIFF
--- a/backend/routes/admin_command.py
+++ b/backend/routes/admin_command.py
@@ -1,0 +1,152 @@
+"""GAP-002 (#1579) — Admin route for Command plan provisioning (Fase 1 MVP).
+
+POST /api/v1/admin/subscriptions/command
+  Creates a Stripe Checkout Session for the SmartLic Command (enterprise) tier.
+
+Admin-only. The existing webhook ``checkout.session.completed`` handler already
+recognises ``plan_id=smartlic_command`` (see TIER-COMMAND-002 in
+webhooks/handlers/checkout.py) and activates the subscription via the generic
+subscription-activation path — no webhook changes needed for Fase 1.
+
+Fase 2 (future issue) will implement the self-serve Command checkout flow.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from admin import require_admin
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin/subscriptions", tags=["admin", "command"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class CommandProvisionRequest(BaseModel):
+    """Request body for provisioning a Command subscription checkout."""
+
+    email: str = Field(
+        ...,
+        min_length=5,
+        max_length=320,
+        description="Customer email for the Stripe Checkout session.",
+    )
+    org_id: str | None = Field(
+        default=None,
+        description="Optional organisation identifier for metadata tracking.",
+    )
+
+
+class CommandProvisionResponse(BaseModel):
+    """Response returned after creating the Command checkout session."""
+
+    checkout_url: str
+    session_id: str
+    plan_id: str = Field(default="smartlic_command")
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.post("/command", response_model=CommandProvisionResponse)
+async def provision_command_subscription(
+    req: CommandProvisionRequest,
+    admin: dict = Depends(require_admin),
+) -> CommandProvisionResponse:
+    """Create a Stripe Checkout session for the SmartLic Command (enterprise) tier.
+
+    Uses the price ID from the ``COMMAND_PRICE_ID`` environment variable.
+    The session is created in ``mode='subscription'`` with metadata that
+    the existing ``checkout.session.completed`` webhook handler recognises
+    (see TIER-COMMAND-002 in webhooks/handlers/checkout.py).
+
+    Returns the Stripe Checkout URL and session ID.
+    """
+    actor_email = admin.get("email", "admin@unknown")
+    logger.info(
+        "Admin provisioning Command checkout — "
+        "email=%s org_id=%s actor=%s",
+        req.email,
+        req.org_id,
+        actor_email,
+    )
+
+    command_price_id = os.getenv("COMMAND_PRICE_ID", "")
+    if not command_price_id:
+        logger.error("COMMAND_PRICE_ID not configured")
+        raise HTTPException(
+            status_code=500,
+            detail="Preco Command nao configurado. Contate o suporte.",
+        )
+
+    stripe_key = os.getenv("STRIPE_SECRET_KEY")
+    if not stripe_key:
+        logger.error("STRIPE_SECRET_KEY not configured for Command checkout")
+        raise HTTPException(
+            status_code=500,
+            detail="Servico de pagamento nao configurado. Contate o suporte.",
+        )
+
+    frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+    import stripe as stripe_lib
+
+    session_params = {
+        "payment_method_types": ["card", "boleto"],
+        "line_items": [{"price": command_price_id, "quantity": 1}],
+        "mode": "subscription",
+        "success_url": f"{frontend_url}/planos/obrigado?plan=smartlic_command",
+        "cancel_url": f"{frontend_url}/admin/command?cancelled=true",
+        "customer_email": req.email,
+        "metadata": {
+            "plan_id": "smartlic_command",
+            "source": "admin_command",
+            "provisioned_by": actor_email,
+            "org_id": req.org_id or "",
+        },
+        "payment_method_options": {
+            "boleto": {"expires_after_days": 3},
+        },
+    }
+
+    try:
+        session = stripe_lib.checkout.Session.create(**session_params, api_key=stripe_key)
+    except stripe_lib.error.InvalidRequestError as e:
+        logger.error(
+            "Stripe InvalidRequestError on Command checkout: %s",
+            e,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Nao foi possivel iniciar o checkout Command. Verifique os dados e tente novamente.",
+        )
+    except stripe_lib.error.StripeError as e:
+        logger.error("Stripe error on Command checkout: %s", e)
+        raise HTTPException(
+            status_code=503,
+            detail="Servico de pagamento temporariamente indisponivel. Tente novamente.",
+        )
+
+    logger.info(
+        "Command checkout session created — session_id=%s email=%s actor=%s",
+        session.id,
+        req.email,
+        actor_email,
+    )
+
+    return CommandProvisionResponse(
+        checkout_url=session.url,
+        session_id=session.id,
+        plan_id="smartlic_command",
+    )

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -96,6 +96,7 @@ from routes.api_search import router as api_search_router
 from routes.admin_metrics import router as admin_metrics_router
 from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
+from routes.admin_command import router as admin_command_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -192,6 +193,9 @@ def register_routes(app: FastAPI) -> None:
 
     # DIGEST-005 (#1421): Admin digest metrics dashboard widget
     app.include_router(admin_digest_metrics_router)
+
+    # GAP-002 (#1579): Command plan provisioning — self-prefixed at /v1/admin/subscriptions/*
+    app.include_router(admin_command_router)
 
     # Stripe webhook at root — DEBT-324: single registration only.
     # Removed from _v1_routers above to prevent duplicate at /v1/webhooks/stripe.

--- a/backend/tests/test_admin_command.py
+++ b/backend/tests/test_admin_command.py
@@ -1,0 +1,165 @@
+"""GAP-002 (#1579) — Tests for admin Command provisioning route.
+
+Covers:
+- POST /v1/admin/subscriptions/command creates Stripe Checkout session.
+- Non-admin gets 403.
+- Missing COMMAND_PRICE_ID env var returns 500.
+- Missing STRIPE_SECRET_KEY returns 500.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_fake")
+os.environ.setdefault("COMMAND_PRICE_ID", "price_command_test")
+os.environ.setdefault("FRONTEND_URL", "http://localhost:3000")
+
+from main import app  # noqa: E402
+from auth import require_auth  # noqa: E402
+from admin import require_admin  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_client():
+    fake_admin = {"id": "00000000-0000-0000-0000-00000000a001", "email": "admin@test"}
+    app.dependency_overrides[require_auth] = lambda: fake_admin
+    app.dependency_overrides[require_admin] = lambda: fake_admin
+    yield TestClient(app)
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+@pytest.fixture
+def regular_client():
+    """Logged-in non-admin user — should get 403 from require_admin."""
+    fake_user = {"id": "regular-user", "email": "user@test"}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    yield TestClient(app)
+    app.dependency_overrides.pop(require_auth, None)
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/admin/subscriptions/command
+# ---------------------------------------------------------------------------
+
+
+@patch("stripe.checkout.Session.create")
+def test_provision_command_checkout_creates_session(mock_stripe_create, admin_client):
+    """Admin creates a Command checkout session successfully."""
+    mock_session = MagicMock()
+    mock_session.id = "cs_test_command_123"
+    mock_session.url = "https://checkout.stripe.com/pay/cs_test_command_123"
+    mock_stripe_create.return_value = mock_session
+
+    r = admin_client.post(
+        "/v1/admin/subscriptions/command",
+        json={"email": "enterprise@example.com", "org_id": "org-42"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["checkout_url"] == "https://checkout.stripe.com/pay/cs_test_command_123"
+    assert body["session_id"] == "cs_test_command_123"
+    assert body["plan_id"] == "smartlic_command"
+
+    # Verify Stripe was called with correct params
+    call_kwargs = mock_stripe_create.call_args.kwargs
+    assert call_kwargs["mode"] == "subscription"
+    assert call_kwargs["customer_email"] == "enterprise@example.com"
+    assert call_kwargs["metadata"]["plan_id"] == "smartlic_command"
+    assert call_kwargs["metadata"]["source"] == "admin_command"
+    assert call_kwargs["metadata"]["provisioned_by"] == "admin@test"
+    assert call_kwargs["metadata"]["org_id"] == "org-42"
+    assert len(call_kwargs["line_items"]) == 1
+    assert call_kwargs["line_items"][0]["price"] == "price_command_test"
+
+
+@patch("stripe.checkout.Session.create")
+def test_provision_command_without_org_id(mock_stripe_create, admin_client):
+    """Admin creates Command checkout without optional org_id."""
+    mock_session = MagicMock()
+    mock_session.id = "cs_test_no_org"
+    mock_session.url = "https://checkout.stripe.com/pay/cs_test_no_org"
+    mock_stripe_create.return_value = mock_session
+
+    r = admin_client.post(
+        "/v1/admin/subscriptions/command",
+        json={"email": "noorganisation@example.com"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["session_id"] == "cs_test_no_org"
+    call_kwargs = mock_stripe_create.call_args.kwargs
+    assert call_kwargs["metadata"]["org_id"] == ""
+
+
+def test_provision_command_rejects_non_admin(regular_client):
+    """Non-admin user gets 403."""
+    r = regular_client.post(
+        "/v1/admin/subscriptions/command",
+        json={"email": "hacker@example.com"},
+    )
+    assert r.status_code == 403
+
+
+@patch.dict(os.environ, {"COMMAND_PRICE_ID": ""})
+def test_provision_command_missing_price_id(admin_client):
+    """Missing COMMAND_PRICE_ID returns 500."""
+    with patch("routes.admin_command.os.getenv", return_value=""):
+        r = admin_client.post(
+            "/v1/admin/subscriptions/command",
+            json={"email": "noprice@example.com"},
+        )
+    assert r.status_code == 500
+    body = r.json()
+    assert "Preco" in body.get("detail", "")
+
+
+@patch.dict(os.environ, {"STRIPE_SECRET_KEY": ""})
+def test_provision_command_missing_stripe_key(admin_client):
+    """Missing STRIPE_SECRET_KEY returns 500."""
+    r = admin_client.post(
+        "/v1/admin/subscriptions/command",
+        json={"email": "nostripe@example.com"},
+    )
+    assert r.status_code == 500
+    body = r.json()
+    assert "Servico" in body.get("detail", "")
+
+
+@patch("stripe.checkout.Session.create")
+def test_provision_command_stripe_invalid_request(mock_stripe_create, admin_client):
+    """Stripe InvalidRequestError returns 400."""
+    import stripe as stripe_lib
+    mock_stripe_create.side_effect = stripe_lib.error.InvalidRequestError(
+        message="Invalid price",
+        param="price",
+    )
+
+    r = admin_client.post(
+        "/v1/admin/subscriptions/command",
+        json={"email": "invalid@example.com"},
+    )
+    assert r.status_code == 400
+
+
+@patch("stripe.checkout.Session.create")
+def test_provision_command_stripe_api_error(mock_stripe_create, admin_client):
+    """Stripe generic error returns 503."""
+    import stripe as stripe_lib
+    mock_stripe_create.side_effect = stripe_lib.error.StripeError("API down")
+
+    r = admin_client.post(
+        "/v1/admin/subscriptions/command",
+        json={"email": "api-down@example.com"},
+    )
+    assert r.status_code == 503

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -1372,6 +1372,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/subscriptions/command": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Provision Command Subscription
+         * @description Create a Stripe Checkout session for the SmartLic Command (enterprise) tier.
+         *
+         *     Uses the price ID from the ``COMMAND_PRICE_ID`` environment variable.
+         *     The session is created in ``mode='subscription'`` with metadata that
+         *     the existing ``checkout.session.completed`` webhook handler recognises
+         *     (see TIER-COMMAND-002 in webhooks/handlers/checkout.py).
+         *
+         *     Returns the Stripe Checkout URL and session ID.
+         */
+        post: operations["provision_command_subscription_v1_admin_subscriptions_command_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/support-sla": {
         parameters: {
             query?: never;
@@ -7947,6 +7974,37 @@ export interface components {
             /** Setor Id */
             setor_id?: string | null;
         };
+        /**
+         * CommandProvisionRequest
+         * @description Request body for provisioning a Command subscription checkout.
+         */
+        CommandProvisionRequest: {
+            /**
+             * Email
+             * @description Customer email for the Stripe Checkout session.
+             */
+            email: string;
+            /**
+             * Org Id
+             * @description Optional organisation identifier for metadata tracking.
+             */
+            org_id?: string | null;
+        };
+        /**
+         * CommandProvisionResponse
+         * @description Response returned after creating the Command checkout session.
+         */
+        CommandProvisionResponse: {
+            /** Checkout Url */
+            checkout_url: string;
+            /**
+             * Plan Id
+             * @default smartlic_command
+             */
+            plan_id: string;
+            /** Session Id */
+            session_id: string;
+        };
         /** ComparadorBid */
         ComparadorBid: {
             /** Data Abertura */
@@ -13274,6 +13332,22 @@ export interface components {
             status: string;
         };
         /**
+         * StripeHealthResponse
+         * @description Response for GET /health/stripe endpoint (DEC-BIL-GAP-02).
+         */
+        StripeHealthResponse: {
+            /** Grace Period Hours */
+            grace_period_hours?: number | null;
+            /** Grace Remaining Hours */
+            grace_remaining_hours?: number | null;
+            /** Notified */
+            notified?: boolean | null;
+            /** Since */
+            since?: string | null;
+            /** Stripe */
+            stripe: string;
+        };
+        /**
          * SubscriptionStatusResponse
          * @description GET /subscription/status — current plan + period info.
          */
@@ -16012,6 +16086,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SloAlertsResponse"];
+                };
+            };
+        };
+    };
+    provision_command_subscription_v1_admin_subscriptions_command_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CommandProvisionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommandProvisionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -19323,7 +19430,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StripeHealthResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
Closes #1579 (GAP-002).

### Scope: Fase 1 — Admin Dashboard (MVP)
- Admin route POST /api/v1/admin/subscriptions/command
- Creates Stripe Checkout session with Command price_id
- Existing webhook checkout.session.completed already handles plan_type sync
- Fallback: admin can set plan_type='command' directly via existing admin tools

### Not included (Fase 2 — future issue)
- Self-serve Command checkout flow
- Multi-user auto-onboarding
- Custom enterprise onboarding

### Validation
- [x] Ruff linting passes
- [x] Admin-only authorization tested
- [x] Stripe checkout creation tested (mocked)

## Type
[x] Feature
[ ] Bug fix
[ ] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)