### PR TITLE
fix(backend): implement intra-UF pagination to prevent PostgREST silent truncation (#1629)

### DIFF
--- a/backend/datalake_query.py
+++ b/backend/datalake_query.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime, timedelta
 import re
 import time
 from typing import Any
@@ -44,6 +45,16 @@ _embedding_cache: dict[str, tuple[float, list[float]]] = {}
 # the 25-connection pool limit. Requests that cannot acquire within 2s fail
 # fast (return []) instead of queuing into a pool-exhaustion wedge.
 _SEO_SEMAPHORE = asyncio.Semaphore(5)
+
+# ---------------------------------------------------------------------------
+# TRUNC-001: PostgREST silent data truncation guard
+# ---------------------------------------------------------------------------
+
+# PostgREST caps RPC results at 1000 rows per call (hard limit, no negotiation).
+_POSTGREST_ROW_CAP = 1000
+# Maximum recursion depth for binary date-range splitting. 2^10 = 1024
+# sub-queries max, sufficient to resolve any realistic truncation.
+_MAX_PAGINATION_DEPTH = 10
 
 
 def _cache_key(
@@ -85,6 +96,141 @@ def _cache_put(key: str, results: list[dict]) -> None:
         oldest_key = min(_query_cache, key=lambda k: _query_cache[k][0])
         del _query_cache[oldest_key]
     _query_cache[key] = (time.monotonic() + _CACHE_TTL, results)
+
+# ---------------------------------------------------------------------------
+# TRUNC-001: Intra-UF pagination with binary date-range splitting
+# ---------------------------------------------------------------------------
+
+
+def _record_sentry_truncation(uf: str) -> None:
+    """Dispatch a Sentry error-level alert + Prometheus metric when truncation
+    is detected.  Both are best-effort and never block the caller."""
+    try:
+        from metrics import DATALAKE_TRUNCATION_SUSPECTED
+        DATALAKE_TRUNCATION_SUSPECTED.labels(uf=uf).inc()
+    except Exception:
+        pass  # Metrics are optional
+    try:
+        import sentry_sdk
+        sentry_sdk.capture_message(
+            f"[DatalakeQuery] PostgREST truncation detected for UF={uf} — "
+            f"returned exactly {_POSTGREST_ROW_CAP} rows. Data loss occurred.",
+            level="error",
+        )
+    except ImportError:
+        pass  # sentry_sdk not available (tests, local dev)
+
+
+async def _query_uf_with_pagination(
+    sb: Any,
+    sb_execute: Any,
+    rpc_params: dict[str, Any],
+    uf: str,
+    date_start: str,
+    date_end: str,
+    depth: int,
+) -> list[dict]:
+    """Query a single UF with automatic binary date-range pagination.
+
+    PostgREST caps RPC results at 1000 rows.  When the UF (e.g. SP) has more
+    data than the cap, this function splits the date range in half and
+    recursively queries each half, merging the results chronologically.
+
+    Args:
+        sb: Supabase client.
+        sb_execute: Wrapped Supabase .execute() with circuit-breaker.
+        rpc_params: Base RPC parameters (shared across all sub-queries).
+        uf: Two-letter UF code.
+        date_start: Inclusive start date "YYYY-MM-DD".
+        date_end: Inclusive end date "YYYY-MM-DD".
+        depth: Current recursion depth (starts at 0, guards against runaway).
+
+    Returns:
+        List of raw rows from the RPC (not yet normalized).
+        Returns [] on error (fail-open).
+    """
+    if depth > _MAX_PAGINATION_DEPTH:
+        logger.error(
+            f"[DatalakeQuery] Max pagination depth ({_MAX_PAGINATION_DEPTH}) "
+            f"exceeded for UF={uf} range [{date_start}, {date_end}] — "
+            f"giving up and returning partial results."
+        )
+        return []
+
+    # Build per-UF params — override date range + UF filter
+    uf_params = {
+        **rpc_params,
+        "p_ufs": [uf],
+        "p_date_start": date_start,
+        "p_date_end": date_end,
+    }
+
+    try:
+        result = await sb_execute(
+            sb.rpc("search_datalake", uf_params), category="rpc"
+        )
+        uf_rows = result.data or []
+    except Exception as e:
+        logger.warning(
+            f"[DatalakeQuery] RPC failed for UF={uf} "
+            f"[{date_start}, {date_end}]: {type(e).__name__}: {e}"
+        )
+        return []
+
+    if len(uf_rows) < _POSTGREST_ROW_CAP:
+        # No truncation — return as-is
+        return uf_rows
+
+    # ---- Truncation detected: split date range and recurse ----
+    _record_sentry_truncation(uf)
+
+    try:
+        d_start = datetime.strptime(date_start, "%Y-%m-%d").date()
+        d_end = datetime.strptime(date_end, "%Y-%m-%d").date()
+    except ValueError as e:
+        logger.warning(
+            f"[DatalakeQuery] Cannot split date range for UF={uf}: "
+            f"invalid date format ({date_start}, {date_end}): {e}"
+        )
+        return uf_rows  # Return partial results rather than lose everything
+
+    total_days = (d_end - d_start).days
+    if total_days < 1:
+        # Single date — cannot split further; return partial
+        logger.warning(
+            f"[DatalakeQuery] UF={uf} still exceeds cap at minimum granularity "
+            f"[{date_start}] — returning {len(uf_rows)} rows (possibly truncated)."
+        )
+        return uf_rows
+
+    # Compute midpoint
+    mid = d_start + timedelta(days=total_days // 2)
+
+    left_start = d_start
+    left_end = mid
+    right_start = mid + timedelta(days=1)
+    right_end = d_end
+
+    logger.info(
+        f"[DatalakeQuery] UF={uf} truncation detected ({len(uf_rows)} rows). "
+        f"Splitting range [{date_start}, {date_end}] → "
+        f"[{left_start}, {left_end}] + [{right_start}, {right_end}] "
+        f"(depth={depth + 1})"
+    )
+
+    left_rows = await _query_uf_with_pagination(
+        sb, sb_execute, rpc_params, uf,
+        left_start.isoformat(), left_end.isoformat(),
+        depth + 1,
+    )
+    right_rows = await _query_uf_with_pagination(
+        sb, sb_execute, rpc_params, uf,
+        right_start.isoformat(), right_end.isoformat(),
+        depth + 1,
+    )
+
+    return left_rows + right_rows
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -206,27 +352,21 @@ async def query_datalake(
             f"embedding={'yes' if query_embedding else 'no'}, limit={limit}"
         )
 
-        # PostgREST caps results at 1000 rows per call.
-        # Paginate per-UF to avoid truncação em queries multi-UF.
-        _POSTGREST_ROW_CAP = 1000
+        # TRUNC-001: Paginate per-UF with binary date-range splitting.
+        # PostgREST caps RPC results at 1000 rows per call; when a UF hits
+        # this cap we split the date range in half and recurse.
         rows: list[dict] = []
         for uf in ufs:
-            uf_params = {**rpc_params, "p_ufs": [uf]}
             try:
-                result = await sb_execute(sb.rpc("search_datalake", uf_params), category="rpc")
-                uf_rows = result.data or []
-                # Detecta possível truncamento silencioso do PostgREST (limite 1000 linhas/chamada)
-                if len(uf_rows) == _POSTGREST_ROW_CAP:
-                    logger.warning(
-                        f"[DatalakeQuery] UF {uf} returned exactly {_POSTGREST_ROW_CAP} rows "
-                        f"— possível truncamento silencioso do PostgREST. "
-                        f"Considere reduzir o intervalo de datas ou aumentar a granularidade da query."
-                    )
-                    try:
-                        from metrics import DATALAKE_TRUNCATION_SUSPECTED
-                        DATALAKE_TRUNCATION_SUSPECTED.labels(uf=uf).inc()
-                    except Exception:
-                        pass  # Métricas são opcionais — nunca bloqueiam o fluxo principal
+                uf_rows = await _query_uf_with_pagination(
+                    sb=sb,
+                    sb_execute=sb_execute,
+                    rpc_params=rpc_params,
+                    uf=uf,
+                    date_start=data_inicial,
+                    date_end=data_final,
+                    depth=0,
+                )
                 rows.extend(uf_rows)
             except Exception as e:
                 logger.warning(f"[DatalakeQuery] RPC failed for UF={uf}: {type(e).__name__}: {e}")

--- a/backend/datalake_query.py
+++ b/backend/datalake_query.py
@@ -211,8 +211,9 @@ async def _query_uf_with_pagination(
     right_start = mid + timedelta(days=1)
     right_end = d_end
 
-    logger.info(
-        f"[DatalakeQuery] UF={uf} truncation detected ({len(uf_rows)} rows). "
+    logger.warning(
+        f"[DatalakeQuery] UF={uf} truncation detected ({len(uf_rows)} rows — "
+        f"exactly the PostgREST cap). "
         f"Splitting range [{date_start}, {date_end}] → "
         f"[{left_start}, {left_end}] + [{right_start}, {right_end}] "
         f"(depth={depth + 1})"

--- a/backend/tests/test_datalake_query.py
+++ b/backend/tests/test_datalake_query.py
@@ -528,7 +528,7 @@ class TestQueryDatalake:
         mock_openai_client.embeddings.create = AsyncMock(return_value=mock_response)
 
         with patch("openai.AsyncOpenAI", return_value=mock_openai_client):
-            result = await query_datalake(
+            await query_datalake(
                 ufs=["SP"],
                 data_inicial="2026-03-01",
                 data_final="2026-03-31",
@@ -732,3 +732,164 @@ class TestRowToNormalized:
         result = _row_to_normalized(SAMPLE_TRIGRAM_ROW)
         assert result["objetoCompra"] == SAMPLE_DB_ROW["objeto_compra"]
         assert "sim_score" not in result
+
+
+# ---------------------------------------------------------------------------
+# TRUNC-001: Intra-UF pagination tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryUfWithPagination:
+    """Tests for _query_uf_with_pagination() — binary date-range splitting."""
+
+    @pytest.mark.asyncio
+    async def test_no_truncation_returns_rows_as_is(self):
+        """When rows < 1000, must return them directly (no splitting)."""
+        from datalake_query import _query_uf_with_pagination
+
+        sb = MagicMock()
+        mock_data = MagicMock()
+        mock_data.data = [SAMPLE_DB_ROW]
+        sb_rpc_result = MagicMock()
+        sb_rpc_result.execute.return_value = mock_data
+        sb.rpc.return_value = sb_rpc_result
+
+        sb_execute = AsyncMock(return_value=mock_data)
+
+        result = await _query_uf_with_pagination(
+            sb=sb, sb_execute=sb_execute,
+            rpc_params={}, uf="SP",
+            date_start="2026-03-01", date_end="2026-03-10",
+            depth=0,
+        )
+
+        assert len(result) == 1
+        assert result[0]["pncp_id"] == SAMPLE_DB_ROW["pncp_id"]
+
+    @pytest.mark.asyncio
+    async def test_truncation_splits_date_range_and_merges(self):
+        """When rows == 1000, must split date range and recursively query."""
+        from datalake_query import _query_uf_with_pagination, _POSTGREST_ROW_CAP
+
+        sb = MagicMock()
+        sb_execute = MagicMock()
+
+        # Simulate the first call returning 1000 rows (truncation signal),
+        # then sub-queries returning smaller sets.
+        call_count = 0
+
+        async def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # First call (full range) — hits the cap
+                result.data = [{"pncp_id": f"row-{i}"} for i in range(_POSTGREST_ROW_CAP)]
+            elif call_count <= 3:
+                # Subsequent calls — under cap (split ranges)
+                result.data = [{"pncp_id": f"row-{call_count}-{i}"} for i in range(100)]
+            else:
+                result.data = []
+            return result
+
+        sb_execute.side_effect = mock_execute
+        sb.rpc.return_value.execute.side_effect = lambda: MagicMock(data=[])
+
+        result = await _query_uf_with_pagination(
+            sb=sb, sb_execute=sb_execute,
+            rpc_params={}, uf="SP",
+            date_start="2026-03-01", date_end="2026-03-10",
+            depth=0,
+        )
+
+        # Must have called at least 3 times (original + 2 splits)
+        assert sb_execute.call_count >= 3
+        # Must have merged results from sub-queries
+        assert len(result) == 200
+
+    @pytest.mark.asyncio
+    async def test_single_day_truncation_returns_partial(self):
+        """When truncation persists at minimum granularity, return partial."""
+        from datalake_query import _query_uf_with_pagination, _POSTGREST_ROW_CAP
+
+        sb = MagicMock()
+        sb_execute = MagicMock()
+
+        async def mock_execute(*args, **kwargs):
+            result = MagicMock()
+            result.data = [{"pncp_id": f"row-{i}"} for i in range(_POSTGREST_ROW_CAP)]
+            return result
+
+        sb_execute.side_effect = mock_execute
+
+        result = await _query_uf_with_pagination(
+            sb=sb, sb_execute=sb_execute,
+            rpc_params={}, uf="SP",
+            date_start="2026-03-01", date_end="2026-03-01",  # single day
+            depth=0,
+        )
+
+        # Should return partial results (1000 rows) instead of crashing
+        assert len(result) == _POSTGREST_ROW_CAP
+
+    @pytest.mark.asyncio
+    async def test_max_depth_exceeded_returns_empty(self):
+        """When depth exceeds max, must return [] to prevent runaway."""
+        from datalake_query import _query_uf_with_pagination, _MAX_PAGINATION_DEPTH
+
+        sb = MagicMock()
+        sb_execute = MagicMock()
+
+        result = await _query_uf_with_pagination(
+            sb=sb, sb_execute=sb_execute,
+            rpc_params={}, uf="SP",
+            date_start="2026-03-01", date_end="2026-03-31",
+            depth=_MAX_PAGINATION_DEPTH + 1,
+        )
+
+        assert result == []
+        # Must NOT have called the RPC at all
+        sb_execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rpc_failure_returns_empty_list(self):
+        """RPC failure must return [] (fail-open)."""
+        from datalake_query import _query_uf_with_pagination
+
+        sb = MagicMock()
+        sb_execute = MagicMock(side_effect=RuntimeError("RPC gone"))
+
+        result = await _query_uf_with_pagination(
+            sb=sb, sb_execute=sb_execute,
+            rpc_params={}, uf="SP",
+            date_start="2026-03-01", date_end="2026-03-31",
+            depth=0,
+        )
+
+        assert result == []
+
+
+class TestRecordSentryTruncation:
+    """Tests for _record_sentry_truncation() — best-effort alerts."""
+
+    def test_does_not_raise_on_metric_failure(self):
+        """Must not raise if metrics module is unavailable."""
+        from datalake_query import _record_sentry_truncation
+
+        # Should not raise when neither metrics nor sentry_sdk are available
+        _record_sentry_truncation("SP")
+
+    def test_sentry_called_with_error_level(self):
+        """When sentry_sdk is available, must call capture_message with level='error'."""
+        from datalake_query import _record_sentry_truncation
+
+        mock_sentry = MagicMock()
+        with patch.dict("sys.modules", {"sentry_sdk": mock_sentry}):
+            # Re-import after mock injection — the lazy import inside the function
+            # may already be cached, so we force a clear of any stale reference.
+            # The function does: import sentry_sdk  (picks up the mocked module)
+            _record_sentry_truncation("RJ")
+
+        mock_sentry.capture_message.assert_called_once()
+        args, kwargs = mock_sentry.capture_message.call_args
+        assert kwargs.get("level") == "error"

--- a/backend/tests/test_prometheus_labels.py
+++ b/backend/tests/test_prometheus_labels.py
@@ -14,8 +14,9 @@ This file ensures neither regression is reintroduced.
 """
 
 import logging
+
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 
 
 # ============================================================================
@@ -193,16 +194,42 @@ class TestPostgREST1000RowTruncationWarning:
     @pytest.mark.asyncio
     @patch("supabase_client.get_supabase")
     async def test_exactly_1000_rows_logs_warning(self, mock_get_supabase, caplog):
-        """When a UF returns exactly 1000 rows, a WARNING must be logged."""
+        """When a UF returns exactly 1000 rows, a WARNING must be logged.
+
+        TRUNC-001 (#1629): The new intra-UF pagination splits date ranges
+        when len == 1000.  The mock must return <1000 rows for sub-ranges
+        so the recursion terminates — otherwise every sub-query returns
+        the same 1000 rows and the recursion hits max depth (90000 rows).
+        """
         from datalake_query import query_datalake
 
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
 
         rows_1000 = self._make_rows(1000)
-        mock_rpc_result = MagicMock()
-        mock_rpc_result.data = rows_1000
-        mock_sb.rpc.return_value.execute.return_value = mock_rpc_result
+        rows_500 = self._make_rows(500)
+
+        def _rpc_side_effect(_fn_name, params):
+            """Return mock chain whose .execute() yields date-range-aware data."""
+            date_start = params.get("p_date_start", "")
+            date_end = params.get("p_date_end", "")
+            # Full range (~90 days) → 1000 rows (triggers split)
+            if date_start == "2026-01-01" and date_end == "2026-03-31":
+                data = rows_1000
+            else:
+                # Sub-range after split → 500 rows (<1000, terminates recursion)
+                data = rows_500
+
+            rpc_result = MagicMock()
+            rpc_result.data = data
+
+            # sb_execute runs query.execute() via asyncio.to_thread,
+            # so .execute() must return rpc_result directly (not a Future).
+            builder = MagicMock()
+            builder.execute.return_value = rpc_result
+            return builder
+
+        mock_sb.rpc.side_effect = _rpc_side_effect
 
         with caplog.at_level(logging.WARNING, logger="datalake_query"):
             result = await query_datalake(
@@ -221,8 +248,9 @@ class TestPostgREST1000RowTruncationWarning:
             f"Expected a warning about 1000-row truncation; got warnings: {warning_texts}"
         )
 
-        # Must still return the rows (not silently discard)
-        assert len(result) == 1000
+        # Pagination REPLACES truncated result with sum of sub-queries:
+        # 500 (left half) + 500 (right half) = 1000
+        assert len(result) == 1000, f"Expected 1000 rows (500+500), got {len(result)}"
 
     @pytest.mark.timeout(30)
     @pytest.mark.asyncio
@@ -259,16 +287,34 @@ class TestPostgREST1000RowTruncationWarning:
     @pytest.mark.asyncio
     @patch("supabase_client.get_supabase")
     async def test_exactly_1000_rows_increments_metric(self, mock_get_supabase):
-        """When a UF returns 1000 rows, DATALAKE_TRUNCATION_SUSPECTED.labels(uf=...).inc() fires."""
+        """When a UF returns 1000 rows, DATALAKE_TRUNCATION_SUSPECTED.labels(uf=...).inc() fires.
+
+        TRUNC-001 (#1629): With intra-UF pagination, the metric fires once per truncation
+        detection. The mock returns <1000 rows for sub-ranges so recursion terminates
+        after the first split (1 metric call for the initial detection).
+        """
         from datalake_query import query_datalake
 
         mock_sb = MagicMock()
         mock_get_supabase.return_value = mock_sb
 
         rows_1000 = self._make_rows(1000)
-        mock_rpc_result = MagicMock()
-        mock_rpc_result.data = rows_1000
-        mock_sb.rpc.return_value.execute.return_value = mock_rpc_result
+        rows_500 = self._make_rows(500)
+
+        def _rpc_side_effect(_fn_name, params):
+            date_start = params.get("p_date_start", "")
+            date_end = params.get("p_date_end", "")
+            if date_start == "2026-01-01" and date_end == "2026-03-31":
+                data = rows_1000
+            else:
+                data = rows_500
+            rpc_result = MagicMock()
+            rpc_result.data = data
+            builder = MagicMock()
+            builder.execute.return_value = rpc_result
+            return builder
+
+        mock_sb.rpc.side_effect = _rpc_side_effect
 
         with patch("metrics.DATALAKE_TRUNCATION_SUSPECTED") as mock_metric:
             mock_label = MagicMock()
@@ -280,6 +326,7 @@ class TestPostgREST1000RowTruncationWarning:
                 data_final="2026-03-31",
             )
 
+        # Called once for the initial truncation (sub-ranges return <1000 → no further calls)
         mock_metric.labels.assert_called_once_with(uf="MG")
         mock_label.inc.assert_called_once()
 
@@ -430,7 +477,6 @@ class TestExecuteStageDatalakeMetric:
     @pytest.mark.timeout(30)
     def test_execute_py_calls_labels_before_inc(self):
         """Source code of execute.py must contain .labels(source= — not bare .inc()."""
-        import ast
         import inspect
         from pipeline.stages import execute as execute_module
 


### PR DESCRIPTION
## Summary

Implements **TRUNC-001**: PostgREST caps RPC results at 1000 rows per call. When a high-volume UF (e.g. SP) exceeds this limit, results are silently truncated — previously the code only logged a warning but took no corrective action.

## Changes

### `backend/datalake_query.py`
- **Intra-UF pagination**: new `_query_uf_with_pagination()` async function that detects truncation (`len(rows) == 1000`) and recursively splits the date range in half until each sub-query returns < 1000 rows
- **Binary date-range splitting**: splits on date boundary (midpoint = start + total_days // 2), queries left and right halves independently, merges results chronologically
- **Max recursion depth guard**: `_MAX_PAGINATION_DEPTH = 10` prevents runaway splits
- **Sentry alert**: `_record_sentry_truncation()` dispatches `sentry_sdk.capture_message(level="error")` + Prometheus metric when truncation is detected
- **Single-day granularity fallback**: when truncation persists at minimum granularity, returns partial results (logged warning) rather than losing everything
- **Fail-open**: RPC failures return `[]` for that sub-range, following existing error handling pattern

### `backend/tests/test_datalake_query.py`
- 7 new tests for `_query_uf_with_pagination()` and `_record_sentry_truncation()`
- Fixed pre-existing ruff issues (`call` import conflict, unused variable)

## Testing

All 112 datalake-related tests pass (111 passed, 1 XFAIL):
- `test_datalake_query.py` — 68 tests (all pass, including 7 new)
- `test_datalake_query_null_dates.py` — 13 tests
- `test_datalake_api.py` — 16 tests
- `test_precision_recall_datalake.py` — 15 tests

Closes #1629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query results no longer silently truncated when exceeding system row limits; large queries are now automatically paginated internally.
  * Enhanced error detection and monitoring for truncation events, providing better visibility into data consistency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->