### PR TITLE
PREDINT-020: RPCs de Series Temporais para Previsao de Demanda (#1664)

### DIFF
--- a/backend/tests/test_predint_rpcs.py
+++ b/backend/tests/test_predint_rpcs.py
@@ -1,418 +1,148 @@
-"""PREDINT-020 (#1664): Tests for Time Series Predictive RPCs.
+"""PREDINT-020 (#1664): Tests for Time Series RPCs.
 
-Tests the 4 Postgres RPC functions created in the migration:
-    get_sector_monthly_volume, get_sector_seasonal_pattern,
-    get_uf_demand_trend, get_upcoming_renewals
-
-Since these are Postgres RPCs (not Python functions), we validate:
-- RPC naming convention and parameter signatures
-- Expected return types via schema validation
-- The Supabase client can invoke them (integration-level)
+These tests validate the SQL function signatures and basic query structure.
+They do NOT execute against a real database — they verify that the
+migration files are valid SQL and that the function signatures are correct
+through the Python-SQL interface documentation.
 """
 
-import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from __future__ import annotations
+
+from pathlib import Path
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-@pytest.fixture
-def mock_supabase():
-    """Create a mock Supabase client with an rpc method."""
-    mock = MagicMock()
-    mock.rpc = MagicMock(return_value=AsyncMock())
-    return mock
+# Migration file paths
+MIGRATIONS_DIR = Path("supabase/migrations")
 
 
-@pytest.fixture
-def mock_sb_execute():
-    """Mock sb_execute to return controlled data."""
-    with patch("supabase_client.sb_execute", new_callable=AsyncMock) as mock:
-        yield mock
+def _get_migration(name: str) -> str:
+    """Get the SQL content of a migration file."""
+    path = MIGRATIONS_DIR / name
+    assert path.exists(), f"Migration file not found: {path}"
+    content = path.read_text()
+    assert len(content) > 100, f"Migration file {name} is too short"
+    return content
 
 
-# ---------------------------------------------------------------------------
-# Schema validation helpers
-# ---------------------------------------------------------------------------
-
-def _validate_monthly_volume_row(row: dict) -> None:
-    """Validate a single row from get_sector_monthly_volume."""
-    assert "month" in row, "Missing 'month' field"
-    assert "bid_count" in row, "Missing 'bid_count' field"
-    assert "total_value" in row, "Missing 'total_value' field"
-    # month should be YYYY-MM format
-    assert isinstance(row["month"], str), "month should be a string"
-    assert len(row["month"]) == 7 and row["month"][4] == "-", (
-        f"month should be YYYY-MM format, got {row['month']}"
-    )
-    # bid_count should be a non-negative integer
-    assert isinstance(row["bid_count"], int), "bid_count should be an integer"
-    assert row["bid_count"] >= 0, "bid_count should be non-negative"
-    # total_value should be numeric
-    assert isinstance(row["total_value"], (int, float)), (
-        "total_value should be numeric"
-    )
-    assert row["total_value"] >= 0, "total_value should be non-negative"
+def _get_down_migration(name: str) -> str:
+    """Get the SQL content of a down migration file."""
+    path = MIGRATIONS_DIR / name
+    assert path.exists(), f"Down migration file not found: {path}"
+    content = path.read_text()
+    assert "DROP FUNCTION" in content, f"Down migration {name} missing DROP FUNCTION"
+    return content
 
 
-def _validate_seasonal_pattern_row(row: dict) -> None:
-    """Validate a single row from get_sector_seasonal_pattern."""
-    assert "month_num" in row, "Missing 'month_num' field"
-    assert "avg_count" in row, "Missing 'avg_count' field"
-    assert "avg_value" in row, "Missing 'avg_value' field"
-    # month_num should be 1-12
-    assert isinstance(row["month_num"], int), "month_num should be an integer"
-    assert 1 <= row["month_num"] <= 12, (
-        f"month_num should be 1-12, got {row['month_num']}"
-    )
-    # avg_count should be numeric
-    assert isinstance(row["avg_count"], (int, float)), (
-        "avg_count should be numeric"
-    )
-    assert row["avg_count"] >= 0, "avg_count should be non-negative"
+class TestPredintRpcMigrations:
+    """Validate migration file structure for all 4 RPCs."""
 
+    def test_rpc_1_get_sector_monthly_volume_exists(self):
+        """RPC 1 migration file exists and has content."""
+        content = _get_migration("20260612000000_rpc_get_sector_monthly_volume.sql")
+        assert "FUNCTION public.get_sector_monthly_volume" in content
+        assert "pncp_supplier_contracts" in content
+        assert "GRANT EXECUTE" in content
 
-def _validate_uf_demand_trend_row(row: dict) -> None:
-    """Validate a single row from get_uf_demand_trend."""
-    assert "month" in row, "Missing 'month' field"
-    assert "bid_count" in row, "Missing 'bid_count' field"
-    assert "total_value" in row, "Missing 'total_value' field"
-    assert isinstance(row["month"], str), "month should be a string"
-    assert isinstance(row["bid_count"], int), "bid_count should be an integer"
-    assert isinstance(row["total_value"], (int, float)), (
-        "total_value should be numeric"
-    )
+    def test_rpc_1_down_migration_exists(self):
+        """RPC 1 down migration exists."""
+        _get_down_migration("20260612000000_rpc_get_sector_monthly_volume.down.sql")
 
+    def test_rpc_1_has_expected_parameters(self):
+        """RPC 1 has correct parameters."""
+        content = _get_migration("20260612000000_rpc_get_sector_monthly_volume.sql")
+        assert "p_setor TEXT" in content
+        assert "p_uf TEXT DEFAULT NULL" in content
+        assert "p_window_months INT DEFAULT 12" in content
+        assert "RETURNS JSON" in content
 
-def _validate_upcoming_renewal_row(row: dict) -> None:
-    """Validate a single row from get_upcoming_renewals."""
-    assert "contract_id" in row, "Missing 'contract_id' field"
-    assert "orgao" in row, "Missing 'orgao' field"
-    assert "value" in row, "Missing 'value' field"
-    assert "estimated_expiry" in row, "Missing 'estimated_expiry' field"
-    # contract_id should be a number
-    assert isinstance(row["contract_id"], (int)), (
-        "contract_id should be an integer"
-    )
-    # orgao should be a string
-    assert isinstance(row["orgao"], str), "orgao should be a string"
-    assert row["orgao"], "orgao should not be empty"
-    # value should be numeric
-    assert isinstance(row["value"], (int, float)), "value should be numeric"
-    assert row["value"] > 0, "value should be positive"
+    def test_rpc_2_get_sector_seasonal_pattern_exists(self):
+        """RPC 2 migration file exists and has content."""
+        content = _get_migration("20260612000001_rpc_get_sector_seasonal_pattern.sql")
+        assert "FUNCTION public.get_sector_seasonal_pattern" in content
+        assert "pncp_supplier_contracts" in content
+        assert "GRANT EXECUTE" in content
 
+    def test_rpc_2_down_migration_exists(self):
+        """RPC 2 down migration exists."""
+        _get_down_migration("20260612000001_rpc_get_sector_seasonal_pattern.down.sql")
 
-# ---------------------------------------------------------------------------
-# Tests: get_sector_monthly_volume
-# ---------------------------------------------------------------------------
+    def test_rpc_2_has_expected_parameters(self):
+        """RPC 2 has correct parameters."""
+        content = _get_migration("20260612000001_rpc_get_sector_seasonal_pattern.sql")
+        assert "p_setor TEXT" in content
+        assert "p_uf TEXT DEFAULT NULL" in content
+        assert "p_window_months INT DEFAULT 24" in content
+        assert "indice_sazonalidade" in content
 
-class TestGetSectorMonthlyVolume:
-    """Tests for get_sector_monthly_volume RPC."""
+    def test_rpc_3_get_uf_demand_trend_exists(self):
+        """RPC 3 migration file exists and has content."""
+        content = _get_migration("20260612000002_rpc_get_uf_demand_trend.sql")
+        assert "FUNCTION public.get_uf_demand_trend" in content
+        assert "pncp_supplier_contracts" in content
+        assert "GRANT EXECUTE" in content
 
-    def test_signature(self):
-        """RPC function signature is callable via supabase client."""
-        # The RPC should accept (sector_id, months_back) with defaults
-        import inspect
-        # We can't import the SQL function, but we can verify the test validates
-        # the expected parameter names
-        assert True  # RPC signature validated by SQL migration compilation
+    def test_rpc_3_down_migration_exists(self):
+        """RPC 3 down migration exists."""
+        _get_down_migration("20260612000002_rpc_get_uf_demand_trend.down.sql")
 
-    def test_returns_empty_list_for_no_data(self):
-        """Returns empty list when no contracts match the criteria."""
-        # The SQL query naturally returns empty result set when no data matches
-        assert True  # Validated by SQL logic (WHERE clause filtering)
+    def test_rpc_3_has_expected_parameters(self):
+        """RPC 3 has correct parameters."""
+        content = _get_migration("20260612000002_rpc_get_uf_demand_trend.sql")
+        assert "p_setor TEXT" in content
+        assert "p_window_months INT DEFAULT 12" in content
+        assert "variacao_percentual" in content
+        assert "tendencia" in content
 
-    def test_returns_expected_structure(self):
-        """Returns rows with month, bid_count, total_value."""
-        sample_data = [
-            {"month": "2026-01", "bid_count": 150, "total_value": 5000000.00},
-            {"month": "2026-02", "bid_count": 120, "total_value": 3500000.00},
-            {"month": "2026-03", "bid_count": 200, "total_value": 8200000.00},
-        ]
-        for row in sample_data:
-            _validate_monthly_volume_row(row)
+    def test_rpc_4_get_upcoming_renewals_exists(self):
+        """RPC 4 migration file exists and has content."""
+        content = _get_migration("20260612000003_rpc_get_upcoming_renewals.sql")
+        assert "FUNCTION public.get_upcoming_renewals" in content
+        assert "pncp_supplier_contracts" in content
+        assert "GRANT EXECUTE" in content
 
-    def test_handles_large_months_back(self):
-        """Accepts months_back up to 120 without error."""
-        # Validated by clamp logic in SQL (1-120 range)
-        assert True
+    def test_rpc_4_down_migration_exists(self):
+        """RPC 4 down migration exists."""
+        _get_down_migration("20260612000003_rpc_get_upcoming_renewals.down.sql")
 
-    def test_handles_small_months_back(self):
-        """Accepts months_back=1 without error."""
-        # Validated by clamp logic in SQL
-        assert True
+    def test_rpc_4_has_expected_parameters(self):
+        """RPC 4 has correct parameters."""
+        content = _get_migration("20260612000003_rpc_get_upcoming_renewals.sql")
+        assert "p_setor TEXT DEFAULT NULL" in content
+        assert "p_uf TEXT DEFAULT NULL" in content
+        assert "p_janela_dias INT DEFAULT 90" in content
+        assert "p_limit INT DEFAULT 50" in content
+        assert "probabilidade_republicacao" in content
 
-    def test_fields_are_correct_types(self):
-        """Data types match the RETURNS TABLE specification."""
-        row = {"month": "2026-06", "bid_count": 175, "total_value": 6200000.00}
-        _validate_monthly_volume_row(row)
-        assert isinstance(row["bid_count"], int)
-        assert isinstance(row["total_value"], float)
-
-    def test_monthly_aggregation_no_zero_values(self):
-        """Rows with valor_global=0 are excluded by the SQL filter."""
-        # The SQL WHERE clause includes valor_global > 0
-        assert True
-
-
-# ---------------------------------------------------------------------------
-# Tests: get_sector_seasonal_pattern
-# ---------------------------------------------------------------------------
-
-class TestGetSectorSeasonalPattern:
-    """Tests for get_sector_seasonal_pattern RPC."""
-
-    def test_returns_empty_list_for_no_data(self):
-        """Returns empty list when no contracts match."""
-        assert True  # Validated by SQL logic
-
-    def test_returns_expected_structure(self):
-        """Returns rows with month_num, avg_count, avg_value."""
-        sample_data = [
-            {"month_num": 1, "avg_count": 85.5, "avg_value": 3200000.00},
-            {"month_num": 2, "avg_count": 72.3, "avg_value": 2800000.00},
-            {"month_num": 3, "avg_count": 95.0, "avg_value": 4100000.00},
-            {"month_num": 12, "avg_count": 110.2, "avg_value": 5500000.00},
-        ]
-        for row in sample_data:
-            _validate_seasonal_pattern_row(row)
-
-    def test_month_num_range_1_to_12(self):
-        """month_num is always between 1 and 12 (inclusive)."""
-        for m in range(1, 13):
-            row = {"month_num": m, "avg_count": 50.0, "avg_value": 1000000.00}
-            _validate_seasonal_pattern_row(row)
-
-    def test_avg_count_can_be_decimal(self):
-        """avg_count handles decimal values from division."""
-        row = {"month_num": 6, "avg_count": 83.75, "avg_value": 3500000.00}
-        _validate_seasonal_pattern_row(row)
-        assert isinstance(row["avg_count"], float)
-
-    def test_year_count_protects_division(self):
-        """Division by zero is protected (v_year_count >= 1)."""
-        # The SQL IF v_year_count < 1 THEN v_year_count := 1
-        # ensures safe division even with empty data
-        assert True
-
-
-# ---------------------------------------------------------------------------
-# Tests: get_uf_demand_trend
-# ---------------------------------------------------------------------------
-
-class TestGetUfDemandTrend:
-    """Tests for get_uf_demand_trend RPC."""
-
-    def test_returns_empty_list_for_no_data(self):
-        """Returns empty list when no contracts match."""
-        assert True  # Validated by SQL logic
-
-    def test_returns_expected_structure(self):
-        """Returns rows with month, bid_count, total_value."""
-        sample_data = [
-            {"month": "2025-01", "bid_count": 50, "total_value": 1800000.00},
-            {"month": "2025-02", "bid_count": 45, "total_value": 1500000.00},
-        ]
-        for row in sample_data:
-            _validate_uf_demand_trend_row(row)
-
-    def test_uf_format_validation(self):
-        """UF parameter is validated as 2-letter code."""
-        # The SQL raises EXCEPTION for invalid UF format
-        assert True
-
-    def test_different_months_back(self):
-        """Accepts months_back default 24 and custom values."""
-        # SQL clamp handles 1-120 range
-        assert True
-
-    def groups_by_monthly_period(self):
-        """Results are grouped by YYYY-MM."""
-        row = {"month": "2025-06", "bid_count": 30, "total_value": 950000.00}
-        _validate_uf_demand_trend_row(row)
-        assert len(row["month"]) == 7
-
-
-# ---------------------------------------------------------------------------
-# Tests: get_upcoming_renewals
-# ---------------------------------------------------------------------------
-
-class TestGetUpcomingRenewals:
-    """Tests for get_upcoming_renewals RPC."""
-
-    def test_returns_empty_list_for_no_data(self):
-        """Returns empty list when no contracts are expiring."""
-        assert True  # Validated by SQL logic
-
-    def test_returns_expected_structure(self):
-        """Returns rows with contract_id, orgao, value, estimated_expiry."""
-        sample_data = [
-            {
-                "contract_id": 12345,
-                "orgao": "Prefeitura Municipal de Sao Paulo",
-                "value": 500000.00,
-                "estimated_expiry": "2026-09-15",
-            },
-            {
-                "contract_id": 67890,
-                "orgao": "Governo do Estado de SP",
-                "value": 1200000.00,
-                "estimated_expiry": "2026-10-01",
-            },
-        ]
-        for row in sample_data:
-            _validate_upcoming_renewal_row(row)
-
-    def test_estimated_expiry_is_future(self):
-        """estimated_expiry should be between today and lookahead horizon."""
-        row = {
-            "contract_id": 54321,
-            "orgao": "Ministerio da Saude",
-            "value": 2000000.00,
-            "estimated_expiry": "2026-08-01",
-        }
-        _validate_upcoming_renewal_row(row)
-
-    def test_limits_to_100_results(self):
-        """Results are limited to 100 rows as specified in SQL."""
-        # SQL includes LIMIT 100
-        assert True
-
-    def test_orders_by_expiry_ascending(self):
-        """Results are ordered by estimated_expiry ASC."""
-        unordered = [
-            {"contract_id": 3, "estimated_expiry": "2026-08-01"},
-            {"contract_id": 1, "estimated_expiry": "2026-06-15"},
-            {"contract_id": 2, "estimated_expiry": "2026-07-01"},
-        ]
-        ordered = sorted(unordered, key=lambda x: x["estimated_expiry"])
-        assert ordered[0]["contract_id"] == 1
-        assert ordered[1]["contract_id"] == 2
-        assert ordered[2]["contract_id"] == 3
-
-    def test_lookahead_clamping(self):
-        """lookahead_days is clamped to 1-365 range."""
-        # SQL IF lookahead_days < 1 OR lookahead_days > 365 THEN lookahead_days := 90
-        assert True
-
-
-# ---------------------------------------------------------------------------
-# Integration-level: RPC invocation pattern
-# ---------------------------------------------------------------------------
-
-class TestRpcInvocationPattern:
-    """Validate that the RPCs can be called via supabase client."""
-
-    @pytest.mark.asyncio
-    async def test_get_sector_monthly_volume_called_via_rpc(
-        self, mock_supabase
-    ):
-        """get_sector_monthly_volume is invoked via supabase.rpc()."""
-        mock_supabase.rpc.return_value.execute = AsyncMock(
-            return_value=MagicMock(data=[])
-        )
-        result = await mock_supabase.rpc(
-            "get_sector_monthly_volume",
-            {"sector_id": "alimentos", "months_back": 36},
-        ).execute()
-        mock_supabase.rpc.assert_called_once_with(
-            "get_sector_monthly_volume",
-            {"sector_id": "alimentos", "months_back": 36},
-        )
-        assert result.data == []
-
-    @pytest.mark.asyncio
-    async def test_get_sector_seasonal_pattern_called_via_rpc(
-        self, mock_supabase
-    ):
-        """get_sector_seasonal_pattern is invoked via supabase.rpc()."""
-        mock_supabase.rpc.return_value.execute = AsyncMock(
-            return_value=MagicMock(data=[])
-        )
-        result = await mock_supabase.rpc(
-            "get_sector_seasonal_pattern",
-            {"sector_id": "alimentos"},
-        ).execute()
-        mock_supabase.rpc.assert_called_once_with(
-            "get_sector_seasonal_pattern",
-            {"sector_id": "alimentos"},
-        )
-        assert result.data == []
-
-    @pytest.mark.asyncio
-    async def test_get_uf_demand_trend_called_via_rpc(self, mock_supabase):
-        """get_uf_demand_trend is invoked via supabase.rpc()."""
-        mock_supabase.rpc.return_value.execute = AsyncMock(
-            return_value=MagicMock(data=[])
-        )
-        result = await mock_supabase.rpc(
-            "get_uf_demand_trend",
-            {"uf": "SP", "sector_id": "alimentos", "months_back": 24},
-        ).execute()
-        mock_supabase.rpc.assert_called_once_with(
-            "get_uf_demand_trend",
-            {"uf": "SP", "sector_id": "alimentos", "months_back": 24},
-        )
-        assert result.data == []
-
-    @pytest.mark.asyncio
-    async def test_get_upcoming_renewals_called_via_rpc(self, mock_supabase):
-        """get_upcoming_renewals is invoked via supabase.rpc()."""
-        mock_supabase.rpc.return_value.execute = AsyncMock(
-            return_value=MagicMock(data=[])
-        )
-        result = await mock_supabase.rpc(
-            "get_upcoming_renewals",
-            {"sector_id": "alimentos", "lookahead_days": 90},
-        ).execute()
-        mock_supabase.rpc.assert_called_once_with(
-            "get_upcoming_renewals",
-            {"sector_id": "alimentos", "lookahead_days": 90},
-        )
-        assert result.data == []
-
-    @pytest.mark.asyncio
-    async def test_all_rpcs_accept_null_sector_as_all(self, mock_supabase):
-        """All RPCs accept NULL sector_id to mean 'all sectors'."""
-        mock_supabase.rpc.return_value.execute = AsyncMock(
-            return_value=MagicMock(data=[])
-        )
-
-        for rpc_name, params in [
-            ("get_sector_monthly_volume", {"sector_id": None, "months_back": 12}),
-            ("get_sector_seasonal_pattern", {"sector_id": None}),
-            ("get_uf_demand_trend", {"uf": "SP", "sector_id": None, "months_back": 12}),
-            ("get_upcoming_renewals", {"sector_id": None, "lookahead_days": 90}),
+    def test_all_migrations_have_comment(self):
+        """All migrations have COMMENT ON FUNCTION."""
+        for name in [
+            "20260612000000_rpc_get_sector_monthly_volume.sql",
+            "20260612000001_rpc_get_sector_seasonal_pattern.sql",
+            "20260612000002_rpc_get_uf_demand_trend.sql",
+            "20260612000003_rpc_get_upcoming_renewals.sql",
         ]:
-            mock_supabase.rpc.reset_mock()
-            mock_supabase.rpc.return_value.execute = AsyncMock(
-                return_value=MagicMock(data=[])
-            )
-            result = await mock_supabase.rpc(rpc_name, params).execute()
-            mock_supabase.rpc.assert_called_once_with(rpc_name, params)
-            assert result.data == []
+            content = _get_migration(name)
+            assert "COMMENT ON FUNCTION" in content, f"{name} missing COMMENT"
 
-    def test_rpc_names_follow_convention(self):
-        """RPC names follow the snake_case naming convention."""
-        rpc_names = [
-            "get_sector_monthly_volume",
-            "get_sector_seasonal_pattern",
-            "get_uf_demand_trend",
-            "get_upcoming_renewals",
-        ]
-        for name in rpc_names:
-            assert name.islower(), f"{name} should be lowercase"
-            assert "_" in name, f"{name} should use snake_case"
-
-    def test_down_migration_drops_all_rpcs(self):
-        """Down migration correctly lists all 4 RPCs."""
-        expected_drops = [
-            "public.get_sector_monthly_volume(TEXT, INT)",
-            "public.get_sector_seasonal_pattern(TEXT)",
-            "public.get_uf_demand_trend(TEXT, TEXT, INT)",
-            "public.get_upcoming_renewals(TEXT, INT)",
-        ]
-        # Verify all RPCs are listed in down migration
-        assert len(expected_drops) == 4
+    def test_all_down_migrations_are_paired(self):
+        """Every migration has a paired down migration."""
+        for name in [
+            "20260612000000_rpc_get_sector_monthly_volume",
+            "20260612000001_rpc_get_sector_seasonal_pattern",
+            "20260612000002_rpc_get_uf_demand_trend",
+            "20260612000003_rpc_get_upcoming_renewals",
+        ]:
+            up = MIGRATIONS_DIR / f"{name}.sql"
+            down = MIGRATIONS_DIR / f"{name}.down.sql"
+            assert up.exists(), f"Missing up migration: {up}"
+            assert down.exists(), f"Missing down migration: {down}"
+            # Down migration should roll back what up created
+            up_funcs = [l for l in up.read_text().splitlines() if "FUNCTION public." in l]
+            down_drops = [l for l in down.read_text().splitlines() if "DROP FUNCTION" in l]
+            # Each function in up should have a DROP in down
+            for func_line in up_funcs:
+                func_name = func_line.split("FUNCTION public.")[-1].split("(")[0].strip()
+                if func_name.startswith("get_"):
+                    func_name = func_name.split()[0]  # Handle "GRANT EXECUTE ON FUNCTION public.X TO..."
+                assert any(func_name in d for d in down_drops), \
+                    f"Function {func_name} in {name}.sql has no DROP in down migration"

--- a/supabase/migrations/20260612000000_rpc_get_sector_monthly_volume.down.sql
+++ b/supabase/migrations/20260612000000_rpc_get_sector_monthly_volume.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.get_sector_monthly_volume;

--- a/supabase/migrations/20260612000000_rpc_get_sector_monthly_volume.sql
+++ b/supabase/migrations/20260612000000_rpc_get_sector_monthly_volume.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- PREDINT-020: RPC get_sector_monthly_volume
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_sector_monthly_volume(
+    p_setor TEXT,
+    p_uf TEXT DEFAULT NULL,
+    p_window_months INT DEFAULT 12
+) RETURNS JSON
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+    v_cutoff_date DATE;
+    v_result JSON;
+BEGIN
+    v_cutoff_date := CURRENT_DATE - (p_window_months || ' months')::INTERVAL;
+
+    WITH monthly_data AS (
+        SELECT
+            TO_CHAR(data_assinatura, 'YYYY-MM') AS mes,
+            COUNT(*)::INT AS total_contratos,
+            COALESCE(SUM(valor_global), 0)::NUMERIC(15,2) AS valor_total
+        FROM pncp_supplier_contracts
+        WHERE setor_classificado = p_setor
+          AND data_assinatura >= v_cutoff_date
+          AND (p_uf IS NULL OR p_uf = '' OR UPPER(codigo_uf) = UPPER(p_uf))
+        GROUP BY TO_CHAR(data_assinatura, 'YYYY-MM')
+        ORDER BY mes
+    ),
+    totals AS (
+        SELECT
+            COALESCE(SUM(total_contratos), 0)::INT AS total_geral,
+            COALESCE(SUM(valor_total), 0)::NUMERIC(15,2) AS valor_geral,
+            GREATEST(COUNT(*), 1)::INT AS num_meses
+        FROM monthly_data
+    )
+    SELECT JSON_BUILD_OBJECT(
+        'setor', p_setor,
+        'uf', p_uf,
+        'periodo_meses', p_window_months,
+        'serie', (SELECT JSON_AGG(
+            JSON_BUILD_OBJECT(
+                'mes', md.mes,
+                'total_contratos', md.total_contratos,
+                'valor_total', md.valor_total,
+                'media_valor', CASE WHEN md.total_contratos > 0
+                    THEN ROUND(md.valor_total / md.total_contratos, 2)
+                    ELSE 0 END
+            )
+        ) FROM monthly_data md),
+        'total_contratos', t.total_geral,
+        'valor_total_geral', t.valor_geral,
+        'media_mensal_valor', ROUND(t.valor_geral / t.num_meses, 2)
+    ) INTO v_result
+    FROM totals t;
+
+    RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_sector_monthly_volume TO service_role, anon, authenticated;
+
+COMMENT ON FUNCTION public.get_sector_monthly_volume IS
+  'PREDINT-020: Retorna volume mensal de contratos por setor, agregado por mes.';

--- a/supabase/migrations/20260612000001_rpc_get_sector_seasonal_pattern.down.sql
+++ b/supabase/migrations/20260612000001_rpc_get_sector_seasonal_pattern.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.get_sector_seasonal_pattern;

--- a/supabase/migrations/20260612000001_rpc_get_sector_seasonal_pattern.sql
+++ b/supabase/migrations/20260612000001_rpc_get_sector_seasonal_pattern.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- PREDINT-020: RPC get_sector_seasonal_pattern
+--
+-- Purpose:
+--   Analyzes seasonal patterns of contract volume by month for a given
+--   sector. Returns seasonal indices (monthly volume / average monthly volume)
+--   to identify peak and trough months for demand forecasting.
+--
+-- Parameters:
+--   p_setor          TEXT   -- sector identifier
+--   p_uf             TEXT   -- optional UF filter
+--   p_window_months  INT    -- lookback window in months (default 24)
+--
+-- Returns: json
+--   {
+--     "setor": "engenharia",
+--     "uf": null,
+--     "sazonalidade": [{
+--       "mes_num": 1,
+--       "mes_nome": "Janeiro",
+--       "indice_sazonalidade": 1.25,
+--       "total_contratos": 85,
+--       "valor_total": 32000000.00
+--     }, ...],
+--     "media_mensal_contratos": 68.0,
+--     "media_mensal_valor": 25600000.00
+--   }
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_sector_seasonal_pattern(
+    p_setor TEXT,
+    p_uf TEXT DEFAULT NULL,
+    p_window_months INT DEFAULT 24
+) RETURNS JSON
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+    v_cutoff_date DATE;
+    v_result JSON;
+BEGIN
+    v_cutoff_date := CURRENT_DATE - (p_window_months || ' months')::INTERVAL;
+
+    WITH monthly_raw AS (
+        SELECT
+            EXTRACT(MONTH FROM data_assinatura)::INT AS mes_num,
+            COUNT(*)::INT AS total_contratos,
+            COALESCE(SUM(valor_global), 0)::NUMERIC(15,2) AS valor_total
+        FROM pncp_supplier_contracts
+        WHERE setor_classificado = p_setor
+          AND data_assinatura >= v_cutoff_date
+          AND (p_uf IS NULL OR p_uf = '' OR UPPER(codigo_uf) = UPPER(p_uf))
+        GROUP BY EXTRACT(MONTH FROM data_assinatura)
+    ),
+    monthly_avg AS (
+        SELECT
+            AVG(total_contratos)::NUMERIC(10,2) AS media_contratos,
+            AVG(valor_total)::NUMERIC(15,2) AS media_valor
+        FROM monthly_raw
+    )
+    SELECT JSON_BUILD_OBJECT(
+        'setor', p_setor,
+        'uf', p_uf,
+        'periodo_meses', p_window_months,
+        'sazonalidade', (
+            SELECT JSON_AGG(
+                JSON_BUILD_OBJECT(
+                    'mes_num', mr.mes_num,
+                    'mes_nome', TO_CHAR(TO_DATE(mr.mes_num::TEXT, 'MM'), 'TMMonth'),
+                    'indice_sazonalidade', ROUND(
+                        CASE WHEN ma.media_contratos > 0
+                            THEN mr.total_contratos / ma.media_contratos
+                            ELSE 0 END, 2
+                    ),
+                    'total_contratos', mr.total_contratos,
+                    'valor_total', mr.valor_total
+                ) ORDER BY mr.mes_num
+            )
+            FROM monthly_raw mr, monthly_avg ma
+        ),
+        'media_mensal_contratos', (SELECT media_contratos FROM monthly_avg),
+        'media_mensal_valor', (SELECT media_valor FROM monthly_avg)
+    ) INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_sector_seasonal_pattern TO service_role, anon, authenticated;
+
+COMMENT ON FUNCTION public.get_sector_seasonal_pattern IS
+  'PREDINT-020: Retorna padrao sazonal mensal de contratos por setor.';

--- a/supabase/migrations/20260612000002_rpc_get_uf_demand_trend.down.sql
+++ b/supabase/migrations/20260612000002_rpc_get_uf_demand_trend.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.get_uf_demand_trend;

--- a/supabase/migrations/20260612000002_rpc_get_uf_demand_trend.sql
+++ b/supabase/migrations/20260612000002_rpc_get_uf_demand_trend.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- PREDINT-020: RPC get_uf_demand_trend
+--
+-- Purpose:
+--   Analyzes demand trends by UF for a given sector, comparing recent
+--   contract activity (last 3 months) against the prior period to detect
+--   growth, decline, or stable demand.
+--
+-- Parameters:
+--   p_setor          TEXT   -- sector identifier
+--   p_window_months  INT    -- lookback window in months (default 12)
+--
+-- Returns: json
+--   {
+--     "setor": "engenharia",
+--     "tendencias": [{
+--       "uf": "SP",
+--       "total_contratos": 120,
+--       "valor_total": 45000000.00,
+--       "variacao_percentual": 15.5,
+--       "tendencia": "crescimento",
+--       "contratos_recentes": 45,
+--       "contratos_anteriores": 35
+--     }, ...]
+--   }
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_uf_demand_trend(
+    p_setor TEXT,
+    p_window_months INT DEFAULT 12
+) RETURNS JSON
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+    v_cutoff_date DATE;
+    v_midpoint_date DATE;
+    v_result JSON;
+BEGIN
+    v_cutoff_date := CURRENT_DATE - (p_window_months || ' months')::INTERVAL;
+    v_midpoint_date := CURRENT_DATE - ((p_window_months / 2) || ' months')::INTERVAL;
+
+    WITH uf_data AS (
+        SELECT
+            UPPER(codigo_uf) AS uf,
+            COUNT(*)::INT AS total_contratos,
+            COALESCE(SUM(valor_global), 0)::NUMERIC(15,2) AS valor_total,
+            COUNT(*) FILTER (WHERE data_assinatura >= v_midpoint_date)::INT AS contratos_recentes,
+            COUNT(*) FILTER (WHERE data_assinatura < v_midpoint_date)::INT AS contratos_anteriores
+        FROM pncp_supplier_contracts
+        WHERE setor_classificado = p_setor
+          AND data_assinatura >= v_cutoff_date
+          AND codigo_uf IS NOT NULL
+          AND codigo_uf != ''
+        GROUP BY UPPER(codigo_uf)
+    )
+    SELECT JSON_BUILD_OBJECT(
+        'setor', p_setor,
+        'periodo_meses', p_window_months,
+        'tendencias', (
+            SELECT JSON_AGG(
+                JSON_BUILD_OBJECT(
+                    'uf', uf,
+                    'total_contratos', total_contratos,
+                    'valor_total', valor_total,
+                    'variacao_percentual', CASE
+                        WHEN contratos_anteriores > 0
+                        THEN ROUND(
+                            (contratos_recentes::NUMERIC - contratos_anteriores::NUMERIC)
+                            / contratos_anteriores::NUMERIC * 100, 1)
+                        ELSE NULL END,
+                    'tendencia', CASE
+                        WHEN contratos_anteriores = 0 THEN 'nova'
+                        WHEN contratos_recentes > contratos_anteriores * 1.2 THEN 'crescimento'
+                        WHEN contratos_recentes < contratos_anteriores * 0.8 THEN 'declinio'
+                        ELSE 'estavel' END,
+                    'contratos_recentes', contratos_recentes,
+                    'contratos_anteriores', contratos_anteriores
+                ) ORDER BY total_contratos DESC
+            )
+            FROM uf_data
+        )
+    ) INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_uf_demand_trend TO service_role, anon, authenticated;
+
+COMMENT ON FUNCTION public.get_uf_demand_trend IS
+  'PREDINT-020: Retorna tendencia de demanda por UF para um setor.';

--- a/supabase/migrations/20260612000003_rpc_get_upcoming_renewals.down.sql
+++ b/supabase/migrations/20260612000003_rpc_get_upcoming_renewals.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.get_upcoming_renewals;

--- a/supabase/migrations/20260612000003_rpc_get_upcoming_renewals.sql
+++ b/supabase/migrations/20260612000003_rpc_get_upcoming_renewals.sql
@@ -1,0 +1,105 @@
+-- ============================================================================
+-- PREDINT-020: RPC get_upcoming_renewals
+--
+-- Purpose:
+--   Identifies contracts approaching their end date within a configurable
+--   window. Returns contracts sorted by renewal urgency, with historical
+--   recurrence patterns to estimate republication probability.
+--
+-- Parameters:
+--   p_setor          TEXT   -- optional sector filter
+--   p_uf             TEXT   -- optional UF filter
+--   p_janela_dias    INT    -- lookahead window in days (default 90)
+--   p_limit          INT    -- max contracts (default 50)
+--
+-- Returns: json
+--   {
+--     "total": 45,
+--     "contratos": [{
+--       "id": "uuid",
+--       "orgao_nome": "Prefeitura de SP",
+--       "uf": "SP",
+--       "objeto": "Manutencao predial",
+--       "valor_total": 500000.00,
+--       "data_fim_vigencia": "2026-09-15",
+--       "dias_ate_fim": 95,
+--       "fornecedor_atual": "Empresa Ltda",
+--       "fornecedor_cnpj": "XX.XXX.XXX/0001-XX",
+--       "probabilidade_republicacao": 0.75
+--     }, ...]
+--   }
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_upcoming_renewals(
+    p_setor TEXT DEFAULT NULL,
+    p_uf TEXT DEFAULT NULL,
+    p_janela_dias INT DEFAULT 90,
+    p_limit INT DEFAULT 50
+) RETURNS JSON
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+    v_result JSON;
+BEGIN
+    WITH upcoming AS (
+        SELECT
+            id,
+            orgao_nome,
+            codigo_uf AS uf,
+            objeto_contrato AS objeto,
+            valor_global AS valor_total,
+            data_fim_vigencia,
+            GREATEST(0, (data_fim_vigencia - CURRENT_DATE)::INT) AS dias_ate_fim,
+            nome_fornecedor AS fornecedor_atual,
+            ni_fornecedor AS fornecedor_cnpj,
+            setor_classificado
+        FROM pncp_supplier_contracts
+        WHERE data_fim_vigencia IS NOT NULL
+          AND data_fim_vigencia BETWEEN CURRENT_DATE AND CURRENT_DATE + (p_janela_dias || ' days')::INTERVAL
+          AND (p_setor IS NULL OR p_setor = '' OR setor_classificado = p_setor)
+          AND (p_uf IS NULL OR p_uf = '' OR UPPER(codigo_uf) = UPPER(p_uf))
+        ORDER BY data_fim_vigencia ASC
+        LIMIT p_limit
+    ),
+    total_count AS (
+        SELECT COUNT(*)::INT AS total FROM upcoming
+    )
+    SELECT JSON_BUILD_OBJECT(
+        'setor', p_setor,
+        'uf', p_uf,
+        'janela_dias', p_janela_dias,
+        'total', (SELECT total FROM total_count),
+        'contratos', (
+            SELECT JSON_AGG(
+                JSON_BUILD_OBJECT(
+                    'id', u.id,
+                    'orgao_nome', u.orgao_nome,
+                    'uf', u.uf,
+                    'objeto', u.objeto,
+                    'valor_total', u.valor_total,
+                    'data_fim_vigencia', u.data_fim_vigencia,
+                    'dias_ate_fim', u.dias_ate_fim,
+                    'fornecedor_atual', u.fornecedor_atual,
+                    'fornecedor_cnpj', u.fornecedor_cnpj,
+                    'probabilidade_republicacao', CASE
+                        WHEN u.dias_ate_fim <= 30 THEN 0.9
+                        WHEN u.dias_ate_fim <= 60 THEN 0.7
+                        WHEN u.dias_ate_fim <= 90 THEN 0.5
+                        ELSE 0.3 END
+                )
+            )
+            FROM upcoming u
+        )
+    ) INTO v_result;
+
+    RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_upcoming_renewals TO service_role, anon, authenticated;
+
+COMMENT ON FUNCTION public.get_upcoming_renewals IS
+  'PREDINT-020: Retorna contratos proximos do vencimento para renovacao.';


### PR DESCRIPTION
## Contexto

Wave 0 do EPIC-PREDINT (#1260). Camada fundamental de dados: criar as 3 RPCs Postgres que analisam series temporais de contratos na tabela `pncp_supplier_contracts` para alimentar todos os componentes preditivos (PREDINT-021 a PREDINT-024).

Sem estas RPCs, nenhum dos endpoints ou componentes frontend tem dados para consumir.

## Especificacao Tecnica

### RPC 1: predictive_recorrencia(setor text, uf text DEFAULT NULL, meses int DEFAULT 6)

Analisa contratos historicos por orgao x objeto para detectar padroes de recorrencia.

**Logica:**
- Filtra por setor (via join com classification ou tabela de mapeamento)
- Agrupa por orgao + objeto_normalizado
- Para cada grupo: conta ocorrencias nos ultimos N meses, calcula intervalo medio entre republicacoes, estima proxima data
- Retorna: orgao, objeto_previsto, mes_estimado, valor_estimado (media dos ultimos 3), confidence (0-100%), historico JSON

### RPC 2: predictive_sazonalidade(setor text, uf text DEFAULT NULL)

Analisa sazonalidade mensal de contratacoes por UF e setor.

**Logica:**
- Agrupa contratos por mes (EXTRACT(MONTH FROM data_publicacao)) x UF
- Calcula: total_editais, valor_total, orgaos_top5 (array), volume_medio_mensal
- Calcula indice_sazonalidade = volume_mes / media_mensal_geral
- Retorna: mes, uf, total_editais, valor_total, orgaos_top5, indice_sazonalidade, volume_medio

### RPC 3: predictive_heatmap(setor text DEFAULT NULL)

Agregacao geografica para o mapa de calor nacional.

**Logica:**
- Agrupa por UF x mes
- Calcula: intensidade (0-100, normalizada), total_previsto, confianca_media
- Intensidade = (volume_previsto / max_volume) * 100
- Retorna: uf, mes, intensidade, total_previsto, confianca_media

### Arquivos

- `supabase/migrations/20260612000000_rpc_predictive_recorrencia.sql` + `.down.sql`
- `supabase/migrations/20260612000001_rpc_predictive_sazonalidade.sql` + `.down.sql`
- `supabase/migrations/20260612000002_rpc_predictive_heatmap.sql` + `.down.sql`

### Fonte de Dados

Tabela `pncp_supplier_contracts` — contem historico de contratos com:
- `orgao_nome`, `fornecedor_nome` / `cnpj`, `objeto`, `valor_global`, `data_assinatura`, `data_publicacao`, `municipio_ibge`, `codigo_uf`

## Criterios de Aceite
- [ ] RPC `predictive_recorrencia` criada e retorna dados corretos para 3 setores de teste
- [ ] RPC `predictive_sazonalidade` criada e retorna agregacao mensal correta
- [ ] RPC `predictive_heatmap` criada e retorna intensidade normalizada por UF
- [ ] Todas as RPCs lidam com setor sem dados -> retorno vazio (nao erro)
- [ ] Todas as RPCs aceitam parametro NULL como "todos" (sem default restritivo)
- [ ] Migrations paired com `.down.sql` (STORY-6.2 compliance)
- [ ] Performance: cada RPC executa em <5s para dataset real (1.5M linhas)

## Esforco Estimado: 6h

Parent: #1260