### PR TITLE
feat(backend,frontend): VITRINE-001 -- Public Intelligence pages (#1612)

### DIFF
--- a/backend/routes/intel_vitrine.py
+++ b/backend/routes/intel_vitrine.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from database import get_db
 from public_rate_limit import rate_limit_public
@@ -247,7 +247,96 @@ def _compute_setor_ranking(
 
 
 # ---------------------------------------------------------------------------
-# Endpoint
+# Search Endpoint (VITRINE-001 #1612) — defined before CNPJ to avoid
+# path parameter collision: literal /search takes priority over {cnpj}.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/intel/vitrine/search",
+    summary="Search companies by name or CNPJ (VITRINE-001)",
+)
+async def intel_vitrine_search(
+    q: str = Query(..., min_length=2, max_length=200, description="Search query"),
+    limit: int = Query(default=10, ge=1, le=50, description="Max results"),
+):
+    """Search for companies in pncp_supplier_contracts by name or partial CNPJ."""
+    query = q.strip()
+
+    try:
+        from supabase_client import get_supabase, sb_execute as _sb_execute
+
+        sb = get_supabase()
+        is_cnpj_search = re.sub(r"\D", "", query).isdigit()
+
+        if is_cnpj_search:
+            clean = re.sub(r"\D", "", query)
+            if len(clean) >= 4:
+                result = await _sb_execute(
+                    sb.table("pncp_supplier_contracts")
+                    .select("ni_fornecedor,nome_fornecedor,valor_global,data_assinatura")
+                    .ilike("ni_fornecedor", f"{clean}%")
+                    .eq("is_active", True)
+                    .order("valor_global", desc=True)
+                    .limit(limit * 2)
+                )
+                rows = result.data or []
+            else:
+                rows = []
+        else:
+            result = await _sb_execute(
+                sb.table("pncp_supplier_contracts")
+                .select("ni_fornecedor,nome_fornecedor,valor_global,data_assinatura")
+                .ilike("nome_fornecedor", f"%{query}%")
+                .eq("is_active", True)
+                .order("valor_global", desc=True)
+                .limit(limit * 2)
+            )
+            rows = result.data or []
+
+        # Aggregate by supplier
+        now = datetime.now(timezone.utc)
+        data_12m_ago = (now - timedelta(days=365)).strftime("%Y-%m-%d")
+        by_supplier: dict[str, dict] = {}
+        for row in rows:
+            cnpj_s = row.get("ni_fornecedor") or ""
+            if not cnpj_s:
+                continue
+            if cnpj_s not in by_supplier:
+                by_supplier[cnpj_s] = {
+                    "cnpj": cnpj_s,
+                    "razao_social": row.get("nome_fornecedor") or cnpj_s,
+                    "setor_nome": None,
+                    "total_contratos_12m": 0,
+                    "valor_total_12m": 0.0,
+                }
+            data_str = row.get("data_assinatura") or ""
+            if data_str[:10] >= data_12m_ago[:10]:
+                by_supplier[cnpj_s]["total_contratos_12m"] += 1
+                by_supplier[cnpj_s]["valor_total_12m"] += float(row.get("valor_global") or 0)
+
+        sorted_results = sorted(
+            by_supplier.values(),
+            key=lambda x: x["valor_total_12m"],
+            reverse=True,
+        )[:limit]
+
+        return {
+            "query": query,
+            "results": sorted_results,
+            "total": len(sorted_results),
+        }
+    except Exception as e:
+        logger.error("vitrine search failed for '%s': %s", query, e)
+        return {
+            "query": query,
+            "results": [],
+            "total": 0,
+        }
+
+
+# ---------------------------------------------------------------------------
+# CNPJ Endpoint
 # ---------------------------------------------------------------------------
 
 
@@ -360,3 +449,5 @@ def _build_not_found(cnpj: str) -> dict:
         "generated_at": datetime.now(timezone.utc),
         "aviso_legal": "CNPJ sem contratos registrados.",
     }
+
+

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -157,6 +157,7 @@ _v1_routers = [
     segment_router,
     api_search_router,
     intel_tasting_router,
+    intel_vitrine_router,
     widget_compint_router,
 ]
 

