### PR TITLE
feat(backend,frontend): COMPINT-011 (#1663) — Seção Inteligência Concorrencial em /fornecedores/[cnpj]

### DIFF
--- a/backend/routes/competitive_intel.py
+++ b/backend/routes/competitive_intel.py
@@ -1,0 +1,285 @@
+"""COMPINT-011 (#1663): Competitive Intelligence route — supplier-level data.
+
+GET /v1/intel-concorrente/fornecedor/{cnpj}
+  Returns aggregated competitive data for a specific supplier (CNPJ).
+  Gated by COMPETITIVE_INTEL_ENABLED + allow_competitive_intel capability.
+
+Consumes:
+  - competitor_territory_map (COMPINT-001 RPC)
+  - competitor_win_metrics (COMPINT-002 RPC)
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+
+from quota.plan_auth import get_competitive_intel_dependency
+from schemas.competitive_intel import (
+    AlertaPosicionamento,
+    ConcorrenteInfo,
+    FornecedorIntelResponse,
+    TerritorioStats,
+    WinMetrics,
+)
+from supabase_client import get_supabase, sb_execute
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["competitive_intel"])
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+_competitive_intel_dep = get_competitive_intel_dependency()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _derive_alertas(
+    territorio: list[dict],
+    stats: dict,
+) -> list[dict]:
+    """Derive positioning alerts from territory data."""
+    alertas: list[dict] = []
+
+    # Tendência de expansão — novas UFs com crescimento
+    expanding_ufs = [
+        t for t in territorio
+        if t.get("tendencia") in ("crescendo", "expansao", "nova")
+    ]
+    if expanding_ufs:
+        nomes = [t["uf"] for t in expanding_ufs[:3]]
+        alertas.append({
+            "tipo": "expansao",
+            "mensagem": f"Expandindo atuação para {'/'.join(nomes)}",
+            "severidade": "info",
+        })
+
+    # Crescimento anual
+    crescimento = stats.get("crescimento_anual")
+    if crescimento is not None:
+        if crescimento > 30:
+            alertas.append({
+                "tipo": "crescimento",
+                "mensagem": f"Crescimento de {crescimento:.0f}% em contratos no último ano",
+                "severidade": "success",
+            })
+        elif crescimento > 10:
+            alertas.append({
+                "tipo": "crescimento",
+                "mensagem": f"Crescimento de {crescimento:.0f}% em contratos",
+                "severidade": "info",
+            })
+        elif crescimento < -10:
+            alertas.append({
+                "tipo": "crescimento",
+                "mensagem": f"Retração de {abs(crescimento):.0f}% em contratos no último ano",
+                "severidade": "warning",
+            })
+
+    # Player dominante em UF com market share alto
+    dominant_ufs = [
+        t for t in territorio
+        if t.get("market_share_uf") is not None and t["market_share_uf"] > 0.3
+    ]
+    if dominant_ufs:
+        top = max(dominant_ufs, key=lambda t: t["market_share_uf"])
+        share_pct = top["market_share_uf"] * 100
+        alertas.append({
+            "tipo": "dominio",
+            "mensagem": f"Player dominante em {top['uf']} com {share_pct:.0f}% de market share",
+            "severidade": "success",
+        })
+
+    return alertas
+
+
+def _extract_territorio(raw: list) -> list[dict]:
+    """Normalize territory entries from RPC output."""
+    return [
+        {
+            "uf": t.get("uf", ""),
+            "contratos": t.get("contratos", 0) or 0,
+            "valor_total": float(t.get("valor_total", 0) or 0),
+            "ticket_medio_uf": float(t.get("ticket_medio_uf", 0) or 0),
+            "orgaos_principais": t.get("orgaos_principais", []),
+            "market_share_uf": (
+                float(t["market_share_uf"])
+                if t.get("market_share_uf") is not None
+                else None
+            ),
+            "tendencia": t.get("tendencia"),
+        }
+        for t in (raw or [])
+    ]
+
+
+def _extract_orgaos(raw: list) -> list[dict]:
+    """Normalize orgaos_favoritos from RPC output."""
+    return [
+        {
+            "orgao_nome": o.get("orgao_nome", ""),
+            "contratos": o.get("contratos", 0) or 0,
+            "valor_total": float(o.get("valor_total", 0) or 0),
+            "categorias": o.get("categorias", []),
+            "ultima_vitoria": o.get("ultima_vitoria"),
+            "frequencia_anual": (
+                float(o["frequencia_anual"])
+                if o.get("frequencia_anual") is not None
+                else None
+            ),
+        }
+        for o in (raw or [])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-concorrente/fornecedor/{cnpj}",
+    summary="Competitive Intelligence data for a supplier CNPJ (COMPINT-011)",
+    response_model=FornecedorIntelResponse,
+)
+async def fornecedor_competitive_intel(
+    cnpj: str = Path(..., description="Supplier CNPJ (14 digits)"),
+    anos: int = 3,
+    user: dict = Depends(_competitive_intel_dep),
+):
+    """Return competitive intelligence data for *cnpj*.
+
+    Aggregates:
+    - Territorial map (COMPINT-001 RPC)
+    - Win metrics (COMPINT-002 RPC)
+    - Derived positioning alerts
+    """
+    # Validate CNPJ format
+    cnpj_clean = "".join(c for c in cnpj if c.isdigit())
+    if len(cnpj_clean) != 14:
+        raise HTTPException(
+            status_code=400,
+            detail="CNPJ inválido: deve conter 14 dígitos.",
+        )
+
+    sb = get_supabase()
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # --- Fetch territory map ---
+    try:
+        territory_resp = await sb_execute(
+            sb.rpc("competitor_territory_map", {
+                "p_cnpj": cnpj_clean,
+                "p_anos": anos,
+            })
+        )
+        territory_data = territory_resp.data
+    except Exception as exc:
+        logger.error("competitor_territory_map RPC failed for %s: %s", cnpj_clean, exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Falha ao buscar dados territoriais do concorrente.",
+        )
+
+    if not territory_data or isinstance(territory_data, dict) and "erro" in territory_data:
+        # No data for this supplier or error from RPC
+        raise HTTPException(
+            status_code=404,
+            detail="Dados de inteligência concorrencial não disponíveis para este CNPJ.",
+        )
+
+    # --- Fetch win metrics ---
+    win_metrics_raw: Optional[dict] = None
+    try:
+        win_resp = await sb_execute(
+            sb.rpc("competitor_win_metrics", {
+                "p_cnpj": cnpj_clean,
+                "p_anos": anos,
+            })
+        )
+        win_data = win_resp.data
+        if isinstance(win_data, dict) and "win_metrics" in win_data:
+            win_metrics_raw = win_data["win_metrics"]
+    except Exception as exc:
+        logger.warning("competitor_win_metrics RPC failed for %s: %s", cnpj_clean, exc)
+        # Non-blocking — win metrics are additive
+
+    # --- Build response ---
+    concorrente_raw = territory_data.get("concorrente", {})
+    territorio_raw = territory_data.get("territorio", [])
+    orgaos_raw = territory_data.get("orgaos_favoritos", [])
+    stats_raw = territory_data.get("stats", {})
+
+    territorio = _extract_territorio(territorio_raw)
+    orgaos_favoritos = _extract_orgaos(orgaos_raw)
+
+    # Derive positioning alerts
+    alertas_raw = _derive_alertas(territorio_raw, stats_raw)
+
+    # Build win_metrics if available
+    win_metrics: Optional[WinMetrics] = None
+    if win_metrics_raw:
+        win_metrics = WinMetrics(
+            taxa_vitoria_estimada=win_metrics_raw.get("taxa_vitoria_estimada"),
+            velocidade_crescimento=win_metrics_raw.get("velocidade_crescimento"),
+            tendencia=win_metrics_raw.get("tendencia"),
+            ticket_p25=(
+                float(win_metrics_raw["ticket_p25"])
+                if win_metrics_raw.get("ticket_p25") is not None
+                else None
+            ),
+            ticket_p50=(
+                float(win_metrics_raw["ticket_p50"])
+                if win_metrics_raw.get("ticket_p50") is not None
+                else None
+            ),
+            ticket_p75=(
+                float(win_metrics_raw["ticket_p75"])
+                if win_metrics_raw.get("ticket_p75") is not None
+                else None
+            ),
+            ticket_p90=(
+                float(win_metrics_raw["ticket_p90"])
+                if win_metrics_raw.get("ticket_p90") is not None
+                else None
+            ),
+            indice_concentracao=win_metrics_raw.get("indice_concentracao"),
+            dependencia_publica=win_metrics_raw.get("dependencia_publica"),
+        )
+
+    return FornecedorIntelResponse(
+        concorrente=ConcorrenteInfo(
+            cnpj=concorrente_raw.get("cnpj", cnpj_clean),
+            nome=concorrente_raw.get("nome", ""),
+            total_contratos=concorrente_raw.get("total_contratos", 0) or 0,
+            ticket_medio=float(concorrente_raw.get("ticket_medio", 0) or 0),
+            ticket_mediana=float(concorrente_raw.get("ticket_mediana", 0) or 0),
+            valor_total_contratado=float(
+                concorrente_raw.get("valor_total_contratado", 0) or 0
+            ),
+        ),
+        territorio=territorio,
+        orgaos_favoritos=orgaos_favoritos,
+        stats=TerritorioStats(
+            ufs_atuacao=stats_raw.get("ufs_atuacao", 0) or 0,
+            orgaos_unicos=stats_raw.get("orgaos_unicos", 0) or 0,
+            anos_atuacao=stats_raw.get("anos_atuacao", 0) or 0,
+            crescimento_anual=(
+                float(stats_raw["crescimento_anual"])
+                if stats_raw.get("crescimento_anual") is not None
+                else None
+            ),
+            tendencia_posicionamento=stats_raw.get("tendencia_posicionamento"),
+        ),
+        win_metrics=win_metrics,
+        alertas=[
+            AlertaPosicionamento(**a) for a in alertas_raw
+        ],
+        feature_enabled=True,
+        generated_at=now_iso,
+    )

--- a/backend/schemas/competitive_intel.py
+++ b/backend/schemas/competitive_intel.py
@@ -1,0 +1,93 @@
+"""COMPINT-011 (#1663): Competitive Intelligence schemas.
+
+FornecedorIntelResponse — returned by GET /v1/intel-concorrente/fornecedor/{cnpj}.
+Aggregates data from competitor_territory_map (COMPINT-001) and
+competitor_win_metrics (COMPINT-002) RPCs.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class TerritorioEntry(BaseModel):
+    """Per-UF competitive territory data."""
+
+    uf: str
+    contratos: int
+    valor_total: float
+    ticket_medio_uf: float
+    orgaos_principais: list[str] = []
+    market_share_uf: Optional[float] = None
+    tendencia: Optional[str] = None
+
+
+class OrgaoFavorito(BaseModel):
+    """Favorite (most-contracted) agencies."""
+
+    orgao_nome: str
+    contratos: int
+    valor_total: float
+    categorias: list[str] = []
+    ultima_vitoria: Optional[str] = None
+    frequencia_anual: Optional[float] = None
+
+
+class TerritorioStats(BaseModel):
+    """Aggregate territorial statistics."""
+
+    ufs_atuacao: int
+    orgaos_unicos: int
+    anos_atuacao: int
+    crescimento_anual: Optional[float] = None
+    tendencia_posicionamento: Optional[str] = None
+
+
+class ConcorrenteInfo(BaseModel):
+    """High-level competitor information."""
+
+    cnpj: str
+    nome: str
+    total_contratos: int
+    ticket_medio: float
+    ticket_mediana: float
+    valor_total_contratado: float
+
+
+class WinMetrics(BaseModel):
+    """Win-rate and performance metrics."""
+
+    taxa_vitoria_estimada: Optional[float] = None
+    velocidade_crescimento: Optional[float] = None
+    tendencia: Optional[str] = None
+    ticket_p25: Optional[float] = None
+    ticket_p50: Optional[float] = None
+    ticket_p75: Optional[float] = None
+    ticket_p90: Optional[float] = None
+    indice_concentracao: Optional[float] = None
+    dependencia_publica: Optional[float] = None
+
+
+class AlertaPosicionamento(BaseModel):
+    """Derived positioning alert."""
+    tipo: str  # "expansao", "crescimento", "dominio", "novo_entrante"
+    mensagem: str
+    severidade: str = "info"  # "info", "warning", "success"
+
+
+class FornecedorIntelResponse(BaseModel):
+    """Complete competitive intelligence response for a supplier CNPJ.
+
+    Returned by GET /v1/intel-concorrente/fornecedor/{cnpj}.
+    """
+
+    concorrente: ConcorrenteInfo
+    territorio: list[TerritorioEntry]
+    orgaos_favoritos: list[OrgaoFavorito]
+    stats: TerritorioStats
+    win_metrics: Optional[WinMetrics] = None
+    alertas: list[AlertaPosicionamento] = []
+    feature_enabled: bool = True
+    generated_at: str = ""

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -105,6 +105,7 @@ from routes.intel_vitrine import router as intel_vitrine_router
 from routes.pseo_intel_feed import router as pseo_intel_feed_router
 from routes.widget_compint import router as widget_compint_router
 from routes.consultoria import router as consultoria_router
+from routes.competitive_intel import router as competitive_intel_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -164,6 +165,7 @@ _v1_routers = [
     monthly_report_router,
     widget_compint_router,
     consultoria_router,
+    competitive_intel_router,
 ]
 
 

--- a/backend/tests/test_competitive_intel.py
+++ b/backend/tests/test_competitive_intel.py
@@ -1,0 +1,211 @@
+"""COMPINT-011 (#1663): Tests for Competitive Intelligence route.
+
+Covers:
+  - Route registered and returns expected status codes
+  - Auth gate: 401 without auth
+  - Competitive intel gate: 404 when flag off, 403 when capability false
+  - CNPJ validation: 400 for invalid format
+  - Data flow: returns FornecedorIntelResponse when data available
+  - Error handling: RPC failure returns 502
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth import require_auth
+from main import app
+
+MOCK_USER = {"id": "user-123", "email": "test@example.com"}
+
+
+def _override_auth():
+    return MOCK_USER
+
+
+# Sample data
+SAMPLE_TERRITORY_DATA = {
+    "concorrente": {
+        "cnpj": "12345678000199",
+        "nome": "Fornecedor ABC Ltda",
+        "total_contratos": 45,
+        "ticket_medio": 250000.0,
+        "ticket_mediana": 180000.0,
+        "valor_total_contratado": 11250000.0,
+    },
+    "territorio": [
+        {
+            "uf": "SP",
+            "contratos": 20,
+            "valor_total": 5000000.0,
+            "ticket_medio_uf": 250000.0,
+            "orgaos_principais": ["Governo SP"],
+            "market_share_uf": 0.35,
+            "tendencia": "crescendo",
+        },
+        {
+            "uf": "RJ",
+            "contratos": 10,
+            "valor_total": 2500000.0,
+            "ticket_medio_uf": 250000.0,
+            "orgaos_principais": ["Prefeitura RJ"],
+            "market_share_uf": 0.15,
+            "tendencia": "estavel",
+        },
+    ],
+    "orgaos_favoritos": [
+        {
+            "orgao_nome": "Governo SP",
+            "contratos": 15,
+            "valor_total": 3750000.0,
+            "categorias": ["Infraestrutura"],
+            "ultima_vitoria": "2026-05-15",
+            "frequencia_anual": 3.0,
+        },
+    ],
+    "stats": {
+        "ufs_atuacao": 2,
+        "orgaos_unicos": 3,
+        "anos_atuacao": 5,
+        "crescimento_anual": 0.35,
+        "tendencia_posicionamento": "expansao",
+    },
+}
+
+SAMPLE_WIN_METRICS_DATA = {
+    "cnpj": "12345678000199",
+    "nome": "Fornecedor ABC Ltda",
+    "win_metrics": {
+        "taxa_vitoria_estimada": 0.45,
+        "velocidade_crescimento": 1.2,
+        "tendencia": "crescendo",
+        "ticket_p25": 80000.0,
+        "ticket_p50": 180000.0,
+        "ticket_p75": 350000.0,
+        "ticket_p90": 500000.0,
+        "indice_concentracao": 0.3,
+        "dependencia_publica": 0.85,
+    },
+}
+
+MOCK_QUOTA_PASS = MagicMock(
+    capabilities={"allow_competitive_intel": True},
+    plan_id="smartlic_command",
+    allowed=True,
+)
+
+
+def _make_rpc_result(data: dict):
+    return MagicMock(data=data)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _setup_auth():
+    """Override auth dependency for all tests."""
+    app.dependency_overrides[require_auth] = _override_auth
+    yield
+    app.dependency_overrides.clear()
+
+
+class TestCompetitiveIntelRoute:
+
+    def _setup_mocks(self, mock_sb=None):
+        """Create common mock patches."""
+        patches = [
+            patch("config.features.get_feature_flag", return_value=True),
+            patch("authorization.has_master_access", new=AsyncMock(return_value=True)),
+            patch("quota.plan_enforcement.check_quota", return_value=MOCK_QUOTA_PASS),
+        ]
+        if mock_sb is not None:
+            patches.append(mock_sb)
+        return patches
+
+    def test_route_registered(self, client):
+        """Route is registered and returns 200 for authenticated request."""
+        with (
+            patch("config.features.get_feature_flag", return_value=True),
+            patch("authorization.has_master_access", new=AsyncMock(return_value=True)),
+            patch("quota.plan_enforcement.check_quota", return_value=MOCK_QUOTA_PASS),
+        ):
+            with patch("routes.competitive_intel.sb_execute") as mock_sb:
+                mock_sb.side_effect = [
+                    _make_rpc_result(SAMPLE_TERRITORY_DATA),
+                    _make_rpc_result(SAMPLE_WIN_METRICS_DATA),
+                ]
+                resp = client.get("/v1/intel-concorrente/fornecedor/12345678000199")
+                assert resp.status_code == 200
+
+    def test_response_schema(self, client):
+        """Returns expected schema fields."""
+        with (
+            patch("config.features.get_feature_flag", return_value=True),
+            patch("authorization.has_master_access", new=AsyncMock(return_value=True)),
+            patch("quota.plan_enforcement.check_quota", return_value=MOCK_QUOTA_PASS),
+        ):
+            with patch("routes.competitive_intel.sb_execute") as mock_sb:
+                mock_sb.side_effect = [
+                    _make_rpc_result(SAMPLE_TERRITORY_DATA),
+                    _make_rpc_result(SAMPLE_WIN_METRICS_DATA),
+                ]
+                resp = client.get("/v1/intel-concorrente/fornecedor/12345678000199")
+                assert resp.status_code == 200
+                body = resp.json()
+                assert "concorrente" in body
+                assert "territorio" in body
+                assert "orgaos_favoritos" in body
+                assert "stats" in body
+                assert "win_metrics" in body
+                assert "alertas" in body
+                assert body["concorrente"]["nome"] == "Fornecedor ABC Ltda"
+                assert body["concorrente"]["total_contratos"] == 45
+                assert len(body["territorio"]) == 2
+                assert len(body["alertas"]) > 0
+
+    def test_invalid_cnpj_returns_400(self, client):
+        """Invalid CNPJ format returns 400 validation error."""
+        with (
+            patch("config.features.get_feature_flag", return_value=True),
+            patch("authorization.has_master_access", new=AsyncMock(return_value=True)),
+            patch("quota.plan_enforcement.check_quota", return_value=MOCK_QUOTA_PASS),
+            patch("routes.competitive_intel.sb_execute"),
+        ):
+            resp = client.get("/v1/intel-concorrente/fornecedor/123")
+            assert resp.status_code == 400
+
+    def test_rpc_error_returns_502(self, client):
+        """RPC failure returns 502 Bad Gateway."""
+        with (
+            patch("config.features.get_feature_flag", return_value=True),
+            patch("authorization.has_master_access", new=AsyncMock(return_value=True)),
+            patch("quota.plan_enforcement.check_quota", return_value=MOCK_QUOTA_PASS),
+        ):
+            with patch("routes.competitive_intel.sb_execute") as mock_sb:
+                mock_sb.side_effect = Exception("RPC failed")
+                resp = client.get("/v1/intel-concorrente/fornecedor/12345678000199")
+                assert resp.status_code == 502
+
+    def test_no_data_returns_404(self, client):
+        """Supplier without competitive data returns 404."""
+        with (
+            patch("config.features.get_feature_flag", return_value=True),
+            patch("authorization.has_master_access", new=AsyncMock(return_value=True)),
+            patch("quota.plan_enforcement.check_quota", return_value=MOCK_QUOTA_PASS),
+        ):
+            with patch("routes.competitive_intel.sb_execute") as mock_sb:
+                mock_sb.side_effect = [
+                    _make_rpc_result({"erro": "CNPJ invalido"}),
+                ]
+                resp = client.get("/v1/intel-concorrente/fornecedor/12345678000199")
+                assert resp.status_code == 404
+
+    def test_requires_auth(self, client):
+        """Route returns 401 without auth."""
+        app.dependency_overrides.clear()
+        resp = client.get("/v1/intel-concorrente/fornecedor/12345678000199")
+        assert resp.status_code == 401

--- a/frontend/__tests__/fornecedores/CompetitiveIntelBlock.test.tsx
+++ b/frontend/__tests__/fornecedores/CompetitiveIntelBlock.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * COMPINT-011 (#1663): Tests for CompetitiveIntelBlock component.
+ *
+ * Covers:
+ * - Rendering nothing when fetch returns 401/403 (no access)
+ * - Rendering nothing when data is null
+ * - Rendering nothing when supplier has 0 contracts
+ * - Rendering full block with data
+ * - Rendering positioning alerts
+ * - Mini-dashboard shows ticket, market share, growth, UFs
+ * - CTA link rendered with correct URL
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import CompetitiveIntelBlock from "@/app/fornecedores/[cnpj]/components/CompetitiveIntelBlock";
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const MOCK_INTEL_DATA = {
+  concorrente: {
+    cnpj: "12345678000199",
+    nome: "Fornecedor ABC Ltda",
+    total_contratos: 45,
+    ticket_medio: 250000.0,
+    ticket_mediana: 180000.0,
+    valor_total_contratado: 11250000.0,
+  },
+  territorio: [
+    {
+      uf: "SP",
+      contratos: 20,
+      valor_total: 5000000.0,
+      ticket_medio_uf: 250000.0,
+      orgaos_principais: ["Governo SP"],
+      market_share_uf: 0.35,
+      tendencia: "crescendo",
+    },
+    {
+      uf: "RJ",
+      contratos: 10,
+      valor_total: 2500000.0,
+      ticket_medio_uf: 250000.0,
+      orgaos_principais: ["Prefeitura RJ"],
+      market_share_uf: 0.15,
+      tendencia: "estavel",
+    },
+  ],
+  orgaos_favoritos: [
+    {
+      orgao_nome: "Governo SP",
+      contratos: 15,
+      valor_total: 3750000.0,
+      categorias: ["Infraestrutura"],
+      ultima_vitoria: "2026-05-15",
+      frequencia_anual: 3.0,
+    },
+  ],
+  stats: {
+    ufs_atuacao: 2,
+    orgaos_unicos: 3,
+    anos_atuacao: 5,
+    crescimento_anual: 0.35,
+    tendencia_posicionamento: "expansao",
+  },
+  win_metrics: {
+    taxa_vitoria_estimada: 0.45,
+    velocidade_crescimento: 1.2,
+    tendencia: "crescendo",
+    ticket_p50: 180000.0,
+    ticket_p75: 350000.0,
+  },
+  alertas: [
+    {
+      tipo: "crescimento",
+      mensagem: "Crescimento de 35% em contratos no último ano",
+      severidade: "success",
+    },
+    {
+      tipo: "dominio",
+      mensagem: "Player dominante em SP com 35% de market share",
+      severidade: "success",
+    },
+  ],
+};
+
+function mockFetch(response: Response | null, status = 200) {
+  const mockResolvedValue = response ?? {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => MOCK_INTEL_DATA,
+  };
+  globalThis.fetch = jest.fn().mockResolvedValue(mockResolvedValue);
+}
+
+function cleanupFetch() {
+  if (jest.isMockFunction(globalThis.fetch)) {
+    (globalThis.fetch as jest.Mock).mockRestore?.();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CompetitiveIntelBlock", () => {
+  afterEach(() => {
+    cleanupFetch();
+  });
+
+  it("renders nothing when fetch returns 401 (no access)", async () => {
+    mockFetch(
+      { ok: false, status: 401, json: async () => ({}) } as Response,
+      401,
+    );
+
+    const { container } = render(<CompetitiveIntelBlock cnpj="12345678000199" />);
+
+    await waitFor(() => {
+      // Component should render nothing
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  it("renders nothing when fetch returns 403 (capability false)", async () => {
+    mockFetch(
+      { ok: false, status: 403, json: async () => ({}) } as Response,
+      403,
+    );
+
+    const { container } = render(<CompetitiveIntelBlock cnpj="12345678000199" />);
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  it("renders nothing when fetch returns 404 (no data)", async () => {
+    mockFetch(
+      { ok: false, status: 404, json: async () => ({}) } as Response,
+      404,
+    );
+
+    const { container } = render(<CompetitiveIntelBlock cnpj="12345678000199" />);
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  it("renders full block with data when access granted", async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_INTEL_DATA,
+    });
+
+    render(<CompetitiveIntelBlock cnpj="12345678000199" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("competitive-intel-block")).toBeInTheDocument();
+    });
+
+    // Verify header
+    expect(screen.getByText("Inteligência Concorrencial")).toBeInTheDocument();
+
+    // Verify positioning alerts
+    expect(
+      screen.getByText(/Crescimento de 35% em contratos no último ano/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Player dominante em SP com 35% de market share/),
+    ).toBeInTheDocument();
+
+    // Verify CTA
+    const cta = screen.getByTestId("competitive-intel-cta");
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute(
+      "href",
+      "/intel-concorrente?cnpj=12345678000199",
+    );
+  });
+
+  it("renders ticket and market share in mini-dashboard", async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_INTEL_DATA,
+    });
+
+    render(<CompetitiveIntelBlock cnpj="12345678000199" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("competitive-intel-block")).toBeInTheDocument();
+    });
+
+    // Ticket Medio should be visible
+    expect(screen.getByText(/R\$ 250/, { exact: false })).toBeInTheDocument();
+  });
+
+  it("renders nothing for supplier with 0 contracts", async () => {
+    const zeroContractsData = {
+      ...MOCK_INTEL_DATA,
+      concorrente: { ...MOCK_INTEL_DATA.concorrente, total_contratos: 0 },
+    };
+
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => zeroContractsData,
+    });
+
+    const { container } = render(<CompetitiveIntelBlock cnpj="12345678000199" />);
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe("");
+    });
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4128,6 +4128,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/intel-concorrente/fornecedor/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Competitive Intelligence data for a supplier CNPJ (COMPINT-011)
+         * @description Return competitive intelligence data for *cnpj*.
+         *
+         *     Aggregates:
+         *     - Territorial map (COMPINT-001 RPC)
+         *     - Win metrics (COMPINT-002 RPC)
+         *     - Derived positioning alerts
+         */
+        get: operations["fornecedor_competitive_intel_v1_intel_concorrente_fornecedor__cnpj__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/intel-reports/": {
         parameters: {
             query?: never;
@@ -7002,6 +7027,21 @@ export interface components {
             /** Valor */
             valor?: number | null;
         };
+        /**
+         * AlertaPosicionamento
+         * @description Derived positioning alert.
+         */
+        AlertaPosicionamento: {
+            /** Mensagem */
+            mensagem: string;
+            /**
+             * Severidade
+             * @default info
+             */
+            severidade: string;
+            /** Tipo */
+            tipo: string;
+        };
         /** AlertasResponse */
         AlertasResponse: {
             /** Bids */
@@ -8327,6 +8367,24 @@ export interface components {
             total_sancoes_ceis: number;
             /** Total Sancoes Cnep */
             total_sancoes_cnep: number;
+        };
+        /**
+         * ConcorrenteInfo
+         * @description High-level competitor information.
+         */
+        ConcorrenteInfo: {
+            /** Cnpj */
+            cnpj: string;
+            /** Nome */
+            nome: string;
+            /** Ticket Mediana */
+            ticket_mediana: number;
+            /** Ticket Medio */
+            ticket_medio: number;
+            /** Total Contratos */
+            total_contratos: number;
+            /** Valor Total Contratado */
+            valor_total_contratado: number;
         };
         /**
          * ConsultantClientListResponse
@@ -9857,6 +9915,36 @@ export interface components {
              * @default in_progress
              */
             status: string;
+        };
+        /**
+         * FornecedorIntelResponse
+         * @description Complete competitive intelligence response for a supplier CNPJ.
+         *
+         *     Returned by GET /v1/intel-concorrente/fornecedor/{cnpj}.
+         */
+        FornecedorIntelResponse: {
+            /**
+             * Alertas
+             * @default []
+             */
+            alertas: components["schemas"]["AlertaPosicionamento"][];
+            concorrente: components["schemas"]["ConcorrenteInfo"];
+            /**
+             * Feature Enabled
+             * @default true
+             */
+            feature_enabled: boolean;
+            /**
+             * Generated At
+             * @default
+             */
+            generated_at: string;
+            /** Orgaos Favoritos */
+            orgaos_favoritos: components["schemas"]["OrgaoFavorito"][];
+            stats: components["schemas"]["TerritorioStats"];
+            /** Territorio */
+            territorio: components["schemas"]["TerritorioEntry"][];
+            win_metrics?: components["schemas"]["WinMetrics"] | null;
         };
         /** FornecedorProfileResponse */
         FornecedorProfileResponse: {
@@ -11435,6 +11523,27 @@ export interface components {
             total_contracts: number;
             /** Total Value */
             total_value: number;
+        };
+        /**
+         * OrgaoFavorito
+         * @description Favorite (most-contracted) agencies.
+         */
+        OrgaoFavorito: {
+            /**
+             * Categorias
+             * @default []
+             */
+            categorias: string[];
+            /** Contratos */
+            contratos: number;
+            /** Frequencia Anual */
+            frequencia_anual?: number | null;
+            /** Orgao Nome */
+            orgao_nome: string;
+            /** Ultima Vitoria */
+            ultima_vitoria?: string | null;
+            /** Valor Total */
+            valor_total: number;
         };
         /** OrgaoRank */
         OrgaoRank: {
@@ -14058,6 +14167,45 @@ export interface components {
             /** Total Won */
             total_won: number;
         };
+        /**
+         * TerritorioEntry
+         * @description Per-UF competitive territory data.
+         */
+        TerritorioEntry: {
+            /** Contratos */
+            contratos: number;
+            /** Market Share Uf */
+            market_share_uf?: number | null;
+            /**
+             * Orgaos Principais
+             * @default []
+             */
+            orgaos_principais: string[];
+            /** Tendencia */
+            tendencia?: string | null;
+            /** Ticket Medio Uf */
+            ticket_medio_uf: number;
+            /** Uf */
+            uf: string;
+            /** Valor Total */
+            valor_total: number;
+        };
+        /**
+         * TerritorioStats
+         * @description Aggregate territorial statistics.
+         */
+        TerritorioStats: {
+            /** Anos Atuacao */
+            anos_atuacao: number;
+            /** Crescimento Anual */
+            crescimento_anual?: number | null;
+            /** Orgaos Unicos */
+            orgaos_unicos: number;
+            /** Tendencia Posicionamento */
+            tendencia_posicionamento?: string | null;
+            /** Ufs Atuacao */
+            ufs_atuacao: number;
+        };
         /** TimeSeriesDataPoint */
         TimeSeriesDataPoint: {
             /** Label */
@@ -14865,6 +15013,30 @@ export interface components {
             message: string;
             /** Sent */
             sent: boolean;
+        };
+        /**
+         * WinMetrics
+         * @description Win-rate and performance metrics.
+         */
+        WinMetrics: {
+            /** Dependencia Publica */
+            dependencia_publica?: number | null;
+            /** Indice Concentracao */
+            indice_concentracao?: number | null;
+            /** Taxa Vitoria Estimada */
+            taxa_vitoria_estimada?: number | null;
+            /** Tendencia */
+            tendencia?: string | null;
+            /** Ticket P25 */
+            ticket_p25?: number | null;
+            /** Ticket P50 */
+            ticket_p50?: number | null;
+            /** Ticket P75 */
+            ticket_p75?: number | null;
+            /** Ticket P90 */
+            ticket_p90?: number | null;
+            /** Velocidade Crescimento */
+            velocidade_crescimento?: number | null;
         };
         /**
          * _LivenessResponse
@@ -20290,6 +20462,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IndiceResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fornecedor_competitive_intel_v1_intel_concorrente_fornecedor__cnpj__get: {
+        parameters: {
+            query?: {
+                anos?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Supplier CNPJ (14 digits) */
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FornecedorIntelResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/app/fornecedores/[cnpj]/components/CompetitiveIntelBlock.tsx
+++ b/frontend/app/fornecedores/[cnpj]/components/CompetitiveIntelBlock.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+/**
+ * COMPINT-011 (#1663): Competitive Intel Block for /fornecedores/[cnpj].
+ *
+ * Additive block at the bottom of the supplier profile page showing
+ * competitive positioning data (territory expansion, market share,
+ * ticket comparison) when the viewing user has the
+ * allow_competitive_intel capability.
+ *
+ * Silent component: renders nothing when the user is not authenticated
+ * or does not have the capability (no placeholder, no upgrade message).
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+// ---------------------------------------------------------------------------
+// Types (mirrors backend response)
+// ---------------------------------------------------------------------------
+
+interface ConcorrenteInfo {
+  cnpj: string;
+  nome: string;
+  total_contratos: number;
+  ticket_medio: number;
+  ticket_mediana: number;
+  valor_total_contratado: number;
+}
+
+interface TerritorioEntry {
+  uf: string;
+  contratos: number;
+  valor_total: number;
+  ticket_medio_uf: number;
+  market_share_uf?: number | null;
+  tendencia?: string | null;
+}
+
+interface OrgaoFavorito {
+  orgao_nome: string;
+  contratos: number;
+  valor_total: number;
+  ultima_vitoria?: string | null;
+}
+
+interface TerritorioStats {
+  ufs_atuacao: number;
+  orgaos_unicos: number;
+  anos_atuacao: number;
+  crescimento_anual?: number | null;
+  tendencia_posicionamento?: string | null;
+}
+
+interface WinMetrics {
+  taxa_vitoria_estimada?: number | null;
+  velocidade_crescimento?: number | null;
+  tendencia?: string | null;
+  ticket_p50?: number | null;
+  ticket_p75?: number | null;
+}
+
+interface AlertaPosicionamento {
+  tipo: string;
+  mensagem: string;
+  severidade: string;
+}
+
+interface IntelData {
+  concorrente: ConcorrenteInfo;
+  territorio: TerritorioEntry[];
+  orgaos_favoritos: OrgaoFavorito[];
+  stats: TerritorioStats;
+  win_metrics?: WinMetrics | null;
+  alertas: AlertaPosicionamento[];
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface CompetitiveIntelBlockProps {
+  cnpj: string;
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+function fmtBRL(value: number): string {
+  if (value >= 1_000_000_000) {
+    return `R$ ${(value / 1_000_000_000).toFixed(1).replace(".", ",")} bi`;
+  }
+  if (value >= 1_000_000) {
+    return `R$ ${(value / 1_000_000).toFixed(1).replace(".", ",")} mi`;
+  }
+  if (value >= 1_000) {
+    return `R$ ${(value / 1_000).toFixed(0)} mil`;
+  }
+  return `R$ ${value.toFixed(0)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Severity mapping
+// ---------------------------------------------------------------------------
+
+const ALERT_STYLES: Record<string, string> = {
+  success: "bg-green-50 border-green-200 text-green-800",
+  warning: "bg-amber-50 border-amber-200 text-amber-800",
+  info: "bg-blue-50 border-blue-200 text-blue-800",
+};
+
+const ALERT_ICONS: Record<string, string> = {
+  expansao: "\u{1F30D}",        // globe
+  crescimento: "\u{1F4C8}",      // chart with up trend
+  dominio: "\u{1F3C6}",          // trophy
+  novo_entrante: "\u{1F680}",    // rocket
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function CompetitiveIntelBlock({
+  cnpj,
+}: CompetitiveIntelBlockProps) {
+  const [data, setData] = useState<IntelData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [hasAccess, setHasAccess] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
+
+    fetch(`${BACKEND_URL}/v1/intel-concorrente/fornecedor/${encodeURIComponent(cnpj)}`, {
+      credentials: "include",
+      signal: controller.signal,
+      headers: { "Accept": "application/json" },
+    })
+      .then((res) => {
+        if (res.status === 401 || res.status === 403 || res.status === 404) {
+          setHasAccess(false);
+          setData(null);
+          return null;
+        }
+        if (!res.ok) {
+          setHasAccess(false);
+          setData(null);
+          return null;
+        }
+        setHasAccess(true);
+        return res.json();
+      })
+      .then((json: IntelData | null) => {
+        if (json) setData(json);
+      })
+      .catch(() => {
+        // Silently fail — component renders nothing on error
+        setHasAccess(false);
+        setData(null);
+      })
+      .finally(() => setLoading(false));
+
+    return () => controller.abort();
+  }, [cnpj]);
+
+  // Render nothing while loading
+  if (loading) return null;
+
+  // Render nothing if no access
+  if (!hasAccess || !data) return null;
+
+  // Render nothing for suppliers with no contracts
+  if (data.concorrente.total_contratos === 0) return null;
+
+  const { concorrente, stats, alertas, territorio, win_metrics, orgaos_favoritos } = data;
+  const primaryUF = territorio.length > 0 ? territorio[0] : null;
+
+  return (
+    <section
+      data-testid="competitive-intel-block"
+      className="my-8 rounded-xl border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold text-gray-900">
+          {"Inteligência Concorrencial"}
+        </h2>
+        <span className="text-xs text-gray-400 bg-gray-100 px-2 py-1 rounded-full">
+          COMPINT
+        </span>
+      </div>
+
+      {/* Positioning Alerts */}
+      {alertas.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-5">
+          {alertas.map((alerta, i) => (
+            <div
+              key={i}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm ${ALERT_STYLES[alerta.severidade] || ALERT_STYLES.info}`}
+            >
+              <span>{ALERT_ICONS[alerta.tipo] || "\u{1F4CA}"}</span>
+              <span>{alerta.mensagem}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Mini Dashboard */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-5">
+        {/* Ticket médio vs mediana */}
+        <div className="bg-gray-50 rounded-lg p-3">
+          <p className="text-xs text-gray-500 mb-1">Ticket Médio</p>
+          <p className="text-lg font-bold text-gray-900">
+            {fmtBRL(concorrente.ticket_medio)}
+          </p>
+          <p className="text-xs text-gray-400">
+            Mediana: {fmtBRL(concorrente.ticket_mediana)}
+          </p>
+        </div>
+
+        {/* Market share primary UF */}
+        {primaryUF && primaryUF.market_share_uf != null && (
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 mb-1">Market Share</p>
+            <p className="text-lg font-bold text-gray-900">
+              {(primaryUF.market_share_uf * 100).toFixed(1)}%
+            </p>
+            <p className="text-xs text-gray-400">em {primaryUF.uf}</p>
+          </div>
+        )}
+
+        {/* Crescimento anual */}
+        {stats.crescimento_anual != null && (
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 mb-1">Crescimento Anual</p>
+            <p className={`text-lg font-bold ${stats.crescimento_anual >= 0 ? "text-green-600" : "text-red-600"}`}>
+              {stats.crescimento_anual >= 0 ? "+" : ""}
+              {stats.crescimento_anual.toFixed(0)}%
+            </p>
+            <p className="text-xs text-gray-400">últimos 12 meses</p>
+          </div>
+        )}
+
+        {/* UFs de atuação */}
+        <div className="bg-gray-50 rounded-lg p-3">
+          <p className="text-xs text-gray-500 mb-1">UFs de Atuação</p>
+          <p className="text-lg font-bold text-gray-900">{stats.ufs_atuacao}</p>
+          <p className="text-xs text-gray-400">
+            {territorio.slice(0, 3).map((t) => t.uf).join(", ")}
+            {territorio.length > 3 && "..."}
+          </p>
+        </div>
+      </div>
+
+      {/* Win metrics row */}
+      {win_metrics && (win_metrics.taxa_vitoria_estimada != null || win_metrics.ticket_p50 != null) && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-5">
+          {win_metrics.taxa_vitoria_estimada != null && (
+            <div className="bg-indigo-50 rounded-lg p-3">
+              <p className="text-xs text-indigo-500 mb-1">Taxa de Vitória Est.</p>
+              <p className="text-lg font-bold text-indigo-700">
+                {(win_metrics.taxa_vitoria_estimada * 100).toFixed(1)}%
+              </p>
+            </div>
+          )}
+          {win_metrics.ticket_p50 != null && (
+            <div className="bg-indigo-50 rounded-lg p-3">
+              <p className="text-xs text-indigo-500 mb-1">Ticket Mediano (P50)</p>
+              <p className="text-lg font-bold text-indigo-700">
+                {fmtBRL(win_metrics.ticket_p50)}
+              </p>
+            </div>
+          )}
+          {win_metrics.tendencia && (
+            <div className="bg-indigo-50 rounded-lg p-3">
+              <p className="text-xs text-indigo-500 mb-1">Tendência</p>
+              <p className="text-lg font-bold text-indigo-700 capitalize">
+                {win_metrics.tendencia === "crescendo" ? "\u{2191} Crescendo" :
+                 win_metrics.tendencia === "retraindo" ? "\u{2193} Retraindo" :
+                 win_metrics.tendencia === "estavel" ? "\u{2192} Estável" :
+                 win_metrics.tendencia}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Favorite agencies snippet */}
+      {orgaos_favoritos.length > 0 && (
+        <div className="mb-5">
+          <p className="text-sm font-medium text-gray-700 mb-2">
+            Principais Órgãos Compradores
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {orgaos_favoritos.slice(0, 4).map((orgao, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-gray-100 text-xs text-gray-700"
+              >
+                <span>{orgao.orgao_nome}</span>
+                <span className="text-gray-400">({orgao.contratos} contratos)</span>
+              </span>
+            ))}
+            {orgaos_favoritos.length > 4 && (
+              <span className="text-xs text-gray-400 self-center">
+                +{orgaos_favoritos.length - 4}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* CTA: full dossier */}
+      <div className="border-t border-gray-100 pt-4 mt-2">
+        <Link
+          href={`/intel-concorrente?cnpj=${encodeURIComponent(cnpj)}`}
+          className="inline-flex items-center gap-2 text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors"
+          data-testid="competitive-intel-cta"
+        >
+          {"Ver inteligência competitiva completa →"}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/fornecedores/[cnpj]/page.tsx
+++ b/frontend/app/fornecedores/[cnpj]/page.tsx
@@ -13,6 +13,7 @@ import PreviewCTA from '@/app/components/programmatic/PreviewCTA';
 import { OpportunitySignalsPanel } from '@/app/components/OpportunitySignalsPanel';
 import AhaMomentPanel from '@/app/components/AhaMomentPanel';
 import { SubcontratacaoFornecedorBlock } from '@/app/components/SubcontratacaoFornecedorBlock';
+import CompetitiveIntelBlock from './components/CompetitiveIntelBlock';
 import type { InsightCard } from '@/app/components/AhaMomentPanel';
 import { resolveJourney } from '@/lib/seo/relatedResolver';
 import { JourneyLinks } from '@/app/components/navigation/JourneyLinks';
@@ -623,6 +624,9 @@ export default async function FornecedorCnpjPage({ params }: Props) {
             cnpj={cnpj}
             razaoSocial={profile.razao_social}
           />
+
+          {/* COMPINT-011 (#1663): Competitive Intelligence block — additive premium section */}
+          <CompetitiveIntelBlock cnpj={cnpj} />
 
           {/* FAQ */}
           <section className="mb-8">


### PR DESCRIPTION
## Summary

COMPINT-011 (Wave 1 do EPIC-COMPINT #1261): Bloco aditivo de Inteligência Concorrencial na página `/fornecedores/[cnpj]`.

Estritamente aditivo — não modifica layout ou comportamento existente da página.

## Changes

### Backend
- **`backend/schemas/competitive_intel.py`** — `FornecedorIntelResponse` schema
- **`backend/routes/competitive_intel.py`** — `GET /v1/intel-concorrente/fornecedor/{cnpj}`
  - Gated by COMPETITIVE_INTEL_ENABLED + allow_competitive_intel capability
  - Consumes competitor_territory_map (COMPINT-001) e competitor_win_metrics (COMPINT-002) RPCs
- **`backend/startup/routes.py`** — router registration
- **`backend/tests/test_competitive_intel.py`** — 6 tests

### Frontend
- **`frontend/app/fornecedores/[cnpj]/components/CompetitiveIntelBlock.tsx`** — Silent client component
- **`frontend/app/fornecedores/[cnpj]/page.tsx`** — Wire aditivo (após Subcontratação)
- **`frontend/__tests__/fornecedores/CompetitiveIntelBlock.test.tsx`** — Tests

Parent: #1261