### PR TITLE
fix(backend): worker memory saturation — cache bounds, GC trigger, faster recycling

### DIFF
--- a/backend/datalake_query.py
+++ b/backend/datalake_query.py
@@ -28,15 +28,15 @@ logger = logging.getLogger(__name__)
 # round-trips and mitigates timeout impact on retries).
 # ---------------------------------------------------------------------------
 
-_CACHE_TTL = 3600  # 1 hour
-_CACHE_MAX_ENTRIES = 50
+_CACHE_TTL = 600  # 10 minutes (was 3600 — CRIT-083 AC6 MEM-1: reduce memory pressure)
+_CACHE_MAX_ENTRIES = 20  # was 50 — CRIT-083 AC6 MEM-1: each entry can be several MB
 
 # dict[str, tuple[float, list[dict]]]  — key -> (expiry_timestamp, results)
 _query_cache: dict[str, tuple[float, list[dict]]] = {}
 
 # STORY-438: In-memory cache for query embeddings (avoids repeated OpenAI calls)
-_EMBEDDING_CACHE_TTL = 3600  # 1 hour
-_EMBEDDING_CACHE_MAX_ENTRIES = 100
+_EMBEDDING_CACHE_TTL = 1800  # 30 minutes (was 3600 — CRIT-083 AC6 MEM-2: reduce memory pressure)
+_EMBEDDING_CACHE_MAX_ENTRIES = 50  # was 100 — CRIT-083 AC6 MEM-2: embeddings are smaller but accumulate
 _embedding_cache: dict[str, tuple[float, list[float]]] = {}
 
 # Concurrency limiter: prevents bot/crawler fan-out from saturating the

--- a/backend/redis_pool.py
+++ b/backend/redis_pool.py
@@ -52,7 +52,10 @@ POOL_SOCKET_TIMEOUT = 30
 POOL_SOCKET_CONNECT_TIMEOUT = 10
 
 # InMemoryCache configuration (AC4)
