### PR TITLE
feat(backend,frontend): NETINT-006 — opt-in/opt-out UI para network analytics (#1676)

### DIFF
--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -153,20 +153,25 @@ async def get_profile(user: dict = Depends(require_auth), db=Depends(get_db)):
         logger.warning(f"Failed to fetch user email: {e}")
         email = user.get("email", "unknown@example.com")
 
-    # ISSUE-070: Fetch real Stripe renewal date from profiles
+    # ISSUE-070: Fetch Stripe renewal date + NETINT-001/006: network analytics opt-in
     subscription_end_date_val = None
+    allow_network_analytics_val: bool | None = None
     try:
         profile_row = await sb_execute(
             db.table("profiles")
-                .select("subscription_end_date")
+                .select("subscription_end_date, allow_network_analytics")
                 .eq("id", user["id"])
                 .single()
         )
-        if isinstance(profile_row.data, dict) and profile_row.data.get("subscription_end_date"):
-            val = profile_row.data["subscription_end_date"]
-            subscription_end_date_val = val if isinstance(val, str) else val.isoformat()
+        if isinstance(profile_row.data, dict):
+            if profile_row.data.get("subscription_end_date"):
+                val = profile_row.data["subscription_end_date"]
+                subscription_end_date_val = val if isinstance(val, str) else val.isoformat()
+            raw_optin = profile_row.data.get("allow_network_analytics")
+            if raw_optin is not None:
+                allow_network_analytics_val = bool(raw_optin)
     except Exception as e:
-        logger.warning(f"Failed to fetch subscription_end_date: {e}")
+        logger.warning(f"Failed to fetch profile fields: {e}")
 
     # STORY-309: Determine subscription_status with dunning awareness
     dunning_phase = getattr(quota_info, "dunning_phase", "healthy")
@@ -197,6 +202,7 @@ async def get_profile(user: dict = Depends(require_auth), db=Depends(get_db)):
         dunning_phase=dunning_phase,
         days_since_failure=days_since_failure,
         subscription_end_date=subscription_end_date_val,
+        allow_network_analytics=allow_network_analytics_val,
     )
 
 
@@ -589,6 +595,65 @@ async def update_alert_preferences(
     except Exception as e:
         logger.error(f"Failed to update alert preferences for {mask_user_id(user_id)}: {e}")
         raise HTTPException(status_code=500, detail="Erro ao salvar preferencias de alerta")
+
+
+# ============================================================================
+# NETINT-006: Network analytics opt-in/opt-out toggle
+# ============================================================================
+
+class NetworkAnalyticsRequest(BaseModel):
+    allow_network_analytics: bool
+
+
+class NetworkAnalyticsResponse(BaseModel):
+    allow_network_analytics: bool
+    success: bool = True
+
+
+@router.put("/profile/network-analytics", response_model=NetworkAnalyticsResponse)
+async def update_network_analytics(
+    body: NetworkAnalyticsRequest,
+    user: dict = Depends(require_auth),
+    user_db=Depends(get_user_db),  # SYS-023: User-scoped client (respects RLS)
+):
+    """NETINT-006: Update user's network analytics opt-in preference.
+
+    Sets ``profiles.allow_network_analytics`` to true or false.
+    Null (undecided) is treated as opt-out — this PATCH is how users
+    explicitly opt in.
+
+    SYS-023: Uses user-scoped Supabase client. RLS on profiles ensures
+    users can only update their own profile row.
+    """
+    user_id = user["id"]
+
+    try:
+        await sb_execute(
+            user_db.table("profiles").update({
+                "allow_network_analytics": body.allow_network_analytics,
+            }).eq("id", user_id),
+            category="write",
+        )
+
+        log_user_action(
+            logger,
+            "network_analytics_updated",
+            user_id,
+            details={"allow_network_analytics": body.allow_network_analytics},
+        )
+        return NetworkAnalyticsResponse(
+            allow_network_analytics=body.allow_network_analytics,
+            success=True,
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to update network analytics for %s: %s",
+            mask_user_id(user_id), e,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Erro ao salvar preferencia de uso anonimo.",
+        )
 
 
 # ============================================================================

--- a/backend/schemas/user.py
+++ b/backend/schemas/user.py
@@ -339,6 +339,14 @@ class UserProfileResponse(BaseModel):
         ge=0,
         description="LIFECYCLE-001: Contador total de logins bem-sucedidos.",
     )
