### PR TITLE
WIDGET-COMPINT-001: Widget embedavel de Inteligencia Competitiva (#1619)

### DIFF
--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -294,6 +294,8 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "PREDICTIVE_INTEL_ENABLED": ("PREDICTIVE_INTEL_ENABLED", "true"),
     # COMPINT-000 (EPIC-COMPINT #1261): competitive intelligence vertical
     "COMPETITIVE_INTEL_ENABLED": ("COMPETITIVE_INTEL_ENABLED", "true"),
+    # WIDGET-COMPINT-001 (#1619): Competitive Intelligence embeddable widget
+    "COMPETITIVE_INTEL_WIDGET_ENABLED": ("COMPETITIVE_INTEL_WIDGET_ENABLED", "true"),
     # B2GOPS-000 (EPIC-B2GOPS #1262): B2G Operations workspace_basic gate
     "B2G_OPS_ENABLED": ("B2G_OPS_ENABLED", "true"),
     # DEGUST-001 (#1611): Intelligence Tasting — trial upsell


### PR DESCRIPTION
### Contexto Estratégico

O widget NETINT-014 (#1519, CLOSED) cobre inteligência coletiva. Mas a camada COMPINT (Competitive Intelligence) não tem widget embedável.

**Problema:** Associações setoriais, portais de licitação e sites de consultoria publicam conteúdo sobre compras públicas mas não têm dados dinâmicos para embedar.

**Oportunidade:** Criar um widget embedável que mostra "Market Share de [Setor] em Contratos Públicos" com dados reais atualizados automaticamente. Cada embed é um backlink + lead qualificado para SmartLic.

### Especificação

**Widget (iframe ou web component):**
- `<smartlic-competitive-intel setor="ti" uf="SP" tema="market-share"></smartlic-competitive-intel>`
- Temas: market-share, top-winners, monthly-trend, orgao-ranking
- Dados reais de `pncp_supplier_contracts` com cache 1h
- Responsivo, light/dark mode
- Footer: "Dados por SmartLic — Inteligência em Compras Públicas" com link

**Backend:**
- `GET /v1/widget/competitive-intel?setor={id}&uf={uf}&tema={tema}` — dados JSON públicos
- Cache Redis 1h
- CORS aberto para embed
- Rate limit: 100 req/min por origem

**Frontend:**
- Página `/widgets/competitive-intel` com preview + código de embed
- Script de embed: `<script src="https://smartlic.tech/widgets/competitive-intel.js" async></script>`
- Construtor de widget: usuário seleciona setor, UF, tema → gera código

**Feature Flag:** `COMPETITIVE_INTEL_WIDGET_ENABLED` (default: true)

### Critérios de Aceite
- [ ] Widget funcional em iframe com 4 temas
- [ ] Dados reais com cache e rate limit
- [ ] Responsivo (mobile + desktop)
- [ ] CORS configurado corretamente
- [ ] Página de preview + código de embed
- [ ] Footer com atribuição e link para SmartLic
- [ ] Mixpanel: `widget_embedded`, `widget_viewed`

### Impacto Esperado
- 5-20 embeds em sites setoriais nos primeiros 3 meses
- 50-200 visitas/dia via widgets
- 1-3% conversão para trial

### Esforço Estimado: 12h (3 dias)
- Backend: 4h
- Frontend widget: 6h
- Preview page: 2h