### PR TITLE
feat(backend): NETINT-007 — ARQ cleanup job for network_events (#1677)

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -88,6 +88,12 @@ from config.features import (
     ZERO_MATCH_JOB_TIMEOUT_S,  # noqa: F401
     ZERO_MATCH_VALUE_RATIO,  # noqa: F401
     ZERO_RESULTS_RELAXATION_ENABLED,  # noqa: F401
+    # NETINT-007: network_events cleanup retention
+    NETWORK_EVENTS_RETENTION_DAYS,  # noqa: F401
+    NETWORK_EVENTS_AGG_WINDOW_DAYS,  # noqa: F401
+    NETWORK_EVENTS_WEEKLY_RETENTION_DAYS,  # noqa: F401
+    NETWORK_EVENTS_CLEANUP_HOUR,  # noqa: F401
+    NETWORK_EVENTS_CLEANUP_ENABLED,  # noqa: F401
     _feature_flag_cache,  # noqa: F401
     get_feature_flag,  # noqa: F401
     log_feature_flags,  # noqa: F401

--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -174,6 +174,13 @@ ATESTADOS_DISPONIVEIS: list[dict] = [
 # Plano Fundadores v2 (epic:fundadores) — kill switch for the lifetime offer
 FOUNDERS_OFFER_ENABLED: bool = str_to_bool(os.getenv("FOUNDERS_OFFER_ENABLED", "true"))
 
+# NETINT-007 (EPIC-NETINT #1263): network_events cleanup job retention config
+NETWORK_EVENTS_RETENTION_DAYS: int = int(os.getenv("NETWORK_EVENTS_RETENTION_DAYS", "365"))
+NETWORK_EVENTS_AGG_WINDOW_DAYS: int = int(os.getenv("NETWORK_EVENTS_AGG_WINDOW_DAYS", "7"))
+NETWORK_EVENTS_WEEKLY_RETENTION_DAYS: int = int(os.getenv("NETWORK_EVENTS_WEEKLY_RETENTION_DAYS", "730"))
+NETWORK_EVENTS_CLEANUP_HOUR: int = int(os.getenv("NETWORK_EVENTS_CLEANUP_HOUR", "3"))
+NETWORK_EVENTS_CLEANUP_ENABLED: bool = str_to_bool(os.getenv("NETWORK_EVENTS_CLEANUP_ENABLED", "true"))
+
 # A/B Testing
 AB_EXPERIMENTS_ENABLED: bool = str_to_bool(os.getenv("AB_EXPERIMENTS_ENABLED", "false"))
 AB_ACTIVE_EXPERIMENTS: str = os.getenv("AB_ACTIVE_EXPERIMENTS", "{}")
@@ -478,6 +485,12 @@ def validate_feature_flags() -> None:
     _check_float("TERM_SEARCH_VALUE_RANGE_MIN", "10000", min_val=0.0)
     _check_float("TERM_SEARCH_VALUE_RANGE_MAX", "50000000", min_val=0.0)
 
+    # NETINT-007: network_events cleanup retention validation
+    _check_int("NETWORK_EVENTS_RETENTION_DAYS", "365", min_val=30, max_val=730)
+    _check_int("NETWORK_EVENTS_AGG_WINDOW_DAYS", "7", min_val=1, max_val=90)
+    _check_int("NETWORK_EVENTS_WEEKLY_RETENTION_DAYS", "730", min_val=30, max_val=1460)
+    _check_int("NETWORK_EVENTS_CLEANUP_HOUR", "3", min_val=0, max_val=23)
+
     if errors:
         for error in errors:
             logger.critical("Invalid feature flag configuration: %s", error)
@@ -491,7 +504,7 @@ def validate_feature_flags() -> None:
 
 # Number of flags validated by validate_feature_flags() — used in log message above.
 # Update this constant whenever a new _check_* call is added.
-_VALIDATED_FLAG_COUNT = 34
+_VALIDATED_FLAG_COUNT = 38
 
 
 def log_feature_flags() -> None:

--- a/backend/jobs/cron/network_events_cleanup.py
+++ b/backend/jobs/cron/network_events_cleanup.py
@@ -1,0 +1,168 @@
+"""NETINT-007: ARQ weekly cleanup job for network_events aggregation tables.
+
+Runs Sunday at configurable hour (default 03:00 UTC). Performs two operations
+in isolated try/except blocks so a failure in step 1 does not prevent step 2:
+
+  1. Weekly rollup: read daily events older than
+     NETWORK_EVENTS_AGG_WINDOW_DAYS (default 7), aggregate in-memory by
+     ISO week, and upsert into network_events_agg_weekly.
+
+  2. Prune: delete daily records older than
+     NETWORK_EVENTS_RETENTION_DAYS (default 365) and weekly records older
+     than NETWORK_EVENTS_WEEKLY_RETENTION_DAYS (default 730).
+
+Metrics:
+  - smartlic_network_cleanup_affected_rows: gauge set to total affected rows
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from logging import getLogger
+
+from supabase_client import get_supabase
+
+logger = getLogger(__name__)
+
+_DEFAULT_RETENTION_DAYS = 365
+_DEFAULT_WEEKLY_RETENTION_DAYS = 730
+_DEFAULT_AGG_WINDOW_DAYS = 7
+
+
+def _to_date(val) -> date | None:
+    """Safely convert a value to a date."""
+    if val is None:
+        return None
+    if isinstance(val, date):
+        return val
+    if isinstance(val, datetime):
+        return val.date()
+    try:
+        return datetime.strptime(str(val)[:10], "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _merge_metadados(metadados_list: list[dict]) -> dict:
+    """Merge a list of metadados dicts into a single dict with merged arrays."""
+    merged: dict[str, set] = {}
+    for md in metadados_list:
+        if not isinstance(md, dict):
+            continue
+        for k, v in md.items():
+            if k not in merged:
+                merged[k] = set()
+            if isinstance(v, list):
+                merged[k].update(str(item) for item in v)
+            elif v is not None:
+                merged[k].add(str(v))
+    return {k: list(v) if len(v) > 1 else list(v) for k, v in merged.items()}
+
+
+async def aggregate_and_cleanup_network_events(ctx: dict) -> dict:
+    """ARQ cron job: aggregate old events + prune expired records.
+
+    Returns a dict with step outcomes for logging/metrics:
+
+        {
+            "weekly_aggregated": int,
+            "daily_pruned": int,
+            "weekly_pruned": int,
+            "error": str | None
+        }
+    """
+    # Load config with graceful fallback.
+    # Use os.getenv directly so the value can be patched in tests.
+    import os as _os
+
+    _retention_str = _os.getenv("NETWORK_EVENTS_RETENTION_DAYS", str(_DEFAULT_RETENTION_DAYS))
+    _window_str = _os.getenv("NETWORK_EVENTS_AGG_WINDOW_DAYS", str(_DEFAULT_AGG_WINDOW_DAYS))
+    _weekly_ret_str = _os.getenv("NETWORK_EVENTS_WEEKLY_RETENTION_DAYS", str(_DEFAULT_WEEKLY_RETENTION_DAYS))
+    _hour_str = _os.getenv("NETWORK_EVENTS_CLEANUP_HOUR", "3")
+    _enabled_str = _os.getenv("NETWORK_EVENTS_CLEANUP_ENABLED", "true")
+
+    NETWORK_EVENTS_RETENTION_DAYS = int(_retention_str)
+    NETWORK_EVENTS_AGG_WINDOW_DAYS = int(_window_str)
+    NETWORK_EVENTS_WEEKLY_RETENTION_DAYS = int(_weekly_ret_str)
+    NETWORK_EVENTS_CLEANUP_ENABLED = _enabled_str.lower() in ("true", "1", "yes")
+
+    result: dict = {
+        "weekly_aggregated": 0,
+        "daily_pruned": 0,
+        "weekly_pruned": 0,
+        "error": None,
+    }
+
+    if not NETWORK_EVENTS_CLEANUP_ENABLED:
+        logger.info("network_events_cleanup: disabled")
+        return result
+
+    _ = ctx  # ARQ compatibility
+    db = get_supabase()
+
+    # ── Step 1: Weekly rollup ──────────────────────────────────────────────
+    cutoff = date.today() - timedelta(days=NETWORK_EVENTS_AGG_WINDOW_DAYS)
+    try:
+        daily_resp = await db.table("network_events_agg")\
+            .select("evento_tipo, dimensao_tipo, dimensao_valor, periodo, contagem, metadados")\
+            .lt("periodo", cutoff.isoformat())\
+            .execute()
+        daily_rows = daily_resp.data if daily_resp and daily_resp.data else []
+
+        if daily_rows:
+            weekly: defaultdict = defaultdict(lambda: {"contagem": 0, "metadados": []})
+            for row in daily_rows:
+                p = _to_date(row.get("periodo"))
+                if p is None:
+                    continue
+                week_start = p - timedelta(days=p.weekday())
+                key = (row["evento_tipo"], row["dimensao_tipo"], row["dimensao_valor"], week_start.isoformat())
+                weekly[key]["contagem"] += (row.get("contagem") or 0)
+                weekly[key]["metadados"].append(row.get("metadados") or {})
+
+            upserted = 0
+            for (evt, dim_t, dim_v, wk), agg in weekly.items():
+                await db.table("network_events_agg_weekly").upsert({
+                    "evento_tipo": evt,
+                    "dimensao_tipo": dim_t,
+                    "dimensao_valor": dim_v,
+                    "semana_inicio": wk,
+                    "contagem": agg["contagem"],
+                    "metadados": _merge_metadados(agg["metadados"]),
+                }, on_conflict=["evento_tipo", "dimensao_tipo", "dimensao_valor", "semana_inicio"]).execute()
+                upserted += 1
+            result["weekly_aggregated"] = upserted
+
+        logger.info("weekly aggregation: %d rows", result["weekly_aggregated"])
+    except Exception as e:
+        result["error"] = f"Weekly aggregation failed: {e}"
+        logger.error("cleanup step1: %s", result["error"])
+
+    # ── Step 2: Prune ──────────────────────────────────────────────────────
+    daily_cutoff = date.today() - timedelta(days=NETWORK_EVENTS_RETENTION_DAYS)
+    weekly_cutoff = date.today() - timedelta(days=NETWORK_EVENTS_WEEKLY_RETENTION_DAYS)
+    try:
+        del_daily = await db.table("network_events_agg").delete().lt("periodo", daily_cutoff.isoformat()).execute()
+        result["daily_pruned"] = len(del_daily.data) if del_daily and del_daily.data else 0
+
+        del_weekly = await db.table("network_events_agg_weekly").delete().lt("semana_inicio", weekly_cutoff.isoformat()).execute()
+        result["weekly_pruned"] = len(del_weekly.data) if del_weekly and del_weekly.data else 0
+
+        logger.info("prune: daily=%d weekly=%d", result["daily_pruned"], result["weekly_pruned"])
+    except Exception as e:
+        err = f"Prune step failed: {e}"
+        logger.error("cleanup step2: %s", err)
+        if result["error"] is None:
+            result["error"] = err
+
+    # Prometheus metric
+    try:
+        from metrics import NETWORK_CLEANUP_AFFECTED_ROWS as gauge
+        gauge.set(result["weekly_aggregated"] + result["daily_pruned"] + result["weekly_pruned"])
+    except Exception:
+        pass
+
+    logger.info("cleanup complete: aggregated=%d pruned_daily=%d pruned_weekly=%d",
+                result["weekly_aggregated"], result["daily_pruned"], result["weekly_pruned"])
+    return result

--- a/backend/jobs/queue/config.py
+++ b/backend/jobs/queue/config.py
@@ -57,6 +57,17 @@ try:
     except ImportError:
         pass
 
+    # NETINT-007: weekly network_events cleanup job (Sun at configurable hour, default 03:00 UTC).
+    try:
+        from config import NETWORK_EVENTS_CLEANUP_HOUR, NETWORK_EVENTS_CLEANUP_ENABLED
+        if NETWORK_EVENTS_CLEANUP_ENABLED:
+            from jobs.cron.network_events_cleanup import aggregate_and_cleanup_network_events
+            _worker_cron_jobs.append(
+                _arq_cron(aggregate_and_cleanup_network_events, weekday={6}, hour={NETWORK_EVENTS_CLEANUP_HOUR}, minute=0, timeout=600)
+            )
+    except ImportError:
+        pass
+
     try:
         from ingestion.config import DATALAKE_ENABLED
         if DATALAKE_ENABLED:
@@ -195,6 +206,13 @@ class WorkerSettings:
         )
         _lead_magnet_functions = []
 
+    # NETINT-007: network_events cleanup function (weekly cron).
+    try:
+        from jobs.cron.network_events_cleanup import aggregate_and_cleanup_network_events as _network_events_cleanup_func
+        _network_events_functions = [_network_events_cleanup_func]
+    except ImportError:
+        _network_events_functions = []
+
     functions = [
         llm_summary_job, excel_generation_job, search_job,
         bid_analysis_job, daily_digest_job, email_alerts_job,
@@ -207,6 +225,7 @@ class WorkerSettings:
         *_monitoring_functions,
         *_founders_functions,
         *_lead_magnet_functions,
+        *_network_events_functions,
     ]
     cron_jobs = _worker_cron_jobs
     on_startup = _worker_on_startup

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1310,6 +1310,11 @@ FEEDBACK_NEGATIVE_TOTAL = _create_counter(
 )
 
 # STORY-SEO-005: GSC weekly sync observability
+NETWORK_CLEANUP_AFFECTED_ROWS = _create_gauge(
+    "smartlic_network_cleanup_affected_rows",
+    "NETINT-007: Rows affected by the last network_events cleanup run",
+)
+
 smartlic_gsc_sync_duration_seconds = _create_histogram(
     "smartlic_gsc_sync_duration_seconds",
     "Duration of the weekly Google Search Console sync job",

--- a/backend/tests/test_network_events_cleanup.py
+++ b/backend/tests/test_network_events_cleanup.py
@@ -1,0 +1,199 @@
+"""Tests for NETINT-007 — network_events cleanup ARQ cron job (Issue #1677).
+
+Validates:
+  - Migration file structure (UP + DOWN)
+  - Job logic (aggregation, prune, error isolation)
+  - Config defaults
+  - Edge cases (empty table, no records to prune, error isolation)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATIONS_DIR = REPO_ROOT / "supabase" / "migrations"
+
+MIGRATION_TIMESTAMP = "20260612100000"
+UP_FILE = f"{MIGRATION_TIMESTAMP}_network_events_agg_weekly.sql"
+DOWN_FILE = f"{MIGRATION_TIMESTAMP}_network_events_agg_weekly.down.sql"
+
+
+def load_migration(filename: str) -> str:
+    """Load a migration SQL file from the supabase migrations directory."""
+    path = MIGRATIONS_DIR / filename
+    assert path.exists(), f"Migration not found: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Migration Structure Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestMigrationFileStructure:
+    """AC: Migration files exist and have correct structure."""
+
+    def test_up_migration_exists(self):
+        """UP migration file must exist."""
+        assert (MIGRATIONS_DIR / UP_FILE).exists()
+        assert (MIGRATIONS_DIR / UP_FILE).stat().st_size > 0
+
+    def test_down_migration_exists(self):
+        """DOWN migration file must exist."""
+        assert (MIGRATIONS_DIR / DOWN_FILE).exists()
+        assert (MIGRATIONS_DIR / DOWN_FILE).stat().st_size > 0
+
+    def test_up_contains_begin_commit(self):
+        """UP migration is wrapped in BEGIN / COMMIT."""
+        sql = load_migration(UP_FILE)
+        assert "BEGIN;" in sql
+        assert sql.strip().endswith("COMMIT;")
+
+    def test_up_creates_weekly_table(self):
+        """UP migration creates network_events_agg_weekly."""
+        sql = load_migration(UP_FILE)
+        assert "CREATE TABLE IF NOT EXISTS public.network_events_agg_weekly" in sql
+
+    def test_up_has_unique_constraint(self):
+        sql = load_migration(UP_FILE)
+        assert "network_events_agg_weekly_unique" in sql
+
+    def test_down_drops_table(self):
+        sql = load_migration(DOWN_FILE)
+        assert "DROP TABLE IF EXISTS public.network_events_agg_weekly" in sql
+
+    def test_down_drops_policies(self):
+        sql = load_migration(DOWN_FILE)
+        assert "DROP POLICY IF EXISTS" in sql
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Config defaults
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCleanupConfig:
+    """AC: Config defaults are reasonable for production."""
+
+    def test_retention_days_default(self):
+        import config.features as f
+        assert f.NETWORK_EVENTS_RETENTION_DAYS == 365
+
+    def test_agg_window_days_default(self):
+        import config.features as f
+        assert f.NETWORK_EVENTS_AGG_WINDOW_DAYS == 7
+
+    def test_weekly_retention_days_default(self):
+        import config.features as f
+        assert f.NETWORK_EVENTS_WEEKLY_RETENTION_DAYS == 730
+
+    def test_cleanup_hour_default(self):
+        import config.features as f
+        assert f.NETWORK_EVENTS_CLEANUP_HOUR == 3
+
+    def test_cleanup_enabled_default(self):
+        import config.features as f
+        assert f.NETWORK_EVENTS_CLEANUP_ENABLED is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Job logic tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _make_async_exec(data_val=None, exception=None):
+    """Return a chain MagicMock with an async execute() method."""
+    chain = MagicMock()
+    exec_fn = AsyncMock()
+    resp = MagicMock()
+    resp.data = data_val
+    exec_fn.return_value = resp
+    if exception:
+        exec_fn.side_effect = exception
+    chain.execute = exec_fn
+    # Support chaining like .lt().gt() etc
+    chain.select = MagicMock(return_value=chain)
+    chain.lt = MagicMock(return_value=chain)
+    chain.delete = MagicMock(return_value=chain)
+    chain.upsert = MagicMock(return_value=chain)
+    chain.order = MagicMock(return_value=chain)
+    chain.limit = MagicMock(return_value=chain)
+    chain.eq = MagicMock(return_value=chain)
+    chain.gte = MagicMock(return_value=chain)
+    return chain
+
+
+def _make_db_mock():
+    """Create a mock Supabase client with async-capable table methods."""
+    db = MagicMock()
+
+    def _table_side_effect(name):
+        chain = _make_async_exec(data_val=[])
+        return chain
+
+    db.table.side_effect = _table_side_effect
+    return db
+
+
+class TestCleanupJob:
+    """AC: Job handles various states correctly."""
+
+    @patch("jobs.cron.network_events_cleanup.get_supabase")
+    async def test_empty_table_no_error(self, mock_get_supabase):
+        """AC: Job does not fail on empty table."""
+        db = _make_db_mock()
+        db.table.return_value.execute = AsyncMock(return_value=MagicMock(data=[]))
+        mock_get_supabase.return_value = db
+
+        from jobs.cron.network_events_cleanup import aggregate_and_cleanup_network_events
+        result = await aggregate_and_cleanup_network_events({})
+
+        assert result["weekly_aggregated"] == 0
+        assert result["daily_pruned"] == 0
+        assert result["weekly_pruned"] == 0
+        assert result["error"] is None
+
+    @patch("jobs.cron.network_events_cleanup.get_supabase")
+    @patch.dict("os.environ", {"NETWORK_EVENTS_CLEANUP_ENABLED": "false"}, clear=False)
+    async def test_disabled_via_config(self, mock_get_supabase):
+        """AC: Job is a no-op when disabled."""
+        from jobs.cron.network_events_cleanup import aggregate_and_cleanup_network_events
+        result = await aggregate_and_cleanup_network_events({})
+
+        assert result["error"] is None
+        assert result["weekly_aggregated"] == 0
+        mock_get_supabase.assert_not_called()
+
+    @patch("jobs.cron.network_events_cleanup.get_supabase")
+    async def test_error_isolation_step1_fails_step2_runs(self, mock_get_supabase):
+        """AC: Error in step 1 does not block step 2."""
+        db = MagicMock()
+
+        # Step 1 select throws
+        chain1 = _make_async_exec(exception=Exception("DB error"))
+        # Step 2 delete succeeds
+        chain2 = _make_async_exec(data_val=[{"id": "1"}], exception=None)
+
+        call_count = [0]
+
+        def _table_side(name):
+            c = call_count[0]
+            call_count[0] += 1
+            if c == 0:
+                return chain1  # select for aggregation (fails)
+            return chain2  # delete (succeeds)
+
+        db.table.side_effect = _table_side
+        mock_get_supabase.return_value = db
+
+        from jobs.cron.network_events_cleanup import aggregate_and_cleanup_network_events
+        result = await aggregate_and_cleanup_network_events({})
+
+        assert result["weekly_aggregated"] == 0
+        assert result["error"] is not None
+        assert "Weekly aggregation failed" in result["error"]
+        # prune still happened
+        assert result["daily_pruned"] == 1

--- a/supabase/migrations/20260612100000_network_events_agg_weekly.down.sql
+++ b/supabase/migrations/20260612100000_network_events_agg_weekly.down.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- DOWN: NETINT-007 — Reverte migration network_events_agg_weekly
+-- Issue: #1677
+-- Epic: #1263 (EPIC-NETINT)
+-- ============================================================================
+-- Context:
+--   Reverte a migracao UP 20260612100000_network_events_agg_weekly.sql.
+--   Remove tabela, indices, RLS policies, constraints e grants.
+-- ============================================================================
+
+BEGIN;
+
+-- Remover RLS policies
+DROP POLICY IF EXISTS "network_events_agg_weekly_select_anon" ON public.network_events_agg_weekly;
+DROP POLICY IF EXISTS "network_events_agg_weekly_select_authenticated" ON public.network_events_agg_weekly;
+DROP POLICY IF EXISTS "network_events_agg_weekly_select_service_role" ON public.network_events_agg_weekly;
+
+-- Remover constraints e indices
+ALTER TABLE IF EXISTS public.network_events_agg_weekly
+    DROP CONSTRAINT IF EXISTS network_events_agg_weekly_unique;
+
+DROP INDEX IF EXISTS idx_network_events_weekly_unique;
+DROP INDEX IF EXISTS idx_network_events_weekly_semana;
+DROP INDEX IF EXISTS idx_network_events_weekly_tipo_valor;
+
+-- Revoke grants (idempotente)
+REVOKE ALL ON public.network_events_agg_weekly FROM anon;
+REVOKE ALL ON public.network_events_agg_weekly FROM authenticated;
+REVOKE ALL ON public.network_events_agg_weekly FROM service_role;
+
+-- Remover tabela
+DROP TABLE IF EXISTS public.network_events_agg_weekly;
+
+COMMIT;

--- a/supabase/migrations/20260612100000_network_events_agg_weekly.sql
+++ b/supabase/migrations/20260612100000_network_events_agg_weekly.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- NETINT-007: Agregacao semanal e politica de retencao network_events
+-- Issue: #1677
+-- Epic: #1263 (EPIC-NETINT)
+-- ============================================================================
+-- Context:
+--   NETINT-001 criou network_events_agg (agregacao diaria). Sem politica de
+--   retencao, a tabela cresce sem limite — custo de armazenamento e degradacao
+--   de performance. Esta migration cria:
+--
+--   1. Tabela network_events_agg_weekly: agregacao semanal dos eventos diarios
+--      com mais de 7 dias, compactando 7 registros em 1 com contagem somada
+--      e metadados merged.
+--   2. Unique constraint: (evento_tipo, dimensao_tipo, dimensao_valor, semana_inicio)
+--   3. RLS: SELECT-only policies (dados agregados anonimos)
+--   4. Grants para anon, authenticated, service_role
+-- ============================================================================
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. Create network_events_agg_weekly table
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.network_events_agg_weekly (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    evento_tipo TEXT NOT NULL,
+    dimensao_tipo TEXT NOT NULL,
+    dimensao_valor TEXT NOT NULL,
+    semana_inicio DATE NOT NULL,
+    contagem INTEGER DEFAULT 1,
+    metadados JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+COMMENT ON TABLE public.network_events_agg_weekly IS
+    'NETINT-007: Agregacao semanal de eventos anonimos. 7 registros diarios → 1 semanal, contagem somada, metadados merged.';
+
+COMMENT ON COLUMN public.network_events_agg_weekly.evento_tipo IS
+    'Tipo do evento: search_query, sector_view, org_view, cnpj_lookup, discount_view, migration_view, competitor_view';
+
+COMMENT ON COLUMN public.network_events_agg_weekly.dimensao_tipo IS
+    'Tipo da dimensao: setor, uf, modalidade, orgao, municipio';
+
+COMMENT ON COLUMN public.network_events_agg_weekly.dimensao_valor IS
+    'Valor da dimensao (ex: "saude", "SP", "pregao") — nunca PII';
+
+COMMENT ON COLUMN public.network_events_agg_weekly.semana_inicio IS
+    'Data de inicio da semana (segunda-feira) — ISO week start';
+
+COMMENT ON COLUMN public.network_events_agg_weekly.contagem IS
+    'Contagem agregada de eventos na semana — soma dos registros diarios';
+
+COMMENT ON COLUMN public.network_events_agg_weekly.metadados IS
+    'Metadados merged da semana: {"setores": [], "ufs": [], "modalidades": []}. NUNCA user_id, cnpj, email, ip.';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. Indexes
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_network_events_weekly_semana
+    ON public.network_events_agg_weekly (semana_inicio, evento_tipo, dimensao_tipo);
+
+CREATE INDEX IF NOT EXISTS idx_network_events_weekly_tipo_valor
+    ON public.network_events_agg_weekly (evento_tipo, dimensao_valor);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. Unique constraint
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_network_events_weekly_unique
+    ON public.network_events_agg_weekly (evento_tipo, dimensao_tipo, dimensao_valor, semana_inicio);
+
+ALTER TABLE public.network_events_agg_weekly
+    ADD CONSTRAINT network_events_agg_weekly_unique
+    UNIQUE USING INDEX idx_network_events_weekly_unique;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. RLS — SELECT-only policies (INSERT via job ARQ com service_role)
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.network_events_agg_weekly ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "network_events_agg_weekly_select_anon"
+    ON public.network_events_agg_weekly
+    FOR SELECT
+    TO anon
+    USING (true);
+
+CREATE POLICY "network_events_agg_weekly_select_authenticated"
+    ON public.network_events_agg_weekly
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+CREATE POLICY "network_events_agg_weekly_select_service_role"
+    ON public.network_events_agg_weekly
+    FOR SELECT
+    TO service_role
+    USING (true);
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 5. Grants
+-- ────────────────────────────────────────────────────────────────────────────
+
+GRANT SELECT ON public.network_events_agg_weekly TO anon;
+GRANT SELECT ON public.network_events_agg_weekly TO authenticated;
+GRANT SELECT ON public.network_events_agg_weekly TO service_role;
+
+-- INSERT/UPDATE/DELETE via service_role apenas (job ARQ)
+GRANT INSERT, UPDATE, DELETE ON public.network_events_agg_weekly TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## Summary

NETINT-007 — ARQ weekly cleanup job for network_events aggregation tables.

## Changes

### Migration
- New `network_events_agg_weekly` table with RLS policies, indexes, and unique constraint on (evento_tipo, dimensao_tipo, dimensao_valor, semana_inicio)
- Paired .down.sql for clean rollback

### Config
- `NETWORK_EVENTS_RETENTION_DAYS` (default 365)
- `NETWORK_EVENTS_AGG_WINDOW_DAYS` (default 7)
- `NETWORK_EVENTS_WEEKLY_RETENTION_DAYS` (default 730)
- `NETWORK_EVENTS_CLEANUP_HOUR` (default 3)
- `NETWORK_EVENTS_CLEANUP_ENABLED` (default true)

### ARQ Cron Job
- Runs Sunday at configurable hour (default 03:00 UTC)
- Step 1: aggregate daily events >7d into weekly table (sum contagem, merge metadados)
- Step 2: prune daily records >365d and weekly records >730d
- Error isolation: step failure does not block the other step
- Prometheus metric: `smartlic_network_cleanup_affected_rows`

### Tests
- Migration structure validation (UP + DOWN, table creation, unique constraint, RLS)
- Config defaults verification
- Job edge cases: empty table no-error, disabled via config, error isolation (step 1 fails, step 2 still runs)

## Related
- Parent: EPIC-NETINT #1263