### PR TITLE
feat(frontend,backend): NETINT-014 — EmbedIntelFeed widget for SEO pages (#1519)

### DIFF
--- a/.github/workflows/banned-phrases-check.yml
+++ b/.github/workflows/banned-phrases-check.yml
@@ -1,2 +1,26 @@
+name: Banned Phrases Check (NO-JARGON-004)
+
+on:
+  pull_request:
+    paths:
+      - "frontend/app/blog/**"
+      - "frontend/app/buscar/**"
+      - "frontend/components/**"
+      - "frontend/lib/copy/**"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/app/blog/**"
+      - "frontend/app/buscar/**"
+      - "frontend/components/**"
+      - "frontend/lib/copy/**"
+
+jobs:
+  check-banned-phrases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for git diff against base ref
+      - name: Run banned phrase scan
+        run: bash scripts/check-banned-phrases.sh

--- a/backend/routes/pseo_intel_feed.py
+++ b/backend/routes/pseo_intel_feed.py
@@ -1,0 +1,298 @@
+"""NETINT-014 (#1519): GET /v1/pseo/intel-feed — EmbedIntelFeed widget endpoint.
+
+Public (no auth) endpoint that returns compact market intelligence signals
+for a given sector. Used by the frontend EmbedIntelFeed component on SEO
+programmatic pages.
+
+Aggregates from pncp_supplier_contracts and pncp_raw_bids:
+  - New contracts this month
+  - Total contract value this month
+  - Active suppliers count
+  - Active bids count
+
+Cache: InMemory 1h TTL.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from schemas.pseo_intel_feed import IntelFeedResponse, IntelFeedSignal
+from sectors import SECTORS
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/pseo",
+    tags=["pseo-intel-feed"],
+)
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+_CACHE_TTL_SECONDS = 3600  # 1h
+_NEGATIVE_CACHE_TTL_SECONDS = 300  # 5min
+_feed_cache: dict[str, tuple[dict, float]] = {}
+
+
+def _cache_get(key: str) -> Optional[dict]:
+    if key not in _feed_cache:
+        return None
+    data, ts = _feed_cache[key]
+    if time.time() - ts >= _CACHE_TTL_SECONDS:
+        del _feed_cache[key]
+        return None
+    return data
+
+
+def _cache_set(key: str, data: dict, ttl: Optional[float] = None) -> None:
+    _feed_cache[key] = (data, time.time())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slug_to_sector_id(slug: str) -> Optional[str]:
+    """Convert URL slug to sector ID.
+
+    'manutencao-predial' → 'manutencao_predial'
+    """
+    sector_id = slug.replace("-", "_")
+    if sector_id in SECTORS:
+        return sector_id
+    return None
+
+
+def _format_compact_brl(value: float) -> str:
+    """Format value in compact BRL notation."""
+    if value >= 1_000_000_000:
+        return f"R${value / 1_000_000_000:.1f} bi"
+    if value >= 1_000_000:
+        return f"R${value / 1_000_000:.1f} mi"
+    if value >= 1_000:
+        return f"R${value / 1_000:.0f} mil"
+    return f"R${value:,.0f}"
+
+
+def _format_number(value: int) -> str:
+    """Format integer with Brazilian locale."""
+    return f"{value:,}".replace(",", ".")
+
+
+# ---------------------------------------------------------------------------
+# Data aggregation
+# ---------------------------------------------------------------------------
+
+
+def _get_sector_keywords(sector_id: str) -> set[str]:
+    """Get lowercased keyword set for a sector."""
+    sector = SECTORS.get(sector_id)
+    if not sector:
+        return set()
+    return {kw.lower() for kw in sector.keywords}
+
+
+def _matches_sector(objeto: str, keywords: set[str]) -> bool:
+    """Check if an object/title string matches any sector keyword."""
+    obj_lower = (objeto or "").lower()
+    return any(kw in obj_lower for kw in keywords)
+
+
+async def _aggregate_intel(sector_id: str, uf: Optional[str] = None) -> dict:
+    """Query supabase and aggregate market intelligence signals.
+
+    Returns a dict with contract_count, contract_value_total,
+    active_suppliers, active_bids, generated_at.
+    On failure returns an empty fallback.
+    """
+    from supabase_client import get_supabase, sb_execute
+
+    keywords = _get_sector_keywords(sector_id)
+    sector = SECTORS.get(sector_id)
+    sector_name = sector.name if sector else sector_id
+
+    now = datetime.now(timezone.utc)
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    contract_count = 0
+    contract_value_total = 0.0
+    active_suppliers: set[str] = set()
+    active_bids_count = 0
+
+    try:
+        # --- Query pncp_supplier_contracts ---
+        sb = get_supabase()
+        query = (
+            sb.table("pncp_supplier_contracts")
+            .select(
+                "ni_fornecedor,valor_global,data_assinatura,objeto_contrato"
+            )
+            .eq("is_active", True)
+            .gte("data_assinatura", month_start.isoformat())
+        )
+        if uf:
+            query = query.eq("uf", uf.upper())
+
+        builder = query.order("data_assinatura", desc=True)
+        rows: list[dict] = []
+        batch_size = 1000
+        max_total = 5000
+        offset = 0
+        while len(rows) < max_total:
+            end = offset + batch_size - 1
+            resp = await sb_execute(builder.range(offset, end))
+            batch = resp.data or []
+            if not batch:
+                break
+            rows.extend(batch)
+            if len(batch) < batch_size:
+                break
+            offset += batch_size
+
+        # Filter by sector keywords
+        for row in rows:
+            obj = row.get("objeto_contrato") or ""
+            if keywords and not _matches_sector(obj, keywords):
+                continue
+            contract_count += 1
+            valor = float(row.get("valor_global") or 0)
+            contract_value_total += valor
+            ni = row.get("ni_fornecedor") or ""
+            if ni:
+                active_suppliers.add(ni)
+
+        # --- Query pncp_raw_bids for active bids (filtered by sector keywords too) ---
+        try:
+            from datalake_query import query_datalake
+
+            bids = await query_datalake(
+                ufs=[uf] if uf else [],
+                modo_busca="abertas",
+                limit=1000,
+            )
+            for bid in bids:
+                obj = (
+                    bid.get("objeto")
+                    or bid.get("titulo")
+                    or bid.get("resumo")
+                    or ""
+                )
+                if not keywords or _matches_sector(obj, keywords):
+                    active_bids_count += 1
+        except Exception as e:
+            logger.debug("IntelFeed: datalake query failed (non-fatal): %s", e)
+
+    except Exception as e:
+        logger.warning(
+            "IntelFeed: aggregation failed for sector=%s uf=%s: %s",
+            sector_id, uf, e,
+        )
+        # Return partial data or empty fallback
+        pass
+
+    # Build signals
+    signals = []
+
+    # Signal 1: New contracts this month
+    if contract_count > 0:
+        signals.append(
+            IntelFeedSignal(
+                label=f"{_format_number(contract_count)} novos contratos este mês",
+                value=_format_compact_brl(contract_value_total),
+                trend="up" if contract_count > 10 else "stable",
+            )
+        )
+    else:
+        signals.append(
+            IntelFeedSignal(
+                label="Dados em consolidação",
+                value="Contratos deste mês",
+                trend=None,
+            )
+        )
+
+    # Signal 2: Total value of contracts
+    if contract_value_total > 0:
+        signals.append(
+            IntelFeedSignal(
+                label="Valor total em contratos",
+                value=_format_compact_brl(contract_value_total),
+                trend="up" if contract_value_total > 1_000_000 else "stable",
+            )
+        )
+    else:
+        signals.append(
+            IntelFeedSignal(
+                label="Mercado em análise",
+                value="Aguardando dados",
+                trend=None,
+            )
+        )
+
+    # Signal 3: Active suppliers and bids
+    n_suppliers = len(active_suppliers)
+    details_parts = []
+    if n_suppliers > 0:
+        details_parts.append(f"{_format_number(n_suppliers)} fornecedores ativos")
+    if active_bids_count > 0:
+        details_parts.append(f"{_format_number(active_bids_count)} licitações abertas")
+
+    if details_parts:
+        signals.append(
+            IntelFeedSignal(
+                label=" · ".join(details_parts),
+                value=f"{sector_name}",
+                trend="up" if active_bids_count > 0 else "stable",
+            )
+        )
+    else:
+        signals.append(
+            IntelFeedSignal(
+                label=f"Setor {sector_name}",
+                value="Acompanhe as oportunidades",
+                trend=None,
+            )
+        )
+
+    return {
+        "sector": sector_name,
+        "signals": [s.model_dump() for s in signals],
+        "generated_at": now.isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-feed",
+    response_model=IntelFeedResponse,
+    summary="Compact market intelligence feed for a sector (EmbedIntelFeed widget)",
+)
+async def get_intel_feed(
+    sector: str = Query(..., description="Sector URL slug, e.g. 'engenharia'"),
+    uf: Optional[str] = Query(None, description="Optional UF filter (e.g. 'SP')"),
+):
+    sector_id = _slug_to_sector_id(sector)
+    if not sector_id:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Setor '{sector}' não encontrado",
+        )
+
+    cache_key = f"intel_feed:{sector_id}:{uf or 'BR'}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return IntelFeedResponse(**cached)
+
+    data = await _aggregate_intel(sector_id, uf)
+    _cache_set(cache_key, data)
+    return IntelFeedResponse(**data)

--- a/backend/schemas/pseo_intel_feed.py
+++ b/backend/schemas/pseo_intel_feed.py
@@ -1,0 +1,25 @@
+"""NETINT-014 (#1519): IntelFeed schemas for EmbedIntelFeed widget.
+
+Models for the compact market intelligence feed shown on SEO programmatic pages.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class IntelFeedSignal(BaseModel):
+    """Single market signal displayed in the widget."""
+
+    label: str
+    value: str
+    trend: Optional[str] = None  # "up" | "down" | "stable"
+
+
+class IntelFeedResponse(BaseModel):
+    """Full response payload for the intel feed endpoint."""
+
+    sector: str
+    signals: list[IntelFeedSignal]
+    generated_at: datetime

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -98,6 +98,7 @@ from routes.admin_metrics import router as admin_metrics_router
 from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
 from routes.admin_command import router as admin_command_router
+from routes.intel_tasting import router as intel_tasting_router
 from routes.pseo_intel_feed import router as pseo_intel_feed_router
 
 _v1_routers = [
@@ -153,6 +154,7 @@ _v1_routers = [
     network_events_router,
     segment_router,
     api_search_router,
+    intel_tasting_router,
     pseo_intel_feed_router,
 ]
 

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -98,6 +98,7 @@ from routes.admin_metrics import router as admin_metrics_router
 from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
 from routes.admin_command import router as admin_command_router
+from routes.pseo_intel_feed import router as pseo_intel_feed_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -152,6 +153,7 @@ _v1_routers = [
     network_events_router,
     segment_router,
     api_search_router,
+    pseo_intel_feed_router,
 ]
 
 

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -155,7 +155,6 @@ _v1_routers = [
     segment_router,
     api_search_router,
     intel_tasting_router,
-    pseo_intel_feed_router,
 ]
 
 

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -99,7 +99,6 @@ from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
 from routes.admin_command import router as admin_command_router
 from routes.intel_tasting import router as intel_tasting_router
-from routes.pseo_intel_feed import router as pseo_intel_feed_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -155,6 +154,7 @@ _v1_routers = [
     segment_router,
     api_search_router,
     intel_tasting_router,
+    pseo_intel_feed_router,
 ]
 
 

--- a/backend/tests/test_pseo_intel_feed.py
+++ b/backend/tests/test_pseo_intel_feed.py
@@ -1,0 +1,99 @@
+"""Tests for NETINT-014 (#1519): pseo_intel_feed endpoint.
+
+Tests:
+- Returns 200 with valid sector
+- Returns 404 for missing sector
+- Response structure matches IntelFeedResponse schema
+- Handles cache correctly
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear intel feed cache between tests."""
+    from routes.pseo_intel_feed import _feed_cache
+    _feed_cache.clear()
+    yield
+    _feed_cache.clear()
+
+
+@pytest.fixture
+def client():
+    from main import app
+    return TestClient(app)
+
+
+class TestPseoIntelFeed:
+    """Test suite for GET /v1/pseo/intel-feed."""
+
+    VALID_SECTOR = "engenharia"
+    INVALID_SECTOR = "setor-inexistente"
+
+    def test_returns_200_with_valid_sector(self, client):
+        """Should return 200 with valid sector."""
+        resp = client.get(f"/v1/pseo/intel-feed?sector={self.VALID_SECTOR}")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_returns_404_for_invalid_sector(self, client):
+        """Should return 404 for non-existent sector."""
+        resp = client.get(f"/v1/pseo/intel-feed?sector={self.INVALID_SECTOR}")
+        assert resp.status_code == 404
+
+    def test_returns_422_when_sector_missing(self, client):
+        """Should return 422 when sector param is omitted (FastAPI validation)."""
+        resp = client.get("/v1/pseo/intel-feed")
+        assert resp.status_code == 422
+
+    def test_response_structure_matches_schema(self, client):
+        """Response should match IntelFeedResponse schema."""
+        resp = client.get(f"/v1/pseo/intel-feed?sector={self.VALID_SECTOR}" +
+                          "&uf=SP")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Check top-level fields
+        assert "sector" in data
+        assert "signals" in data
+        assert "generated_at" in data
+
+        # sector should be a non-empty string
+        assert isinstance(data["sector"], str) and len(data["sector"]) > 0
+
+        # signals should be a list with 3 items
+        assert isinstance(data["signals"], list)
+        assert len(data["signals"]) == 3
+
+        # Each signal should have label and value
+        for signal in data["signals"]:
+            assert "label" in signal
+            assert "value" in signal
+            assert isinstance(signal["label"], str)
+            assert isinstance(signal["value"], str)
+
+        # generated_at should be a valid ISO datetime
+        assert isinstance(data["generated_at"], str)
+        from datetime import datetime
+        datetime.fromisoformat(data["generated_at"])
+
+    def test_cache_hit(self, client):
+        """Second request should return from cache (fast)."""
+        # First request populates cache
+        resp1 = client.get(f"/v1/pseo/intel-feed?sector={self.VALID_SECTOR}")
+        assert resp1.status_code == 200
+
+        # Second request should be fast (from cache)
+        resp2 = client.get(f"/v1/pseo/intel-feed?sector={self.VALID_SECTOR}")
+        assert resp2.status_code == 200
+        assert resp2.json()["sector"] == resp1.json()["sector"]
+
+    def test_different_sectors_return_different_data(self, client):
+        """Different sectors should return different responses."""
+        resp_eng = client.get("/v1/pseo/intel-feed?sector=engenharia")
+        resp_vest = client.get("/v1/pseo/intel-feed?sector=vestuario")
+        assert resp_eng.status_code == 200
+        assert resp_vest.status_code == 200
+        # At minimum the sector name should differ
+        assert resp_eng.json()["sector"] != resp_vest.json()["sector"]

--- a/frontend/__tests__/components/pseo/EmbedIntelFeed.test.tsx
+++ b/frontend/__tests__/components/pseo/EmbedIntelFeed.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for EmbedIntelFeed — Issue #1519 (NETINT-014)
+ *
+ * Covers:
+ *  - Renders loading skeleton initially (before IntersectionObserver triggers)
+ *  - Lazy-loads via IntersectionObserver when visible
+ *  - Shows market signals after successful API fetch
+ *  - Falls back to static content on API error
+ *  - ISR-safe: does not throw during build/render
+ *  - Has data-embed-intel-feed attribute for testing
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { EmbedIntelFeed } from "@/components/pseo/EmbedIntelFeed";
+
+const MOCK_RESPONSE = {
+  sector: "Engenharia",
+  signals: [
+    { label: "45 novos contratos este mês", value: "R$2,5 mi", trend: "up" },
+    { label: "Valor total em contratos", value: "R$2,5 mi", trend: "up" },
+    { label: "12 fornecedores ativos", value: "Engenharia", trend: "stable" },
+  ],
+  generated_at: "2026-06-11T00:00:00Z",
+};
+
+const EMPTY_RESPONSE = {
+  sector: "Engenharia",
+  signals: [],
+  generated_at: "2026-06-11T00:00:00Z",
+};
+
+function mockFetch(response: object, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => response,
+  } as Response);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Mock IntersectionObserver to always trigger immediately
+  const mockObserve = jest.fn();
+  const mockDisconnect = jest.fn();
+  global.IntersectionObserver = jest.fn().mockImplementation((callback) => {
+    // Immediately trigger intersection
+    callback([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+    return {
+      observe: mockObserve,
+      disconnect: mockDisconnect,
+      unobserve: jest.fn(),
+      root: null,
+      rootMargin: "",
+      thresholds: [],
+      takeRecords: () => [],
+    };
+  });
+});
+
+describe("EmbedIntelFeed", () => {
+  const defaultProps = {
+    sector: "engenharia",
+  };
+
+  it("renders with data-embed-intel-feed attribute", () => {
+    // Keep loading state
+    global.fetch = jest.fn().mockImplementation(() => new Promise(() => {}));
+    const { container } = render(<EmbedIntelFeed {...defaultProps} />);
+    const section = container.querySelector("[data-embed-intel-feed]");
+    expect(section).toBeInTheDocument();
+  });
+
+  it("shows market signals after successful fetch", async () => {
+    mockFetch(MOCK_RESPONSE);
+    render(<EmbedIntelFeed {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Mercado de Engenharia")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("45 novos contratos este mês"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Valor total em contratos")).toBeInTheDocument();
+    expect(screen.getByText("12 fornecedores ativos")).toBeInTheDocument();
+  });
+
+  it("falls back to static content on API error", async () => {
+    mockFetch({ error: "Server error" }, 500);
+    render(<EmbedIntelFeed sector="engenharia" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Mercado de Engenharia")).toBeInTheDocument();
+    });
+
+    // Should show fallback content instead of erroring
+    await waitFor(() => {
+      expect(
+        screen.getByText("Acompanhe as oportunidades"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to static content on network error", async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("Network error"));
+    render(<EmbedIntelFeed sector="engenharia" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Mercado de Engenharia")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Acompanhe as oportunidades"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders with UF parameter", async () => {
+    mockFetch(MOCK_RESPONSE);
+    render(<EmbedIntelFeed sector="engenharia" uf="SP" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Mercado de Engenharia")).toBeInTheDocument();
+    });
+  });
+
+  it("handles empty signals list gracefully", async () => {
+    mockFetch(EMPTY_RESPONSE);
+    render(<EmbedIntelFeed {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Mercado de Engenharia"),
+      ).toBeInTheDocument();
+    });
+
+    // Should show consolidation message
+    expect(
+      screen.getByText("Dados de mercado em consolidação."),
+    ).toBeInTheDocument();
+  });
+
+  it("ISR-safe: does not throw during render", () => {
+    // Simulate what would happen during build (no fetch resolution)
+    global.fetch = jest.fn().mockImplementation(() => new Promise(() => {}));
+    expect(() => render(<EmbedIntelFeed {...defaultProps} />)).not.toThrow();
+  });
+});

--- a/frontend/app/api/pseo/intel-feed/route.ts
+++ b/frontend/app/api/pseo/intel-feed/route.ts
@@ -1,0 +1,112 @@
+/**
+ * API proxy: GET /api/pseo/intel-feed -> backend GET /v1/pseo/intel-feed
+ * Issue #1519 (NETINT-014): Embedded intelligence feed widget for SEO pages.
+ *
+ * Public endpoint (no auth). Cache: 1h revalidate (ISR-safe).
+ * Falls back to static/generic data when backend is unavailable.
+ */
+import { NextRequest, NextResponse } from "next/server";
+
+export interface IntelFeedSignal {
+  label: string;
+  value: string;
+  trend?: "up" | "down" | "stable" | null;
+}
+
+export interface IntelFeedResponse {
+  sector: string;
+  signals: IntelFeedSignal[];
+  generated_at: string;
+}
+
+/** Static fallback data for a sector — used when backend is offline */
+function staticFallback(sector: string): IntelFeedResponse {
+  const sectorName = sector.charAt(0).toUpperCase() + sector.slice(1);
+  return {
+    sector: sectorName,
+    signals: [
+      {
+        label: "Acompanhe as oportunidades",
+        value: `${sectorName}`,
+        trend: null,
+      },
+      {
+        label: "Mercado em análise",
+        value: "Aguardando dados",
+        trend: null,
+      },
+      {
+        label: "Dados em consolidação",
+        value: "Contratos deste mês",
+        trend: null,
+      },
+    ],
+    generated_at: new Date().toISOString(),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const sector = searchParams.get("sector");
+  const uf = searchParams.get("uf");
+
+  if (!sector) {
+    return NextResponse.json({ error: "sector is required" }, { status: 400 });
+  }
+
+  const BACKEND_URL =
+    process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL;
+
+  if (!BACKEND_URL) {
+    // No backend configured — serve static fallback
+    const data = staticFallback(sector);
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=7200",
+      },
+    });
+  }
+
+  try {
+    const params = new URLSearchParams({ sector });
+    if (uf) params.set("uf", uf);
+
+    const resp = await fetch(
+      `${BACKEND_URL}/v1/pseo/intel-feed?${params.toString()}`,
+      {
+        headers: { "Content-Type": "application/json" },
+        next: { revalidate: 3600 },
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+
+    if (!resp.ok) {
+      // Backend error — serve static fallback
+      const data = staticFallback(sector);
+      return NextResponse.json(data, {
+        headers: {
+          "Cache-Control":
+            "public, s-maxage=3600, stale-while-revalidate=7200",
+        },
+      });
+    }
+
+    const data: IntelFeedResponse = await resp.json();
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=7200",
+      },
+    });
+  } catch {
+    // Network error — serve static fallback
+    const data = staticFallback(sector);
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=7200",
+      },
+    });
+  }
+}

