### PR TITLE
fix(frontend): align Command tier pricing with backend spec — R$970->R$4.970/mes (#1617)

### DIFF
--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -3696,6 +3696,59 @@
         "title": "CnaeMappingUpdate",
         "type": "object"
       },
+      "CommandProvisionRequest": {
+        "description": "Request body for provisioning a Command subscription checkout.",
+        "properties": {
+          "email": {
+            "description": "Customer email for the Stripe Checkout session.",
+            "maxLength": 320,
+            "minLength": 5,
+            "title": "Email",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional organisation identifier for metadata tracking.",
+            "title": "Org Id"
+          }
+        },
+        "required": [
+          "email"
+        ],
+        "title": "CommandProvisionRequest",
+        "type": "object"
+      },
+      "CommandProvisionResponse": {
+        "description": "Response returned after creating the Command checkout session.",
+        "properties": {
+          "checkout_url": {
+            "title": "Checkout Url",
+            "type": "string"
+          },
+          "plan_id": {
+            "default": "smartlic_command",
+            "title": "Plan Id",
+            "type": "string"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "checkout_url",
+          "session_id"
+        ],
+        "title": "CommandProvisionResponse",
+        "type": "object"
+      },
       "ComparadorBid": {
         "properties": {
           "data_abertura": {
@@ -20524,6 +20577,54 @@
         "summary": "Get Slo Alerts",
         "tags": [
           "admin-slo"
+        ]
+      }
+    },
+    "/v1/admin/subscriptions/command": {
+      "post": {
+        "description": "Create a Stripe Checkout session for the SmartLic Command (enterprise) tier.\n\nUses the price ID from the ``COMMAND_PRICE_ID`` environment variable.\nThe session is created in ``mode='subscription'`` with metadata that\nthe existing ``checkout.session.completed`` webhook handler recognises\n(see TIER-COMMAND-002 in webhooks/handlers/checkout.py).\n\nReturns the Stripe Checkout URL and session ID.",
+        "operationId": "provision_command_subscription_v1_admin_subscriptions_command_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommandProvisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandProvisionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Provision Command Subscription",
+        "tags": [
+          "admin",
+          "command"
         ]
       }
     },

--- a/frontend/__tests__/planos/ProductSchema.test.tsx
+++ b/frontend/__tests__/planos/ProductSchema.test.tsx
@@ -9,6 +9,7 @@ import { ProductSchema } from "@/app/planos/components/ProductSchema";
 import {
   PRO_PRICING,
   CONSULTORIA_PRICING,
+  COMMAND_PRICING,
   AGGREGATE_OFFER_BOUNDS,
   getPriceValidUntil,
 } from "@/lib/plan-pricing";
@@ -40,11 +41,11 @@ function extractSchemas(container: HTMLElement): ProductNode[] {
 }
 
 describe("ProductSchema (STORY-SEO-004)", () => {
-  it("emits exactly 2 Product schemas (Pro + Consultoria)", () => {
+  it("emits exactly 3 Product schemas (Pro + Consultoria + Command)", () => {
     const { container } = render(<ProductSchema />);
     const schemas = extractSchemas(container);
-    expect(schemas).toHaveLength(2);
-    expect(schemas.map((s) => s.name)).toEqual(["SmartLic Pro", "SmartLic Consultoria"]);
+    expect(schemas).toHaveLength(3);
+    expect(schemas.map((s) => s.name)).toEqual(["SmartLic Pro", "SmartLic Consultoria", "SmartLic Command"]);
   });
 
   it("each Product schema is well-formed JSON-LD with required fields", () => {
@@ -63,7 +64,8 @@ describe("ProductSchema (STORY-SEO-004)", () => {
 
   it("Pro offers match PRO_PRICING source of truth", () => {
     const { container } = render(<ProductSchema />);
-    const [proSchema] = extractSchemas(container);
+    const schemas = extractSchemas(container);
+    const [proSchema] = schemas;
 
     const priceByPeriod = Object.fromEntries(
       proSchema.offers.map((o) => [o.category, Number(o.price)])
@@ -76,7 +78,8 @@ describe("ProductSchema (STORY-SEO-004)", () => {
 
   it("Consultoria offers match CONSULTORIA_PRICING source of truth", () => {
     const { container } = render(<ProductSchema />);
-    const [, consultoriaSchema] = extractSchemas(container);
+    const schemas = extractSchemas(container);
+    const consultoriaSchema = schemas[1];
 
     const priceByPeriod = Object.fromEntries(
       consultoriaSchema.offers.map((o) => [o.category, Number(o.price)])
@@ -85,6 +88,20 @@ describe("ProductSchema (STORY-SEO-004)", () => {
     expect(priceByPeriod.monthly).toBe(CONSULTORIA_PRICING.monthly.monthly);
     expect(priceByPeriod.semiannual).toBe(CONSULTORIA_PRICING.semiannual.monthly);
     expect(priceByPeriod.annual).toBe(CONSULTORIA_PRICING.annual.monthly);
+  });
+
+  it("Command offers match COMMAND_PRICING source of truth", () => {
+    const { container } = render(<ProductSchema />);
+    const schemas = extractSchemas(container);
+    const commandSchema = schemas[2];
+
+    const priceByPeriod = Object.fromEntries(
+      commandSchema.offers.map((o) => [o.category, Number(o.price)])
+    );
+
+    expect(priceByPeriod.monthly).toBe(COMMAND_PRICING.monthly.monthly);
+    expect(priceByPeriod.semiannual).toBe(COMMAND_PRICING.semiannual.monthly);
+    expect(priceByPeriod.annual).toBe(COMMAND_PRICING.annual.monthly);
   });
 
   it("all offers declare BRL currency, InStock availability, and priceValidUntil ≥ today", () => {

--- a/frontend/app/planos/components/ProductSchema.tsx
+++ b/frontend/app/planos/components/ProductSchema.tsx
@@ -8,6 +8,7 @@
  * priceValidUntil, availability. Aligned with schema.org/Product spec.
  */
 import {
+  COMMAND_PRICING,
   CONSULTORIA_PRICING,
   PRO_PRICING,
   PricingTable,
@@ -37,6 +38,13 @@ const PRODUCTS: ProductSpec[] = [
       "Plano Consultoria SmartLic: até 5 usuários, 5.000 análises/mês, dashboard consolidado e suporte dedicado para consultorias e assessorias de licitação.",
     pricing: CONSULTORIA_PRICING,
     urlQueryKey: "consultoria",
+  },
+  {
+    name: "SmartLic Command",
+    description:
+      "Tier enterprise do SmartLic: API exclusiva, multi-usuário, relatórios executivos com IA, análise preditiva de mercado e suporte dedicado 24/7.",
+    pricing: COMMAND_PRICING,
+    urlQueryKey: "command",
   },
 ];
 

--- a/frontend/lib/plan-pricing.ts
+++ b/frontend/lib/plan-pricing.ts
@@ -36,17 +36,17 @@ export const CONSULTORIA_PRICING: PricingTable = {
 };
 
 export const COMMAND_PRICING: PricingTable = {
-  monthly: { monthly: 970, total: 970, period: "mês" },
-  semiannual: { monthly: 873, total: 5238, period: "semestre", discount: 10 },
-  annual: { monthly: 808, total: 9700, period: "ano", discount: 17 },
+  monthly: { monthly: 4970, total: 4970, period: "mês" },
+  semiannual: { monthly: 4473, total: 26838, period: "semestre", discount: 10 },
+  annual: { monthly: 4125, total: 49500, period: "ano", discount: 17 },
 };
 
-/** Stable min/max across both tiers, for AggregateOffer schema. */
+/** Stable min/max across all tiers, for AggregateOffer schema. */
 export const AGGREGATE_OFFER_BOUNDS = {
-  lowPrice: Math.min(PRO_PRICING.annual.monthly, CONSULTORIA_PRICING.annual.monthly),
-  highPrice: Math.max(PRO_PRICING.monthly.monthly, CONSULTORIA_PRICING.monthly.monthly),
-  // 2 tiers × 3 periods each
-  offerCount: 6,
+  lowPrice: Math.min(PRO_PRICING.annual.monthly, CONSULTORIA_PRICING.annual.monthly, COMMAND_PRICING.annual.monthly),
+  highPrice: Math.max(PRO_PRICING.monthly.monthly, CONSULTORIA_PRICING.monthly.monthly, COMMAND_PRICING.monthly.monthly),
+  // 3 tiers × 3 periods each
+  offerCount: 9,
   priceCurrency: "BRL" as const,
 };
 


### PR DESCRIPTION
## Summary
Closes #1617 (PRICE-001).

### Problem
Frontend COMMAND_PRICING showed R$970/mes while backend PLAN_PRICES has smartlic_command = 4_970 (R$4.970/mes). 5x discrepancy on the most valuable tier.

### Fix
- Updated COMMAND_PRICING in frontend/lib/plan-pricing.ts
- Monthly: R$970 -> R$4.970
- Semiannual: R$873 -> R$4.473/mes (10% discount)
- Annual: R$808 -> R$4.125/mes (17% discount)
- Included Command tier in AGGREGATE_OFFER_BOUNDS
- Added Command tier to ProductSchema JSON-LD structured data

### Validation
- [x] TypeScript compilation passes
- [x] Frontend tests pass (7703+ tests)
- [x] ProductSchema test updated for 3 tiers

### Not included (separate follow-up)
- Stripe price ID audit
- Communication plan for existing Command subscribers
- Tier differentiation documentation

## Type
[x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "SmartLic Command" plan tier alongside Pro and Consultoria.
  * Pricing updated to include monthly, semiannual, and annual options for the new tier; aggregate offer ranges and totals adjusted accordingly.
  * Embedded product metadata (JSON-LD) now emits three product entries for improved SEO/structured-data coverage.
  * New admin provisioning endpoint to create checkout sessions for the Command tier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->