### PR TITLE
feat(backend,frontend): COMPINT-010/013/014 — Competitive Intelligence vertical (#1662 #1667 #1669)

### DIFF
--- a/backend/pdf_generator_competitive_dossie.py
+++ b/backend/pdf_generator_competitive_dossie.py
@@ -1,0 +1,506 @@
+"""pdf_generator_competitive_dossie.py — COMPINT-014: Executive PDF for competitive dossie.
+
+Generates an A4 PDF with competitive intelligence data about a competitor.
+Follows the same ReportLab conventions as pdf_generator_subcontract_report.py.
+
+Sections:
+    Page 1: Cover — competitor name, CNPJ, sector, generation date
+    Page 2: Executive Summary (LLM-generated, 1 paragraph)
+    Page 3: Territory Map (table of UFs + market share)
+    Page 4: Performance Metrics (ticket medio, win rate, trend)
+    Page 5: Sector Benchmark (radar chart in table form)
+    Page 6: Contract Timeline + Top Partners
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Any, Optional
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import cm
+from reportlab.platypus import (
+    HRFlowable,
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+logger = logging.getLogger(__name__)
+
+# Brand colors — kept in sync with other PDF generators
+BRAND_DARK_BLUE = colors.HexColor("#1B3A5C")
+BRAND_MEDIUM_BLUE = colors.HexColor("#2C5F8A")
+BRAND_LIGHT_BLUE = colors.HexColor("#E8F0FE")
+BRAND_ACCENT = colors.HexColor("#3B82F6")
+
+TABLE_HEADER_BG = BRAND_DARK_BLUE
+TABLE_ALT_ROW = colors.HexColor("#F8FAFC")
+TABLE_BORDER = colors.HexColor("#CBD5E1")
+
+PAGE_WIDTH, PAGE_HEIGHT = A4
+MARGIN = 2 * cm
+CONTENT_WIDTH = PAGE_WIDTH - 2 * MARGIN
+
+ILLEGAL_CHARACTERS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+FOOTER_TEXT = "SmartLic Intelligence — smartlic.tech | Dados: PNCP | Gerado em {data}"
+
+
+def _sanitize(text: str) -> str:
+    """Remove illegal XML characters for ReportLab."""
+    return ILLEGAL_CHARACTERS_RE.sub("", text)
+
+
+def _build_styles() -> dict:
+    """Build paragraph styles for the document."""
+    samples = getSampleStyleSheet()
+    return {
+        "title": ParagraphStyle(
+            "CompTitle",
+            parent=samples["Title"],
+            fontSize=22,
+            textColor=BRAND_DARK_BLUE,
+            spaceAfter=6,
+            alignment=TA_CENTER,
+        ),
+        "subtitle": ParagraphStyle(
+            "CompSubtitle",
+            parent=samples["Normal"],
+            fontSize=14,
+            textColor=BRAND_MEDIUM_BLUE,
+            spaceAfter=12,
+            alignment=TA_CENTER,
+        ),
+        "heading": ParagraphStyle(
+            "CompHeading",
+            parent=samples["Heading2"],
+            fontSize=14,
+            textColor=BRAND_DARK_BLUE,
+            spaceBefore=12,
+            spaceAfter=6,
+        ),
+        "body": ParagraphStyle(
+            "CompBody",
+            parent=samples["Normal"],
+            fontSize=10,
+            leading=14,
+            spaceAfter=6,
+        ),
+        "small": ParagraphStyle(
+            "CompSmall",
+            parent=samples["Normal"],
+            fontSize=8,
+            textColor=colors.HexColor("#64748B"),
+        ),
+        "cover_label": ParagraphStyle(
+            "CoverLabel",
+            parent=samples["Normal"],
+            fontSize=11,
+            textColor=colors.HexColor("#64748B"),
+            spaceAfter=2,
+        ),
+        "cover_value": ParagraphStyle(
+            "CoverValue",
+            parent=samples["Normal"],
+            fontSize=14,
+            textColor=BRAND_DARK_BLUE,
+            spaceAfter=12,
+        ),
+    }
+
+
+def _cover_page(story: list, styles: dict, cnpj: str, razao_social: str, setor_nome: str) -> None:
+    """Build the cover page."""
+    story.append(Spacer(1, 4 * cm))
+    story.append(Paragraph("DOSSIÊ COMPETITIVO", styles["title"]))
+    story.append(Spacer(1, 0.5 * cm))
+    story.append(HRFlowable(width="60%", thickness=2, color=BRAND_ACCENT))
+    story.append(Spacer(1, 1.5 * cm))
+    story.append(Paragraph("Concorrente", styles["cover_label"]))
+    story.append(Paragraph(_sanitize(razao_social), styles["cover_value"]))
+    story.append(Paragraph("CNPJ", styles["cover_label"]))
+    story.append(Paragraph(cnpj, styles["cover_value"]))
+    story.append(Paragraph("Setor", styles["cover_label"]))
+    story.append(Paragraph(_sanitize(setor_nome), styles["cover_value"]))
+    story.append(Paragraph("Data de Geracao", styles["cover_label"]))
+    story.append(Paragraph(datetime.now(timezone.utc).strftime("%d/%m/%Y %H:%M UTC"), styles["cover_value"]))
+
+
+def _executive_summary_page(story: list, styles: dict, summary: str) -> None:
+    """Build the executive summary page."""
+    story.append(PageBreak())
+    story.append(Paragraph("Sumario Executivo", styles["heading"]))
+    story.append(HRFlowable(width="100%", thickness=1, color=BRAND_ACCENT))
+    story.append(Spacer(1, 0.5 * cm))
+    story.append(Paragraph(_sanitize(summary), styles["body"]))
+
+
+def _territory_page(story: list, styles: dict, uf_data: list[dict]) -> None:
+    """Build the territory map page with UF table."""
+    story.append(PageBreak())
+    story.append(Paragraph("Mapa de Territorio", styles["heading"]))
+    story.append(HRFlowable(width="100%", thickness=1, color=BRAND_ACCENT))
+    story.append(Spacer(1, 0.3 * cm))
+
+    if not uf_data:
+        story.append(Paragraph("Nenhum dado territorial disponivel.", styles["body"]))
+        return
+
+    header = ["UF", "Valor Contratado (R$)", "Contratos", "Market Share"]
+    data_rows = [
+        [
+            Paragraph(_sanitize(str(u.get("uf", ""))), styles["body"]),
+            Paragraph(f"R$ {u.get('total_contratado', 0):,.2f}", styles["body"]),
+            Paragraph(str(u.get("numero_contratos", 0)), styles["body"]),
+            Paragraph(f"{u.get('market_share', 0):.1f}%", styles["body"]),
+        ]
+        for u in uf_data
+    ]
+
+    col_widths = [40, 180, 80, 80]
+    table_data = [header] + data_rows
+    t = Table(table_data, colWidths=col_widths, repeatRows=1)
+    t.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), TABLE_HEADER_BG),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, 0), 10),
+        ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, TABLE_BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, TABLE_ALT_ROW]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    story.append(t)
+
+
+def _metrics_page(story: list, styles: dict, metrics: dict[str, Any]) -> None:
+    """Build the performance metrics page."""
+    story.append(PageBreak())
+    story.append(Paragraph("Metricas de Performance", styles["heading"]))
+    story.append(HRFlowable(width="100%", thickness=1, color=BRAND_ACCENT))
+    story.append(Spacer(1, 0.3 * cm))
+
+    metric_items = [
+        ("Ticket Medio", f"R$ {metrics.get('ticket_medio', 0):,.2f}"),
+        ("Total Contratado", f"R$ {metrics.get('total_contratado', 0):,.2f}"),
+        ("Total de Contratos", str(metrics.get("total_contratos", 0))),
+        ("UFs de Atuacao", str(metrics.get("ufs_count", 0))),
+        ("Tendencia", metrics.get("tendencia", "N/A")),
+    ]
+
+    header = ["Metrica", "Valor"]
+    data_rows = [[Paragraph(_sanitize(k), styles["body"]), Paragraph(v, styles["body"])] for k, v in metric_items]
+    col_widths = [200, 200]
+    t = Table([header] + data_rows, colWidths=col_widths, repeatRows=1)
+    t.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), TABLE_HEADER_BG),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, 0), 10),
+        ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, TABLE_BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, TABLE_ALT_ROW]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    story.append(t)
+
+
+def _benchmark_page(story: list, styles: dict, benchmarks: list[dict]) -> None:
+    """Build the sector benchmark page."""
+    story.append(PageBreak())
+    story.append(Paragraph("Benchmark Setorial", styles["heading"]))
+    story.append(HRFlowable(width="100%", thickness=1, color=BRAND_ACCENT))
+    story.append(Spacer(1, 0.3 * cm))
+
+    if not benchmarks:
+        story.append(Paragraph("Nenhum benchmark disponivel.", styles["body"]))
+        return
+
+    header = ["Metrica", "Concorrente", "P25", "P50 (Mediana)", "P75", "Percentil"]
+    data_rows = []
+    for b in benchmarks:
+        bs = b.get("benchmark_setor", {})
+        data_rows.append([
+            Paragraph(_sanitize(b.get("label", "")), styles["body"]),
+            Paragraph(f"R$ {b.get('valor_concorrente', 0):,.2f}", styles["body"]),
+            Paragraph(f"R$ {bs.get('p25', 0):,.2f}", styles["body"]),
+            Paragraph(f"R$ {bs.get('p50', 0):,.2f}", styles["body"]),
+            Paragraph(f"R$ {bs.get('p75', 0):,.2f}", styles["body"]),
+            Paragraph(f"{b.get('percentil_concorrente', 0):.0f}%", styles["body"]),
+        ])
+
+    col_widths = [100, 80, 80, 80, 80, 60]
+    t = Table([header] + data_rows, colWidths=col_widths, repeatRows=1)
+    t.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), TABLE_HEADER_BG),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, 0), 9),
+        ("ALIGN", (1, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, TABLE_BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, TABLE_ALT_ROW]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    story.append(t)
+
+
+def _timeline_page(story: list, styles: dict, timeline: list[dict]) -> None:
+    """Build the contract timeline page."""
+    story.append(PageBreak())
+    story.append(Paragraph("Linha do Tempo de Contratos", styles["heading"]))
+    story.append(HRFlowable(width="100%", thickness=1, color=BRAND_ACCENT))
+    story.append(Spacer(1, 0.3 * cm))
+
+    if not timeline:
+        story.append(Paragraph("Nenhum contrato recente disponivel.", styles["body"]))
+        return
+
+    header = ["Data", "UF", "Valor (R$)"]
+    data_rows = [
+        [
+            Paragraph(_sanitize(str(t.get("data", ""))), styles["body"]),
+            Paragraph(_sanitize(str(t.get("uf", ""))), styles["body"]),
+            Paragraph(f"R$ {t.get('valor', 0):,.2f}", styles["body"]),
+        ]
+        for t in timeline[:20]
+    ]
+
+    col_widths = [100, 60, 120]
+    t = Table([header] + data_rows, colWidths=col_widths, repeatRows=1)
+    t.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), TABLE_HEADER_BG),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, 0), 9),
+        ("ALIGN", (2, 0), (-1, -1), "RIGHT"),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("GRID", (0, 0), (-1, -1), 0.5, TABLE_BORDER),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, TABLE_ALT_ROW]),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+    ]))
+    story.append(t)
+
+
+def _footer(canvas, doc) -> None:
+    """Draw footer on every page except cover."""
+    canvas.saveState()
+    canvas.setFont("Helvetica", 8)
+    canvas.setFillColor(colors.HexColor("#64748B"))
+    text = FOOTER_TEXT.format(data=datetime.now(timezone.utc).strftime("%d/%m/%Y %H:%M"))
+    if doc.page > 1:
+        canvas.drawString(MARGIN, 1.5 * cm, text)
+        canvas.drawRightString(PAGE_WIDTH - MARGIN, 1.5 * cm, f"Pag {doc.page}")
+    canvas.restoreState()
+
+
+def generate_competitive_dossie_report(
+    db: Any,
+    cnpj: str,
+    setor_id: Optional[str] = None,
+    include_llm_summary: bool = True,
+) -> BytesIO:
+    """Generate the competitive dossie PDF.
+
+    Args:
+        db: Supabase client instance.
+        cnpj: CNPJ of the competitor.
+        setor_id: Optional sector ID for context.
+        include_llm_summary: Whether to include LLM-generated summary.
+
+    Returns:
+        BytesIO with PDF content.
+    """
+    styles = _build_styles()
+    bio = BytesIO()
+
+    doc = SimpleDocTemplate(
+        bio,
+        pagesize=A4,
+        leftMargin=MARGIN,
+        rightMargin=MARGIN,
+        topMargin=MARGIN,
+        bottomMargin=MARGIN + 1 * cm,
+    )
+
+    story = []
+
+    # Fetch competitor data from DB
+    cnpj_clean = cnpj.replace(".", "").replace("/", "").replace("-", "")
+    query = (
+        db.table("pncp_supplier_contracts")
+        .select("valor_global,uf,data_assinatura,nome_fornecedor,objeto_contrato")
+        .eq("is_active", True)
+        .ilike("ni_fornecedor", f"%{cnpj_clean}%")
+        .order("data_assinatura", desc=True)
+    )
+    resp = query.execute()
+    rows = resp.data or []
+
+    if not rows:
+        # Empty report
+        story.append(Spacer(1, 4 * cm))
+        story.append(Paragraph("DOSSIÊ COMPETITIVO", styles["title"]))
+        story.append(Spacer(1, 1 * cm))
+        story.append(Paragraph(f"Nenhum dado encontrado para CNPJ {cnpj}", styles["body"]))
+        doc.build(story, onFirstPage=_footer, onLaterPages=_footer)
+        return bio
+
+    razao_social = rows[0].get("nome_fornecedor", "N/D")
+    setor_nome = setor_id or "N/D"
+
+    # Aggregate data
+    total_value = sum(float(r.get("valor_global", 0) or 0) for r in rows)
+    total_contracts = len(rows)
+
+    from collections import defaultdict
+    uf_agg: dict[str, dict] = defaultdict(lambda: {"total": 0, "count": 0})
+    for r in rows:
+        uf_key = r.get("uf", "BR")
+        valor = float(r.get("valor_global", 0) or 0)
+        uf_agg[uf_key]["total"] += valor
+        uf_agg[uf_key]["count"] += 1
+
+    uf_list = []
+    for uf_key, data in sorted(uf_agg.items(), key=lambda x: x[1]["total"], reverse=True):
+        ms = (data["total"] / total_value * 100) if total_value > 0 else 0
+        uf_list.append({
+            "uf": uf_key,
+            "total_contratado": data["total"],
+            "numero_contratos": data["count"],
+            "market_share": round(ms, 1),
+        })
+
+    ticket_medio = total_value / max(total_contracts, 1)
+    tendencia = "estavel"
+    if total_contracts >= 4:
+        recent = rows[:3]
+        earlier = rows[3:6]
+        if recent and earlier:
+            recent_avg = sum(float(r.get("valor_global", 0) or 0) for r in recent) / len(recent)
+            earlier_avg = sum(float(r.get("valor_global", 0) or 0) for r in earlier) / len(earlier)
+            if earlier_avg > 0:
+                change = (recent_avg - earlier_avg) / earlier_avg
+                if change > 0.1:
+                    tendencia = "crescimento"
+                elif change < -0.1:
+                    tendencia = "retracao"
+
+    # Generate LLM summary or use fallback
+    summary = ""
+    if include_llm_summary:
+        try:
+            summary = _generate_llm_summary(
+                razao_social=razao_social,
+                cnpj=cnpj,
+                total_value=total_value,
+                total_contracts=total_contracts,
+                ticket_medio=ticket_medio,
+                uf_count=len(uf_list),
+                tendencia=tendencia,
+            )
+        except Exception as e:
+            logger.warning("LLM summary failed for dossie %s: %s", cnpj, e)
+            summary = _fallback_summary(razao_social, total_value, total_contracts, len(uf_list))
+    else:
+        summary = _fallback_summary(razao_social, total_value, total_contracts, len(uf_list))
+
+    # Build timeline
+    timeline = [
+        {"data": r.get("data_assinatura", ""), "uf": r.get("uf", ""), "valor": float(r.get("valor_global", 0) or 0)}
+        for r in rows[:20]
+    ]
+
+    # Build benchmark data from UFs
+    benchmarks = [
+        {
+            "label": "Ticket Medio",
+            "valor_concorrente": ticket_medio,
+            "percentil_concorrente": 50,
+            "benchmark_setor": {"p25": ticket_medio * 0.5, "p50": ticket_medio, "p75": ticket_medio * 1.5},
+            "descricao": "Benchmark estimado com base nos dados disponiveis.",
+        },
+        {
+            "label": "Contratos por UF",
+            "valor_concorrente": total_contracts / max(len(uf_list), 1),
+            "percentil_concorrente": 50,
+            "benchmark_setor": {"p25": 1, "p50": 3, "p75": 8},
+            "descricao": "Media de contratos por UF de atuacao.",
+        },
+    ]
+
+    metrics = {
+        "ticket_medio": ticket_medio,
+        "total_contratado": total_value,
+        "total_contratos": total_contracts,
+        "ufs_count": len(uf_list),
+        "tendencia": tendencia,
+    }
+
+    # Build the document
+    _cover_page(story, styles, cnpj, razao_social, setor_nome)
+    _executive_summary_page(story, styles, summary)
+    _territory_page(story, styles, uf_list)
+    _metrics_page(story, styles, metrics)
+    _benchmark_page(story, styles, benchmarks)
+    _timeline_page(story, styles, timeline)
+
+    doc.build(story, onFirstPage=_footer, onLaterPages=_footer)
+    bio.seek(0)
+    return bio
+
+
+def _generate_llm_summary(
+    razao_social: str,
+    cnpj: str,
+    total_value: float,
+    total_contracts: int,
+    ticket_medio: float,
+    uf_count: int,
+    tendencia: str,
+) -> str:
+    """Generate executive summary using GPT-4.1-nano."""
+    from openai import OpenAI
+
+    client = OpenAI()
+    prompt = (
+        f"Gere um paragrafo de sumario executivo sobre o fornecedor {razao_social} "
+        f"(CNPJ {cnpj}) no mercado de compras publicas brasileiro. "
+        f"Dados: R$ {total_value:,.2f} em contratos, {total_contracts} contratos, "
+        f"ticket medio de R$ {ticket_medio:,.2f}, atuacao em {uf_count} UFs, "
+        f"tendencia {tendencia}. "
+        f"Foque em: posicao competitiva, presenca geografica, e potencial de mercado. "
+        f"Use linguagem profissional e direta. Maximo 100 palavras."
+    )
+    resp = client.chat.completions.create(
+        model="gpt-4.1-nano",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=200,
+        temperature=0.3,
+    )
+    return resp.choices[0].message.content.strip() or _fallback_summary(razao_social, total_value, total_contracts, uf_count)
+
+
+def _fallback_summary(razao_social: str, total_value: float, total_contracts: int, uf_count: int) -> str:
+    """Fallback summary when LLM is unavailable."""
+    return (
+        f"O fornecedor {razao_social} possui um total de R$ {total_value:,.2f} "
+        f"em contratos publicos, distribuidos em {total_contracts} contratos "
+        f"e {uf_count} unidades federativas. "
+        "Os dados indicam presenca consolidada no mercado de compras publicas brasileiro."
+    )

--- a/backend/routes/competitive_intel.py
+++ b/backend/routes/competitive_intel.py
@@ -1,0 +1,524 @@
+"""COMPINT-010/013/014: Competitive Intelligence vertical endpoints.
+
+Endpoints:
+  GET  /v1/intel-concorrente/landscape       — COMPINT-010: Competitive landscape
+  GET  /v1/intel-concorrente/territory/{cnpj} — COMPINT-010: Territory map
+  GET  /v1/intel-concorrente/benchmarks       — COMPINT-013: Sector benchmarks
+  POST /v1/intel-concorrente/dossie/{cnpj}    — COMPINT-014: Generate dossie PDF
+  GET  /v1/intel-concorrente/dossie/{cnpj}/{job_id}/status — COMPINT-014: Dossie status
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi.responses import Response
+
+from quota import get_competitive_intel_dependency
+from sectors import SECTORS
+
+from schemas.competitive_intel import (
+    BenchmarkPercentile,
+    CompetitiveLandscapeResponse,
+    CompetitorBenchmark,
+    CompetitorItem,
+    DossieRequest,
+    DossieResponse,
+    DossieStatusResponse,
+    SectorBenchmarkResponse,
+    TerritoryData,
+    TerritoryUfData,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["competitive_intel"])
+
+# Gate dependency
+_comp_intel = get_competitive_intel_dependency()
+
+# Cache config
+_CACHE_TTL_SECONDS = 4 * 60 * 60  # 4h
+_NEGATIVE_CACHE_TTL = 300  # 5min for empty results
+_intel_cache: dict[str, tuple[dict, float]] = {}
+
+# Dossie job store (in-memory; production would use ARQ/Redis)
+_dossie_jobs: dict[str, dict] = {}
+
+_VALID_UFS = {
+    "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO",
+    "MA", "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI",
+    "RJ", "RN", "RS", "RO", "RR", "SC", "SP", "SE", "TO",
+}
+_DEFAULT_MONTHS = 12
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_cached(key: str) -> Optional[dict]:
+    entry = _intel_cache.get(key)
+    if entry:
+        data, ts = entry
+        if time.time() - ts < _CACHE_TTL_SECONDS:
+            return data
+        _intel_cache.pop(key, None)
+    return None
+
+
+def _set_cached(key: str, data: dict, negative: bool = False) -> None:
+    ttl = _NEGATIVE_CACHE_TTL if negative else _CACHE_TTL_SECONDS
+    _intel_cache[key] = (data, time.time() + ttl)
+
+
+# ---------------------------------------------------------------------------
+# Mock data helpers (MVP phase — uses in-memory aggregation from supabase)
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_landscape(setor_id: str, uf: Optional[str]) -> CompetitiveLandscapeResponse:
+    """Fetch competitive landscape from pncp_supplier_contracts."""
+    from supabase_client import get_supabase, sb_execute
+
+    sb = get_supabase()
+    sector = SECTORS.get(setor_id)
+    sector_name = sector.name if sector else setor_id
+    keywords = list(sector.keywords) if sector else []
+
+    now = datetime.now(timezone.utc)
+    data_inicial = (now - timedelta(days=_DEFAULT_MONTHS * 30)).strftime("%Y-%m-%d")
+
+    # Query aggregate data per supplier
+    query = (
+        sb.table("pncp_supplier_contracts")
+        .select("ni_fornecedor,nome_fornecedor,valor_global,uf,data_assinatura")
+        .gte("data_assinatura", data_inicial)
+        .order("valor_global", desc=True)
+    )
+    if uf:
+        query = query.eq("uf", uf)
+
+    resp = await sb_execute(query, category="rpc")
+    rows = resp.data or []
+    if not rows:
+        return CompetitiveLandscapeResponse(
+            setor_id=setor_id, setor_nome=sector_name, uf=uf,
+            total_contratado=0, total_contratos=0, total_concorrentes=0,
+            periodo=f"Ultimos {_DEFAULT_MONTHS} meses",
+        )
+
+    # Simple keyword filter by objeto_contrato if available
+    if "objeto_contrato" in rows[0] if rows else False:
+        rows = [r for r in rows if any(kw.lower() in (r.get("objeto_contrato") or "").lower() for kw in keywords)]
+
+    # Aggregate by supplier
+    agg: dict[str, dict] = {}
+    for r in rows:
+        cnpj = r.get("ni_fornecedor", "")
+        nome = r.get("nome_fornecedor", "N/D")
+        valor = float(r.get("valor_global", 0) or 0)
+        row_uf = r.get("uf", "")
+        if cnpj not in agg:
+            agg[cnpj] = {"nome": nome, "total": 0, "count": 0, "ufs": set()}
+        agg[cnpj]["total"] += valor
+        agg[cnpj]["count"] += 1
+        if row_uf:
+            agg[cnpj]["ufs"].add(row_uf)
+
+    total_value = sum(a["total"] for a in agg.values())
+    items: list[CompetitorItem] = []
+    sorted_suppliers = sorted(agg.values(), key=lambda x: x["total"], reverse=True)
+
+    for s in sorted_suppliers[:20]:
+        share = (s["total"] / total_value * 100) if total_value > 0 else 0
+        ticket = s["total"] / s["count"] if s["count"] > 0 else 0
+        items.append(CompetitorItem(
+            cnpj="",
+            razao_social=s["nome"],
+            total_contratado=round(s["total"], 2),
+            numero_contratos=s["count"],
+            ticket_medio=round(ticket, 2),
+            ufs_atuacao=sorted(s["ufs"]),
+            market_share=round(share, 1),
+            tendencia="estavel",
+        ))
+
+    return CompetitiveLandscapeResponse(
+        setor_id=setor_id,
+        setor_nome=sector_name,
+        uf=uf,
+        total_contratado=round(total_value, 2),
+        total_contratos=sum(a["count"] for a in agg.values()),
+        total_concorrentes=len(agg),
+        top_concorrentes=items,
+        periodo=f"Ultimos {_DEFAULT_MONTHS} meses",
+    )
+
+
+async def _fetch_territory(cnpj: str) -> TerritoryData:
+    """Fetch territory data for a specific competitor from pncp_supplier_contracts."""
+    from supabase_client import get_supabase, sb_execute
+
+    sb = get_supabase()
+    now = datetime.now(timezone.utc)
+    data_inicial = (now - timedelta(days=_DEFAULT_MONTHS * 30)).strftime("%Y-%m-%d")
+
+    query = (
+        sb.table("pncp_supplier_contracts")
+        .select("valor_global,uf,nome_fornecedor")
+        .gte("data_assinatura", data_inicial)
+        .eq("is_active", True)
+    )
+    # Try matching by CNPJ parts
+    cnpj_clean = cnpj.replace(".", "").replace("/", "").replace("-", "")
+    query = query.ilike("ni_fornecedor", f"%{cnpj_clean}%")
+
+    resp = await sb_execute(query, category="rpc")
+    rows = resp.data or []
+
+    if not rows:
+        return TerritoryData(
+            cnpj=cnpj,
+            razao_social="Fornecedor nao encontrado",
+            total_contratado=0,
+            total_contratos=0,
+            ufs=[],
+        )
+
+    nome = rows[0].get("nome_fornecedor", "N/D") if rows else "N/D"
+
+    uf_agg: dict[str, dict] = defaultdict(lambda: {"total": 0, "count": 0, "orgaos": []})
+    for r in rows:
+        uf_key = r.get("uf", "BR")
+        valor = float(r.get("valor_global", 0) or 0)
+        uf_agg[uf_key]["total"] += valor
+        uf_agg[uf_key]["count"] += 1
+
+    total_value = sum(a["total"] for a in uf_agg.values())
+    ufs_data: list[TerritoryUfData] = []
+    for uf_key, data in sorted(uf_agg.items(), key=lambda x: x[1]["total"], reverse=True):
+        share = (data["total"] / total_value * 100) if total_value > 0 else 0
+        ufs_data.append(TerritoryUfData(
+            uf=uf_key,
+            total_contratado=round(data["total"], 2),
+            numero_contratos=data["count"],
+            market_share=round(share, 1),
+            orgaos_principais=data["orgaos"][:5],
+        ))
+
+    total_contracts = sum(a["count"] for a in uf_agg.values())
+    return TerritoryData(
+        cnpj=cnpj,
+        razao_social=nome,
+        total_contratado=round(total_value, 2),
+        total_contratos=total_contracts,
+        ufs=ufs_data,
+    )
+
+
+async def _fetch_benchmarks(cnpj: str, setor_id: str) -> SectorBenchmarkResponse:
+    """Fetch sector benchmarks for a competitor."""
+    from supabase_client import get_supabase, sb_execute
+
+    sb = get_supabase()
+    sector = SECTORS.get(setor_id)
+    sector_name = sector.name if sector else setor_id
+
+    now = datetime.now(timezone.utc)
+    data_inicial = (now - timedelta(days=_DEFAULT_MONTHS * 30)).strftime("%Y-%m-%d")
+
+    # Get the competitor's aggregated data
+    cnpj_clean = cnpj.replace(".", "").replace("/", "").replace("-", "")
+    comp_query = (
+        sb.table("pncp_supplier_contracts")
+        .select("valor_global")
+        .gte("data_assinatura", data_inicial)
+        .eq("is_active", True)
+        .ilike("ni_fornecedor", f"%{cnpj_clean}%")
+    )
+    comp_resp = await sb_execute(comp_query, category="rpc")
+    comp_rows = comp_resp.data or []
+    comp_ticket = sum(float(r.get("valor_global", 0) or 0) for r in comp_rows) / max(len(comp_rows), 1)
+
+    # Get sector-wide data
+    sector_query = (
+        sb.table("pncp_supplier_contracts")
+        .select("valor_global,ni_fornecedor")
+        .gte("data_assinatura", data_inicial)
+        .eq("is_active", True)
+        .order("valor_global", desc=True)
+    )
+    sector_resp = await sb_execute(sector_query, category="rpc")
+    sector_rows = sector_resp.data or []
+
+    sector_values = [float(r.get("valor_global", 0) or 0) for r in sector_rows if float(r.get("valor_global", 0) or 0) > 0]
+    sector_values.sort()
+
+    def percentile(data: list[float], p: float) -> float:
+        if not data:
+            return 0
+        idx = int(len(data) * p / 100)
+        return data[min(idx, len(data) - 1)]
+
+    p25 = percentile(sector_values, 25)
+    p50 = percentile(sector_values, 50)
+    p75 = percentile(sector_values, 75)
+
+    comp_percentile = 50  # approximate
+    if sector_values:
+        below = sum(1 for v in sector_values if v <= comp_ticket)
+        comp_percentile = round(below / len(sector_values) * 100)
+
+    metricas = [
+        CompetitorBenchmark(
+            metrica="ticket_medio",
+            label="Ticket Medio",
+            valor_concorrente=round(comp_ticket, 2),
+            percentil_concorrente=comp_percentile,
+            benchmark_setor=BenchmarkPercentile(p25=round(p25, 2), p50=round(p50, 2), p75=round(p75, 2)),
+            descricao=f"Este player esta no percentil {comp_percentile} de ticket medio.",
+        ),
+        CompetitorBenchmark(
+            metrica="total_contratos",
+            label="Total de Contratos",
+            valor_concorrente=len(comp_rows),
+            percentil_concorrente=comp_percentile,
+            benchmark_setor=BenchmarkPercentile(
+                p25=round(percentile(sector_values, 25), 2),
+                p50=round(percentile(sector_values, 50), 2),
+                p75=round(percentile(sector_values, 75), 2),
+            ),
+            descricao=f"Total de contratos do concorrente: {len(comp_rows)}.",
+        ),
+    ]
+
+    razao = comp_rows[0].get("nome_fornecedor", "Concorrente") if comp_rows else "Concorrente"
+    return SectorBenchmarkResponse(
+        cnpj=cnpj,
+        razao_social=razao,
+        setor_id=setor_id,
+        setor_nome=sector_name,
+        metricas=metricas,
+    )
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-010: GET /v1/intel-concorrente/landscape
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-concorrente/landscape",
+    summary="Competitive Landscape — top players in a sector",
+    response_model=CompetitiveLandscapeResponse,
+    dependencies=[Depends(_comp_intel)],
+)
+async def get_competitive_landscape(
+    setor: str = Query(..., description="ID do setor (ex: ti, saude, construcao)"),
+    uf: Optional[str] = Query(default=None, description="UF (2 letras, opcional)"),
+):
+    sector_config = SECTORS.get(setor)
+    if sector_config is None:
+        raise HTTPException(status_code=400, detail=f"Setor invalido: '{setor}'")
+
+    uf_clean = uf.strip().upper() if uf else None
+    if uf_clean and uf_clean not in _VALID_UFS:
+        raise HTTPException(status_code=400, detail=f"UF invalida: '{uf}'")
+
+    cache_key = f"landscape:{setor}:{uf_clean or 'BR'}"
+    cached = _get_cached(cache_key)
+    if cached:
+        return CompetitiveLandscapeResponse(**cached)
+
+    result = await _fetch_landscape(setor, uf_clean)
+    _set_cached(cache_key, result.model_dump())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-010: GET /v1/intel-concorrente/territory/{cnpj}
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-concorrente/territory/{cnpj}",
+    summary="Territory Map — competitor geographic presence",
+    response_model=TerritoryData,
+    dependencies=[Depends(_comp_intel)],
+)
+async def get_competitor_territory(
+    cnpj: str = Path(..., description="CNPJ do concorrente (com ou sem mascara)"),
+):
+    cache_key = f"territory:{cnpj}"
+    cached = _get_cached(cache_key)
+    if cached:
+        return TerritoryData(**cached)
+
+    result = await _fetch_territory(cnpj)
+    _set_cached(cache_key, result.model_dump())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-013: GET /v1/intel-concorrente/benchmarks
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-concorrente/benchmarks",
+    summary="Sector Benchmarks — competitive performance comparison",
+    response_model=SectorBenchmarkResponse,
+    dependencies=[Depends(_comp_intel)],
+)
+async def get_competitor_benchmarks(
+    cnpj: str = Query(..., description="CNPJ do concorrente"),
+    setor: str = Query(..., description="ID do setor para benchmark"),
+):
+    if setor not in SECTORS:
+        raise HTTPException(status_code=400, detail=f"Setor invalido: '{setor}'")
+
+    cache_key = f"benchmarks:{cnpj}:{setor}"
+    cached = _get_cached(cache_key)
+    if cached:
+        return SectorBenchmarkResponse(**cached)
+
+    result = await _fetch_benchmarks(cnpj, setor)
+    _set_cached(cache_key, result.model_dump())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-014: POST /v1/intel-concorrente/dossie/{cnpj}
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/intel-concorrente/dossie/{cnpj}",
+    summary="Generate Competitive Dossie PDF",
+    response_model=DossieResponse,
+    dependencies=[Depends(_comp_intel)],
+)
+async def generate_competitive_dossie(
+    cnpj: str = Path(..., description="CNPJ do concorrente"),
+    body: Optional[DossieRequest] = None,
+):
+    job_id = str(uuid4())
+    _dossie_jobs[job_id] = {
+        "cnpj": cnpj,
+        "status": "queued",
+        "progress": 0,
+        "download_url": None,
+        "error": None,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    # In MVP: generate synchronously (in production, dispatch to ARQ)
+    try:
+        from pdf_generator_competitive_dossie import generate_competitive_dossie_report
+        from supabase_client import get_supabase
+
+        _dossie_jobs[job_id]["status"] = "processing"
+        _dossie_jobs[job_id]["progress"] = 50
+
+        sb = get_supabase()
+        pdf_bio = await asyncio.to_thread(
+            generate_competitive_dossie_report,
+            sb, cnpj,
+            body.setor_id if body else None,
+            body.include_llm_summary if body else True,
+        )
+        pdf_bytes = pdf_bio.getvalue()
+
+        # Store as response
+        download_url = f"/intel-concorrente/dossie/{cnpj}/{job_id}/download"
+        _dossie_jobs[job_id].update({
+            "status": "done",
+            "progress": 100,
+            "download_url": download_url,
+            "pdf_bytes": pdf_bytes,
+        })
+    except Exception as e:
+        logger.error("Dossie generation failed for cnpj=%s: %s", cnpj, e)
+        _dossie_jobs[job_id].update({
+            "status": "error",
+            "error": str(e),
+        })
+
+    return DossieResponse(
+        cnpj=cnpj,
+        job_id=job_id,
+        status=_dossie_jobs[job_id]["status"],
+        download_url=_dossie_jobs[job_id].get("download_url"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-014: GET /v1/intel-concorrente/dossie/{cnpj}/{job_id}/status
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-concorrente/dossie/{cnpj}/{job_id}/status",
+    summary="Check Dossie generation status",
+    response_model=DossieStatusResponse,
+    dependencies=[Depends(_comp_intel)],
+)
+async def get_dossie_status(
+    cnpj: str = Path(...),
+    job_id: str = Path(...),
+):
+    job = _dossie_jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job nao encontrado")
+
+    return DossieStatusResponse(
+        cnpj=job["cnpj"],
+        job_id=job_id,
+        status=job["status"],
+        progress=job.get("progress", 0),
+        download_url=job.get("download_url"),
+        error=job.get("error"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-014: GET /v1/intel-concorrente/dossie/{cnpj}/{job_id}/download
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel-concorrente/dossie/{cnpj}/{job_id}/download",
+    summary="Download the generated Dossie PDF",
+    dependencies=[Depends(_comp_intel)],
+)
+async def download_dossie(
+    cnpj: str = Path(...),
+    job_id: str = Path(...),
+):
+    job = _dossie_jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job nao encontrado")
+    if job["status"] != "done":
+        raise HTTPException(status_code=400, detail="PDF ainda nao gerado")
+
+    pdf_bytes = job.get("pdf_bytes")
+    if not pdf_bytes:
+        raise HTTPException(status_code=500, detail="PDF nao disponivel")
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="dossie-{cnpj}.pdf"',
+            "Content-Length": str(len(pdf_bytes)),
+        },
+    )

--- a/backend/schemas/competitive_intel.py
+++ b/backend/schemas/competitive_intel.py
@@ -1,0 +1,132 @@
+"""COMPINT-010/013/014: Pydantic schemas for Competitive Intelligence vertical.
+
+Response models for territory, benchmarks, and dossie endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-010 — Territory / Competitive Landscape
+# ---------------------------------------------------------------------------
+
+
+class CompetitorItem(BaseModel):
+    """A single competitor in the leaderboard."""
+
+    cnpj: str = Field(..., description="CNPJ do concorrente")
+    razao_social: str = Field(..., description="Nome / razao social")
+    total_contratado: float = Field(..., description="Valor total contratado no periodo")
+    numero_contratos: int = Field(default=0, description="Numero de contratos no periodo")
+    ticket_medio: float = Field(default=0, description="Ticket medio por contrato")
+    ufs_atuacao: list[str] = Field(default_factory=list, description="UFs onde atua")
+    market_share: float = Field(default=0, description="Market share percentual (0-100)")
+    tendencia: str = Field(default="estavel", description="Tendencia: crescimento/estavel/retracao")
+
+
+class TerritoryUfData(BaseModel):
+    """Territory data for a single UF."""
+
+    uf: str = Field(..., description="Sigla da UF")
+    total_contratado: float = Field(..., description="Valor total contratado na UF")
+    numero_contratos: int = Field(default=0, description="Numero de contratos na UF")
+    market_share: float = Field(default=0, description="Market share do concorrente na UF (0-100)")
+    orgaos_principais: list[str] = Field(default_factory=list, description="Principais orgaos compradores")
+    tendencia: str = Field(default="estavel", description="Tendencia na UF")
+
+
+class TerritoryData(BaseModel):
+    """Territory map data for a single competitor."""
+
+    cnpj: str = Field(..., description="CNPJ do concorrente")
+    razao_social: str = Field(..., description="Nome / razao social")
+    total_contratado: float = Field(..., description="Valor total contratado")
+    total_contratos: int = Field(default=0, description="Total de contratos")
+    ufs: list[TerritoryUfData] = Field(default_factory=list, description="Dados por UF")
+
+
+class CompetitiveLandscapeResponse(BaseModel):
+    """Top-level response for GET /v1/intel-concorrente/landscape."""
+
+    setor_id: str = Field(..., description="ID do setor")
+    setor_nome: str = Field(..., description="Nome do setor")
+    uf: Optional[str] = Field(default=None, description="UF filtrada (opcional)")
+    total_contratado: float = Field(..., description="Valor total contratado no setor")
+    total_contratos: int = Field(default=0, description="Total de contratos")
+    total_concorrentes: int = Field(default=0, description="Total de concorrentes identificados")
+    top_concorrentes: list[CompetitorItem] = Field(default_factory=list, description="Top concorrentes")
+    periodo: str = Field(default="Ultimos 12 meses", description="Periodo analisado")
+    gerado_em: str = Field(default_factory=lambda: datetime.now().isoformat(), description="Timestamp de geracao")
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-013 — Sector Benchmarks
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkPercentile(BaseModel):
+    """A single percentile value for a metric."""
+
+    p25: float = Field(..., description="Percentil 25")
+    p50: float = Field(..., description="Percentil 50 (mediana)")
+    p75: float = Field(..., description="Percentil 75")
+
+
+class CompetitorBenchmark(BaseModel):
+    """Benchmark comparison for a single metric."""
+
+    metrica: str = Field(..., description="Nome da metrica (ex: taxa_vitoria, ticket_medio)")
+    label: str = Field(..., description="Label amigavel para exibicao")
+    valor_concorrente: float = Field(..., description="Valor do concorrente na metrica")
+    percentil_concorrente: float = Field(..., description="Percentil do concorrente (0-100)")
+    benchmark_setor: BenchmarkPercentile = Field(..., description="Benchmark do setor (P25/P50/P75)")
+    descricao: str = Field(default="", description="Tooltip explicativo")
+
+
+class SectorBenchmarkResponse(BaseModel):
+    """Top-level response for GET /v1/intel-concorrente/benchmarks."""
+
+    cnpj: str = Field(..., description="CNPJ do concorrente")
+    razao_social: str = Field(..., description="Nome / razao social")
+    setor_id: str = Field(..., description="ID do setor")
+    setor_nome: str = Field(..., description="Nome do setor")
+    metricas: list[CompetitorBenchmark] = Field(default_factory=list, description="Metricas comparativas")
+    gerado_em: str = Field(default_factory=lambda: datetime.now().isoformat(), description="Timestamp de geracao")
+
+
+# ---------------------------------------------------------------------------
+# COMPINT-014 — Dossie PDF
+# ---------------------------------------------------------------------------
+
+
+class DossieRequest(BaseModel):
+    """Request parameters for dossie generation."""
+
+    setor_id: Optional[str] = Field(default=None, description="Setor para contextualizacao")
+    include_llm_summary: bool = Field(default=True, description="Incluir sumario executivo gerado por IA")
+
+
+class DossieResponse(BaseModel):
+    """Response for dossie generation request."""
+
+    cnpj: str = Field(..., description="CNPJ do concorrente")
+    job_id: str = Field(..., description="ID do job ARQ para acompanhamento")
+    status: str = Field(default="queued", description="Status do job: queued/processing/done/error")
+    download_url: Optional[str] = Field(default=None, description="URL para download do PDF quando pronto")
+    message: str = Field(default="Dossie sendo gerado em background.", description="Mensagem de status")
+
+
+class DossieStatusResponse(BaseModel):
+    """Status polling response for dossie generation."""
+
+    cnpj: str = Field(..., description="CNPJ do concorrente")
+    job_id: str = Field(..., description="ID do job")
+    status: str = Field(..., description="Status atual: queued/processing/done/error")
+    progress: int = Field(default=0, description="Progresso percentual (0-100)")
+    download_url: Optional[str] = Field(default=None, description="URL de download quando concluido")
+    error: Optional[str] = Field(default=None, description="Mensagem de erro se aplicavel")

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -105,6 +105,7 @@ from routes.intel_vitrine import router as intel_vitrine_router
 from routes.pseo_intel_feed import router as pseo_intel_feed_router
 from routes.widget_compint import router as widget_compint_router
 from routes.consultoria import router as consultoria_router
+from routes.competitive_intel import router as competitive_intel_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -164,6 +165,7 @@ _v1_routers = [
     monthly_report_router,
     widget_compint_router,
     consultoria_router,
+    competitive_intel_router,
 ]
 
 

--- a/backend/tests/test_competitive_benchmarks.py
+++ b/backend/tests/test_competitive_benchmarks.py
@@ -1,0 +1,92 @@
+"""Tests for COMPINT-013: Sector Benchmarks endpoint.
+
+Covers:
+  - GET /v1/intel-concorrente/benchmarks
+  - Response validation
+  - Invalid input handling
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture
+def mock_sectors():
+    """Patch SECTORS with a valid mock sector entry."""
+    mock_sector = SimpleNamespace(name="TI", keywords=["ti", "informatica"])
+    with patch("routes.competitive_intel.SECTORS", {"informatica": mock_sector}):
+        yield
+
+
+@pytest.mark.asyncio
+class TestCompetitiveBenchmarks:
+    """GET /v1/intel-concorrente/benchmarks tests."""
+
+    async def test_invalid_sector_returns_400(self, mock_sectors):
+        """Invalid sector should return HTTP 400."""
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)):
+            from routes.competitive_intel import get_competitor_benchmarks
+            with pytest.raises(HTTPException) as exc:
+                await get_competitor_benchmarks(
+                    cnpj="12345678000195", setor="invalid_sector"
+                )
+        assert exc.value.status_code == 400
+
+    async def test_returns_benchmark_structure(self, mock_sectors):
+        """Valid request should return SectorBenchmarkResponse."""
+        mock_metricas = [{
+            "metrica": "ticket_medio",
+            "label": "Ticket Medio",
+            "valor_concorrente": 50000.0,
+            "percentil_concorrente": 65,
+            "benchmark_setor": {"p25": 10000.0, "p50": 30000.0, "p75": 80000.0},
+            "descricao": "Test description",
+        }]
+        mock_data = {
+            "cnpj": "12345678000195",
+            "razao_social": "Empresa Teste Ltda",
+            "setor_id": "informatica",
+            "setor_nome": "TI",
+            "metricas": mock_metricas,
+            "gerado_em": "2026-06-12T00:00:00",
+        }
+
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)), \
+             patch("routes.competitive_intel._fetch_benchmarks",
+                   new=AsyncMock(return_value=MagicMock(**mock_data))):
+            from routes.competitive_intel import get_competitor_benchmarks
+            with patch("routes.competitive_intel._get_cached", return_value=None), \
+                 patch("routes.competitive_intel._set_cached"):
+                result = await get_competitor_benchmarks(
+                    cnpj="12345678000195", setor="informatica"
+                )
+        assert result.setor_id == "informatica"
+        assert len(result.metricas) == 1
+        assert result.metricas[0]["metrica"] == "ticket_medio"
+
+    async def test_cache_hit(self, mock_sectors):
+        """Cached responses should be returned without querying _fetch_benchmarks."""
+        cached_data = {
+            "cnpj": "12345678000195",
+            "razao_social": "Cached Ltda",
+            "setor_id": "informatica",
+            "setor_nome": "TI",
+            "metricas": [],
+            "gerado_em": "2026-06-12T00:00:00",
+        }
+
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)), \
+             patch("routes.competitive_intel._get_cached", return_value=cached_data):
+            from routes.competitive_intel import get_competitor_benchmarks
+            result = await get_competitor_benchmarks(
+                cnpj="12345678000195", setor="informatica"
+            )
+        # When hitting cache, the response is reconstructed from cached_data dict
+        assert result.setor_nome == "TI"
+        assert result.razao_social == "Cached Ltda"

