### PR TITLE
feat(backend,frontend): DEGUST-001 — Intelligence Tasting no trial (#1611)

### DIFF
--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -213,6 +213,10 @@ COMPETITIVE_INTEL_ENABLED: bool = str_to_bool(os.getenv("COMPETITIVE_INTEL_ENABL
 # Default ON (true) — the vertical is active by default.
 # Set env var to "false" to disable.
 B2G_OPS_ENABLED: bool = str_to_bool(os.getenv("B2G_OPS_ENABLED", "true"))
+# DEGUST-001 (#1611): Intelligence Tasting no trial — mostra dados agregados
+# reais do mercado com blur nos nomes de concorrentes. Default ON (true).
+# Set env var to "false" to disable globally.
+INTELLIGENCE_TASTING_ENABLED: bool = str_to_bool(os.getenv("INTELLIGENCE_TASTING_ENABLED", "true"))
 
 
 # ============================================
@@ -285,6 +289,8 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "COMPETITIVE_INTEL_ENABLED": ("COMPETITIVE_INTEL_ENABLED", "true"),
     # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations workspace_basic gate
     "B2G_OPS_ENABLED": ("B2G_OPS_ENABLED", "true"),
+    # DEGUST-001 (#1611): Intelligence Tasting — trial upsell
+    "INTELLIGENCE_TASTING_ENABLED": ("INTELLIGENCE_TASTING_ENABLED", "true"),
     # --- Infra ---
     "METRICS_ENABLED": ("METRICS_ENABLED", "true"),
     "RATE_LIMITING_ENABLED": ("RATE_LIMITING_ENABLED", "true"),

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -232,6 +232,7 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "COMMAND_WORKSPACE_ADVANCED": "Command tier: advanced workspace capability (TIER-COMMAND-003)",
     "COMMAND_DATA_EXPORT": "Command tier: data export capability (TIER-COMMAND-003)",
     "COMMAND_CUSTOM_ALERTS": "Command tier: custom alerts capability (TIER-COMMAND-003)",
+    "INTELLIGENCE_TASTING_ENABLED": "Intelligence Tasting no trial — degustação de dados reais com blur (DEGUST-001 #1611)",
 }
 
 
@@ -313,6 +314,8 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "COMMAND_WORKSPACE_ADVANCED": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
     "COMMAND_DATA_EXPORT": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
     "COMMAND_CUSTOM_ALERTS": {"owner": "billing", "category": "command", "lifecycle": "experimental", "created": "2026-06"},
+    # DEGUST-001 (#1611): Intelligence Tasting
+    "INTELLIGENCE_TASTING_ENABLED": {"owner": "product", "category": "growth", "lifecycle": "experimental", "created": "2026-06"},
 }
 
 

--- a/backend/routes/intel_tasting.py
+++ b/backend/routes/intel_tasting.py
@@ -6,7 +6,6 @@ Data is REAL (from pncp_supplier_contracts), blur decision is client-side based 
 Feature flag: INTELLIGENCE_TASTING_ENABLED (config/features.py)
 """
 
-import asyncio
 import logging
 import time
 from datetime import datetime, timezone, timedelta
@@ -14,6 +13,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from pydantic import BaseModel
 from config.features import get_feature_flag
 from sectors import SECTORS
 
@@ -42,7 +42,6 @@ _MAX_MONTHS = 24
 # ---------------------------------------------------------------------------
 # Response models
 # ---------------------------------------------------------------------------
-from pydantic import BaseModel
 
 
 class TastingWinner(BaseModel):

--- a/backend/routes/intel_tasting.py
+++ b/backend/routes/intel_tasting.py
@@ -1,0 +1,283 @@
+"""DEGUST-001 (#1611): Intelligence Tasting route — aggregated market data for trial upsell.
+
+GET /v1/intel/tasting — returns real supplier winning data with sector-level aggregation.
+Data is REAL (from pncp_supplier_contracts), blur decision is client-side based on tier.
+
+Feature flag: INTELLIGENCE_TASTING_ENABLED (config/features.py)
+"""
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from config.features import get_feature_flag
+from sectors import SECTORS
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["intel_tasting"])
+
+# ---------------------------------------------------------------------------
+# Cache configuration
+# ---------------------------------------------------------------------------
+_CACHE_TTL_SECONDS = 4 * 60 * 60  # 4h — data doesn't change in real-time
+_tasting_cache: dict[str, tuple[dict, float]] = {}
+_NEGATIVE_CACHE_TTL_SECONDS = 300  # 5min for errors / empty results
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_VALID_UFS = {
+    "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO",
+    "MA", "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI",
+    "RJ", "RN", "RS", "RO", "RR", "SC", "SP", "SE", "TO",
+}
+_DEFAULT_MONTHS = 12
+_MAX_MONTHS = 24
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+from pydantic import BaseModel
+
+
+class TastingWinner(BaseModel):
+    """Top winner entry. cnpj/razao_social are REAL data — blur is client-side."""
+    cnpj: str
+    razao_social: str
+    total_won: float
+    contracts_count: int
+
+
+class IntelTastingResponse(BaseModel):
+    sector_id: str
+    sector_name: str
+    uf: Optional[str] = None
+    period_months: int
+    total_contracts_value: float
+    total_winners: int
+    total_contracts: int
+    avg_contract_value: float
+    top_winners: list[TastingWinner]
+    generated_at: str
+    feature_enabled: bool = True
+
+
+def _get_cached(key: str) -> Optional[dict]:
+    if key not in _tasting_cache:
+        return None
+    data, ts = _tasting_cache[key]
+    if time.time() - ts >= _CACHE_TTL_SECONDS:
+        del _tasting_cache[key]
+        return None
+    return data
+
+
+def _set_cached(key: str, data: dict) -> None:
+    _tasting_cache[key] = (data, time.time())
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel/tasting",
+    summary="Intelligence Tasting — aggregated supplier data for trial upsell (DEGUST-001)",
+    response_model=IntelTastingResponse,
+)
+async def intel_tasting(
+    request: Request,
+    setor_id: Optional[str] = Query(
+        default=None,
+        description="Sector ID to filter (e.g., 'alimentos'). If omitted, returns global.",
+    ),
+    uf: Optional[str] = Query(
+        default=None,
+        description="UF filter (2-letter). If omitted, returns national aggregation.",
+    ),
+    meses: int = Query(
+        default=_DEFAULT_MONTHS,
+        ge=1,
+        le=_MAX_MONTHS,
+        description=f"Lookback period in months (1–{_MAX_MONTHS}, default {_DEFAULT_MONTHS})",
+    ),
+):
+    # Feature flag check — fail-closed: if flag is off, return feature_enabled=False
+    if not get_feature_flag("INTELLIGENCE_TASTING_ENABLED", True):
+        return IntelTastingResponse(
+            sector_id=setor_id or "global",
+            sector_name="Todos os setores" if not setor_id else setor_id,
+            uf=uf,
+            period_months=meses,
+            total_contracts_value=0,
+            total_winners=0,
+            total_contracts=0,
+            avg_contract_value=0,
+            top_winners=[],
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            feature_enabled=False,
+        )
+
+    # Validate inputs
+    uf_upper = uf.strip().upper() if uf else None
+    if uf_upper and uf_upper not in _VALID_UFS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"UF inválida: '{uf}'. Use uma sigla de 2 letras válida.",
+        )
+
+    sector_id_clean = setor_id.strip().lower() if setor_id else None
+    if sector_id_clean and sector_id_clean not in SECTORS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Setor inválido: '{setor_id}'. Setores válidos: {', '.join(sorted(SECTORS.keys()))}",
+        )
+
+    # Cache key
+    cache_key = f"tasting:{sector_id_clean or 'global'}:{uf_upper or 'BR'}:{meses}"
+    cached = _get_cached(cache_key)
+    if cached:
+        return IntelTastingResponse(**cached)
+
+    # Generate tasting data
+    try:
+        data = await _generate_tasting(sector_id_clean, uf_upper, meses)
+        _set_cached(cache_key, data)
+        return IntelTastingResponse(**data)
+    except Exception as e:
+        logger.error("intel_tasting generation failed for %s: %s", cache_key, e)
+        raise HTTPException(status_code=500, detail="Falha ao gerar dados de inteligência.")
+
+
+# ---------------------------------------------------------------------------
+# Data generation
+# ---------------------------------------------------------------------------
+
+
+async def _generate_tasting(
+    sector_id: Optional[str],
+    uf: Optional[str],
+    meses: int,
+) -> dict:
+    """Aggregate supplier contracts from pncp_supplier_contracts.
+
+    Returns total won value, unique winner count, top 10 winners, and average
+    contract value for the given sector/UF/months combination.
+    """
+    from supabase_client import get_supabase, sb_execute
+    from resilience.budget import _run_with_budget
+
+    sb = get_supabase()
+
+    now = datetime.now(timezone.utc)
+    data_inicial = (now - timedelta(days=meses * 30)).strftime("%Y-%m-%d")
+    generated_at = now.isoformat()
+    sector_name = SECTORS[sector_id].name if sector_id else "Todos os setores"
+
+    # Build sector keywords for object filtering
+    keywords_lower: set[str] = set()
+    if sector_id and sector_id in SECTORS:
+        keywords_lower = {kw.lower() for kw in SECTORS[sector_id].keywords}
+
+    async def _paginate_contracts() -> list[dict]:
+        batch_size = 1000
+        max_total = 10000
+        all_rows: list[dict] = []
+        offset = 0
+        while len(all_rows) < max_total:
+            end = offset + batch_size - 1
+            query = (
+                sb.table("pncp_supplier_contracts")
+                .select(
+                    "ni_fornecedor,nome_fornecedor,valor_global,data_assinatura,objeto_contrato"
+                )
+                .eq("is_active", True)
+                .gte("data_assinatura", data_inicial)
+                .order("valor_global", desc=True)
+                .range(offset, end)
+            )
+            if uf:
+                query = query.eq("uf", uf)
+            resp = await sb_execute(query)
+            batch = resp.data or []
+            if not batch:
+                break
+            all_rows.extend(batch)
+            if len(batch) < batch_size:
+                break
+            offset += batch_size
+        return all_rows
+
+    rows = await _run_with_budget(
+        _paginate_contracts(),
+        budget=8.0,
+        phase="route",
+        source="intel_tasting._paginate_contracts",
+    )
+
+    # Filter by sector keywords if sector specified
+    if keywords_lower:
+        rows = [
+            row for row in rows
+            if any(
+                kw in (row.get("objeto_contrato") or "").lower()
+                for kw in keywords_lower
+            )
+        ]
+
+    # Aggregate by supplier
+    by_supplier: dict[str, dict] = {}
+    total_value = 0.0
+    for row in rows:
+        cnpj = row.get("ni_fornecedor") or ""
+        if not cnpj:
+            continue
+        nome = row.get("nome_fornecedor") or cnpj
+        valor = float(row.get("valor_global") or 0)
+        total_value += valor
+
+        if cnpj not in by_supplier:
+            by_supplier[cnpj] = {
+                "cnpj": cnpj,
+                "razao_social": nome,
+                "total_won": 0.0,
+                "contracts_count": 0,
+            }
+        by_supplier[cnpj]["total_won"] += valor
+        by_supplier[cnpj]["contracts_count"] += 1
+
+    # Sort by total won descending
+    sorted_winners = sorted(
+        by_supplier.values(), key=lambda x: x["total_won"], reverse=True
+    )
+    top_winners = sorted_winners[:10]
+    total_contracts = len(rows)
+    avg_value = total_value / total_contracts if total_contracts > 0 else 0.0
+
+    return {
+        "sector_id": sector_id or "global",
+        "sector_name": sector_name,
+        "uf": uf,
+        "period_months": meses,
+        "total_contracts_value": round(total_value, 2),
+        "total_winners": len(by_supplier),
+        "total_contracts": total_contracts,
+        "avg_contract_value": round(avg_value, 2),
+        "top_winners": [
+            {
+                "cnpj": w["cnpj"],
+                "razao_social": w["razao_social"],
+                "total_won": round(w["total_won"], 2),
+                "contracts_count": w["contracts_count"],
+            }
+            for w in top_winners
+        ],
+        "generated_at": generated_at,
+        "feature_enabled": True,
+    }

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -98,6 +98,7 @@ from routes.admin_metrics import router as admin_metrics_router
 from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
 from routes.admin_command import router as admin_command_router
+from routes.intel_tasting import router as intel_tasting_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -152,6 +153,7 @@ _v1_routers = [
     network_events_router,
     segment_router,
     api_search_router,
+    intel_tasting_router,
 ]
 
 

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -8605,6 +8605,78 @@
         "title": "IntelReportStatusResponse",
         "type": "object"
       },
+      "IntelTastingResponse": {
+        "properties": {
+          "avg_contract_value": {
+            "title": "Avg Contract Value",
+            "type": "number"
+          },
+          "feature_enabled": {
+            "default": true,
+            "title": "Feature Enabled",
+            "type": "boolean"
+          },
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "period_months": {
+            "title": "Period Months",
+            "type": "integer"
+          },
+          "sector_id": {
+            "title": "Sector Id",
+            "type": "string"
+          },
+          "sector_name": {
+            "title": "Sector Name",
+            "type": "string"
+          },
+          "top_winners": {
+            "items": {
+              "$ref": "#/components/schemas/TastingWinner"
+            },
+            "title": "Top Winners",
+            "type": "array"
+          },
+          "total_contracts": {
+            "title": "Total Contracts",
+            "type": "integer"
+          },
+          "total_contracts_value": {
+            "title": "Total Contracts Value",
+            "type": "number"
+          },
+          "total_winners": {
+            "title": "Total Winners",
+            "type": "integer"
+          },
+          "uf": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uf"
+          }
+        },
+        "required": [
+          "sector_id",
+          "sector_name",
+          "period_months",
+          "total_contracts_value",
+          "total_winners",
+          "total_contracts",
+          "avg_contract_value",
+          "top_winners",
+          "generated_at"
+        ],
+        "title": "IntelTastingResponse",
+        "type": "object"
+      },
       "InviteMemberRequest": {
         "properties": {
           "email": {
@@ -15895,6 +15967,35 @@
           }
         },
         "title": "SystemHealthResponse",
+        "type": "object"
+      },
+      "TastingWinner": {
+        "description": "Top winner entry. cnpj/razao_social are REAL data \u2014 blur is client-side.",
+        "properties": {
+          "cnpj": {
+            "title": "Cnpj",
+            "type": "string"
+          },
+          "contracts_count": {
+            "title": "Contracts Count",
+            "type": "integer"
+          },
+          "razao_social": {
+            "title": "Razao Social",
+            "type": "string"
+          },
+          "total_won": {
+            "title": "Total Won",
+            "type": "number"
+          }
+        },
+        "required": [
+          "cnpj",
+          "razao_social",
+          "total_won",
+          "contracts_count"
+        ],
+        "title": "TastingWinner",
         "type": "object"
       },
       "TimeSeriesDataPoint": {
@@ -26080,6 +26181,89 @@
         "summary": "Download Intel Report",
         "tags": [
           "intel_reports"
+        ]
+      }
+    },
+    "/v1/intel/tasting": {
+      "get": {
+        "operationId": "intel_tasting_v1_intel_tasting_get",
+        "parameters": [
+          {
+            "description": "Sector ID to filter (e.g., 'alimentos'). If omitted, returns global.",
+            "in": "query",
+            "name": "setor_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Sector ID to filter (e.g., 'alimentos'). If omitted, returns global.",
+              "title": "Setor Id"
+            }
+          },
+          {
+            "description": "UF filter (2-letter). If omitted, returns national aggregation.",
+            "in": "query",
+            "name": "uf",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "UF filter (2-letter). If omitted, returns national aggregation.",
+              "title": "Uf"
+            }
+          },
+          {
+            "description": "Lookback period in months (1\u201324, default 12)",
+            "in": "query",
+            "name": "meses",
+            "required": false,
+            "schema": {
+              "default": 12,
+              "description": "Lookback period in months (1\u201324, default 12)",
+              "maximum": 24,
+              "minimum": 1,
+              "title": "Meses",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntelTastingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Intelligence Tasting \u2014 aggregated supplier data for trial upsell (DEGUST-001)",
+        "tags": [
+          "intel_tasting"
         ]
       }
     },

--- a/backend/tests/test_intel_tasting.py
+++ b/backend/tests/test_intel_tasting.py
@@ -1,0 +1,58 @@
+"""DEGUST-001 (#1611): Tests for Intelligence Tasting route."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestIntelTastingRoute:
+    """Basic route validation for GET /v1/intel/tasting."""
+
+    def test_route_registered(self, client: TestClient):
+        """Route is registered and returns 200 for valid params."""
+        resp = client.get("/v1/intel/tasting?setor_id=alimentos&uf=SP&meses=1")
+        # Route exists — may return 200 (data) or 500 (no Supabase in test)
+        assert resp.status_code in (200, 422, 500)
+
+    def test_invalid_uf_returns_422(self, client: TestClient):
+        """Invalid UF returns validation error."""
+        resp = client.get("/v1/intel/tasting?uf=XX")
+        assert resp.status_code in (400, 422)
+
+    def test_invalid_sector_returns_422(self, client: TestClient):
+        """Invalid sector returns validation error."""
+        resp = client.get("/v1/intel/tasting?setor_id=invalid_sector_xyz")
+        assert resp.status_code in (400, 422)
+
+    def test_meses_below_range(self, client: TestClient):
+        """meses < 1 returns validation error."""
+        resp = client.get("/v1/intel/tasting?meses=0")
+        assert resp.status_code == 422
+
+    def test_meses_above_range(self, client: TestClient):
+        """meses > 24 returns validation error."""
+        resp = client.get("/v1/intel/tasting?meses=25")
+        assert resp.status_code == 422
+
+    def test_no_params_returns_ok(self, client: TestClient):
+        """No params uses defaults — returns 200 or 500 (no DB in test env)."""
+        resp = client.get("/v1/intel/tasting")
+        assert resp.status_code in (200, 422, 500)
+
+    def test_response_model_structure(self, client: TestClient):
+        """Response JSON has expected keys when data is returned."""
+        resp = client.get("/v1/intel/tasting?setor_id=alimentos&uf=SP")
+        if resp.status_code == 200:
+            data = resp.json()
+            assert "sector_id" in data
+            assert "sector_name" in data
+            assert "total_contracts_value" in data
+            assert "total_winners" in data
+            assert "top_winners" in data
+            assert isinstance(data["top_winners"], list)

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4153,6 +4153,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/intel/tasting": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Intelligence Tasting — aggregated supplier data for trial upsell (DEGUST-001) */
+        get: operations["intel_tasting_v1_intel_tasting_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/itens/{catmat}/profile": {
         parameters: {
             query?: never;
@@ -10242,6 +10259,34 @@ export interface components {
             /** Status */
             status: string;
         };
+        /** IntelTastingResponse */
+        IntelTastingResponse: {
+            /** Avg Contract Value */
+            avg_contract_value: number;
+            /**
+             * Feature Enabled
+             * @default true
+             */
+            feature_enabled: boolean;
+            /** Generated At */
+            generated_at: string;
+            /** Period Months */
+            period_months: number;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Top Winners */
+            top_winners: components["schemas"]["TastingWinner"][];
+            /** Total Contracts */
+            total_contracts: number;
+            /** Total Contracts Value */
+            total_contracts_value: number;
+            /** Total Winners */
+            total_winners: number;
+            /** Uf */
+            uf?: string | null;
+        };
         /** InviteMemberRequest */
         InviteMemberRequest: {
             /** Email */
@@ -13470,6 +13515,20 @@ export interface components {
             timestamp?: string | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * TastingWinner
+         * @description Top winner entry. cnpj/razao_social are REAL data — blur is client-side.
+         */
+        TastingWinner: {
+            /** Cnpj */
+            cnpj: string;
+            /** Contracts Count */
+            contracts_count: number;
+            /** Razao Social */
+            razao_social: string;
+            /** Total Won */
+            total_won: number;
         };
         /** TimeSeriesDataPoint */
         TimeSeriesDataPoint: {
@@ -19653,6 +19712,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    intel_tasting_v1_intel_tasting_get: {
+        parameters: {
+            query?: {
+                /** @description Sector ID to filter (e.g., 'alimentos'). If omitted, returns global. */
+                setor_id?: string | null;
+                /** @description UF filter (2-letter). If omitted, returns national aggregation. */
+                uf?: string | null;
+                /** @description Lookback period in months (1–24, default 12) */
+                meses?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelTastingResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/app/components/IntelligenceTasting.tsx
+++ b/frontend/app/components/IntelligenceTasting.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+/**
+ * DEGUST-001 (#1611): Intelligence Tasting component.
+ *
+ * Shows aggregated market intelligence from pncp_supplier_contracts.
+ * - Free/trial users: real data with blurred winner names + CTA
+ * - Paid users: full data without blur
+ *
+ * Inserted post-search and in dashboard.
+ */
+
+import { useEffect, useState } from "react";
+import mixpanel from "mixpanel-browser";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TastingWinner {
+  cnpj: string;
+  razao_social: string;
+  total_won: number;
+  contracts_count: number;
+}
+
+interface TastingData {
+  sector_id: string;
+  sector_name: string;
+  uf?: string | null;
+  period_months: number;
+  total_contracts_value: number;
+  total_winners: number;
+  total_contracts: number;
+  avg_contract_value: number;
+  top_winners: TastingWinner[];
+  generated_at: string;
+  feature_enabled: boolean;
+}
+
+interface IntelligenceTastingProps {
+  /** Sector ID from the search context, if available */
+  sectorId?: string;
+  /** UF from the search context, if available */
+  uf?: string;
+  /** Whether the user has a paid plan (Insight/Pro/Command) */
+  isPaidUser?: boolean;
+  /** CTA URL for upgrade */
+  upgradeUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function fmtBRL(value: number): string {
+  if (value >= 1_000_000_000) {
+    return `R$ ${(value / 1_000_000_000).toFixed(1).replace(".", ",")} bi`;
+  }
+  if (value >= 1_000_000) {
+    return `R$ ${(value / 1_000_000).toFixed(1).replace(".", ",")} mi`;
+  }
+  if (value >= 1_000) {
+    return `R$ ${(value / 1_000).toFixed(0)} mil`;
+  }
+  return `R$ ${value.toFixed(0)}`;
+}
+
+function fmtInt(n: number): string {
+  return n.toLocaleString("pt-BR");
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function IntelligenceTasting({
+  sectorId,
+  uf,
+  isPaidUser = false,
+  upgradeUrl = "/pricing?tier=insight",
+}: IntelligenceTastingProps) {
+  const [data, setData] = useState<TastingData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchTasting() {
+      try {
+        setLoading(true);
+        const params = new URLSearchParams();
+        if (sectorId) params.set("setor_id", sectorId);
+        if (uf) params.set("uf", uf);
+        params.set("meses", "12");
+
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/v1/intel/tasting?${params}`
+        );
+        if (!res.ok) {
+          if (res.status === 404) {
+            // Feature disabled or not found — silent
+            setData(null);
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const json: TastingData = await res.json();
+        if (!cancelled) {
+          setData(json);
+          // Track shown event
+          try {
+            mixpanel.track("intelligence_tasting_shown", {
+              sector_id: json.sector_id,
+              total_winners: json.total_winners,
+              total_value: json.total_contracts_value,
+              is_paid_user: isPaidUser,
+              uf: uf || "BR",
+            });
+          } catch {
+            // Mixpanel may not be initialized (consent)
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Erro ao carregar");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchTasting();
+    return () => {
+      cancelled = true;
+    };
+  }, [sectorId, uf, isPaidUser]);
+
+  function handleCtaClick() {
+    try {
+      mixpanel.track("intelligence_tasting_clicked", {
+        sector_id: data?.sector_id || "unknown",
+        is_paid_user: isPaidUser,
+      });
+    } catch {
+      // Mixpanel may not be initialized
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // States: loading / error / disabled / empty / content
+  // ------------------------------------------------------------------
+
+  if (loading) {
+    return (
+      <div className="animate-pulse rounded-xl border border-slate-200 bg-white p-6">
+        <div className="mb-4 h-5 w-3/4 rounded bg-slate-200" />
+        <div className="grid grid-cols-3 gap-4">
+          <div className="h-16 rounded bg-slate-100" />
+          <div className="h-16 rounded bg-slate-100" />
+          <div className="h-16 rounded bg-slate-100" />
+        </div>
+        <div className="mt-4 space-y-2">
+          <div className="h-10 rounded bg-slate-100" />
+          <div className="h-10 rounded bg-slate-100" />
+          <div className="h-10 rounded bg-slate-100" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    // Graceful degradation — don't show error to user
+    return null;
+  }
+
+  if (!data.feature_enabled || data.total_winners === 0) {
+    return null; // No data or feature disabled
+  }
+
+  const showBlur = !isPaidUser;
+
+  return (
+    <div className="rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50 to-white p-6 shadow-sm">
+      {/* Header */}
+      <div className="mb-5 flex items-start justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">
+            Inteligência de Mercado
+            {data.sector_id !== "global" && (
+              <span className="font-normal text-slate-500">
+                {" "}
+                — {data.sector_name}
+              </span>
+            )}
+          </h3>
+          <p className="mt-1 text-sm text-slate-500">
+            Dados reais dos últimos {data.period_months} meses
+            {data.uf ? ` em ${data.uf}` : " no Brasil"}
+          </p>
+        </div>
+        {showBlur && (
+          <span className="shrink-0 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700">
+            🔒 Preview
+          </span>
+        )}
+      </div>
+
+      {/* Stats grid */}
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-lg bg-white p-3 shadow-sm ring-1 ring-slate-200/60">
+          <div className="text-2xl font-bold text-blue-700">
+            {fmtBRL(data.total_contracts_value)}
+          </div>
+          <div className="text-xs text-slate-500">Valor total contratado</div>
+        </div>
+        <div className="rounded-lg bg-white p-3 shadow-sm ring-1 ring-slate-200/60">
+          <div className="text-2xl font-bold text-blue-700">
+            {fmtInt(data.total_winners)}
+          </div>
+          <div className="text-xs text-slate-500">Empresas vencedoras</div>
+        </div>
+        <div className="rounded-lg bg-white p-3 shadow-sm ring-1 ring-slate-200/60">
+          <div className="text-2xl font-bold text-blue-700">
+            {fmtInt(data.total_contracts)}
+          </div>
+          <div className="text-xs text-slate-500">Contratos fechados</div>
+        </div>
+        <div className="rounded-lg bg-white p-3 shadow-sm ring-1 ring-slate-200/60">
+          <div className="text-2xl font-bold text-blue-700">
+            {fmtBRL(data.avg_contract_value)}
+          </div>
+          <div className="text-xs text-slate-500">Valor médio por contrato</div>
+        </div>
+      </div>
+
+      {/* Top Winners */}
+      <div className="mb-4">
+        <h4 className="mb-2 text-sm font-semibold text-slate-700">
+          Top {data.top_winners.length} vencedores
+          {showBlur && (
+            <span className="ml-2 font-normal text-slate-400">
+              (nomes ocultos)
+            </span>
+          )}
+        </h4>
+        <div className="space-y-2">
+          {data.top_winners.map((winner, i) => (
+            <div
+              key={winner.cnpj || i}
+              className="flex items-center justify-between rounded-lg bg-white px-4 py-2.5 shadow-sm ring-1 ring-slate-200/60"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-xs font-medium text-slate-400">
+                  #{i + 1}
+                </span>
+                <span
+                  className={
+                    showBlur
+                      ? "select-none rounded bg-slate-200 px-3 py-1 text-sm text-transparent blur-[4px]"
+                      : "text-sm font-medium text-slate-800"
+                  }
+                >
+                  {winner.razao_social}
+                </span>
+                {showBlur && (
+                  <span className="text-xs text-slate-400">██████</span>
+                )}
+              </div>
+              <div className="text-right">
+                <div className="text-sm font-semibold text-slate-700">
+                  {fmtBRL(winner.total_won)}
+                </div>
+                <div className="text-xs text-slate-400">
+                  {winner.contracts_count} contrato
+                  {winner.contracts_count !== 1 ? "s" : ""}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* CTA for non-paid users */}
+      {showBlur && (
+        <div className="rounded-lg bg-blue-600 p-4 text-center">
+          <p className="mb-2 text-sm font-medium text-blue-100">
+            🔓 Veja os nomes reais e acesse análises completas de inteligência
+            competitiva
+          </p>
+          <a
+            href={upgradeUrl}
+            onClick={handleCtaClick}
+            className="inline-block rounded-lg bg-white px-6 py-2.5 text-sm font-semibold text-blue-700 shadow transition hover:bg-blue-50"
+          >
+            Fazer upgrade para SmartLic Insight — R$497/mês
+          </a>
+          <p className="mt-1 text-xs text-blue-200">
+            Dados reais do PNCP processados pelo SmartLic
+          </p>
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="mt-3 text-center text-xs text-slate-400">
+        Dados: PNCP — Portal Nacional de Contratações Públicas · Atualizado{" "}
+        {new Date(data.generated_at).toLocaleDateString("pt-BR")}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Contexto
DEGUST-001 (#1611): Intelligence Tasting no trial — mostra dados agregados reais do mercado para usuários trial/free com blur nos nomes de concorrentes.

## Mudanças
### Backend
- Feature flag `INTELLIGENCE_TASTING_ENABLED` (default: true)
- Nova rota `GET /v1/intel/tasting` com agregação sobre `pncp_supplier_contracts`
- Query por setor + UF + período (1-24 meses), cache 4h

### Frontend
- Componente `<IntelligenceTasting>` com:
  - Skeleton loading
  - Stats grid (valor total, empresas, contratos, valor médio)
  - Top 10 vencedores com nomes em blur (CSS `filter: blur(4px)`)
  - CTA para upgrade (Insight R\97/mês)
  - Mixpanel events: `intelligence_tasting_shown`, `intelligence_tasting_clicked`
  - Paid users (Insight/Pro/Command) veem dados completos sem blur

## Testes
- Backend: import verificado, testes pending
- Frontend: component compila, testes pending

## Closes
Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Intelligence Tasting endpoint returning aggregated supplier/contract insights with sector, state and timeframe filters, top winners, and generated timestamp.
* **Frontend**
  * New IntelligenceTasting component displays stats, top winners, paid-user blurring and upgrade CTA; tracks basic view/click events.
* **Feature Flags**
  * New runtime-controllable flag to enable/disable the feature, exposed in the admin/public flag list.
* **API / Docs**
  * OpenAPI/schema updated with new response shapes and endpoint.
* **Tests**
  * End-to-end tests validating route, params, and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->