--- a/frontend/app/blog/programmatic/[setor]/page.tsx
+++ b/frontend/app/blog/programmatic/[setor]/page.tsx
@@ -7,6 +7,7 @@ import SchemaMarkup from '@/components/blog/SchemaMarkup';
 import BlogCTA from '@/components/blog/BlogCTA';
 import RelatedPages from '@/components/blog/RelatedPages';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
+import { EmbedIntelFeed } from '@/components/pseo/EmbedIntelFeed';
 import {
   generateSectorParams,
   fetchSectorBlogStats,
@@ -249,6 +250,11 @@ export default async function SectorProgrammaticPage({
               </div>
             </section>
           )}
+
+          {/* #1519 (NETINT-014): EmbedIntelFeed — compact market intelligence widget */}
+          <div className="mb-10">
+            <EmbedIntelFeed sector={setor} />
+          </div>
 
           {/* FAQ Section */}
           <section className="mb-10">

--- a/frontend/app/licitacoes/[setor]/page.tsx
+++ b/frontend/app/licitacoes/[setor]/page.tsx
@@ -21,6 +21,7 @@ import { AdvisoryDisclaimer } from "@/components/legal/AdvisoryDisclaimer";
 import { RecentEditaisBlock } from "@/app/components/programmatic/RecentEditaisBlock";
 import { TopSuppliersBlock } from "@/app/components/programmatic/TopSuppliersBlock";
 import { MarketPatternsBlock } from "@/components/pseo/MarketPatternsBlock";
+import { EmbedIntelFeed } from "@/components/pseo/EmbedIntelFeed";
 import { SubcontratacaoSetorBlock } from "@/app/components/SubcontratacaoSetorBlock";
 import { TrackedCTALink } from "@/app/components/seo/TrackedCTALink";
 import { SeoOpportunityBanner } from "@/app/components/seo/SeoOpportunityBanner";
@@ -316,6 +317,11 @@ export default async function SectorPage({
 
       {/* #1288 (NETINT-011): Padrões de Mercado — aggregated market intelligence */}
       <MarketPatternsBlock setor={setor} />
+
+      {/* #1519 (NETINT-014): EmbedIntelFeed — compact market intelligence widget */}
+      <div className="max-w-5xl mx-auto px-4 py-6">
+        <EmbedIntelFeed sector={setor} />
+      </div>
 
       {/* CONV-REV-005 (#1321): Subcontratação block — pontes no setor */}
       <div className="max-w-5xl mx-auto px-4">

--- a/frontend/app/observatorio/[slug]/page.tsx
+++ b/frontend/app/observatorio/[slug]/page.tsx
@@ -23,6 +23,7 @@ import { buildCanonical } from '@/lib/seo';
 import ObservatorioRelatorioClient from './ObservatorioRelatorioClient';
 import { FoundersRibbon } from '@/components/banners/FoundersRibbon';
 import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
+import { EmbedIntelFeed } from '@/components/pseo/EmbedIntelFeed';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
@@ -275,6 +276,17 @@ export default async function RelatorioPage({
           variant="contextual"
           copy="Receba inteligência B2G sem mensalidade. Acesso vitalício R$997."
           src="pseo_observatorio"
+        />
+      </div>
+
+      {/* #1519 (NETINT-014): EmbedIntelFeed — compact market intelligence widget */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <EmbedIntelFeed
+          sector={(
+            relatorio?.setores_em_alta?.[0]?.setor_id
+              ? String(relatorio.setores_em_alta[0].setor_id).replace(/_/g, "-")
+              : slug
+          )}
         />
       </div>
     </>

--- a/frontend/components/pseo/EmbedIntelFeed.tsx
+++ b/frontend/components/pseo/EmbedIntelFeed.tsx
@@ -1,0 +1,246 @@
+"use client";
+/**
+ * EmbedIntelFeed — Issue #1519 (NETINT-014)
+ *
+ * Compact market intelligence feed widget for SEO programmatic pages.
+ * Shows "O mercado está aquecendo em [setor]" with 3 relevant signals.
+ *
+ * - Lazy-load via IntersectionObserver (only fetches when visible)
+ * - ISR-safe: static fallback if API fails (no build break)
+ * - Height: ~300px, horizontal scroll on mobile (<640px)
+ * - Vertical stack on desktop
+ *
+ * Usage:
+ *   <EmbedIntelFeed sector="engenharia" uf="SP" />
+ */
+import { useEffect, useRef, useState } from "react";
+
+export interface EmbedIntelFeedProps {
+  /** Nome do setor em formato slug (ex: "engenharia") */
+  sector: string;
+  /** UF opcional (ex: "SP") */
+  uf?: string;
+}
+
+interface SignalData {
+  label: string;
+  value: string;
+  trend?: string | null;
+}
+
+interface IntelFeedData {
+  sector: string;
+  signals: SignalData[];
+  generated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Static fallback — ISR-safe, usado quando API offline
+// ---------------------------------------------------------------------------
+
+function staticFallback(sectorLabel: string): IntelFeedData {
+  const name = sectorLabel.charAt(0).toUpperCase() + sectorLabel.slice(1);
+  return {
+    sector: name,
+    signals: [
+      { label: "Acompanhe as oportunidades", value: name, trend: null },
+      { label: "Mercado em análise", value: "Aguardando dados", trend: null },
+      { label: "Dados em consolidação", value: "Contratos deste mês", trend: null },
+    ],
+    generated_at: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Trend icon
+// ---------------------------------------------------------------------------
+
+function TrendIcon({ trend }: { trend?: string | null }) {
+  if (trend === "up") {
+    return (
+      <svg
+        className="w-4 h-4 text-green-500 shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+      </svg>
+    );
+  }
+  if (trend === "down") {
+    return (
+      <svg
+        className="w-4 h-4 text-red-500 shrink-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    );
+  }
+  // stable or null — render subtle dash
+  return (
+    <svg
+      className="w-4 h-4 text-[var(--ink-muted)] shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function IntelFeedSkeleton() {
+  return (
+    <div
+      className="rounded-xl border border-[var(--border)] bg-[var(--surface-0)] p-5 animate-pulse"
+      style={{ minHeight: "280px" }}
+      aria-label="Carregando inteligência de mercado"
+    >
+      <div className="h-5 bg-[var(--surface-2)] rounded w-56 mb-5" />
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex items-start gap-3">
+            <div className="w-4 h-4 bg-[var(--surface-2)] rounded shrink-0 mt-0.5" />
+            <div className="flex-1 space-y-1">
+              <div className="h-4 bg-[var(--surface-2)] rounded w-3/4" />
+              <div className="h-3 bg-[var(--surface-2)] rounded w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export function EmbedIntelFeed({ sector, uf }: EmbedIntelFeedProps) {
+  const [data, setData] = useState<IntelFeedData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  const fetchedRef = useRef(false);
+
+  useEffect(() => {
+    const el = observerRef.current;
+    if (!el) return;
+
+    const handleIntersection = (entries: IntersectionObserverEntry[]) => {
+      const entry = entries[0];
+      if (!entry.isIntersecting) return;
+      if (fetchedRef.current) return;
+      fetchedRef.current = true;
+
+      // Lazy-load data when visible
+      setLoading(true);
+
+      const params = new URLSearchParams({ sector });
+      if (uf) params.set("uf", uf);
+
+      fetch(`/api/pseo/intel-feed?${params.toString()}`)
+        .then((res) => {
+          if (!res.ok) throw new Error("API error");
+          return res.json();
+        })
+        .then((json: IntelFeedData) => {
+          setData(json);
+          setLoading(false);
+        })
+        .catch(() => {
+          // ISR-safe: serve fallback estático
+          setData(staticFallback(sector));
+          setLoading(false);
+        });
+    };
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      rootMargin: "200px",
+    });
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [sector, uf]);
+
+  const sectorDisplay =
+    data?.sector ||
+    sector.charAt(0).toUpperCase() + sector.slice(1);
+
+  return (
+    <section
+      ref={observerRef}
+      className="w-full"
+      data-embed-intel-feed
+      aria-label="Inteligência de Mercado"
+    >
+      {loading && !data ? (
+        <IntelFeedSkeleton />
+      ) : (
+        <div
+          className="rounded-xl border border-[var(--border)] bg-[var(--surface-0)] p-5"
+          style={{ minHeight: "280px" }}
+        >
+          {/* Header */}
+          <h3 className="text-base font-semibold text-[var(--ink)] mb-1">
+            Mercado de {sectorDisplay}
+          </h3>
+          <p className="text-xs text-[var(--ink-secondary)] mb-4">
+            Inteligência agregada em tempo real
+          </p>
+
+          {/* Signals: horizontal scroll on mobile, vertical stack on desktop */}
+          <div className="flex gap-3 overflow-x-auto pb-2 sm:flex-col sm:overflow-x-visible scrollbar-thin">
+            {(data?.signals ?? []).length === 0 ? (
+              <p className="text-sm text-[var(--ink-muted)]">
+                Dados de mercado em consolidação.
+              </p>
+            ) : (
+              (data?.signals ?? []).map((signal, idx) => (
+                <div
+                  key={idx}
+                  className="flex items-start gap-3 min-w-[220px] sm:min-w-0 p-3 rounded-lg bg-[var(--surface-1)] sm:bg-transparent sm:p-0 shrink-0"
+                >
+                  <TrendIcon trend={signal.trend} />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-[var(--ink)] leading-snug">
+                      {signal.label}
+                    </p>
+                    <p className="text-xs text-[var(--ink-secondary)] mt-0.5">
+                      {signal.value}
+                    </p>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Footer */}
+          {data?.generated_at && (
+            <p className="text-[10px] text-[var(--ink-muted)] mt-3 text-right">
+              Dados:{" "}
+              {new Date(data.generated_at).toLocaleDateString("pt-BR", {
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+              })}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Issue #1519

EmbedIntelFeed component — compact market intelligence feed widget for SEO programmatic pages.

### Changes
- **Frontend:** EmbedIntelFeed component with IntersectionObserver lazy-loading, ISR-safe fallback
- **Backend:** GET /v1/pseo/intel-feed endpoint with sector-aggregated market signals
- **Integration:** Added to licitacoes, blog/programmatic, and observatorio templates
- **Tests:** Component tests (7 passing) + backend endpoint tests (6 passing)

### Acceptance
- [x] Component rendered in 3+ SEO templates
- [x] Lazy-load with IntersectionObserver
- [x] Static fallback for ISR (no build break if API offline)
- [x] Performance: component size under 50KB
- [x] Tests: render, lazy-load, fallback, ISR compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced market intelligence widget displaying key sector signals: new contracts this month, total contract value, and active suppliers/bids count
  * Widget integrated across sector landing pages, blog posts, and market observatory reports
  * Includes performance optimization through intelligent caching and automatic fallback for reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->