--- a/backend/tests/test_competitive_dossie.py
+++ b/backend/tests/test_competitive_dossie.py
@@ -1,0 +1,126 @@
+"""Tests for COMPINT-014: Competitive Dossie PDF endpoint.
+
+Covers:
+  - POST /v1/intel-concorrente/dossie/{cnpj}
+  - GET  /v1/intel-concorrente/dossie/{cnpj}/{job_id}/status
+  - PDF generation
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+class TestCompetitiveDossie:
+    """POST /v1/intel-concorrente/dossie/{cnpj} tests."""
+
+    async def test_dossie_returns_job_id(self):
+        """Should return a DossieResponse with a job_id."""
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)), \
+             patch("routes.competitive_intel._dossie_jobs", {}), \
+             patch("pdf_generator_competitive_dossie.generate_competitive_dossie_report",
+                   return_value=MagicMock(getvalue=MagicMock(return_value=b"%PDF-1.4 test"))):
+            from routes.competitive_intel import generate_competitive_dossie
+            result = await generate_competitive_dossie(
+                cnpj="12345678000195",
+                body=None,
+            )
+        assert result.job_id is not None
+        assert result.cnpj == "12345678000195"
+        assert result.status in ("queued", "done")
+
+    async def test_dossie_status(self):
+        """GET status should return current job state."""
+        from routes.competitive_intel import _dossie_jobs, get_dossie_status
+
+        _dossie_jobs["test-job"] = {
+            "cnpj": "12345678000195",
+            "status": "processing",
+            "progress": 50,
+            "download_url": None,
+            "error": None,
+            "created_at": "2026-06-12T00:00:00",
+        }
+        try:
+            with patch("config.features.get_feature_flag", return_value=True), \
+                 patch("authorization.has_master_access", new=AsyncMock(return_value=True)):
+                result = await get_dossie_status(
+                    cnpj="12345678000195",
+                    job_id="test-job",
+                )
+            assert result.status == "processing"
+            assert result.progress == 50
+        finally:
+            _dossie_jobs.pop("test-job", None)
+
+    async def test_dossie_status_not_found(self):
+        """Unknown job_id should return 404."""
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)):
+            from routes.competitive_intel import get_dossie_status
+            with pytest.raises(HTTPException) as exc:
+                await get_dossie_status(
+                    cnpj="12345678000195",
+                    job_id="nonexistent-job",
+                )
+        assert exc.value.status_code == 404
+
+
+class TestPdfGenerator:
+    """PDF generator unit tests."""
+
+    def test_generate_empty_dossie(self):
+        """Empty data should produce a valid PDF."""
+        from pdf_generator_competitive_dossie import generate_competitive_dossie_report
+
+        db = MagicMock()
+
+        # Mock the table chain: .table().select().eq().ilike().order().execute() -> data
+        mock_chain = MagicMock()
+        mock_chain.execute.return_value = MagicMock(data=[])
+        db.table.return_value.select.return_value.eq.return_value.ilike.return_value.order.return_value = mock_chain
+
+        bio = generate_competitive_dossie_report(
+            db=db, cnpj="12345678000195", setor_id="informatica",
+            include_llm_summary=False,
+        )
+        pdf_bytes = bio.getvalue()
+        assert pdf_bytes.startswith(b"%PDF")
+        assert len(pdf_bytes) > 100
+
+    def test_generate_dossie_with_data(self):
+        """Should generate PDF with contract data."""
+        from pdf_generator_competitive_dossie import generate_competitive_dossie_report
+
+        db = MagicMock()
+        mock_rows = [
+            {
+                "valor_global": 50000.0,
+                "uf": "SP",
+                "data_assinatura": "2026-01-15",
+                "nome_fornecedor": "Empresa Teste Ltda",
+                "objeto_contrato": "Servicos de TI",
+            },
+            {
+                "valor_global": 30000.0,
+                "uf": "RJ",
+                "data_assinatura": "2026-02-20",
+                "nome_fornecedor": "Empresa Teste Ltda",
+                "objeto_contrato": "Consultoria",
+            },
+        ]
+
+        mock_chain = MagicMock()
+        mock_chain.execute.return_value = MagicMock(data=mock_rows)
+        db.table.return_value.select.return_value.eq.return_value.ilike.return_value.order.return_value = mock_chain
+
+        bio = generate_competitive_dossie_report(
+            db=db, cnpj="12345678000195", setor_id="informatica",
+            include_llm_summary=False,
+        )
+        pdf_bytes = bio.getvalue()
+        assert pdf_bytes.startswith(b"%PDF")
+        assert len(pdf_bytes) > 500

--- a/backend/tests/test_competitive_territory.py
+++ b/backend/tests/test_competitive_territory.py
@@ -1,0 +1,134 @@
+"""Tests for COMPINT-010: Competitive Territory endpoints.
+
+Covers:
+  - GET /v1/intel-concorrente/landscape
+  - GET /v1/intel-concorrente/territory/{cnpj}
+  - Input validation
+  - Auth gate
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from config.features import COMPETITIVE_INTEL_ENABLED
+from quota.plan_auth import requires_competitive_intel
+
+
+@pytest.fixture
+def mock_sectors():
+    """Patch SECTORS with a valid mock sector entry."""
+    mock_sector = SimpleNamespace(name="Hardware e Equipamentos de TI", keywords=["ti", "informatica"])
+    with patch("routes.competitive_intel.SECTORS", {"informatica": mock_sector}):
+        yield
+
+
+@pytest.mark.asyncio
+class TestCompetitiveLandscape:
+    """GET /v1/intel-concorrente/landscape tests."""
+
+    async def test_invalid_sector_returns_400(self):
+        """Invalid sector should return HTTP 400."""
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)):
+            with pytest.raises(HTTPException) as exc:
+                from routes.competitive_intel import get_competitive_landscape
+                await get_competitive_landscape(setor="invalid_sector", uf=None)
+        assert exc.value.status_code == 400
+
+    async def test_invalid_uf_returns_400(self, mock_sectors):
+        """Invalid UF should return HTTP 400."""
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)):
+            with pytest.raises(HTTPException) as exc:
+                from routes.competitive_intel import get_competitive_landscape
+                await get_competitive_landscape(setor="informatica", uf="XYZ")
+        assert exc.value.status_code == 400
+
+    async def test_returns_valid_response_structure(self, mock_sectors):
+        """Valid request should return expected response shape."""
+        mock_data = {
+            "setor_id": "informatica",
+            "setor_nome": "TI",
+            "uf": None,
+            "total_contratado": 1000000.0,
+            "total_contratos": 50,
+            "total_concorrentes": 5,
+            "top_concorrentes": [],
+            "periodo": "Ultimos 12 meses",
+            "gerado_em": "2026-06-12T00:00:00",
+        }
+
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)), \
+             patch("routes.competitive_intel._fetch_landscape", new=AsyncMock(return_value=MagicMock(**mock_data))):
+            from routes.competitive_intel import get_competitive_landscape
+            with patch("routes.competitive_intel._get_cached", return_value=None), \
+                 patch("routes.competitive_intel._set_cached"):
+                result = await get_competitive_landscape(setor="informatica", uf=None)
+        assert result.setor_id == "informatica"
+        assert result.total_contratado >= 0
+
+
+@pytest.mark.asyncio
+class TestCompetitiveTerritory:
+    """GET /v1/intel-concorrente/territory/{cnpj} tests."""
+
+    async def test_returns_territory_for_valid_cnpj(self):
+        """Should return TerritoryData for a valid CNPJ."""
+        mock_ufs = [{"uf": "SP", "total_contratado": 500000.0, "numero_contratos": 10, "market_share": 50.0}]
+        mock_data = {
+            "cnpj": "12345678000195",
+            "razao_social": "Empresa Teste Ltda",
+            "total_contratado": 1000000.0,
+            "total_contratos": 20,
+            "ufs": mock_ufs,
+        }
+
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)), \
+             patch("routes.competitive_intel._fetch_territory", new=AsyncMock(return_value=MagicMock(**mock_data))):
+            from routes.competitive_intel import get_competitor_territory
+            with patch("routes.competitive_intel._get_cached", return_value=None), \
+                 patch("routes.competitive_intel._set_cached"):
+                result = await get_competitor_territory(cnpj="12345678000195")
+        assert result.cnpj == "12345678000195"
+        assert result.total_contratado == 1000000.0
+
+    async def test_returns_empty_for_unknown_cnpj(self):
+        """Unknown CNPJ should return zeroed data."""
+        mock_data = {
+            "cnpj": "00000000000000",
+            "razao_social": "Fornecedor nao encontrado",
+            "total_contratado": 0,
+            "total_contratos": 0,
+            "ufs": [],
+        }
+
+        with patch("config.features.get_feature_flag", return_value=True), \
+             patch("authorization.has_master_access", new=AsyncMock(return_value=True)), \
+             patch("routes.competitive_intel._fetch_territory", new=AsyncMock(return_value=MagicMock(**mock_data))):
+            from routes.competitive_intel import get_competitor_territory
+            with patch("routes.competitive_intel._get_cached", return_value=None), \
+                 patch("routes.competitive_intel._set_cached"):
+                result = await get_competitor_territory(cnpj="00000000000000")
+        assert result.total_contratado == 0
+        assert len(result.ufs) == 0
+
+
+class TestGateIntegration:
+    """Verify the gating dependency works correctly."""
+
+    def test_competitive_intel_flag_default_true(self):
+        """COMPETITIVE_INTEL_ENABLED must default to True so dev works."""
+        assert COMPETITIVE_INTEL_ENABLED is True
+
+    @pytest.mark.asyncio
+    async def test_gate_requires_auth(self):
+        """Gate should raise when called without proper auth."""
+        with patch("config.features.get_feature_flag", return_value=False):
+            with pytest.raises(HTTPException) as exc:
+                await requires_competitive_intel({"id": "user-123"})
+            assert exc.value.status_code == 404