+    # ── NETINT-001/006: Network analytics consent ───────────────────────────────
+    allow_network_analytics: Optional[bool] = Field(
+        default=None,
+        description=(
+            "NETINT-001/006: User consent for anonymized network analytics collection. "
+            "NULL = undecided (treated as opt-out), true = opted in, false = opted out."
+        ),
+    )
 
 
 class DeleteAccountResponse(BaseModel):

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -9877,6 +9877,37 @@
         "title": "MunicipioProfileResponse",
         "type": "object"
       },
+      "NetworkAnalyticsRequest": {
+        "properties": {
+          "allow_network_analytics": {
+            "title": "Allow Network Analytics",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allow_network_analytics"
+        ],
+        "title": "NetworkAnalyticsRequest",
+        "type": "object"
+      },
+      "NetworkAnalyticsResponse": {
+        "properties": {
+          "allow_network_analytics": {
+            "title": "Allow Network Analytics",
+            "type": "boolean"
+          },
+          "success": {
+            "default": true,
+            "title": "Success",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allow_network_analytics"
+        ],
+        "title": "NetworkAnalyticsResponse",
+        "type": "object"
+      },
       "NewBidsCountResponse": {
         "properties": {
           "count": {
@@ -17248,6 +17279,18 @@
       "UserProfileResponse": {
         "description": "User profile with plan capabilities and quota status.\n\nReturned by /api/me endpoint to provide frontend with all\nnecessary plan information for UI rendering.",
         "properties": {
+          "allow_network_analytics": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "NETINT-001/006: User consent for anonymized network analytics collection. NULL = undecided (treated as opt-out), true = opted in, false = opted out.",
+            "title": "Allow Network Analytics"
+          },
           "capabilities": {
             "additionalProperties": true,
             "description": "Plan capabilities (max_history_days, allow_excel, etc.)",
@@ -28176,6 +28219,53 @@
           }
         ],
         "summary": "Save Profile Context",
+        "tags": [
+          "user"
+        ]
+      }
+    },
+    "/v1/profile/network-analytics": {
+      "put": {
+        "description": "NETINT-006: Update user's network analytics opt-in preference.\n\nSets ``profiles.allow_network_analytics`` to true or false.\nNull (undecided) is treated as opt-out \u2014 this PATCH is how users\nexplicitly opt in.\n\nSYS-023: Uses user-scoped Supabase client. RLS on profiles ensures\nusers can only update their own profile row.",
+        "operationId": "update_network_analytics_v1_profile_network_analytics_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NetworkAnalyticsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkAnalyticsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Network Analytics",
         "tags": [
           "user"
         ]

--- a/frontend/__tests__/configuracoes/NetworkAnalyticsToggle.test.tsx
+++ b/frontend/__tests__/configuracoes/NetworkAnalyticsToggle.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NetworkAnalyticsToggle } from "../../app/configuracoes/components/NetworkAnalyticsToggle";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock NEXT_PUBLIC_API_URL
+const ORIGINAL_ENV = process.env;
+beforeEach(() => {
+  jest.resetAllMocks();
+  process.env = { ...ORIGINAL_ENV, NEXT_PUBLIC_API_URL: "https://api.test.com" };
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function createFetchResponse(data: unknown, ok = true) {
+  return Promise.resolve({
+    ok,
+    json: () => Promise.resolve(data),
+  } as Response);
+}
+
+describe("NetworkAnalyticsToggle", () => {
+  const accessToken = "test-token-123";
+
+  it("renders loading state initially", () => {
+    // Keep fetch pending
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    // Should show skeleton while loading
+    const toggleContainer = screen.getByTestId("network-analytics-toggle");
+    expect(toggleContainer).toBeInTheDocument();
+    // Loading state has animate-pulse elements
+    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("shows toggle as off when allow_network_analytics is null", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: null, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-switch")).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("shows toggle as on when allow_network_analytics is true", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: true, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  it("shows toggle as off when allow_network_analytics is false", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: false, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  it("toggles optimistically and saves on click (false -> true)", async () => {
+    // First call: GET /me returns allow_network_analytics = false
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: false, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+
+    // Second call: PUT /profile/network-analytics succeeds
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: true, success: true })
+    );
+
+    // Click the toggle
+    fireEvent.click(screen.getByRole("switch"));
+
+    // Should be optimistically true
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+
+    // Wait for the async PATCH to resolve
+    await waitFor(() => {
+      // Should have called PUT with the right body
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.test.com/v1/profile/network-analytics",
+        expect.objectContaining({
+          method: "PUT",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          }),
+          body: JSON.stringify({ allow_network_analytics: true }),
+        })
+      );
+    });
+  });
+
+  it("toggles optimistically and saves on click (true -> false)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: true, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: false, success: true })
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.test.com/v1/profile/network-analytics",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ allow_network_analytics: false }),
+        })
+      );
+    });
+  });
+
+  it("rolls back visual state on PATCH error", async () => {
+    // Initial state: true (opted in)
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: true, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+
+    // PATCH fails
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ detail: "Erro ao salvar" }, false)
+    );
+
+    // Click to toggle off
+    fireEvent.click(screen.getByRole("switch"));
+
+    // Should revert to true after the failed call
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+  });
+
+  it("shows tooltip on hover", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse({ allow_network_analytics: true, email: "test@test.com" })
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-tooltip")).toBeInTheDocument();
+    });
+
+    const tooltipTrigger = screen.getByTestId("toggle-tooltip");
+    expect(tooltipTrigger).toHaveAttribute("aria-label");
+    expect(tooltipTrigger.getAttribute("aria-label")).toContain("anonimos");
+  });
+
+  it("handles null API response gracefully", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createFetchResponse(null)
+    );
+
+    render(<NetworkAnalyticsToggle accessToken={accessToken} />);
+
+    await waitFor(() => {
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -5131,6 +5131,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/profile/network-analytics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update Network Analytics
+         * @description NETINT-006: Update user's network analytics opt-in preference.
+         *
+         *     Sets ``profiles.allow_network_analytics`` to true or false.
+         *     Null (undecided) is treated as opt-out — this PATCH is how users
+         *     explicitly opt in.
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS on profiles ensures
+         *     users can only update their own profile row.
+         */
+        put: operations["update_network_analytics_v1_profile_network_analytics_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/profile/sector-affinity": {
         parameters: {
             query?: never;
@@ -10838,6 +10865,21 @@ export interface components {
             /** Valor Total Licitacoes */
             valor_total_licitacoes: number;
         };
+        /** NetworkAnalyticsRequest */
+        NetworkAnalyticsRequest: {
+            /** Allow Network Analytics */
+            allow_network_analytics: boolean;
+        };
+        /** NetworkAnalyticsResponse */
+        NetworkAnalyticsResponse: {
+            /** Allow Network Analytics */
+            allow_network_analytics: boolean;
+            /**
+             * Success
+             * @default true
+             */
+            success: boolean;
+        };
         /** NewBidsCountResponse */
         NewBidsCountResponse: {
             /** Count */
@@ -14092,6 +14134,11 @@ export interface components {
          *     necessary plan information for UI rendering.
          */
         UserProfileResponse: {
+            /**
+             * Allow Network Analytics
+             * @description NETINT-001/006: User consent for anonymized network analytics collection. NULL = undecided (treated as opt-out), true = opted in, false = opted out.
+             */
+            allow_network_analytics?: boolean | null;
             /**
              * Capabilities
              * @description Plan capabilities (max_history_days, allow_excel, etc.)
@@ -21025,6 +21072,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PerfilContextoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_network_analytics_v1_profile_network_analytics_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NetworkAnalyticsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NetworkAnalyticsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/app/configuracoes/components/NetworkAnalyticsToggle.tsx
+++ b/frontend/app/configuracoes/components/NetworkAnalyticsToggle.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Info, Loader2 } from "lucide-react";
+
+/**
+ * NETINT-006: Network analytics opt-in/opt-out toggle.
+ *
+ * Allows users to control whether anonymized usage data is collected
+ * for network intelligence features. LGPD-compliant opt-in (Art. 9).
+ *
+ * States:
+ *   Loading  — Skeleton while fetching current preference
+ *   null     — Undecided (neutral toggle, tooltip "Voce ainda nao optou")
+ *   true     — Opted in (green, tooltip "Contribuindo com dados anonimos")
+ *   false    — Opted out (inactive, tooltip "Contribuicao desativada")
+ *   Error    — Silent fallback (toggle keeps last known state)
+ *
+ * Optimistic: toggle responds immediately, PATCH is async.
+ * Rollback: if PATCH fails, visual state reverts.
+ */
+
+interface NetworkAnalyticsToggleProps {
+  accessToken: string;
+}
+
+export function NetworkAnalyticsToggle({ accessToken }: NetworkAnalyticsToggleProps) {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [tooltipText, setTooltipText] = useState("");
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  const getTooltip = (val: boolean | null): string => {
+    if (val === null) return "Voce ainda nao optou por contribuir com dados anonimos.";
+    if (val === true) return "Contribuindo com dados anonimos de uso para melhorar os sinais de mercado.";
+    return "Contribuicao desativada. Nenhum dado de uso e coletado.";
+  };
+
+  const fetchPreference = useCallback(async () => {
+    if (!accessToken) return;
+    try {
+      setLoading(true);
+      const res = await fetch(
+        `${apiUrl}/v1/me`,
+        { headers: { Authorization: `Bearer ${accessToken}` } },
+      );
+      if (!res.ok) throw new Error("Falha ao carregar preferencia");
+      const data = await res.json();
+      // allow_network_analytics is on the full profile object
+      const value = data.allow_network_analytics ?? null;
+      setEnabled(value);
+      setTooltipText(getTooltip(value));
+    } catch {
+      // Silent fallback
+      setEnabled(null);
+      setTooltipText(getTooltip(null));
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, apiUrl]);
+
+  useEffect(() => {
+    fetchPreference();
+  }, [fetchPreference]);
+
+  const handleToggle = async () => {
+    if (!accessToken || saving) return;
+    const newValue = !enabled;
+    const previousValue = enabled;
+
+    // Optimistic update
+    setEnabled(newValue);
+    setTooltipText(getTooltip(newValue));
+    setSaving(true);
+
+    try {
+      const res = await fetch(
+        `${apiUrl}/v1/profile/network-analytics`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ allow_network_analytics: newValue }),
+        },
+      );
+      if (!res.ok) throw new Error("Falha ao salvar preferencia");
+
+      const result = await res.json();
+      setEnabled(result.allow_network_analytics);
+      setTooltipText(getTooltip(result.allow_network_analytics));
+    } catch {
+      // Rollback on error
+      setEnabled(previousValue);
+      setTooltipText(getTooltip(previousValue));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Loading state ──────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="flex items-center justify-between py-3" data-testid="network-analytics-toggle">
+        <div className="space-y-1">
+          <div className="h-4 w-48 bg-[var(--surface-1)] rounded animate-pulse" />
+          <div className="h-3 w-64 bg-[var(--surface-1)] rounded animate-pulse" />
+        </div>
+        <div className="h-6 w-11 bg-[var(--surface-1)] rounded-full animate-pulse" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center justify-between py-3"
+      data-testid="network-analytics-toggle"
+    >
+      {/* Label and tooltip */}
+      <div className="flex flex-col gap-0.5 min-w-0 pr-4">
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-medium text-[var(--ink)]">
+            Contribuir com dados anonimos de uso
+          </span>
+          <span
+            className="relative group cursor-help"
+            aria-label={tooltipText}
+            data-testid="toggle-tooltip"
+          >
+            <Info
+              className="w-4 h-4 text-[var(--ink-muted)]"
+              strokeWidth={1.5}
+              aria-hidden="true"
+            />
+            <span
+              className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5
+                         text-xs text-white bg-gray-800 rounded-md shadow-lg
+                         opacity-0 group-hover:opacity-100 transition-opacity
+                         whitespace-nowrap z-10 pointer-events-none"
+              role="tooltip"
+            >
+              {tooltipText}
+            </span>
+          </span>
+        </div>
+        <p className="text-xs text-[var(--ink-muted)]">
+          Apenas contagens anonimas de setores/UF — nunca dados pessoais ou CNPJ
+        </p>
+      </div>
+
+      {/* Toggle switch */}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={enabled === true}
+        aria-label="Contribuir com dados anonimos de uso"
+        disabled={saving}
+        onClick={handleToggle}
+        className={`
+          relative inline-flex h-6 w-11 items-center rounded-full
+          transition-colors duration-200 ease-in-out focus:outline-none
+          focus:ring-2 focus:ring-[var(--brand-navy)] focus:ring-offset-2
+          disabled:opacity-60 disabled:cursor-not-allowed flex-shrink-0
+          ${enabled === true
+            ? "bg-[var(--brand-navy)]"
+            : "bg-[var(--surface-2)]"
+          }
+        `}
+        data-testid="toggle-switch"
+      >
+        {saving ? (
+          <span className="inline-flex items-center justify-center w-full">
+            <Loader2 className="w-4 h-4 text-white animate-spin" />
+          </span>
+        ) : (
+          <span
+            className={`
+              inline-block h-5 w-5 transform rounded-full bg-white shadow-sm
+              ring-0 transition-transform duration-200 ease-in-out
+              ${enabled === true ? "translate-x-[22px]" : "translate-x-[2px]"}
+            `}
+          />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/conta/preferencias/page.tsx
+++ b/frontend/app/conta/preferencias/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { Shield } from "lucide-react";
 import { useAuth } from "../../components/AuthProvider";
 import { SectorAffinitySettings } from "../../components/SectorAffinitySettings";
+import { NetworkAnalyticsToggle } from "../../configuracoes/components/NetworkAnalyticsToggle";
 
-/** FEEDBACK-005: Preferências page that hosts the SectorAffinitySettings component. */
+/**
+ * FEEDBACK-005: Preferências page that hosts the SectorAffinitySettings component.
+ * NETINT-006: Added NetworkAnalyticsToggle for privacy opt-in/opt-out.
+ */
 export default function PreferenciasPage() {
   const { session } = useAuth();
 
@@ -15,5 +20,28 @@ export default function PreferenciasPage() {
     );
   }
 
-  return <SectorAffinitySettings accessToken={session.access_token} />;
+  return (
+    <div className="space-y-10">
+      {/* Privacy section — NETINT-006 */}
+      <section aria-label="Privacidade">
+        <div className="flex items-center gap-2 mb-1">
+          <Shield
+            className="w-5 h-5 text-[var(--ink-secondary)]"
+            strokeWidth={1.5}
+            aria-hidden="true"
+          />
+          <h2 className="text-xl font-bold text-[var(--ink)]">Privacidade</h2>
+        </div>
+        <p className="text-sm text-[var(--ink-secondary)] mb-2">
+          Controle como seus dados de uso contribuem para melhorar os sinais de mercado para todos.
+        </p>
+        <div className="p-4 rounded-lg bg-[var(--surface-1)] border border-[var(--border-color)]">
+          <NetworkAnalyticsToggle accessToken={session.access_token} />
+        </div>
+      </section>
+
+      {/* Sector preferences — FEEDBACK-005 */}
+      <SectorAffinitySettings accessToken={session.access_token} />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

NETINT-006: Interface de opt-in/opt-out para network analytics (parte do EPIC-NETINT #1263).

## Changes

### Backend
- `backend/schemas/user.py` — Added `allow_network_analytics` field to UserProfileResponse
- `backend/routes/user.py` — Added `PUT /v1/profile/network-analytics` endpoint
  - Updates profiles.allow_network_analytics via user-scoped client (RLS)
- `backend/routes/user.py` — GET /v1/me now returns allow_network_analytics

### Frontend
- `frontend/app/configuracoes/components/NetworkAnalyticsToggle.tsx`
  - Toggle switch with optimistic update + rollback on error
  - States: loading, null (undecided), true (opted in), false (opted out)
  - Tooltip explicativo com aria-label acessivel
  - Responsivo (mobile + desktop)
- `frontend/app/conta/preferencias/page.tsx`
  - Added "Privacidade" section with NetworkAnalyticsToggle
  - Preserves existing SectorAffinitySettings below

### Tests
- `frontend/__tests__/configuracoes/NetworkAnalyticsToggle.test.tsx`
  - 9 tests: loading, null/true/false states, optimistic toggle, rollback, tooltip

Closes #1676
Parent: #1263