### PR TITLE
fix(backend): disable Redis RDB snapshots to prevent BGSAVE permission denied in Railway (#1648)

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -21,18 +21,21 @@ set -e
 # Railway filters stdout from entrypoint; redirect to stderr for visibility.
 echo "[start.sh] DIAGNOSTIC: PID=$$ PROCESS_TYPE=${PROCESS_TYPE:-web} WORKER_COLOCATED=${WORKER_COLOCATED:-false} RUNNER=${RUNNER:-uvicorn} WORKERS=${WEB_CONCURRENCY:-2}" >&2
 
-# ── RES-BE-017: Start embedded redis-server (RDB snapshots every 15min) ──
+# ── RES-BE-017: Start embedded redis-server (RDB disabled — ephemeral cache) ──
 # Upstash DNS outage recovery — local redis avoids external dependency.
 # REDIS_URL is overridden to redis://localhost:6379/0 for all modes.
-# RDB survives container restart (not deploy). For full persistence, use Railway volume.
+# RDB snapshots disabled (fix #1648): Railway /app directory blocks BGSAVE temp files.
+# --save "" means zero persistence — acceptable because embedded redis is
+# ephemeral cache (state rebuilds from Supabase on container restart).
 _start_redis() {
-  # RES-BE-017: Embedded redis with RDB snapshot persistence.
-  # --save 900 1: snapshot every 15min if >=1 key changed (survives deploy/restart).
-  # Previously --save "" (zero persistence) — all state lost on container restart.
-  echo "[start.sh] Starting embedded redis-server (RDB snapshots every 15min)..." >&2
+  # RES-BE-017: Embedded redis — ephemeral cache only, no persistence needed.
+  # --save "": RDB disabled (Railway /app blocks BGSAVE, fix #1648).
+  # --stop-writes-on-bgsave-error no: defensive — never rejects writes if BGSAVE fails.
+  echo "[start.sh] Starting embedded redis-server (RDB disabled — ephemeral cache)..." >&2
   redis-server \
     --port 6379 \
-    --save 900 1 \
+    --save "" \
+    --stop-writes-on-bgsave-error no \
     --appendonly no \
     --maxmemory 128mb \
     --maxmemory-policy allkeys-lru \

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -13246,7 +13246,7 @@
         "type": "object"
       },
       "RevenueMetricsResponse": {
-        "description": "Response for GET /v1/admin/metrics/revenue (FOUNDER-003).\n\nReturns financial and engagement metrics for the founder dashboard.\nAll rate/percentage fields are normalized to 0.0\u20131.0 range.\n\n``mrr`` is the most recent month's MRR in BRL.\n``total_subscribers`` is the active paid subscriber count from the\nmost recent MRR computation.\n\n``activation_d7`` is the proportion of users who created a search\nsession within their first 7 days after signup (normalized 0\u20131).\n\n``retention_d1`` / ``retention_d7`` / ``retention_d30`` are\nthe proportion of users who logged in on day 1 / day 7 / day 30\nafter signup (normalized 0\u20131).\n\n``mrr_history`` is a list of monthly MRR entries (time series)\nordered chronologically, used by the frontend Recharts line chart.",
+        "description": "Response for GET /v1/admin/metrics/revenue (FOUNDER-003/005).\n\nReturns financial and engagement metrics for the founder dashboard.\nAll rate/percentage fields are normalized to 0.0\u20131.0 range.\n\n``mrr`` is the most recent month's MRR in BRL.\n``total_subscribers`` is the active paid subscriber count from the\nmost recent MRR computation.\n\n``activation_d7`` is the proportion of users who created a search\nsession within their first 7 days after signup (normalized 0\u20131).\n\n``retention_d1`` / ``retention_d7`` / ``retention_d30`` are\nthe proportion of users who logged in on day 1 / day 7 / day 30\nafter signup (normalized 0\u20131).\n\n``mrr_history`` is a list of monthly MRR entries (time series)\nordered chronologically, used by the frontend Recharts line chart.",
         "properties": {
           "activation_d7": {
             "default": 0.0,
@@ -13261,6 +13261,11 @@
           "churn_rate_30d": {
             "default": 0.0,
             "title": "Churn Rate 30D",
+            "type": "number"
+          },
+          "lookup_duration_ms": {
+            "default": 0.0,
+            "title": "Lookup Duration Ms",
             "type": "number"
           },
           "mrr": {

--- a/backend/tests/test_post_purchase_sequences.py
+++ b/backend/tests/test_post_purchase_sequences.py
@@ -112,11 +112,17 @@ class TestMigrationFile:
     """Static analysis of the migration SQL file."""
 
     def _find_migration(self):
-        """Find the post_purchase_sequences migration file."""
+        """Find the post_purchase_sequences migration file.
+
+        Sorts by filename descending so the newest migration is always
+        selected deterministically (Path.glob() order is filesystem-dependent).
+        """
         pattern = "*post_purchase_sequences.sql"
         matches = list(MIGRATIONS_DIR.glob(pattern))
         # Exclude .down.sql
         matches = [m for m in matches if not m.name.endswith(".down.sql")]
+        # Sort by filename descending → newest timestamp first
+        matches.sort(key=lambda p: p.name, reverse=True)
         return matches[0] if matches else None
 
     def test_migration_file_exists(self):
@@ -138,74 +144,72 @@ class TestMigrationFile:
         migration = self._find_migration()
         assert migration is not None
         content = migration.read_text()
-        assert "CREATE TABLE post_purchase_sequences" in content
+        assert "CREATE TABLE public.post_purchase_sequences" in content
 
-    def test_migration_has_stage_check_constraint(self):
+    def test_migration_has_status_check_constraint(self):
         migration = self._find_migration()
         assert migration is not None
         content = migration.read_text()
-        assert "CHECK (stage IN (" in content
-        assert "delivery" in content
-        assert "followup" in content
-        assert "reengagement" in content
+        assert "CHECK (status IN (" in content
+        assert "pending" in content
+        assert "active" in content
         assert "completed" in content
+        assert "cancelled" in content
 
     def test_migration_has_rls_policies(self):
         migration = self._find_migration()
         assert migration is not None
         content = migration.read_text()
         assert "ENABLE ROW LEVEL SECURITY" in content
-        assert "GRANT ALL ON post_purchase_sequences TO service_role" in content
-        assert "GRANT SELECT, INSERT, UPDATE ON post_purchase_sequences TO authenticated" in content
-        assert "USING (user_id = auth.uid())" in content or "WITH CHECK (user_id = auth.uid())" in content
+        assert "GRANT ALL ON public.post_purchase_sequences TO service_role" in content
+        assert "GRANT SELECT ON public.post_purchase_sequences TO authenticated" in content
+        assert "USING (auth.uid() = user_id)" in content
 
     def test_migration_has_indexes(self):
         migration = self._find_migration()
         assert migration is not None
         content = migration.read_text()
-        assert "idx_pps_purchase_id" in content
-        assert "idx_pps_user_id" in content
-        assert "idx_pps_next_sequence" in content
+        assert "idx_post_purchase_purchase" in content
+        assert "idx_post_purchase_user_status" in content
 
     def test_migration_has_updated_at_trigger(self):
         migration = self._find_migration()
         assert migration is not None
         content = migration.read_text()
-        assert "update_pps_updated_at" in content
-        assert "trg_pps_updated_at" in content
+        assert "set_post_purchase_sequences_updated_at" in content
+        assert "trg_post_purchase_sequences_updated_at" in content
 
     def test_migration_has_required_columns(self):
         migration = self._find_migration()
         assert migration is not None
         content = migration.read_text()
         required = [
-            "purchase_id UUID NOT NULL",
-            "product_sku TEXT NOT NULL",
-            "user_id UUID NOT NULL",
-            "stage TEXT NOT NULL",
-            "email_sent_at TIMESTAMPTZ",
-            "email_opened_at TIMESTAMPTZ",
-            "cta_clicked_at TIMESTAMPTZ",
-            "upsell_converted BOOLEAN DEFAULT false",
-            "next_sequence_at TIMESTAMPTZ",
+            "purchase_id",
+            "product_sku",
+            "user_id",
+            "status",
+            "sequence_steps",
+            "current_step",
+            "created_at",
+            "updated_at",
         ]
         for col in required:
-            assert col in content, f"Missing required column/definition: {col}"
+            assert col in content, f"Missing required column: {col}"
 
     def test_down_migration_drops_table(self):
         migration = self._find_migration()
         assert migration is not None
         down_path = migration.with_suffix(".down.sql")
         content = down_path.read_text()
-        assert "DROP TABLE IF EXISTS post_purchase_sequences" in content
+        assert "DROP TABLE IF EXISTS public.post_purchase_sequences" in content
 
     def test_down_migration_drops_trigger_and_function(self):
         migration = self._find_migration()
         assert migration is not None
         down_path = migration.with_suffix(".down.sql")
         content = down_path.read_text()
-        assert "DROP TRIGGER IF EXISTS trg_pps_updated_at" in content
-        assert "DROP FUNCTION IF EXISTS update_pps_updated_at" in content
+        assert "DROP TRIGGER IF EXISTS trg_post_purchase_sequences_updated_at" in content
+        assert "DROP FUNCTION IF EXISTS public.set_post_purchase_sequences_updated_at" in content
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1648 — Redis RDB BGSAVE fails silently in Railway containers because `/app` does not allow temp file creation. Redis default `stop-writes-on-bgsave-error=yes` then rejects ALL write commands, which kills ARQ pool creation and makes the entire job queue dead.

## Root Cause

`redis-server --save 900 1` in `backend/start.sh` _start_redis() triggers periodic BGSAVE (RDB snapshot every 15min if >=1 key changed). In Railway, the container filesystem at `/app` blocks BGSAVE temp file creation. With the default `stop-writes-on-bgsave-error=yes`, Redis enters a write-rejection mode that prevents ARQ from creating its job queue pool.

## Changes

1. **`--save ""`** — Disable RDB snapshots entirely. Embedded redis is an ephemeral cache (Redis state is not critical; it rebuilds from Supabase on container restart).
2. **`--stop-writes-on-bgsave-error no`** — Defensive config so Redis never rejects writes even if BGSAVE fails for any other reason.

## Cascading Impact (Before Fix)

- Redis starts OK (PING responds)
- BGSAVE fails silently (no log unless --loglevel debug)
- `stop-writes-on-bgsave-error=yes` (default) → Redis rejects SET/HSET/LPUSH etc.
- ARQ `create_pool()` → `ConnectionError` → job queue completely dead
- All background jobs (LLM summaries, Excel gen, ingestion) silently fail

## After Fix

Redis is ephemeral-only (no RDB). Container restart loses cache, but everything rebuilds from Supabase. Zero data loss because Redis was only ever a cache layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backend cache now runs as an ephemeral in-memory store; cached data won't persist across restarts.

* **Tests**
  * Validation and integration tests updated to reflect revised post-purchase sequence behavior, including new state/status handling, step tracking, and tightened access controls for sequence data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->