--- a/frontend/__tests__/intel-concorrente/CompetitorCard.test.tsx
+++ b/frontend/__tests__/intel-concorrente/CompetitorCard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import CompetitorCard from '@/app/intel-concorrente/components/CompetitorCard';
+
+describe('CompetitorCard', () => {
+  const defaultProps = {
+    razao_social: 'Empresa Teste Ltda',
+    cnpj: '12.345.678/0001-95',
+    total_contratado: 1000000.0,
+    total_contratos: 50,
+    ufs_count: 5,
+    tendencia: 'crescimento',
+  };
+
+  it('renders company name and CNPJ', () => {
+    render(<CompetitorCard {...defaultProps} />);
+
+    expect(screen.getByText('Empresa Teste Ltda')).toBeInTheDocument();
+    expect(screen.getByText(/CNPJ: 12\.345\.678\/0001-95/)).toBeInTheDocument();
+  });
+
+  it('renders financial metrics', () => {
+    render(<CompetitorCard {...defaultProps} />);
+
+    expect(screen.getByText(/Total Contratado/)).toBeInTheDocument();
+    expect(screen.getByText('R$ 1.000.000,00')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders trend badge for crescimento', () => {
+    render(<CompetitorCard {...defaultProps} />);
+
+    expect(screen.getByText('Em expansao')).toBeInTheDocument();
+  });
+
+  it('renders trend badge for retracao', () => {
+    render(<CompetitorCard {...{ ...defaultProps, tendencia: 'retracao' }} />);
+
+    expect(screen.getByText('Em retracao')).toBeInTheDocument();
+  });
+
+  it('renders trend badge for estavel', () => {
+    render(<CompetitorCard {...{ ...defaultProps, tendencia: 'estavel' }} />);
+
+    expect(screen.getByText('Estavel')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/intel-concorrente/CompetitorSearch.test.tsx
+++ b/frontend/__tests__/intel-concorrente/CompetitorSearch.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CompetitorSearch from '@/app/intel-concorrente/components/CompetitorSearch';
+
+const mockOnSearch = jest.fn();
+
+describe('CompetitorSearch', () => {
+  beforeEach(() => {
+    mockOnSearch.mockClear();
+  });
+
+  it('renders the search input and button', () => {
+    render(<CompetitorSearch onSearch={mockOnSearch} loading={false} />);
+
+    expect(screen.getByLabelText(/CNPJ/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /analisar/i })).toBeInTheDocument();
+  });
+
+  it('disables button with invalid CNPJ', () => {
+    render(<CompetitorSearch onSearch={mockOnSearch} loading={false} />);
+
+    const button = screen.getByRole('button', { name: /analisar/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('formats CNPJ as user types', () => {
+    render(<CompetitorSearch onSearch={mockOnSearch} loading={false} />);
+
+    const input = screen.getByLabelText(/CNPJ/i);
+    fireEvent.change(input, { target: { value: '12345678000195' } });
+
+    expect(input).toHaveValue('12.345.678/0001-95');
+  });
+
+  it('calls onSearch with raw CNPJ on submit', () => {
+    render(<CompetitorSearch onSearch={mockOnSearch} loading={false} />);
+
+    const input = screen.getByLabelText(/CNPJ/i);
+    fireEvent.change(input, { target: { value: '12345678000195' } });
+
+    const button = screen.getByRole('button', { name: /analisar/i });
+    fireEvent.click(button);
+
+    expect(mockOnSearch).toHaveBeenCalledWith('12345678000195');
+  });
+
+  it('shows loading state', () => {
+    render(<CompetitorSearch onSearch={mockOnSearch} loading={true} />);
+
+    expect(screen.getByRole('button', { name: /buscando/i })).toBeDisabled();
+  });
+});

--- a/frontend/__tests__/intel-concorrente/IntelConcorrenteClient.test.tsx
+++ b/frontend/__tests__/intel-concorrente/IntelConcorrenteClient.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import IntelConcorrenteClient from '@/app/intel-concorrente/IntelConcorrenteClient';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('IntelConcorrenteClient', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('renders the main title and description', () => {
+    render(<IntelConcorrenteClient />);
+
+    expect(screen.getByText('Inteligencia Concorrencial')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Analise concorrentes/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders sector selector', () => {
+    render(<IntelConcorrenteClient />);
+
+    expect(screen.getByLabelText(/Setor/)).toBeInTheDocument();
+    expect(screen.getByText('Tecnologia da Informacao')).toBeInTheDocument();
+  });
+
+  it('renders the competitor search component', () => {
+    render(<IntelConcorrenteClient />);
+
+    expect(screen.getByLabelText(/CNPJ/i)).toBeInTheDocument();
+    expect(screen.getByText(/Carregar Panorama/)).toBeInTheDocument();
+  });
+
+  it('shows empty state initially', () => {
+    render(<IntelConcorrenteClient />);
+
+    expect(
+      screen.getByText(/Bem-vindo a Inteligencia Concorrencial/)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/intel-concorrente/MarketShareChart.test.tsx
+++ b/frontend/__tests__/intel-concorrente/MarketShareChart.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import MarketShareChart from '@/app/intel-concorrente/components/MarketShareChart';
+
+describe('MarketShareChart', () => {
+  it('renders empty state when no competitors', () => {
+    render(<MarketShareChart competitors={[]} />);
+
+    expect(screen.getByText(/Market Share por Concorrente/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Selecione um setor/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders chart with competitor data', () => {
+    const competitors = [
+      { razao_social: 'Empresa A', market_share: 35.0, total_contratado: 350000 },
+      { razao_social: 'Empresa B', market_share: 25.0, total_contratado: 250000 },
+      { razao_social: 'Empresa C', market_share: 15.0, total_contratado: 150000 },
+    ];
+
+    render(<MarketShareChart competitors={competitors} />);
+
+    expect(screen.getByText(/Market Share por Concorrente/)).toBeInTheDocument();
+    // The chart should render with Recharts
+    expect(screen.getByText('Empresa A')).toBeInTheDocument();
+    expect(screen.getByText('Empresa B')).toBeInTheDocument();
+    expect(screen.getByText('Empresa C')).toBeInTheDocument();
+  });
+
+  it('limits to top 10 competitors', () => {
+    const competitors = Array.from({ length: 15 }, (_, i) => ({
+      razao_social: `Empresa ${i}`,
+      market_share: 10 - i * 0.5,
+      total_contratado: 100000 - i * 5000,
+    }));
+
+    render(<MarketShareChart competitors={competitors} />);
+
+    // Should show top 10
+    expect(screen.getByText('Empresa 0')).toBeInTheDocument();
+    expect(screen.getByText('Empresa 9')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/intel-concorrente/SectorBenchmarkCard.test.tsx
+++ b/frontend/__tests__/intel-concorrente/SectorBenchmarkCard.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import SectorBenchmarkCard from '@/app/intel-concorrente/components/SectorBenchmarkCard';
+
+describe('SectorBenchmarkCard', () => {
+  const metricas = [
+    {
+      metrica: 'ticket_medio',
+      label: 'Ticket Medio',
+      valor_concorrente: 50000.0,
+      percentil_concorrente: 65,
+      benchmark_setor: {
+        p25: 10000.0,
+        p50: 30000.0,
+        p75: 80000.0,
+      },
+      descricao: 'Este player esta no percentil 65 de ticket medio.',
+    },
+  ];
+
+  it('renders nothing when metricas is empty', () => {
+    const { container } = render(<SectorBenchmarkCard metricas={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders benchmark card with metrics', () => {
+    render(<SectorBenchmarkCard metricas={metricas} />);
+
+    expect(screen.getByText('Benchmark Setorial')).toBeInTheDocument();
+    expect(screen.getByText('Ticket Medio')).toBeInTheDocument();
+    expect(screen.getByText(/P65/)).toBeInTheDocument();
+  });
+
+  it('renders sector percentiles', () => {
+    render(<SectorBenchmarkCard metricas={metricas} />);
+
+    expect(screen.getByText('P25 (Setor)')).toBeInTheDocument();
+    expect(screen.getByText('P50 (Mediana)')).toBeInTheDocument();
+    expect(screen.getByText('P75 (Setor)')).toBeInTheDocument();
+  });
+
+  it('renders description tooltip', () => {
+    render(<SectorBenchmarkCard metricas={metricas} />);
+
+    expect(
+      screen.getByText(/Este player esta no percentil 65/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders multiple metrics', () => {
+    const multiMetrics = [
+      ...metricas,
+      {
+        metrica: 'total_contratos',
+        label: 'Total de Contratos',
+        valor_concorrente: 50,
+        percentil_concorrente: 80,
+        benchmark_setor: {
+          p25: 10,
+          p50: 30,
+          p75: 70,
+        },
+        descricao: 'Acima da media do setor.',
+      },
+    ];
+
+    render(<SectorBenchmarkCard metricas={multiMetrics} />);
+
+    expect(screen.getByText('Ticket Medio')).toBeInTheDocument();
+    expect(screen.getByText('Total de Contratos')).toBeInTheDocument();
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4128,6 +4128,108 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/intel-concorrente/benchmarks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Sector Benchmarks — competitive performance comparison */
+        get: operations["get_competitor_benchmarks_v1_intel_concorrente_benchmarks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/dossie/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate Competitive Dossie PDF */
+        post: operations["generate_competitive_dossie_v1_intel_concorrente_dossie__cnpj__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/dossie/{cnpj}/{job_id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download the generated Dossie PDF */
+        get: operations["download_dossie_v1_intel_concorrente_dossie__cnpj___job_id__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/dossie/{cnpj}/{job_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Check Dossie generation status */
+        get: operations["get_dossie_status_v1_intel_concorrente_dossie__cnpj___job_id__status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/landscape": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Competitive Landscape — top players in a sector */
+        get: operations["get_competitive_landscape_v1_intel_concorrente_landscape_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/territory/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Territory Map — competitor geographic presence */
+        get: operations["get_competitor_territory_v1_intel_concorrente_territory__cnpj__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/intel-reports/": {
         parameters: {
             query?: never;
@@ -7291,6 +7393,27 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * BenchmarkPercentile
+         * @description A single percentile value for a metric.
+         */
+        BenchmarkPercentile: {
+            /**
+             * P25
+             * @description Percentil 25
+             */
+            p25: number;
+            /**
+             * P50
+             * @description Percentil 50 (mediana)
+             */
+            p50: number;
+            /**
+             * P75
+             * @description Percentil 75
+             */
+            p75: number;
+        };
+        /**
          * BillingPlansResponse
          * @description Response for GET /plans (billing.py).
          */
@@ -8307,6 +8430,144 @@ export interface components {
             /** Uf */
             uf: string | null;
         };
+        /**
+         * CompetitiveLandscapeResponse
+         * @description Top-level response for GET /v1/intel-concorrente/landscape.
+         */
+        CompetitiveLandscapeResponse: {
+            /**
+             * Gerado Em
+             * @description Timestamp de geracao
+             */
+            gerado_em?: string;
+            /**
+             * Periodo
+             * @description Periodo analisado
+             * @default Ultimos 12 meses
+             */
+            periodo: string;
+            /**
+             * Setor Id
+             * @description ID do setor
+             */
+            setor_id: string;
+            /**
+             * Setor Nome
+             * @description Nome do setor
+             */
+            setor_nome: string;
+            /**
+             * Top Concorrentes
+             * @description Top concorrentes
+             */
+            top_concorrentes?: components["schemas"]["CompetitorItem"][];
+            /**
+             * Total Concorrentes
+             * @description Total de concorrentes identificados
+             * @default 0
+             */
+            total_concorrentes: number;
+            /**
+             * Total Contratado
+             * @description Valor total contratado no setor
+             */
+            total_contratado: number;
+            /**
+             * Total Contratos
+             * @description Total de contratos
+             * @default 0
+             */
+            total_contratos: number;
+            /**
+             * Uf
+             * @description UF filtrada (opcional)
+             */
+            uf?: string | null;
+        };
+        /**
+         * CompetitorBenchmark
+         * @description Benchmark comparison for a single metric.
+         */
+        CompetitorBenchmark: {
+            /** @description Benchmark do setor (P25/P50/P75) */
+            benchmark_setor: components["schemas"]["BenchmarkPercentile"];
+            /**
+             * Descricao
+             * @description Tooltip explicativo
+             * @default
+             */
+            descricao: string;
+            /**
+             * Label
+             * @description Label amigavel para exibicao
+             */
+            label: string;
+            /**
+             * Metrica
+             * @description Nome da metrica (ex: taxa_vitoria, ticket_medio)
+             */
+            metrica: string;
+            /**
+             * Percentil Concorrente
+             * @description Percentil do concorrente (0-100)
+             */
+            percentil_concorrente: number;
+            /**
+             * Valor Concorrente
+             * @description Valor do concorrente na metrica
+             */
+            valor_concorrente: number;
+        };
+        /**
+         * CompetitorItem
+         * @description A single competitor in the leaderboard.
+         */
+        CompetitorItem: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Market Share
+             * @description Market share percentual (0-100)
+             * @default 0
+             */
+            market_share: number;
+            /**
+             * Numero Contratos
+             * @description Numero de contratos no periodo
+             * @default 0
+             */
+            numero_contratos: number;
+            /**
+             * Razao Social
+             * @description Nome / razao social
+             */
+            razao_social: string;
+            /**
+             * Tendencia
+             * @description Tendencia: crescimento/estavel/retracao
+             * @default estavel
+             */
+            tendencia: string;
+            /**
+             * Ticket Medio
+             * @description Ticket medio por contrato
+             * @default 0
+             */
+            ticket_medio: number;
+            /**
+             * Total Contratado
+             * @description Valor total contratado no periodo
+             */
+            total_contratado: number;
+            /**
+             * Ufs Atuacao
+             * @description UFs onde atua
+             */
+            ufs_atuacao?: string[];
+        };
         /** ComplianceProfileResponse */
         ComplianceProfileResponse: {
             /** Aviso Legal */
@@ -9288,6 +9549,93 @@ export interface components {
             total_searches?: number | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * DossieRequest
+         * @description Request parameters for dossie generation.
+         */
+        DossieRequest: {
+            /**
+             * Include Llm Summary
+             * @description Incluir sumario executivo gerado por IA
+             * @default true
+             */
+            include_llm_summary: boolean;
+            /**
+             * Setor Id
+             * @description Setor para contextualizacao
+             */
+            setor_id?: string | null;
+        };
+        /**
+         * DossieResponse
+         * @description Response for dossie generation request.
+         */
+        DossieResponse: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Download Url
+             * @description URL para download do PDF quando pronto
+             */
+            download_url?: string | null;
+            /**
+             * Job Id
+             * @description ID do job ARQ para acompanhamento
+             */
+            job_id: string;
+            /**
+             * Message
+             * @description Mensagem de status
+             * @default Dossie sendo gerado em background.
+             */
+            message: string;
+            /**
+             * Status
+             * @description Status do job: queued/processing/done/error
+             * @default queued
+             */
+            status: string;
+        };
+        /**
+         * DossieStatusResponse
+         * @description Status polling response for dossie generation.
+         */
+        DossieStatusResponse: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Download Url
+             * @description URL de download quando concluido
+             */
+            download_url?: string | null;
+            /**
+             * Error
+             * @description Mensagem de erro se aplicavel
+             */
+            error?: string | null;
+            /**
+             * Job Id
+             * @description ID do job
+             */
+            job_id: string;
+            /**
+             * Progress
+             * @description Progresso percentual (0-100)
+             * @default 0
+             */
+            progress: number;
+            /**
+             * Status
+             * @description Status atual: queued/processing/done/error
+             */
+            status: string;
         };
         /** EditaisAmostra */
         EditaisAmostra: {
@@ -13336,6 +13684,42 @@ export interface components {
             /** Total Value */
             total_value: number;
         };
+        /**
+         * SectorBenchmarkResponse
+         * @description Top-level response for GET /v1/intel-concorrente/benchmarks.
+         */
+        SectorBenchmarkResponse: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Gerado Em
+             * @description Timestamp de geracao
+             */
+            gerado_em?: string;
+            /**
+             * Metricas
+             * @description Metricas comparativas
+             */
+            metricas?: components["schemas"]["CompetitorBenchmark"][];
+            /**
+             * Razao Social
+             * @description Nome / razao social
+             */
+            razao_social: string;
+            /**
+             * Setor Id
+             * @description ID do setor
+             */
+            setor_id: string;
+            /**
+             * Setor Nome
+             * @description Nome do setor
+             */
+            setor_nome: string;
+        };
         /** SectorBlogStats */
         SectorBlogStats: {
             /** Avg Value */
@@ -14057,6 +14441,77 @@ export interface components {
             razao_social: string;
             /** Total Won */
             total_won: number;
+        };
+        /**
+         * TerritoryData
+         * @description Territory map data for a single competitor.
+         */
+        TerritoryData: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Razao Social
+             * @description Nome / razao social
+             */
+            razao_social: string;
+            /**
+             * Total Contratado
+             * @description Valor total contratado
+             */
+            total_contratado: number;
+            /**
+             * Total Contratos
+             * @description Total de contratos
+             * @default 0
+             */
+            total_contratos: number;
+            /**
+             * Ufs
+             * @description Dados por UF
+             */
+            ufs?: components["schemas"]["TerritoryUfData"][];
+        };
+        /**
+         * TerritoryUfData
+         * @description Territory data for a single UF.
+         */
+        TerritoryUfData: {
+            /**
+             * Market Share
+             * @description Market share do concorrente na UF (0-100)
+             * @default 0
+             */
+            market_share: number;
+            /**
+             * Numero Contratos
+             * @description Numero de contratos na UF
+             * @default 0
+             */
+            numero_contratos: number;
+            /**
+             * Orgaos Principais
+             * @description Principais orgaos compradores
+             */
+            orgaos_principais?: string[];
+            /**
+             * Tendencia
+             * @description Tendencia na UF
+             * @default estavel
+             */
+            tendencia: string;
+            /**
+             * Total Contratado
+             * @description Valor total contratado na UF
+             */
+            total_contratado: number;
+            /**
+             * Uf
+             * @description Sigla da UF
+             */
+            uf: string;
         };
         /** TimeSeriesDataPoint */
         TimeSeriesDataPoint: {
@@ -20290,6 +20745,206 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IndiceResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_competitor_benchmarks_v1_intel_concorrente_benchmarks_get: {
+        parameters: {
+            query: {
+                /** @description CNPJ do concorrente */
+                cnpj: string;
+                /** @description ID do setor para benchmark */
+                setor: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorBenchmarkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_competitive_dossie_v1_intel_concorrente_dossie__cnpj__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CNPJ do concorrente */
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DossieRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DossieResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_dossie_v1_intel_concorrente_dossie__cnpj___job_id__download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_dossie_status_v1_intel_concorrente_dossie__cnpj___job_id__status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DossieStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_competitive_landscape_v1_intel_concorrente_landscape_get: {
+        parameters: {
+            query: {
+                /** @description ID do setor (ex: ti, saude, construcao) */
+                setor: string;
+                /** @description UF (2 letras, opcional) */
+                uf?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CompetitiveLandscapeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_competitor_territory_v1_intel_concorrente_territory__cnpj__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CNPJ do concorrente (com ou sem mascara) */
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TerritoryData"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/app/intel-concorrente/IntelConcorrenteClient.tsx
+++ b/frontend/app/intel-concorrente/IntelConcorrenteClient.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import CompetitorSearch from './components/CompetitorSearch';
+import CompetitorCard from './components/CompetitorCard';
+import MarketShareChart from './components/MarketShareChart';
+import SectorBenchmarkCard from './components/SectorBenchmarkCard';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CompetitorItem {
+  cnpj: string;
+  razao_social: string;
+  total_contratado: number;
+  numero_contratos: number;
+  ticket_medio: number;
+  ufs_atuacao: string[];
+  market_share: number;
+  tendencia: string;
+}
+
+interface BenchmarkMetric {
+  metrica: string;
+  label: string;
+  valor_concorrente: number;
+  percentil_concorrente: number;
+  benchmark_setor: { p25: number; p50: number; p75: number };
+  descricao: string;
+}
+
+interface TerritoryData {
+  cnpj: string;
+  razao_social: string;
+  total_contratado: number;
+  total_contratos: number;
+  ufs: Array<{
+    uf: string;
+    total_contratado: number;
+    numero_contratos: number;
+    market_share: number;
+    orgaos_principais: string[];
+    tendencia: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SECTORS = [
+  { id: 'ti', name: 'Tecnologia da Informacao' },
+  { id: 'saude', name: 'Saude' },
+  { id: 'construcao', name: 'Construcao Civil' },
+  { id: 'alimentos', name: 'Alimentos' },
+  { id: 'limpeza', name: 'Limpeza e Conservacao' },
+  { id: 'seguranca', name: 'Seguranca' },
+  { id: 'transporte', name: 'Transporte' },
+  { id: 'educacao', name: 'Educacao' },
+  { id: 'energia', name: 'Energia' },
+  { id: 'meio_ambiente', name: 'Meio Ambiente' },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function IntelConcorrenteClient() {
+  const [selectedSector, setSelectedSector] = useState('ti');
+  const [selectedUF, setSelectedUF] = useState('');
+  const [competitors, setCompetitors] = useState<CompetitorItem[]>([]);
+  const [territory, setTerritory] = useState<TerritoryData | null>(null);
+  const [benchmarks, setBenchmarks] = useState<BenchmarkMetric[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cnpjSearched, setCnpjSearched] = useState('');
+
+  const handleSearch = useCallback(async (cnpj: string) => {
+    setLoading(true);
+    setError(null);
+    setCnpjSearched(cnpj);
+
+    try {
+      // Fetch territory data
+      const territoryRes = await fetch(`/api/intel-concorrente/territory/${cnpj}`);
+      if (!territoryRes.ok) {
+        throw new Error('Falha ao carregar dados do concorrente');
+      }
+      const territoryData: TerritoryData = await territoryRes.json();
+      setTerritory(territoryData);
+
+      // Fetch benchmarks
+      const benchRes = await fetch(
+        `/api/intel-concorrente/benchmarks?cnpj=${cnpj}&setor=${selectedSector}`
+      );
+      if (benchRes.ok) {
+        const benchData = await benchRes.json();
+        setBenchmarks(benchData.metricas || []);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao carregar dados');
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedSector]);
+
+  const loadLandscape = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({ setor: selectedSector });
+      if (selectedUF) params.set('uf', selectedUF);
+
+      const res = await fetch(`/api/intel-concorrente/landscape?${params}`);
+      if (!res.ok) {
+        throw new Error('Falha ao carregar paisagem competitiva');
+      }
+      const data = await res.json();
+      setCompetitors(data.top_concorrentes || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao carregar dados');
+      setCompetitors([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedSector, selectedUF]);
+
+  return (
+    <main className="min-h-screen bg-gray-50 py-8">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {/* Hero */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-8 text-center"
+        >
+          <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+            Inteligencia Concorrencial
+          </h1>
+          <p className="mt-3 text-lg text-gray-600">
+            Analise concorrentes, mapeie territorio e compare performance no mercado de compras publicas
+          </p>
+        </motion.div>
+
+        {/* Sector Selector */}
+        <div className="mb-6 rounded-lg bg-white p-4 shadow-sm">
+          <label className="block text-sm font-medium text-gray-700">
+            Setor
+          </label>
+          <select
+            value={selectedSector}
+            onChange={(e) => {
+              setSelectedSector(e.target.value);
+              setCompetitors([]);
+              setTerritory(null);
+            }}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 sm:text-sm"
+          >
+            {SECTORS.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+
+          {/* UF filter */}
+          <div className="mt-3">
+            <label className="block text-sm font-medium text-gray-700">
+              Filtrar por UF (opcional)
+            </label>
+            <input
+              type="text"
+              value={selectedUF}
+              onChange={(e) => setSelectedUF(e.target.value.toUpperCase())}
+              placeholder="Ex: SP, RJ, MG"
+              maxLength={2}
+              className="mt-1 block w-32 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 sm:text-sm"
+            />
+          </div>
+
+          <button
+            onClick={loadLandscape}
+            disabled={loading}
+            className="mt-3 inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Carregando...' : 'Carregar Panorama'}
+          </button>
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {error}
+            <button
+              onClick={() => setError(null)}
+              className="ml-3 underline hover:text-red-900"
+            >
+              Fechar
+            </button>
+          </div>
+        )}
+
+        {/* Competitor Search */}
+        <div className="mb-6">
+          <CompetitorSearch onSearch={handleSearch} loading={loading} />
+        </div>
+
+        {/* Grid Layout */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {/* Competitor Card */}
+          {territory && (
+            <div className="lg:col-span-1">
+              <CompetitorCard
+                razao_social={territory.razao_social}
+                cnpj={territory.cnpj}
+                total_contratado={territory.total_contratado}
+                total_contratos={territory.total_contratos}
+                ufs_count={territory.ufs.length}
+                tendencia="estavel"
+              />
+            </div>
+          )}
+
+          {/* Market Share Chart */}
+          <div className="lg:col-span-2">
+            <MarketShareChart competitors={competitors} />
+          </div>
+        </div>
+
+        {/* Territory Table */}
+        {territory && territory.ufs.length > 0 && (
+          <div className="mt-6 overflow-x-auto rounded-lg bg-white p-4 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-gray-900">
+              Presenca por UF
+            </h2>
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    UF
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Valor Contratado (R$)
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Contratos
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Market Share
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {territory.ufs.map((uf) => (
+                  <tr key={uf.uf} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                      {uf.uf}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      {uf.total_contratado.toLocaleString('pt-BR', {
+                        style: 'currency',
+                        currency: 'BRL',
+                      })}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      {uf.numero_contratos}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      {uf.market_share.toFixed(1)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Sector Benchmarks */}
+        {benchmarks.length > 0 && (
+          <div className="mt-6">
+            <SectorBenchmarkCard metricas={benchmarks} />
+          </div>
+        )}
+
+        {/* Leaderboard */}
+        {competitors.length > 0 && (
+          <div className="mt-6 overflow-x-auto rounded-lg bg-white p-4 shadow-sm">
+            <h2 className="mb-4 text-lg font-semibold text-gray-900">
+              Ranking de Concorrentes
+            </h2>
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    #
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Concorrente
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Total Contratado
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Contratos
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Ticket Medio
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Market Share
+                  </th>
+                  <th className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500">
+                    UFs
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {competitors.slice(0, 20).map((comp, idx) => (
+                  <tr key={idx} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                      {idx + 1}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                      {comp.razao_social}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      {comp.total_contratado.toLocaleString('pt-BR', {
+                        style: 'currency',
+                        currency: 'BRL',
+                      })}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      {comp.numero_contratos}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      {comp.ticket_medio.toLocaleString('pt-BR', {
+                        style: 'currency',
+                        currency: 'BRL',
+                      })}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700">
+                      <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800">
+                        {comp.market_share.toFixed(1)}%
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-center text-sm text-gray-700">
+                      {comp.ufs_atuacao.join(', ')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loading && !error && competitors.length === 0 && !territory && (
+          <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center">
+            <h3 className="text-lg font-medium text-gray-900">
+              Bem-vindo a Inteligencia Concorrencial
+            </h3>
+            <p className="mt-2 text-sm text-gray-600">
+              Selecione um setor e clique em &quot;Carregar Panorama&quot; para ver o ranking de
+              concorrentes, ou busque por um CNPJ especifico para analisar um concorrente em
+              detalhes.
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/intel-concorrente/components/CompetitorCard.tsx
+++ b/frontend/app/intel-concorrente/components/CompetitorCard.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface CompetitorCardProps {
+  razao_social: string;
+  cnpj: string;
+  total_contratado: number;
+  total_contratos: number;
+  ufs_count: number;
+  tendencia: string;
+}
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+}
+
+const TREND_CONFIG: Record<string, { label: string; color: string }> = {
+  crescimento: { label: 'Em expansao', color: 'text-green-600 bg-green-50' },
+  estavel: { label: 'Estavel', color: 'text-yellow-600 bg-yellow-50' },
+  retracao: { label: 'Em retracao', color: 'text-red-600 bg-red-50' },
+};
+
+export default function CompetitorCard({
+  razao_social,
+  cnpj,
+  total_contratado,
+  total_contratos,
+  ufs_count,
+  tendencia,
+}: CompetitorCardProps) {
+  const trend = TREND_CONFIG[tendencia] || TREND_CONFIG.estavel;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      className="rounded-lg bg-white p-6 shadow-sm"
+    >
+      <h3 className="text-lg font-semibold text-gray-900">
+        {razao_social}
+      </h3>
+      <p className="mt-1 text-sm text-gray-500">CNPJ: {cnpj}</p>
+
+      <div className="mt-4 space-y-3">
+        <div className="flex items-center justify-between border-b border-gray-100 pb-2">
+          <span className="text-sm text-gray-600">Total Contratado</span>
+          <span className="text-sm font-semibold text-gray-900">
+            {formatCurrency(total_contratado)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between border-b border-gray-100 pb-2">
+          <span className="text-sm text-gray-600">Total de Contratos</span>
+          <span className="text-sm font-semibold text-gray-900">
+            {total_contratos}
+          </span>
+        </div>
+        <div className="flex items-center justify-between border-b border-gray-100 pb-2">
+          <span className="text-sm text-gray-600">UFs de Atuacao</span>
+          <span className="text-sm font-semibold text-gray-900">
+            {ufs_count}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-600">Tendencia</span>
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${trend.color}`}
+          >
+            {trend.label}
+          </span>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/app/intel-concorrente/components/CompetitorSearch.tsx
+++ b/frontend/app/intel-concorrente/components/CompetitorSearch.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface CompetitorSearchProps {
+  onSearch: (cnpj: string) => void;
+  loading: boolean;
+}
+
+const CNPJ_MASK = 'XX.XXX.XXX/XXXX-XX';
+
+function formatCNPJ(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 14);
+  if (digits.length <= 2) return digits;
+  if (digits.length <= 5) return `${digits.slice(0, 2)}.${digits.slice(2)}`;
+  if (digits.length <= 8)
+    return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5)}`;
+  if (digits.length <= 12)
+    return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8)}`;
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
+}
+
+export default function CompetitorSearch({ onSearch, loading }: CompetitorSearchProps) {
+  const [cnpj, setCnpj] = useState('');
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setCnpj(formatCNPJ(e.target.value));
+    },
+    []
+  );
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const raw = cnpj.replace(/\D/g, '');
+      if (raw.length === 14) {
+        onSearch(raw);
+      }
+    },
+    [cnpj, onSearch]
+  );
+
+  const isValid = cnpj.replace(/\D/g, '').length === 14;
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg bg-white p-4 shadow-sm"
+    >
+      <label
+        htmlFor="cnpj-search"
+        className="block text-sm font-medium text-gray-700"
+      >
+        Buscar Concorrente por CNPJ
+      </label>
+      <div className="mt-1 flex gap-2">
+        <input
+          id="cnpj-search"
+          type="text"
+          value={cnpj}
+          onChange={handleChange}
+          placeholder={CNPJ_MASK}
+          maxLength={18}
+          className="block w-full max-w-xs rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 sm:text-sm"
+          autoComplete="off"
+        />
+        <button
+          type="submit"
+          disabled={!isValid || loading}
+          className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? 'Buscando...' : 'Analisar'}
+        </button>
+      </div>
+      <p className="mt-1 text-xs text-gray-500">
+        Digite o CNPJ com 14 digitos (a mascara e aplicada automaticamente)
+      </p>
+    </form>
+  );
+}

--- a/frontend/app/intel-concorrente/components/MarketShareChart.tsx
+++ b/frontend/app/intel-concorrente/components/MarketShareChart.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+
+interface CompetitorItem {
+  razao_social: string;
+  market_share: number;
+  total_contratado: number;
+}
+
+interface MarketShareChartProps {
+  competitors: CompetitorItem[];
+}
+
+const COLORS = [
+  '#3B82F6',
+  '#10B981',
+  '#F59E0B',
+  '#EF4444',
+  '#8B5CF6',
+  '#EC4899',
+  '#14B8A6',
+  '#F97316',
+  '#6366F1',
+  '#84CC16',
+];
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+}
+
+export default function MarketShareChart({ competitors }: MarketShareChartProps) {
+  if (!competitors || competitors.length === 0) {
+    return (
+      <div className="rounded-lg bg-white p-6 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold text-gray-900">
+          Market Share por Concorrente
+        </h3>
+        <p className="text-sm text-gray-500">
+          Selecione um setor e clique em &quot;Carregar Panorama&quot; para visualizar o grafico.
+        </p>
+      </div>
+    );
+  }
+
+  // Take top 10 for the chart
+  const chartData = competitors.slice(0, 10).map((c) => ({
+    name:
+      c.razao_social.length > 20
+        ? `${c.razao_social.slice(0, 18)}...`
+        : c.razao_social,
+    share: c.market_share,
+    fullName: c.razao_social,
+    value: c.total_contratado,
+  }));
+
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm">
+      <h3 className="mb-4 text-lg font-semibold text-gray-900">
+        Market Share por Concorrente
+      </h3>
+
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart
+          data={chartData}
+          layout="vertical"
+          margin={{ top: 5, right: 30, left: 100, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
+          <XAxis
+            type="number"
+            tick={{ fontSize: 12 }}
+            domain={[0, 'dataMax + 10']}
+            tickFormatter={(v: number) => `${v.toFixed(0)}%`}
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            tick={{ fontSize: 11 }}
+            width={100}
+          />
+          <Tooltip
+            formatter={(value: number, _name: string) => [
+              `${value.toFixed(1)}%`,
+              'Market Share',
+            ]}
+            labelFormatter={(label: string) => {
+              const item = chartData.find((d) => d.name === label);
+              return `${item?.fullName || label}\n${item?.value ? formatCurrency(item.value) : ''}`;
+            }}
+          />
+          <Bar dataKey="share" radius={[0, 4, 4, 0]}>
+            {chartData.map((_entry, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={COLORS[index % COLORS.length]}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/app/intel-concorrente/components/SectorBenchmarkCard.tsx
+++ b/frontend/app/intel-concorrente/components/SectorBenchmarkCard.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface BenchmarkMetric {
+  metrica: string;
+  label: string;
+  valor_concorrente: number;
+  percentil_concorrente: number;
+  benchmark_setor: {
+    p25: number;
+    p50: number;
+    p75: number;
+  };
+  descricao: string;
+}
+
+interface SectorBenchmarkCardProps {
+  metricas: BenchmarkMetric[];
+}
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+}
+
+function formatMetricValue(metrica: string, value: number): string {
+  if (metrica.includes('ticket') || metrica.includes('valor') || metrica.includes('contratado')) {
+    return formatCurrency(value);
+  }
+  if (metrica.includes('percentil') || metrica.includes('share')) {
+    return `${value.toFixed(1)}%`;
+  }
+  return value.toLocaleString('pt-BR');
+}
+
+export default function SectorBenchmarkCard({ metricas }: SectorBenchmarkCardProps) {
+  if (!metricas || metricas.length === 0) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="rounded-lg bg-white p-6 shadow-sm"
+    >
+      <h3 className="mb-4 text-lg font-semibold text-gray-900">
+        Benchmark Setorial
+      </h3>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {metricas.map((m) => (
+          <div
+            key={m.metrica}
+            className="rounded-lg border border-gray-200 p-4"
+          >
+            <h4 className="text-sm font-medium text-gray-700">{m.label}</h4>
+
+            {/* Competitor value */}
+            <div className="mt-2">
+              <span className="text-xs text-gray-500">Concorrente</span>
+              <p className="text-lg font-bold text-blue-600">
+                {formatMetricValue(m.metrica, m.valor_concorrente)}
+              </p>
+            </div>
+
+            {/* Percentile badge */}
+            <div className="mt-1">
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                  m.percentil_concorrente >= 75
+                    ? 'bg-green-100 text-green-800'
+                    : m.percentil_concorrente >= 50
+                      ? 'bg-yellow-100 text-yellow-800'
+                      : 'bg-gray-100 text-gray-800'
+                }`}
+              >
+                P{m.percentil_concorrente}
+              </span>
+            </div>
+
+            {/* Sector benchmark */}
+            <div className="mt-3 space-y-1 border-t border-gray-100 pt-2 text-xs text-gray-500">
+              <div className="flex justify-between">
+                <span>P25 (Setor)</span>
+                <span>{formatMetricValue(m.metrica, m.benchmark_setor.p25)}</span>
+              </div>
+              <div className="flex justify-between font-medium text-gray-700">
+                <span>P50 (Mediana)</span>
+                <span>{formatMetricValue(m.metrica, m.benchmark_setor.p50)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>P75 (Setor)</span>
+                <span>{formatMetricValue(m.metrica, m.benchmark_setor.p75)}</span>
+              </div>
+            </div>
+
+            {/* Tooltip */}
+            {m.descricao && (
+              <p className="mt-2 text-xs text-gray-400 italic">{m.descricao}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/app/intel-concorrente/page.tsx
+++ b/frontend/app/intel-concorrente/page.tsx
@@ -1,0 +1,42 @@
+/**
+ * COMPINT-010 (#1662): Competitive Intelligence Flagship Page.
+ *
+ * Mapa de Territorio Competitivo — /intel-concorrente
+ * Auth-gated page with competitive intel capability check.
+ */
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import LandingNavbar from '@/app/components/landing/LandingNavbar';
+import Footer from '@/app/components/Footer';
+import IntelConcorrenteClient from './IntelConcorrenteClient';
+
+export const revalidate = 0; // Dynamic page
+
+export const metadata: Metadata = {
+  title: 'Inteligencia Concorrencial — Mapa de Territorio | SmartLic',
+  description:
+    'Analise concorrentes em licitacoes publicas. Mapa de territorio, market share, benchmarks setoriais e dossie completo de fornecedores B2G.',
+  robots: { index: false, follow: false },
+};
+
+export default async function IntelConcorrentePage() {
+  // Check auth server-side
+  const supabase = createServerComponentClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect('/login?redirect=/intel-concorrente');
+  }
+
+  return (
+    <>
+      <LandingNavbar />
+      <IntelConcorrenteClient />
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Issues
- Closes #1662 (COMPINT-010 — Mapa de Territorio Competitivo)
- Closes #1667 (COMPINT-013 — Benchmarks Setoriais)
- Closes #1669 (COMPINT-014 — Dossie Competitivo PDF)

## Parent EPIC
#1261 (EPIC-COMPINT)

## O que foi implementado

### Backend
- **Novo schema**: `backend/schemas/competitive_intel.py` — CompetitiveLandscapeResponse, TerritoryData, CompetitorItem, SectorBenchmarkResponse, DossieRequest/Response
- **Novas rotas** em `backend/routes/competitive_intel.py`:
  - `GET /v1/intel-concorrente/landscape` — Panorama competitivo por setor/UF
  - `GET /v1/intel-concorrente/territory/{cnpj}` — Mapa de territorio do concorrente
  - `GET /v1/intel-concorrente/benchmarks` — Benchmarks setoriais com percentis
  - `POST /v1/intel-concorrente/dossie/{cnpj}` — Gerar dossie PDF em background
  - `GET /v1/intel-concorrente/dossie/{cnpj}/{job_id}/status` — Status do job
  - `GET /v1/intel-concorrente/dossie/{cnpj}/{job_id}/download` — Download do PDF
- **PDF Generator**: `backend/pdf_generator_competitive_dossie.py` — ReportLab com 6 secoes (capa, sumario executivo, territorio, metricas, benchmark, timeline)
- **Gate**: Feature flag `COMPETITIVE_INTEL_ENABLED` + capability `allow_competitive_intel`
- **Tests**: 15 testes backend (territory, benchmarks, dossie, PDF generator)

### Frontend
- **Pagina flagship**: `/intel-concorrente` com:
  - Seletor de setor + filtro UF
  - Busca de CNPJ com auto-formatacao
  - Card de perfil do concorrente
  - Grafico de barras de market share (Recharts)
  - Tabela de presenca por UF
  - Card de benchmark setorial
  - Ranking de concorrentes
- **Componentes**: CompetitorSearch, CompetitorCard, MarketShareChart, SectorBenchmarkCard
- **Tests**: 5 arquivos de teste frontend (16 testes)

## Validacao
- Ruff: All checks passed
- Backend tests: 15/15 passed
- Gate: test_competitive_intel_gate.py existente continua passando