-INMEMORY_MAX_ENTRIES = 10_000
+# CRIT-083 AC6 MEM-3: Reduced from 10K→5K to limit memory when Redis is unavailable.
+# Each entry stores a serialized search result (can be 10-50KB each).
+# 5K entries × 50KB max = ~250MB worst case instead of ~500MB.
+INMEMORY_MAX_ENTRIES = 5_000
 
 # Singleton state
 _redis_pool = None

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -115,7 +115,10 @@ _start_worker() {
 # ── Uvicorn launcher (foreground) ───────────────────────────────────────
 _start_uvicorn() {
   local workers="${WEB_CONCURRENCY:-2}"
-  local limit_max_requests="${GUNICORN_MAX_REQUESTS:-10000}"
+  # CRIT-083 AC6 MEM-6: Reduced from 10000→5000 to limit memory accumulation.
+  # Worker RSS grows ~50KB/request (cache churn + object churn). At 5000 requests
+  # that's ~250MB growth — well within the 512MB threshold with margin.
+  local limit_max_requests="${GUNICORN_MAX_REQUESTS:-5000}"
   local graceful_timeout="${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-120}"
   local keep_alive="${GUNICORN_KEEP_ALIVE:-75}"
   local log_level="${UVICORN_LOG_LEVEL:-info}"
@@ -181,7 +184,7 @@ case "$PROCESS_TYPE" in
         --log-level "${UVICORN_LOG_LEVEL:-info}" \
         --timeout-keep-alive "${GUNICORN_KEEP_ALIVE:-75}" \
         --workers "${WEB_CONCURRENCY:-2}" \
-        --limit-max-requests "${GUNICORN_MAX_REQUESTS:-10000}" \
+        --limit-max-requests "${GUNICORN_MAX_REQUESTS:-5000}" \
         --timeout-graceful-shutdown "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-120}"
     fi
     ;;

--- a/backend/startup/lifespan.py
+++ b/backend/startup/lifespan.py
@@ -223,6 +223,43 @@ async def _periodic_saturation_metrics() -> None:
                         "consider reducing WEB_CONCURRENCY or investigating memory leak",
                         _pid, _rss_mb,
                     )
+                # CRIT-083 AC6 MEM-4: Proactive GC when memory exceeds 400MB
+                # Python's GC may not keep up with rapid object churn from the
+                # search pipeline (thousands of dicts per request). Triggering
+                # gc.collect() preemptively avoids the 512MB threshold.
+                # CRIT-083 AC6 MEM-5: Log cache sizes every 5min for memory leak diagnosis
+                if int(time.monotonic() / 30) % 10 == 0:
+                    try:
+                        _query_cache_size = 0
+                        _inmemory_cache_size = 0
+                        try:
+                            from datalake_query import _query_cache as _qc
+                            _query_cache_size = len(_qc)
+                        except Exception:
+                            pass
+                        try:
+                            from redis_pool import get_fallback_cache
+                            _imb = get_fallback_cache()
+                            _inmemory_cache_size = len(_imb)
+                        except Exception:
+                            pass
+                        logger.info(
+                            "CRIT-083 AC6 MEM-5: Cache sizes — datalake=%d InMemory=%d "
+                            "(RSS=%.1fMB, pid=%d)",
+                            _query_cache_size, _inmemory_cache_size,
+                            _rss_mb, _pid,
+                        )
+                    except Exception:
+                        pass
+                if _rss_mb > 400:
+                    import gc
+                    _collected = gc.collect()
+                    if _collected > 0:
+                        logger.info(
+                            "CRIT-083 AC6 MEM-4: gc.collect() freed %d objects "
+                            "(RSS=%.1fMB, pid=%d)",
+                            _collected, _rss_mb, _pid,
+                        )
             except Exception:
                 pass  # Graceful degradation — never block saturation loop
         except asyncio.CancelledError:

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -13246,7 +13246,7 @@
         "type": "object"
       },
       "RevenueMetricsResponse": {
-        "description": "Response for GET /v1/admin/metrics/revenue (FOUNDER-003).\n\nReturns financial and engagement metrics for the founder dashboard.\nAll rate/percentage fields are normalized to 0.0\u20131.0 range.\n\n``mrr`` is the most recent month's MRR in BRL.\n``total_subscribers`` is the active paid subscriber count from the\nmost recent MRR computation.\n\n``activation_d7`` is the proportion of users who created a search\nsession within their first 7 days after signup (normalized 0\u20131).\n\n``retention_d1`` / ``retention_d7`` / ``retention_d30`` are\nthe proportion of users who logged in on day 1 / day 7 / day 30\nafter signup (normalized 0\u20131).\n\n``mrr_history`` is a list of monthly MRR entries (time series)\nordered chronologically, used by the frontend Recharts line chart.",
+        "description": "Response for GET /v1/admin/metrics/revenue (FOUNDER-003/005).\n\nReturns financial and engagement metrics for the founder dashboard.\nAll rate/percentage fields are normalized to 0.0\u20131.0 range.\n\n``mrr`` is the most recent month's MRR in BRL.\n``total_subscribers`` is the active paid subscriber count from the\nmost recent MRR computation.\n\n``activation_d7`` is the proportion of users who created a search\nsession within their first 7 days after signup (normalized 0\u20131).\n\n``retention_d1`` / ``retention_d7`` / ``retention_d30`` are\nthe proportion of users who logged in on day 1 / day 7 / day 30\nafter signup (normalized 0\u20131).\n\n``mrr_history`` is a list of monthly MRR entries (time series)\nordered chronologically, used by the frontend Recharts line chart.",
         "properties": {
           "activation_d7": {
             "default": 0.0,
@@ -13261,6 +13261,11 @@
           "churn_rate_30d": {
             "default": 0.0,
             "title": "Churn Rate 30D",
+            "type": "number"
+          },
+          "lookup_duration_ms": {
+            "default": 0.0,
+            "title": "Lookup Duration Ms",
             "type": "number"
           },
           "mrr": {

--- a/backend/tests/test_redis_pool.py
+++ b/backend/tests/test_redis_pool.py
@@ -175,10 +175,10 @@ class TestInMemoryCacheBasicOps:
 class TestInMemoryCacheLRUEviction:
     """LRU eviction behavior at max_entries boundary."""
 
-    def test_lru_default_max_10k(self):
+    def test_lru_default_max_5k(self):
         """Default InMemoryCache max_entries is 10_000 (AC14)."""
         cache = InMemoryCache()
-        assert cache._max_entries == 10_000
+        assert cache._max_entries == 5_000
         assert cache._max_entries == INMEMORY_MAX_ENTRIES
 
     def test_lru_eviction_at_max(self, small_cache):
@@ -552,4 +552,4 @@ class TestPoolConfiguration:
         assert redis_pool.POOL_MAX_CONNECTIONS == 50
         assert redis_pool.POOL_SOCKET_TIMEOUT == 30
         assert redis_pool.POOL_SOCKET_CONNECT_TIMEOUT == 10
-        assert redis_pool.INMEMORY_MAX_ENTRIES == 10_000
+        assert redis_pool.INMEMORY_MAX_ENTRIES == 5_000

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -12285,7 +12285,7 @@ export interface components {
         };
         /**
          * RevenueMetricsResponse
-         * @description Response for GET /v1/admin/metrics/revenue (FOUNDER-003).
+         * @description Response for GET /v1/admin/metrics/revenue (FOUNDER-003/005).
          *
          *     Returns financial and engagement metrics for the founder dashboard.
          *     All rate/percentage fields are normalized to 0.0–1.0 range.
@@ -12320,6 +12320,11 @@ export interface components {
              * @default 0
              */
             churn_rate_30d: number;
+            /**
+             * Lookup Duration Ms
+             * @default 0
+             */
+            lookup_duration_ms: number;
             /**
              * Mrr
              * @default 0


### PR DESCRIPTION
## Summary

Fix #1649: Worker RSS grows to 516MB over 10K requests, hitting uvicorn `--limit-max-requests` limit. Root cause: in-memory caches accumulating large result sets.

## Investigation

### Root Cause Analysis

The worker RSS grows ~50KB per request from cache churn + object churn. Four coordinated fixes:

### MEM-1: datalake query cache reduction
- `backend/datalake_query.py`: `_CACHE_MAX_ENTRIES 50→20`, `_CACHE_TTL 3600→600`
- Each entry stores `list[dict]` of full search results (several MB per entry)
- 50 entries × ~4MB avg = ~200MB worst case vs 80MB with 20

### MEM-2: embedding cache reduction
- `backend/datalake_query.py`: `_EMBEDDING_CACHE_MAX_ENTRIES 100→50`, TTL 3600→1800

### MEM-3: InMemoryCache fallback reduction
- `backend/redis_pool.py`: `INMEMORY_MAX_ENTRIES 10K→5K`
- Stores serialized search result JSONs (10-50KB each)
- 10K × 50KB = ~500MB worst case, halved to ~250MB

### MEM-4: Proactive GC on high memory
- `backend/startup/lifespan.py`: `gc.collect()` when RSS > 400MB
- Python GC may not keep up with rapid object churn (thousands of dicts per request)

### MEM-5: Cache size observability
- Log datalake + InMemoryCache sizes every 5 min in saturation metrics

### MEM-6: Faster worker recycling
- `backend/start.sh`: `GUNICORN_MAX_REQUESTS 10K→5K`
- 5K requests × ~50KB/request = ~250MB growth vs 10K = ~500MB
- Leaves ~260MB headroom before 512MB threshold

## Testing

- [x] `ruff check` passed on modified files
- [x] `tests/test_datalake_query.py` — 68 passed
- [x] `tests/test_harden024_saturation_metrics.py` — 16 passed
- [x] `tests/test_cache_correctness.py` — 26 passed
- [x] `tests/test_datalake_api.py` — 15 passed
- [x] `tests/startup/` — 22 passed
- [x] Full backend test suite: 3730 passed, 1 pre-existing failure (unrelated: quota validation env gap)

Closes #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)