### PR TITLE
feat(predint): PREDINT-020 — 4 time series RPCs for predictive intelligence (#1664)

### DIFF
--- a/frontend/__tests__/consultoria/ClientInviteModal.test.tsx
+++ b/frontend/__tests__/consultoria/ClientInviteModal.test.tsx
@@ -72,7 +72,7 @@ describe("ClientInviteModal", () => {
     const submitButton = screen.getByText("Convidar");
     fireEvent.click(submitButton);
 
-    expect(screen.getByText("Informe o email do cliente.")).toBeInTheDocument();
+    expect(await screen.findByText("Informe o email do cliente.", undefined, { timeout: 3000 })).toBeInTheDocument();
     expect(mockOnInvite).not.toHaveBeenCalled();
   });
 

--- a/frontend/__tests__/consultoria/ShareWithClient.test.tsx
+++ b/frontend/__tests__/consultoria/ShareWithClient.test.tsx
@@ -92,7 +92,7 @@ describe("ShareWithClient", () => {
     });
   });
 
-  it("shows error when resource id is empty", () => {
+  it("shows error when resource id is empty", async () => {
     render(
       <ShareWithClient
         clientId="client-1"

--- a/frontend/__tests__/relatorios/SubscriptionList.test.tsx
+++ b/frontend/__tests__/relatorios/SubscriptionList.test.tsx
@@ -70,7 +70,7 @@ describe("SubscriptionList", () => {
     expect(screen.getByText("Cancelar")).toBeInTheDocument();
   });
 
-  it("renders canceled subscription without cancel button", () => {
+  it("renders canceled subscription without cancel button", async () => {
     render(
       <SubscriptionList
         subscriptions={[canceledSub]}
@@ -82,7 +82,7 @@ describe("SubscriptionList", () => {
     expect(
       screen.getByText(/Panorama Mensal — Engenharia/),
     ).toBeInTheDocument();
-    expect(screen.getByText("Cancelado")).toBeInTheDocument();
+    expect(await screen.findByText("Cancelado", undefined, { timeout: 3000 })).toBeInTheDocument();
     expect(
       screen.queryByText("Cancelar"),
     ).not.toBeInTheDocument();

--- a/frontend/__tests__/widget-compint.test.tsx
+++ b/frontend/__tests__/widget-compint.test.tsx
@@ -148,9 +148,7 @@ describe('Widget Competitive Intel Page', () => {
     const WidgetPage = (await import('../app/widgets/competitive-intel/page')).default;
     render(<WidgetPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Market Share')).toBeInTheDocument();
-    });
+    await screen.findByText(/Market Share/, undefined, { timeout: 5000 });
 
     expect(screen.getByText('Tech Solutions Ltda')).toBeInTheDocument();
     expect(screen.getByText('Dados & Sistemas S.A.')).toBeInTheDocument();
@@ -166,9 +164,7 @@ describe('Widget Competitive Intel Page', () => {
     const WidgetPage = (await import('../app/widgets/competitive-intel/page')).default;
     render(<WidgetPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Top Vencedores')).toBeInTheDocument();
-    });
+    await screen.findByText(/Top Vencedores/, undefined, { timeout: 5000 });
   });
 
   it('renderiza monthly-trend widget com dados', async () => {
@@ -181,9 +177,7 @@ describe('Widget Competitive Intel Page', () => {
     const WidgetPage = (await import('../app/widgets/competitive-intel/page')).default;
     render(<WidgetPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Tendência Mensal')).toBeInTheDocument();
-    });
+    await screen.findByText(/Tendência Mensal/, undefined, { timeout: 5000 });
 
     expect(screen.getByText(/em crescimento/)).toBeInTheDocument();
   });
@@ -198,9 +192,7 @@ describe('Widget Competitive Intel Page', () => {
     const WidgetPage = (await import('../app/widgets/competitive-intel/page')).default;
     render(<WidgetPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText('Ranking de Órgãos')).toBeInTheDocument();
-    });
+    await screen.findByText(/Ranking de Órgãos/, undefined, { timeout: 5000 });
 
     expect(screen.getByText('Secretaria de Tecnologia')).toBeInTheDocument();
   });

--- a/frontend/app/widgets/competitive-intel/page.tsx
+++ b/frontend/app/widgets/competitive-intel/page.tsx
@@ -25,47 +25,6 @@ interface WidgetData {
   dados: Record<string, unknown>;
 }
 
-type MarketShareWidgetProps = {
-  dados: {
-    valor_total: number;
-    total_contratos: number;
-    top_fornecedores: Array<{
-      nome: string;
-      percentual: number;
-      valor: number;
-      contratos: number;
-    }>;
-    concentracao: string;
-  };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-};
-
-type TopWinnersWidgetProps = {
-  dados: { winners: Array<{ nome: string; contratos: number; valor_total: number; crescimento?: string | null }> };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-};
-
-type MonthlyTrendWidgetProps = {
-  dados: {
-    serie: Array<{ mes: string; valor: number; contratos: number }>;
-    tendencia: string;
-  };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-};
-
-type OrgaoRankingWidgetProps = {
-  dados: { orgaos: Array<{ nome: string; valor: number; contratos: number }> };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-};
-
 // ---------- Formatting helpers ----------
 
 function fmtBRL(value: number): string {
@@ -91,7 +50,22 @@ function MarketShareWidget({
   setor,
   uf,
   periodo,
-}: MarketShareWidgetProps) {
+}: {
+  dados: {
+    valor_total: number;
+    total_contratos: number;
+    top_fornecedores: Array<{
+      nome: string;
+      percentual: number;
+      valor: number;
+      contratos: number;
+    }>;
+    concentracao: string;
+  };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+}) {
   const maxPct = Math.max(...dados.top_fornecedores.map((f) => f.percentual), 1);
 
   return (
@@ -149,7 +123,12 @@ function TopWinnersWidget({
   setor,
   uf,
   periodo,
-}: TopWinnersWidgetProps) {
+}: {
+  dados: { winners: Array<{ nome: string; contratos: number; valor_total: number; crescimento?: string | null }> };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+}) {
   return (
     <div className="widget-body">
       <h2 className="widget-title">
@@ -183,7 +162,15 @@ function MonthlyTrendWidget({
   setor,
   uf,
   periodo,
-}: MonthlyTrendWidgetProps) {
+}: {
+  dados: {
+    serie: Array<{ mes: string; valor: number; contratos: number }>;
+    tendencia: string;
+  };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+}) {
   const maxValor = Math.max(...dados.serie.map((m) => m.valor), 1);
 
   const tendenciaLabel: Record<string, string> = {
@@ -240,7 +227,12 @@ function OrgaoRankingWidget({
   setor,
   uf,
   periodo,
-}: OrgaoRankingWidgetProps) {
+}: {
+  dados: { orgaos: Array<{ nome: string; valor: number; contratos: number }> };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+}) {
   const maxValor = Math.max(...dados.orgaos.map((o) => o.valor), 1);
 
   return (
@@ -284,7 +276,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'market-share':
       return (
         <MarketShareWidget
-          dados={dados as MarketShareWidgetProps['dados']}
+          dados={dados as Record<string, unknown>}
           setor={setor}
           uf={uf}
           periodo={periodo}
@@ -293,7 +285,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'top-winners':
       return (
         <TopWinnersWidget
-          dados={dados as TopWinnersWidgetProps['dados']}
+          dados={dados as Record<string, unknown>}
           setor={setor}
           uf={uf}
           periodo={periodo}
@@ -302,7 +294,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'monthly-trend':
       return (
         <MonthlyTrendWidget
-          dados={dados as MonthlyTrendWidgetProps['dados']}
+          dados={dados as Record<string, unknown>}
           setor={setor}
           uf={uf}
           periodo={periodo}
@@ -311,7 +303,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'orgao-ranking':
       return (
         <OrgaoRankingWidget
-          dados={dados as OrgaoRankingWidgetProps['dados']}
+          dados={dados as Record<string, unknown>}
           setor={setor}
           uf={uf}
           periodo={periodo}

--- a/frontend/app/widgets/competitive-intel/page.tsx
+++ b/frontend/app/widgets/competitive-intel/page.tsx
@@ -25,6 +25,47 @@ interface WidgetData {
   dados: Record<string, unknown>;
 }
 
+type MarketShareWidgetProps = {
+  dados: {
+    valor_total: number;
+    total_contratos: number;
+    top_fornecedores: Array<{
+      nome: string;
+      percentual: number;
+      valor: number;
+      contratos: number;
+    }>;
+    concentracao: string;
+  };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+};
+
+type TopWinnersWidgetProps = {
+  dados: { winners: Array<{ nome: string; contratos: number; valor_total: number; crescimento?: string | null }> };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+};
+
+type MonthlyTrendWidgetProps = {
+  dados: {
+    serie: Array<{ mes: string; valor: number; contratos: number }>;
+    tendencia: string;
+  };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+};
+
+type OrgaoRankingWidgetProps = {
+  dados: { orgaos: Array<{ nome: string; valor: number; contratos: number }> };
+  setor: string;
+  uf?: string | null;
+  periodo: string;
+};
+
 // ---------- Formatting helpers ----------
 
 function fmtBRL(value: number): string {
@@ -50,22 +91,7 @@ function MarketShareWidget({
   setor,
   uf,
   periodo,
-}: {
-  dados: {
-    valor_total: number;
-    total_contratos: number;
-    top_fornecedores: Array<{
-      nome: string;
-      percentual: number;
-      valor: number;
-      contratos: number;
-    }>;
-    concentracao: string;
-  };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-}) {
+}: MarketShareWidgetProps) {
   const maxPct = Math.max(...dados.top_fornecedores.map((f) => f.percentual), 1);
 
   return (
@@ -123,12 +149,7 @@ function TopWinnersWidget({
   setor,
   uf,
   periodo,
-}: {
-  dados: { winners: Array<{ nome: string; contratos: number; valor_total: number; crescimento?: string | null }> };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-}) {
+}: TopWinnersWidgetProps) {
   return (
     <div className="widget-body">
       <h2 className="widget-title">
@@ -162,15 +183,7 @@ function MonthlyTrendWidget({
   setor,
   uf,
   periodo,
-}: {
-  dados: {
-    serie: Array<{ mes: string; valor: number; contratos: number }>;
-    tendencia: string;
-  };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-}) {
+}: MonthlyTrendWidgetProps) {
   const maxValor = Math.max(...dados.serie.map((m) => m.valor), 1);
 
   const tendenciaLabel: Record<string, string> = {
@@ -227,12 +240,7 @@ function OrgaoRankingWidget({
   setor,
   uf,
   periodo,
-}: {
-  dados: { orgaos: Array<{ nome: string; valor: number; contratos: number }> };
-  setor: string;
-  uf?: string | null;
-  periodo: string;
-}) {
+}: OrgaoRankingWidgetProps) {
   const maxValor = Math.max(...dados.orgaos.map((o) => o.valor), 1);
 
   return (
@@ -276,7 +284,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'market-share':
       return (
         <MarketShareWidget
-          dados={dados as Record<string, unknown>}
+          dados={dados as MarketShareWidgetProps['dados']}
           setor={setor}
           uf={uf}
           periodo={periodo}
@@ -285,7 +293,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'top-winners':
       return (
         <TopWinnersWidget
-          dados={dados as Record<string, unknown>}
+          dados={dados as TopWinnersWidgetProps['dados']}
           setor={setor}
           uf={uf}
           periodo={periodo}
@@ -294,7 +302,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'monthly-trend':
       return (
         <MonthlyTrendWidget
-          dados={dados as Record<string, unknown>}
+          dados={dados as MonthlyTrendWidgetProps['dados']}
           setor={setor}
           uf={uf}
           periodo={periodo}
@@ -303,7 +311,7 @@ function WidgetContent({ tema, data }: { tema: WidgetTema; data: WidgetData }) {
     case 'orgao-ranking':
       return (
         <OrgaoRankingWidget
-          dados={dados as Record<string, unknown>}
+          dados={dados as OrgaoRankingWidgetProps['dados']}
           setor={setor}
           uf={uf}
           periodo={periodo}

--- a/frontend/app/widgets/competitive-intel/preview/page.tsx
+++ b/frontend/app/widgets/competitive-intel/preview/page.tsx
@@ -90,10 +90,11 @@ export default function WidgetPreviewPage() {
           <div className="md:col-span-1 space-y-6">
             {/* Setor */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label htmlFor="setor-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Setor
               </label>
               <select
+                id="setor-select"
                 value={selectedSetor}
                 onChange={(e) => setSelectedSetor(e.target.value)}
                 className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-white"
@@ -108,10 +109,11 @@ export default function WidgetPreviewPage() {
 
             {/* UF */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label htmlFor="uf-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 UF <span className="text-gray-400">(opcional)</span>
               </label>
               <select
+                id="uf-select"
                 value={uf}
                 onChange={(e) => setUf(e.target.value)}
                 className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-white"


### PR DESCRIPTION
## Summary

PREDINT-020 (Wave 0 of EPIC-PREDINT #1260). Creates 4 Postgres RPCs in `pncp_supplier_contracts` for time series predictive analysis, providing the fundamental data layer for all predictive components.

### RPCs Created

| RPC | Purpose | Parameters |
|-----|---------|------------|
| `get_sector_monthly_volume` | Monthly contract volume (count + value) | sector_id TEXT, months_back INT DEFAULT 36 |
| `get_sector_seasonal_pattern` | Average monthly patterns (Jan-Dec, 4yr window) | sector_id TEXT |
| `get_uf_demand_trend` | Monthly demand trend per UF | uf TEXT, sector_id TEXT, months_back INT DEFAULT 24 |
| `get_upcoming_renewals` | Contracts with estimated expiry within lookahead | sector_id TEXT, lookahead_days INT DEFAULT 90 |

### Files

- `supabase/migrations/20260612000000_predint_time_series.sql` — UP migration with all 4 RPCs
- `supabase/migrations/20260612000000_predint_time_series.down.sql` — paired rollback
- `backend/tests/test_predint_rpcs.py` — 29 tests covering schema validation, RPC invocation patterns, edge cases

### Test Results

```
29 passed in 5.08s
```

### Key Design Decisions

- **SECURITY INVOKER** (not DEFINER) — follows project pattern for read-only RPCs
- **Input clamping** — months_back (1-120), lookahead_days (1-365) with sensible defaults
- **Empty data** — returns empty result set (never errors) when no data matches
- **Expiry heuristic** — `get_upcoming_renewals` uses `data_assinatura + 1 year` as estimated expiry (table lacks vigencia column)
- **sector_id** — accepted for API compatibility; data aggregation is across all sectors (table lacks sector column)

Issue: #1664
Epic: #1260