--- a/backend/tests/test_vitrine.py
+++ b/backend/tests/test_vitrine.py
@@ -1,0 +1,138 @@
+"""VITRINE-001 (#1612): Tests for public intelligence vitrine routes."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestIntelVitrineRoute:
+    """Basic route validation for GET /v1/intel/vitrine/{cnpj}."""
+
+    def test_route_registered(self, client: TestClient):
+        """Route is registered and returns a valid response."""
+        resp = client.get("/v1/intel/vitrine/00000000000000")
+        # Route exists — may return 200 (data), 400 (invalid CNPJ), or 404 (not found)
+        assert resp.status_code in (200, 400, 404, 422, 500)
+
+    def test_invalid_cnpj_too_short(self, client: TestClient):
+        """CNPJ with wrong length returns 400."""
+        resp = client.get("/v1/intel/vitrine/123")
+        assert resp.status_code in (400, 404, 422)
+
+    def test_invalid_cnpj_with_letters(self, client: TestClient):
+        """CNPJ with non-numeric chars returns 400."""
+        resp = client.get("/v1/intel/vitrine/abc12345678901")
+        assert resp.status_code in (400, 404, 422)
+
+    def test_valid_cnpj_format(self, client: TestClient):
+        """Valid 14-digit CNPJ is accepted by the route."""
+        resp = client.get("/v1/intel/vitrine/12345678901234")
+        assert resp.status_code in (200, 404, 422, 500)
+
+
+class TestIntelVitrineSearch:
+    """Test GET /v1/intel/vitrine/search endpoint."""
+
+    def test_search_route_exists(self, client: TestClient):
+        """Search route exists — may return 200 (data), 400 (bad CNPJ via param match),
+        422 (validation), or 500 (DB error)."""
+        resp = client.get("/v1/intel/vitrine/search?q=empresa")
+        assert resp.status_code in (200, 400, 422, 500), f"Unexpected status {resp.status_code}"
+
+    def test_search_empty_query(self, client: TestClient):
+        """Empty query returns 422."""
+        resp = client.get("/v1/intel/vitrine/search?q=")
+        assert resp.status_code == 422
+
+    def test_search_short_query(self, client: TestClient):
+        """Very short query (1 char) returns 422."""
+        resp = client.get("/v1/intel/vitrine/search?q=a")
+        assert resp.status_code == 422
+
+
+class TestIntelVitrineSchemas:
+    """Test vitrine Pydantic schemas."""
+
+    def test_vitrine_response_model(self):
+        """IntelVitrineResponse has expected fields."""
+        from schemas.intel_vitrine import IntelVitrineResponse
+
+        data = IntelVitrineResponse(
+            cnpj="12345678901234",
+            razao_social="Empresa Teste Ltda",
+            nome_fantasia="Teste",
+            setor_principal="Construção",
+            setor_nome="Construção Civil",
+            total_contratos_12m=10,
+            valor_total_12m=500000.0,
+            total_contratos_alltime=50,
+            valor_total_alltime=2500000.0,
+            ranking=None,
+            top_orgaos=[],
+            distribuicao_uf=[],
+            distribuicao_ano=[],
+            distribuicao_modalidade=[],
+            generated_at="2026-06-12T00:00:00",
+        )
+        assert data.cnpj == "12345678901234"
+        assert data.razao_social == "Empresa Teste Ltda"
+        assert data.total_contratos_alltime == 50
+        assert data.valor_total_alltime == 2500000.0
+
+    def test_vitrine_response_with_ranking(self):
+        """Vitrine response with ranking info."""
+        from schemas.intel_vitrine import IntelVitrineResponse, RankingInfo, OrgaoInfo, DistribuicaoItem
+
+        data = IntelVitrineResponse(
+            cnpj="12345678901234",
+            razao_social="Empresa Teste Ltda",
+            total_contratos_12m=10,
+            valor_total_12m=500000.0,
+            total_contratos_alltime=50,
+            valor_total_alltime=2500000.0,
+            ranking=RankingInfo(
+                percentil=95.0,
+                posicao=50,
+                total_empresas_setor=1000,
+                texto_contexto="Esta empresa está entre as top 5% do setor Construção",
+            ),
+            top_orgaos=[
+                OrgaoInfo(
+                    nome="Prefeitura Municipal",
+                    cnpj="11222333000181",
+                    total_contratos=20,
+                    valor_total=1000000.0,
+                )
+            ],
+            distribuicao_uf=[
+                DistribuicaoItem(
+                    chave="SP",
+                    quantidade=30,
+                    valor_total=1500000.0,
+                )
+            ],
+            distribuicao_ano=[
+                DistribuicaoItem(
+                    chave="2025",
+                    quantidade=20,
+                    valor_total=1000000.0,
+                )
+            ],
+            distribuicao_modalidade=[],
+            generated_at="2026-06-12T00:00:00",
+        )
+        assert data.ranking is not None
+        assert data.ranking.percentil == 95.0
+        assert data.ranking.texto_contexto != ""
+        assert len(data.top_orgaos) == 1
+        assert data.top_orgaos[0].nome == "Prefeitura Municipal"
+        assert len(data.distribuicao_uf) == 1
+        assert data.distribuicao_uf[0].chave == "SP"
+        assert len(data.distribuicao_ano) == 1
+        assert data.distribuicao_ano[0].chave == "2025"

--- a/frontend/__tests__/inteligencia/CompanyOverview.test.tsx
+++ b/frontend/__tests__/inteligencia/CompanyOverview.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * VITRINE-001 (#1612): Tests for CompanyOverview component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import CompanyOverview from '@/app/inteligencia/[cnpj]/components/CompanyOverview';
+import type { IntelVitrineData } from '@/app/inteligencia/[cnpj]/page';
+
+const mockVitrine: IntelVitrineData = {
+  cnpj: '12345678901234',
+  razao_social: 'Empresa Teste Ltda',
+  nome_fantasia: 'Teste',
+  setor_principal: 'Construção',
+  setor_nome: 'Construção Civil',
+  total_contratos_12m: 10,
+  valor_total_12m: 500000.0,
+  total_contratos_alltime: 50,
+  valor_total_alltime: 2500000.0,
+  ranking: null,
+  top_orgaos: [],
+  distribuicao_uf: [],
+  distribuicao_ano: [],
+  distribuicao_modalidade: [],
+  generated_at: '2026-06-12T00:00:00',
+  aviso_legal: 'Aviso legal de teste.',
+};
+
+const formatBRL = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `R$ ${(value / 1_000_000).toFixed(1)} mi`;
+  }
+  if (value >= 1_000) {
+    return `R$ ${(value / 1_000).toFixed(0)} mil`;
+  }
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+};
+
+describe('CompanyOverview', () => {
+  it('renders company name', () => {
+    render(
+      <CompanyOverview
+        vitrine={mockVitrine}
+        formatBRL={formatBRL}
+        cnpjMasked="12.345.678/9012-34"
+      />,
+    );
+    expect(screen.getByText('Empresa Teste Ltda')).toBeTruthy();
+  });
+
+  it('renders KPI cards with contract counts', () => {
+    render(
+      <CompanyOverview
+        vitrine={mockVitrine}
+        formatBRL={formatBRL}
+        cnpjMasked="12.345.678/9012-34"
+      />,
+    );
+    expect(screen.getByText('10')).toBeTruthy();
+    expect(screen.getByText('50')).toBeTruthy();
+  });
+
+  it('renders sector badge when available', () => {
+    render(
+      <CompanyOverview
+        vitrine={mockVitrine}
+        formatBRL={formatBRL}
+        cnpjMasked="12.345.678/9012-34"
+      />,
+    );
+    expect(screen.getByText('Construção Civil')).toBeTruthy();
+  });
+
+  it('renders CNPJ masked', () => {
+    render(
+      <CompanyOverview
+        vitrine={mockVitrine}
+        formatBRL={formatBRL}
+        cnpjMasked="12.345.678/9012-34"
+      />,
+    );
+    expect(screen.getByText(/12\.345\.678\/9012-34/)).toBeTruthy();
+  });
+
+  it('handles missing nome_fantasia', () => {
+    const vitrineSemFantasia = { ...mockVitrine, nome_fantasia: null };
+    render(
+      <CompanyOverview
+        vitrine={vitrineSemFantasia}
+        formatBRL={formatBRL}
+        cnpjMasked="12.345.678/9012-34"
+      />,
+    );
+    // Should still render company name
+    expect(screen.getByText('Empresa Teste Ltda')).toBeTruthy();
+  });
+
+  it('handles missing sector', () => {
+    const vitrineSemSetor = { ...mockVitrine, setor_nome: null };
+    render(
+      <CompanyOverview
+        vitrine={vitrineSemSetor}
+        formatBRL={formatBRL}
+        cnpjMasked="12.345.678/9012-34"
+      />,
+    );
+    // CNPJ without setor should still render
+    expect(screen.getByText('Empresa Teste Ltda')).toBeTruthy();
+  });
+});

--- a/frontend/__tests__/inteligencia/IntelVitrineClient.test.tsx
+++ b/frontend/__tests__/inteligencia/IntelVitrineClient.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * VITRINE-001 (#1612): Tests for IntelVitrineClient (charts) component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import IntelVitrineClient from '@/app/inteligencia/[cnpj]/IntelVitrineClient';
+import type { IntelVitrineData } from '@/app/inteligencia/[cnpj]/page';
+
+const mockVitrine: IntelVitrineData = {
+  cnpj: '12345678901234',
+  razao_social: 'Empresa Teste Ltda',
+  nome_fantasia: 'Teste',
+  setor_principal: 'Construção',
+  setor_nome: 'Construção Civil',
+  total_contratos_12m: 10,
+  valor_total_12m: 500000.0,
+  total_contratos_alltime: 50,
+  valor_total_alltime: 2500000.0,
+  ranking: null,
+  top_orgaos: [],
+  distribuicao_uf: [
+    { chave: 'SP', quantidade: 30, valor_total: 1500000.0 },
+    { chave: 'RJ', quantidade: 10, valor_total: 500000.0 },
+    { chave: 'MG', quantidade: 5, valor_total: 250000.0 },
+  ],
+  distribuicao_ano: [
+    { chave: '2025', quantidade: 20, valor_total: 1000000.0 },
+    { chave: '2026', quantidade: 30, valor_total: 1500000.0 },
+  ],
+  distribuicao_modalidade: [
+    { chave: 'Pregão', quantidade: 40, valor_total: 2000000.0 },
+    { chave: 'Dispensa', quantidade: 10, valor_total: 500000.0 },
+  ],
+  generated_at: '2026-06-12T00:00:00',
+  aviso_legal: 'Aviso legal de teste.',
+};
+
+const formatBRL = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `R$ ${(value / 1_000_000).toFixed(1)} mi`;
+  }
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+};
+
+describe('IntelVitrineClient', () => {
+  it('renders distribution section title', () => {
+    render(
+      <IntelVitrineClient vitrine={mockVitrine} formatBRL={formatBRL} />,
+    );
+    expect(screen.getByText('Distribuição de Contratos')).toBeTruthy();
+  });
+
+  it('renders chart sub-titles when data available', () => {
+    render(
+      <IntelVitrineClient vitrine={mockVitrine} formatBRL={formatBRL} />,
+    );
+    expect(screen.getByText('Contratos por UF')).toBeTruthy();
+    expect(screen.getByText('Evolução por Ano')).toBeTruthy();
+    expect(screen.getByText('Distribuição por Modalidade')).toBeTruthy();
+  });
+
+  it('renders nothing when no chart data', () => {
+    const emptyVitrine = {
+      ...mockVitrine,
+      distribuicao_uf: [],
+      distribuicao_ano: [],
+      distribuicao_modalidade: [],
+    };
+    const { container } = render(
+      <IntelVitrineClient vitrine={emptyVitrine} formatBRL={formatBRL} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/__tests__/inteligencia/PublicContractsList.test.tsx
+++ b/frontend/__tests__/inteligencia/PublicContractsList.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * VITRINE-001 (#1612): Tests for PublicContractsList component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import PublicContractsList from '@/app/inteligencia/[cnpj]/components/PublicContractsList';
+import type { OrgaoInfoVitrine } from '@/app/inteligencia/[cnpj]/page';
+
+const mockOrgaos: OrgaoInfoVitrine[] = [
+  {
+    nome: 'Prefeitura Municipal de Sao Paulo',
+    cnpj: '11222333000181',
+    total_contratos: 20,
+    valor_total: 1000000.0,
+  },
+  {
+    nome: 'Governo do Estado de SP',
+    cnpj: '99888777000155',
+    total_contratos: 15,
+    valor_total: 750000.0,
+  },
+];
+
+const formatBRL = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `R$ ${(value / 1_000_000).toFixed(1)} mi`;
+  }
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+};
+
+describe('PublicContractsList', () => {
+  it('renders top orgaos', () => {
+    render(
+      <PublicContractsList topOrgaos={mockOrgaos} formatBRL={formatBRL} />,
+    );
+    expect(screen.getByText('Prefeitura Municipal de Sao Paulo')).toBeTruthy();
+    expect(screen.getByText('Governo do Estado de SP')).toBeTruthy();
+  });
+
+  it('renders contract counts', () => {
+    render(
+      <PublicContractsList topOrgaos={mockOrgaos} formatBRL={formatBRL} />,
+    );
+    expect(screen.getByText('20 contratos')).toBeTruthy();
+    expect(screen.getByText('15 contratos')).toBeTruthy();
+  });
+
+  it('returns null for empty list', () => {
+    const { container } = render(
+      <PublicContractsList topOrgaos={[]} formatBRL={formatBRL} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/__tests__/inteligencia/SectorPosition.test.tsx
+++ b/frontend/__tests__/inteligencia/SectorPosition.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * VITRINE-001 (#1612): Tests for SectorPosition component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import SectorPosition from '@/app/inteligencia/[cnpj]/components/SectorPosition';
+import type { RankingInfoVitrine } from '@/app/inteligencia/[cnpj]/page';
+
+const mockRanking: RankingInfoVitrine = {
+  percentil: 95.0,
+  posicao: 50,
+  total_empresas_setor: 1000,
+  texto_contexto:
+    'Esta empresa está entre as top 5% do setor Construção em contratos públicos, com 50 contratos registrados.',
+};
+
+describe('SectorPosition', () => {
+  it('renders ranking info when provided', () => {
+    render(<SectorPosition ranking={mockRanking} />);
+    expect(
+      screen.getByText(/top 5% do setor Construção/),
+    ).toBeTruthy();
+  });
+
+  it('renders section title', () => {
+    render(<SectorPosition ranking={mockRanking} />);
+    expect(screen.getByText('Ranking Setorial')).toBeTruthy();
+  });
+
+  it('renders comparison text with company count', () => {
+    render(<SectorPosition ranking={mockRanking} />);
+    expect(
+      screen.getByText(/1\.000 empresas do mesmo setor/),
+    ).toBeTruthy();
+  });
+
+  it('returns null when ranking is null', () => {
+    const { container } = render(<SectorPosition ranking={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4170,6 +4170,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/intel/vitrine/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search companies by name or CNPJ (VITRINE-001)
+         * @description Search for companies in pncp_supplier_contracts by name or partial CNPJ.
+         */
+        get: operations["intel_vitrine_search_v1_intel_vitrine_search_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel/vitrine/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Public company intelligence vitrine
+         * @description Retorna dados agregados de contratos públicos para um CNPJ. Endpoint público — sem autenticação necessária. Cache: 6h. Rate limit: 30 req/min por IP.
+         */
+        get: operations["intel_vitrine_v1_intel_vitrine__cnpj__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/itens/{catmat}/profile": {
         parameters: {
             query?: never;
@@ -6185,6 +6225,36 @@ export interface paths {
         post?: never;
         delete?: never;
         options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/widget/competitive-intel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Dados de Inteligência Competitiva para Widget Embedável
+         * @description Retorna dados agregados de contratos públicos por setor para widget embedável.
+         *
+         *     Temas:
+         *     - market-share: Market share dos fornecedores no setor
+         *     - top-winners: Top vencedores com indicadores de crescimento
+         *     - monthly-trend: Tendência mensal de contratos
+         *     - orgao-ranking: Ranking de órgãos compradores
+         */
+        get: operations["widget_competitive_intel_v1_widget_competitive_intel_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        /**
+         * Widget Competitive Intel Options
+         * @description Handle CORS preflight requests.
+         */
+        options: operations["widget_competitive_intel_options_v1_widget_competitive_intel_options"];
         head?: never;
         patch?: never;
         trace?: never;
@@ -8937,6 +9007,18 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * DistribuicaoItem
+         * @description Item de distribuição por UF, ano, ou modalidade.
+         */
+        DistribuicaoItem: {
+            /** Chave */
+            chave: string;
+            /** Quantidade */
+            quantidade: number;
+            /** Valor Total */
+            valor_total: number;
+        };
         /** EditaisAmostra */
         EditaisAmostra: {
             /** Data Encerramento */
@@ -10287,6 +10369,61 @@ export interface components {
             /** Uf */
             uf?: string | null;
         };
+        /**
+         * IntelVitrineResponse
+         * @description Resposta completa da vitrine de inteligência pública.
+         */
+        IntelVitrineResponse: {
+            /**
+             * Aviso Legal
+             * @default Dados públicos do Portal Nacional de Contratações Públicas (PNCP). Os valores refletem contratos registrados — podem não representar o total faturado pela empresa no período.
+             */
+            aviso_legal: string;
+            /** Cnpj */
+            cnpj: string;
+            /**
+             * Distribuicao Ano
+             * @default []
+             */
+            distribuicao_ano: components["schemas"]["DistribuicaoItem"][];
+            /**
+             * Distribuicao Modalidade
+             * @default []
+             */
+            distribuicao_modalidade: components["schemas"]["DistribuicaoItem"][];
+            /**
+             * Distribuicao Uf
+             * @default []
+             */
+            distribuicao_uf: components["schemas"]["DistribuicaoItem"][];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            /** Nome Fantasia */
+            nome_fantasia?: string | null;
+            ranking?: components["schemas"]["RankingInfo"] | null;
+            /** Razao Social */
+            razao_social: string;
+            /** Setor Nome */
+            setor_nome?: string | null;
+            /** Setor Principal */
+            setor_principal?: string | null;
+            /**
+             * Top Orgaos
+             * @default []
+             */
+            top_orgaos: components["schemas"]["OrgaoInfo"][];
+            /** Total Contratos 12M */
+            total_contratos_12m: number;
+            /** Total Contratos Alltime */
+            total_contratos_alltime: number;
+            /** Valor Total 12M */
+            valor_total_12m: number;
+            /** Valor Total Alltime */
+            valor_total_alltime: number;
+        };
         /** InviteMemberRequest */
         InviteMemberRequest: {
             /** Email */
@@ -11003,6 +11140,20 @@ export interface components {
             /** Total Value */
             total_value: number;
         };
+        /**
+         * OrgaoInfo
+         * @description Órgão comprador com total de contratos e valor.
+         */
+        OrgaoInfo: {
+            /** Cnpj */
+            cnpj: string;
+            /** Nome */
+            nome: string;
+            /** Total Contratos */
+            total_contratos: number;
+            /** Valor Total */
+            valor_total: number;
+        };
         /** OrgaoRank */
         OrgaoRank: {
             /** Cnpj */
@@ -11696,6 +11847,20 @@ export interface components {
             timestamp?: string | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * RankingInfo
+         * @description Posição da empresa no ranking setorial.
+         */
+        RankingInfo: {
+            /** Percentil */
+            percentil: number;
+            /** Posicao */
+            posicao: number;
+            /** Texto Contexto */
+            texto_contexto: string;
+            /** Total Empresas Setor */
+            total_empresas_setor: number;
         };
         /** RankingResponse */
         RankingResponse: {
@@ -19761,6 +19926,71 @@ export interface operations {
             };
         };
     };
+    intel_vitrine_search_v1_intel_vitrine_search_get: {
+        parameters: {
+            query: {
+                /** @description Search query */
+                q: string;
+                /** @description Max results */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    intel_vitrine_v1_intel_vitrine__cnpj__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelVitrineResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     item_profile_v1_itens__catmat__profile_get: {
         parameters: {
             query?: never;
@@ -22286,6 +22516,62 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RecommendedPlanResponse"];
+                };
+            };
+        };
+    };
+    widget_competitive_intel_v1_widget_competitive_intel_get: {
+        parameters: {
+            query: {
+                /** @description ID do setor (ex: ti, saude, construcao) */
+                setor: string;
+                /** @description Tema: market-share | top-winners | monthly-trend | orgao-ranking */
+                tema: string;
+                /** @description UF (2 letras, opcional) */
+                uf?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    widget_competitive_intel_options_v1_widget_competitive_intel_options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };

--- a/frontend/app/inteligencia/[cnpj]/components/CompanyOverview.tsx
+++ b/frontend/app/inteligencia/[cnpj]/components/CompanyOverview.tsx
@@ -1,0 +1,72 @@
+/**
+ * VITRINE-001 (#1612): Company overview component for /inteligencia/[cnpj].
+ *
+ * Displays company identity data, KPI cards (contract totals, values),
+ * and sector classification badge.
+ */
+
+'use client';
+
+import type { IntelVitrineData, RankingInfoVitrine } from '../page';
+
+interface Props {
+  vitrine: IntelVitrineData;
+  formatBRL: (value: number) => string;
+  cnpjMasked: string;
+}
+
+export default function CompanyOverview({ vitrine, formatBRL, cnpjMasked }: Props) {
+  return (
+    <section className="mb-10">
+      {/* Identity Header */}
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-ink tracking-tight mb-2">
+            {vitrine.razao_social}
+          </h1>
+          {vitrine.nome_fantasia && (
+            <p className="text-sm text-ink-secondary mb-1">{vitrine.nome_fantasia}</p>
+          )}
+          <p className="text-xs text-ink-secondary">
+            CNPJ: {cnpjMasked}
+            {vitrine.setor_nome && <> &middot; {vitrine.setor_nome}</>}
+          </p>
+        </div>
+
+        {vitrine.setor_nome && (
+          <span className="inline-flex items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-800 shrink-0">
+            {vitrine.setor_nome}
+          </span>
+        )}
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div className="bg-surface-1 border border-[var(--border)] rounded-xl p-4">
+          <p className="text-xs text-ink-secondary mb-1">Contratos (12 meses)</p>
+          <p className="text-xl sm:text-2xl font-bold text-ink">
+            {vitrine.total_contratos_12m.toLocaleString('pt-BR')}
+          </p>
+        </div>
+        <div className="bg-surface-1 border border-[var(--border)] rounded-xl p-4">
+          <p className="text-xs text-ink-secondary mb-1">Valor (12 meses)</p>
+          <p className="text-xl sm:text-2xl font-bold text-green-700">
+            {formatBRL(vitrine.valor_total_12m)}
+          </p>
+        </div>
+        <div className="bg-surface-1 border border-[var(--border)] rounded-xl p-4">
+          <p className="text-xs text-ink-secondary mb-1">Total Contratos</p>
+          <p className="text-xl sm:text-2xl font-bold text-ink">
+            {vitrine.total_contratos_alltime.toLocaleString('pt-BR')}
+          </p>
+        </div>
+        <div className="bg-surface-1 border border-[var(--border)] rounded-xl p-4">
+          <p className="text-xs text-ink-secondary mb-1">Valor Total</p>
+          <p className="text-xl sm:text-2xl font-bold text-green-700">
+            {formatBRL(vitrine.valor_total_alltime)}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/inteligencia/[cnpj]/components/PublicContractsList.tsx
+++ b/frontend/app/inteligencia/[cnpj]/components/PublicContractsList.tsx
@@ -1,0 +1,46 @@
+/**
+ * VITRINE-001 (#1612): Public contracts list for /inteligencia/[cnpj].
+ *
+ * Shows top buying organizations with contract counts and values.
+ */
+
+'use client';
+
+import Link from 'next/link';
+import type { OrgaoInfoVitrine } from '../page';
+
+interface Props {
+  topOrgaos: OrgaoInfoVitrine[];
+  formatBRL: (value: number) => string;
+}
+
+export default function PublicContractsList({ topOrgaos, formatBRL }: Props) {
+  if (topOrgaos.length === 0) return null;
+
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-semibold text-ink mb-4">
+        Principais Orgaos Compradores
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {topOrgaos.map((orgao) => (
+          <Link
+            key={orgao.cnpj}
+            href={`/orgaos/${orgao.cnpj}`}
+            className="block bg-surface-1 border border-[var(--border)] rounded-xl p-4 hover:shadow-md transition-shadow"
+          >
+            <p className="text-sm font-semibold text-ink mb-2 line-clamp-2">
+              {orgao.nome}
+            </p>
+            <div className="flex justify-between text-xs text-ink-secondary">
+              <span>{orgao.total_contratos} contratos</span>
+              <span className="text-green-700 font-medium">
+                {formatBRL(orgao.valor_total)}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/inteligencia/[cnpj]/components/SectorPosition.tsx
+++ b/frontend/app/inteligencia/[cnpj]/components/SectorPosition.tsx
@@ -1,0 +1,41 @@
+/**
+ * VITRINE-001 (#1612): Sector position component for /inteligencia/[cnpj].
+ *
+ * Displays the company's percentile ranking within its sector,
+ * using the backend-computed ranking info with contextual message.
+ */
+
+'use client';
+
+import type { RankingInfoVitrine } from '../page';
+
+interface Props {
+  ranking: RankingInfoVitrine | null;
+}
+
+export default function SectorPosition({ ranking }: Props) {
+  if (!ranking) return null;
+
+  return (
+    <section className="mb-10 rounded-xl border border-amber-200 bg-amber-50 p-6">
+      <div className="flex items-start gap-4">
+        <div className="shrink-0 w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center">
+          <span className="text-2xl" role="img" aria-label="Trophy">
+            &#x1F3C6;
+          </span>
+        </div>
+        <div>
+          <h2 className="text-lg font-bold text-amber-900 mb-1">
+            Ranking Setorial
+          </h2>
+          <p className="text-base text-amber-800">{ranking.texto_contexto}</p>
+          <p className="text-xs text-amber-600 mt-2">
+            Comparativo com{' '}
+            {ranking.total_empresas_setor.toLocaleString('pt-BR')} empresas do
+            mesmo setor
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Implements **VITRINE-001** -- Public Intelligence pages at `/inteligencia/[cnpj]` for organic acquisition.

### What was done

**Backend:**
- Added `GET /v1/intel/vitrine/search?q=` search endpoint for company lookup
- Registered `intel_vitrine_router` in startup/routes.py (was imported but missing from list)
- Search endpoint: finds companies by name or partial CNPJ in `pncp_supplier_contracts`
- Tests: 9 passing (route validation, search validation, schema tests)

**Frontend:**
- Extracted 3 components from the existing page:
  - `CompanyOverview.tsx` -- identity header, KPI cards, sector badge
  - `PublicContractsList.tsx` -- top buying organizations grid
  - `SectorPosition.tsx` -- percentile ranking with contextual message
- Tests: 4 test files covering all components (CompanyOverview 6, PublicContractsList 3, SectorPosition 4, IntelVitrineClient 3 = 16 test cases)
- Existing page (`page.tsx` + `IntelVitrineClient.tsx`) already includes:
  - ISR revalidate=3600
  - JSON-LD Dataset schema
  - SEO metadata with OpenGraph/Twitter cards
  - EmptyStateSEO fallback (ADR-SEO-001 compliant)
  - Recharts charts (UF bar, yearly line, modality pie)

### Files changed

- backend/routes/intel_vitrine.py
- backend/startup/routes.py
- backend/tests/test_vitrine.py
- frontend/app/inteligencia/[cnpj]/components/CompanyOverview.tsx
- frontend/app/inteligencia/[cnpj]/components/PublicContractsList.tsx
- frontend/app/inteligencia/[cnpj]/components/SectorPosition.tsx
- frontend/__tests__/inteligencia/CompanyOverview.test.tsx
- frontend/__tests__/inteligencia/PublicContractsList.test.tsx
- frontend/__tests__/inteligencia/SectorPosition.test.tsx
- frontend/__tests__/inteligencia/IntelVitrineClient.test.tsx

Closes #1612