### PR TITLE
feat(supabase): SUBINTEL-001 (#1668) — RPC subcontract_capacity_signals

### DIFF
--- a/backend/tests/test_subcontract_capacity_rpc.py
+++ b/backend/tests/test_subcontract_capacity_rpc.py
@@ -1,0 +1,217 @@
+"""SUBINTEL-001 (#1668): Tests for the subcontract_capacity_signals RPC.
+
+Tests the RPC SQL migration and expected JSON structure.
+Covers:
+  - Migration file structure (up + down, SECURITY DEFINER, grants)
+  - JSON response shape verification
+  - Input validation logic
+  - Score calculation weights
+  - Non-regression for existing RPCs/tables
+"""
+
+import os
+
+
+def _read_migration() -> str:
+    """Read the migration SQL file."""
+    path = "supabase/migrations/20260612100000_subcontract_capacity_signals.sql"
+    assert os.path.exists(path), f"Migration file not found: {path}"
+    with open(path) as f:
+        return f.read()
+
+
+def _read_down_migration() -> str:
+    """Read the down migration SQL file."""
+    path = "supabase/migrations/20260612100000_subcontract_capacity_signals.down.sql"
+    assert os.path.exists(path), f"Down migration file not found: {path}"
+    with open(path) as f:
+        return f.read()
+
+
+class TestMigrationStructure:
+    """Migration file structure and conventions."""
+
+    def test_migration_up_exists(self):
+        """Migration up file exists."""
+        path = "supabase/migrations/20260612100000_subcontract_capacity_signals.sql"
+        assert os.path.exists(path), f"Migration file not found: {path}"
+
+    def test_migration_down_exists(self):
+        """Migration down file exists."""
+        path = "supabase/migrations/20260612100000_subcontract_capacity_signals.down.sql"
+        assert os.path.exists(path), f"Down migration not found: {path}"
+
+    def test_migration_creates_function(self):
+        """Migration SQL contains CREATE OR REPLACE FUNCTION."""
+        content = _read_migration()
+        assert "CREATE OR REPLACE FUNCTION" in content
+        assert "subcontract_capacity_signals" in content
+        assert "RETURNS JSONB" in content
+
+    def test_migration_has_security_definer(self):
+        """Migration uses SECURITY DEFINER."""
+        content = _read_migration()
+        assert "SECURITY DEFINER" in content
+
+    def test_migration_has_service_role_grant(self):
+        """Migration grants EXECUTE to service_role only."""
+        content = _read_migration()
+        assert "GRANT EXECUTE ON FUNCTION" in content
+        assert "service_role" in content
+
+    def test_down_drops_function(self):
+        """Down migration drops the function."""
+        content = _read_down_migration()
+        assert "DROP FUNCTION" in content
+        assert "subcontract_capacity_signals" in content
+
+
+class TestJsonStructure:
+    """Validate the JSON structure returned by the RPC."""
+
+    def test_expected_top_level_keys_present(self):
+        """Migration builds all expected top-level keys in jsonb_build_object."""
+        content = _read_migration()
+        expected_keys = [
+            "signal_repeat_winner",
+            "signal_large_contract",
+            "signal_subcontracting_pattern",
+            "overall_capacity_score",
+            "total_contracts",
+            "total_value",
+        ]
+        for key in expected_keys:
+            assert key in content, f"Expected key '{key}' not found in migration SQL"
+
+    def test_signal_repeat_winner_keys_present(self):
+        """signal_repeat_winner has score, same_orgao_count, orgaos."""
+        content = _read_migration()
+        for key in ("score", "same_orgao_count", "orgaos"):
+            assert key in content, f"Missing key '{key}' in signal_repeat_winner"
+
+    def test_signal_large_contract_keys_present(self):
+        """signal_large_contract has score, contracts_above_5m, recent_large."""
+        content = _read_migration()
+        for key in ("score", "contracts_above_5m", "recent_large"):
+            assert key in content, f"Missing key '{key}' in signal_large_contract"
+
+    def test_signal_subcontracting_keys_present(self):
+        """signal_subcontracting_pattern has score, cnae_diversity, related_suppliers."""
+        content = _read_migration()
+        for key in ("score", "cnae_diversity", "related_suppliers"):
+            assert key in content, f"Missing key '{key}' in signal_subcontracting_pattern"
+
+    def test_related_supplier_entry_fields(self):
+        """related_suppliers entries have cnpj, razao_social, co_occurrence_count, total_value."""
+        content = _read_migration()
+        for field in ("cnpj", "razao_social", "co_occurrence_count", "total_value"):
+            assert field in content, f"Missing field '{field}' in related_suppliers"
+
+    def test_orgao_entry_fields(self):
+        """orgao entries have nome, count, total_value."""
+        content = _read_migration()
+        for field in ("nome", "count", "total_value"):
+            assert field in content, f"Missing field '{field}' in orgao entries"
+
+    def test_recent_large_entry_fields(self):
+        """recent_large entries have id, value, orgao, year."""
+        content = _read_migration()
+        for field in ("id", "value", "orgao", "year"):
+            assert field in content, f"Missing field '{field}' in recent_large"
+
+
+class TestInputValidation:
+    """Tests for RPC input validation."""
+
+    def test_empty_cnpj_raises_exception(self):
+        """Empty CNPJ triggers RAISE EXCEPTION."""
+        content = _read_migration()
+        assert "RAISE EXCEPTION" in content
+        assert "p_cnpj IS NULL" in content
+
+    def test_limit_has_default(self):
+        """p_limit has a default value of 50."""
+        content = _read_migration()
+        assert "p_limit INT DEFAULT 50" in content
+
+    def test_limit_bounds_are_clamped(self):
+        """p_limit is clamped between 1 and 200."""
+        content = _read_migration()
+        assert "p_limit < 1" in content
+        assert "p_limit > 200" in content
+
+    def test_zero_contracts_returns_zero_score(self):
+        """No contracts returns all zero scores."""
+        content = _read_migration()
+        assert "v_total_contracts = 0" in content
+        assert "overall_capacity_score" in content
+        assert "0" in content
+
+
+class TestScoreLogic:
+    """Tests for scoring weights and thresholds."""
+
+    def test_overall_score_weights_repeat_winner_03(self):
+        """Repeat winner weight is 0.3."""
+        content = _read_migration()
+        assert "0.3" in content
+
+    def test_overall_score_weights_large_contract_04(self):
+        """Large contract weight is 0.4."""
+        content = _read_migration()
+        assert "0.4" in content
+
+    def test_overall_score_weights_subcontract_03(self):
+        """Subcontracting pattern weight is 0.3."""
+        content = _read_migration()
+        assert "* 0.3" in content
+
+    def test_large_contract_threshold_is_5m(self):
+        """Large contract threshold is R$5M."""
+        content = _read_migration()
+        assert "5000000" in content
+
+    def test_repeat_winner_uses_top_orgao_ratio(self):
+        """Repeat winner score uses proportion of top orgao contracts."""
+        content = _read_migration()
+        assert "v_same_orgao_count" in content
+        assert "v_total_contracts" in content
+
+    def test_capacity_score_is_rounded(self):
+        """Overall capacity score uses ROUND with 4 decimal places."""
+        content = _read_migration()
+        assert "ROUND" in content
+        assert "overall_capacity_score" in content
+
+
+class TestNonRegression:
+    """Ensure no existing RPCs or tables are affected."""
+
+    def test_no_table_modifications(self):
+        """Migration does not ALTER, CREATE, or DROP any table."""
+        content = _read_migration()
+        forbidden_patterns = [
+            "ALTER TABLE",
+            "DROP TABLE",
+            "DROP INDEX",
+            "CREATE TABLE",
+            "CREATE INDEX",
+        ]
+        for pattern in forbidden_patterns:
+            assert pattern not in content, f"Migration contains forbidden pattern: {pattern}"
+
+    def test_only_one_function_created(self):
+        """Migration creates exactly one new function."""
+        content = _read_migration()
+        count = content.count("CREATE OR REPLACE FUNCTION")
+        assert count == 1, f"Expected 1 function creation, found {count}"
+
+    def test_function_uses_supplier_contracts_table(self):
+        """Migration queries pncp_supplier_contracts."""
+        content = _read_migration()
+        assert "pncp_supplier_contracts" in content
+
+    def test_has_statement_timeout(self):
+        """Migration sets statement_timeout for safety."""
+        content = _read_migration()
+        assert "statement_timeout" in content

--- a/supabase/migrations/20260612100000_subcontract_capacity_signals.down.sql
+++ b/supabase/migrations/20260612100000_subcontract_capacity_signals.down.sql
@@ -1,0 +1,7 @@
+-- ============================================================================
+-- DOWN: subcontract_capacity_signals — Remove the RPC function
+-- Date: 2026-06-12
+-- Issue: #1668 (SUBINTEL-001)
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.subcontract_capacity_signals(VARCHAR, INT);

--- a/supabase/migrations/20260612100000_subcontract_capacity_signals.sql
+++ b/supabase/migrations/20260612100000_subcontract_capacity_signals.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- UP: subcontract_capacity_signals — RPC for Subcontracting Capacity Analysis
+-- Date: 2026-06-12
+-- Issue: #1668 (SUBINTEL-001)
+-- Parent: #1224 (EPIC-SUBINTEL)
+-- ============================================================================
+-- Context:
+--   SUBINTEL-001: First RPC of the SUBINTEL data layer. Extracts capacity
+--   signals from pncp_supplier_contracts (~2-4M rows):
+--
+--     signal_repeat_winner       — supplier repeatedly wins with same orgao
+--     signal_large_contract      — avg contract > sector median (R$5M threshold)
+--     signal_subcontracting_pattern — object mentions co-occurrence patterns
+--     overall_capacity_score     — weighted avg (0.3/0.4/0.3)
+--
+--   SECURITY DEFINER + SET search_path = public, pg_temp is mandatory per
+--   SEC-SECDEF-001/002. GRANT to service_role only.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.subcontract_capacity_signals(
+    p_cnpj  VARCHAR(14),
+    p_limit INT DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_total_contracts      BIGINT;
+    v_total_value          NUMERIC;
+    v_same_orgao_count     BIGINT;
+    v_top_orgao_cnpj       TEXT;
+    v_top_orgao_nome       TEXT;
+    v_contracts_above_5m   BIGINT;
+
+    -- Scores (0-1)
+    v_repeat_winner_score       NUMERIC;
+    v_large_contract_score      NUMERIC;
+    v_subcontracting_score      NUMERIC;
+    v_overall_capacity_score    NUMERIC;
+
+    -- JSONB aggregations
+    v_orgaos_list              JSONB;
+    v_recent_large_list        JSONB;
+    v_related_suppliers_list   JSONB;
+BEGIN
+    -- Defesa em profundidade: timeout local de 15s
+    SET LOCAL statement_timeout = '15s';
+
+    -- Validate input
+    IF p_cnpj IS NULL OR length(trim(p_cnpj)) = 0 THEN
+        RAISE EXCEPTION 'p_cnpj is required and must be a non-empty string';
+    END IF;
+
+    -- Limit bounds
+    IF p_limit < 1 THEN
+        p_limit := 1;
+    ELSIF p_limit > 200 THEN
+        p_limit := 200;
+    END IF;
+
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Base metrics for the supplier
+    -- ═══════════════════════════════════════════════════════════════════════
+    SELECT
+        COUNT(*)::BIGINT,
+        COALESCE(SUM(valor_global), 0)::NUMERIC
+    INTO v_total_contracts, v_total_value
+    FROM public.pncp_supplier_contracts
+    WHERE ni_fornecedor = p_cnpj
+      AND is_active = TRUE;
+
+    -- If no contracts, return zeroed result
+    IF v_total_contracts = 0 THEN
+        RETURN jsonb_build_object(
+            'cnpj',                  p_cnpj,
+            'total_contracts',       0,
+            'total_value',           0,
+            'signal_repeat_winner',  jsonb_build_object('score', 0, 'same_orgao_count', 0, 'orgaos', '[]'::JSONB),
+            'signal_large_contract', jsonb_build_object('score', 0, 'contracts_above_5m', 0, 'recent_large', '[]'::JSONB),
+            'signal_subcontracting_pattern', jsonb_build_object('score', 0, 'cnae_diversity', 0, 'related_suppliers', '[]'::JSONB),
+            'overall_capacity_score', 0
+        );
+    END IF;
+
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Signal 1: repeat_winner — concentration in a single orgao
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Find the orgao with the most contracts
+    SELECT
+        COUNT(*)::BIGINT,
+        orgao_cnpj,
+        MAX(orgao_nome)
+    INTO v_same_orgao_count, v_top_orgao_cnpj, v_top_orgao_nome
+    FROM public.pncp_supplier_contracts
+    WHERE ni_fornecedor = p_cnpj
+      AND is_active = TRUE
+      AND orgao_cnpj IS NOT NULL
+    GROUP BY orgao_cnpj
+    ORDER BY COUNT(*) DESC
+    LIMIT 1;
+
+    -- Score: proportion of total contracts won by the top orgao
+    -- If no orgao data, score = 0
+    IF v_same_orgao_count IS NULL OR v_total_contracts = 0 THEN
+        v_repeat_winner_score := 0;
+    ELSE
+        v_repeat_winner_score := LEAST(v_same_orgao_count::NUMERIC / v_total_contracts::NUMERIC, 1.0);
+    END IF;
+
+    -- Top orgaos list (limit 10)
+    SELECT COALESCE(
+        jsonb_agg(entry ORDER BY (entry->>'count')::BIGINT DESC),
+        '[]'::JSONB
+    )
+    INTO v_orgaos_list
+    FROM (
+        SELECT jsonb_build_object(
+            'nome',        MAX(orgao_nome),
+            'count',       COUNT(*)::BIGINT,
+            'total_value', COALESCE(SUM(valor_global), 0)::NUMERIC
+        ) AS entry
+        FROM public.pncp_supplier_contracts
+        WHERE ni_fornecedor = p_cnpj
+          AND is_active = TRUE
+          AND orgao_cnpj IS NOT NULL
+        GROUP BY orgao_cnpj
+        ORDER BY COUNT(*) DESC
+        LIMIT 10
+    ) sub;
+
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Signal 2: large_contract — contracts > R$5M
+    -- ═══════════════════════════════════════════════════════════════════════
+    SELECT COUNT(*)::BIGINT
+    INTO v_contracts_above_5m
+    FROM public.pncp_supplier_contracts
+    WHERE ni_fornecedor = p_cnpj
+      AND is_active = TRUE
+      AND valor_global > 5000000;
+
+    -- Score: proportion of contracts above 5M, capped at 1.0
+    v_large_contract_score := LEAST(v_contracts_above_5m::NUMERIC / GREATEST(v_total_contracts, 1)::NUMERIC, 1.0);
+
+    -- Recent large contracts list (top 5)
+    SELECT COALESCE(
+        jsonb_agg(entry ORDER BY (entry->>'year')::INT DESC, (entry->>'value')::NUMERIC DESC),
+        '[]'::JSONB
+    )
+    INTO v_recent_large_list
+    FROM (
+        SELECT jsonb_build_object(
+            'id',        id::TEXT,
+            'value',     COALESCE(valor_global, 0)::NUMERIC,
+            'orgao',     COALESCE(orgao_nome, ''),
+            'year',      EXTRACT(YEAR FROM data_assinatura)::INT
+        ) AS entry
+        FROM public.pncp_supplier_contracts
+        WHERE ni_fornecedor = p_cnpj
+          AND is_active = TRUE
+          AND valor_global > 5000000
+        ORDER BY data_assinatura DESC NULLS LAST
+        LIMIT p_limit
+    ) sub;
+
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Signal 3: subcontracting_pattern — co-occurrence with other suppliers
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Detect other suppliers that co-occur in the same orgaos where this
+    -- supplier has contracts.
+    WITH supplier_orgaos AS (
+        SELECT DISTINCT orgao_cnpj
+        FROM public.pncp_supplier_contracts
+        WHERE ni_fornecedor = p_cnpj
+          AND is_active = TRUE
+          AND orgao_cnpj IS NOT NULL
+    ),
+    co_occurring AS (
+        SELECT
+            c.ni_fornecedor,
+            MAX(c.nome_fornecedor) AS nome_fornecedor,
+            COUNT(*)::BIGINT AS co_occurrence_count,
+            COALESCE(SUM(c.valor_global), 0)::NUMERIC AS total_value
+        FROM public.pncp_supplier_contracts c
+        JOIN supplier_orgaos so ON so.orgao_cnpj = c.orgao_cnpj
+        WHERE c.ni_fornecedor != p_cnpj
+          AND c.is_active = TRUE
+          AND c.orgao_cnpj IS NOT NULL
+        GROUP BY c.ni_fornecedor
+        ORDER BY COUNT(*) DESC
+        LIMIT p_limit
+    )
+    SELECT COALESCE(
+        jsonb_agg(entry ORDER BY (entry->>'co_occurrence_count')::BIGINT DESC),
+        '[]'::JSONB
+    )
+    INTO v_related_suppliers_list
+    FROM (
+        SELECT jsonb_build_object(
+            'cnpj',                 ni_fornecedor,
+            'razao_social',         COALESCE(nome_fornecedor, ''),
+            'co_occurrence_count',  co_occurrence_count,
+            'total_value',          total_value
+        ) AS entry
+        FROM co_occurring
+    ) sub;
+
+    -- Score: normalized co-occurrence ratio
+    -- Higher diversity of co-occurring suppliers = higher subcontracting signal
+    SELECT
+        CASE
+            WHEN jsonb_array_length(v_related_suppliers_list) > 0
+            THEN LEAST(
+                jsonb_array_length(v_related_suppliers_list)::NUMERIC / 20.0,
+                1.0
+            )
+            ELSE 0
+        END
+    INTO v_subcontracting_score;
+
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Overall capacity score: weighted average
+    -- ═══════════════════════════════════════════════════════════════════════
+    v_overall_capacity_score := ROUND(
+        (v_repeat_winner_score    * 0.3) +
+        (v_large_contract_score   * 0.4) +
+        (v_subcontracting_score   * 0.3),
+    4);
+
+    -- ═══════════════════════════════════════════════════════════════════════
+    -- Assemble and return final payload
+    -- ═══════════════════════════════════════════════════════════════════════
+    RETURN jsonb_build_object(
+        'cnpj',                        p_cnpj,
+        'total_contracts',             v_total_contracts,
+        'total_value',                 ROUND(v_total_value, 2),
+        'signal_repeat_winner',        jsonb_build_object(
+            'score',              ROUND(v_repeat_winner_score, 4),
+            'same_orgao_count',   COALESCE(v_same_orgao_count, 0),
+            'orgaos',             v_orgaos_list
+        ),
+        'signal_large_contract',       jsonb_build_object(
+            'score',              ROUND(v_large_contract_score, 4),
+            'contracts_above_5m', v_contracts_above_5m,
+            'recent_large',       v_recent_large_list
+        ),
+        'signal_subcontracting_pattern', jsonb_build_object(
+            'score',              ROUND(v_subcontracting_score, 4),
+            'cnae_diversity',     jsonb_array_length(v_related_suppliers_list),
+            'related_suppliers',  v_related_suppliers_list
+        ),
+        'overall_capacity_score',      ROUND(v_overall_capacity_score, 4)
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.subcontract_capacity_signals(VARCHAR, INT) IS
+    'SUBINTEL-001 (#1668) — Subcontracting Capacity Signals. Extracts repeat_winner, large_contract, and subcontracting_pattern signals from pncp_supplier_contracts. SECURITY DEFINER, service_role only.';
+
+REVOKE ALL ON FUNCTION public.subcontract_capacity_signals(VARCHAR, INT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.subcontract_capacity_signals(VARCHAR, INT) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.subcontract_capacity_signals(VARCHAR, INT) TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## Summary

SUBINTEL-001: First RPC of the SUBINTEL data layer. Extracts subcontracting capacity signals from `pncp_supplier_contracts` (~2-4M rows).

### RPC: `subcontract_capacity_signals(p_cnpj VARCHAR(14), p_limit INT DEFAULT 50)`

Returns JSON with 3 signals and an overall capacity score:

1. **signal_repeat_winner** — Score based on contract concentration in the same orgao (proportion of top orgao contracts / total)
2. **signal_large_contract** — Score based on proportion of contracts > R$5M
3. **signal_subcontracting_pattern** — Score based on co-occurrence diversity with other suppliers in the same orgaos
4. **overall_capacity_score** — Weighted average: 0.3 * repeat_winner + 0.4 * large_contract + 0.3 * subcontracting

### Migration

| File | Purpose |
|------|---------|
| `20260612100000_subcontract_capacity_signals.sql` | Creates RPC with SECURITY DEFINER, service_role only |
| `20260612100000_subcontract_capacity_signals.down.sql` | DROP FUNCTION |

### Testing

27 tests covering:
- Migration file structure and conventions (6 tests)
- JSON response shape verification (7 tests)
- Input validation (4 tests)
- Score logic and weights (6 tests)
- Non-regression for existing tables/RPCs (4 tests)

### Compliance

- SECURITY DEFINER + SET search_path = public, pg_temp
- GRANT service_role only (revoked from anon, authenticated)
- LOCAL statement_timeout = '15s'
- No table/index modifications (strictly additive)

Closes #1668
Parent: #1224