### PR TITLE
feat(backend): NETINT-005 — fire-and-forget event collector middleware (#1672)

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1388,6 +1388,14 @@ FOUNDING_CHECKOUTS_TOTAL = _create_counter(
 )
 
 
+# NETINT-005: Network events collection counter
+NETWORK_EVENTS_COLLECTED_TOTAL = _create_counter(
+    "smartlic_network_events_collected_total",
+    "Network intelligence events collected (fire-and-forget)",
+    labelnames=["evento_tipo", "status"],  # status: success, timeout, error
+)
+
+
 # ============================================================================
 # ASGI app factory for /metrics endpoint
 # ============================================================================


### PR DESCRIPTION
## Summary

Recreating PR #1687 (closed).

Adds NETINT-005: fire-and-forget event collector middleware.

### Changes
- Add Prometheus counter `smartlic_network_events_collected_total` in `backend/metrics.py`
- Core services (event_sanitizer, network_collector) already present from bulk merge

### Tests
```
tests/test_network_collector.py — 24 passed
```

Issue: #1672