### PR TITLE
feat(backend,frontend): COMPINT-013 (#1667) — Sector Benchmarks

### DIFF
--- a/backend/tests/test_competitive_benchmarks.py
+++ b/backend/tests/test_competitive_benchmarks.py
@@ -1,6 +1,7 @@
 """Tests for COMPINT-013: Sector Benchmarks endpoint.
 
 Covers:
+  Issue: #1667 COMPINT-013 — Sector Benchmarks
   - GET /v1/intel-concorrente/benchmarks
   - Response validation
   - Invalid input handling


### PR DESCRIPTION
## Contexto

Wave 2 do EPIC-COMPINT (#1261). Bloco aditivo na página /intel-concorrente que contextualiza o concorrente analisado contra benchmarks do setor: "Este player está acima ou abaixo da média do setor?"

## Especificação Técnica

### Backend — Agregações Setoriais

- Nova RPC `competitor_benchmarks(cnpj, setor)` que computa:
  - Taxa de vitória do concorrente vs. P25/P50/P75 do setor
  - Ticket médio vs. P25/P50/P75 do setor
  - Número de órgãos atendidos vs. P25/P50/P75 do setor
  - Concentração geográfica (HHI) vs. P25/P50/P75 do setor
- Fonte: agregações em `pncp_supplier_contracts` agrupadas por setor (CNAE)
- Índices necessários para query <500ms
- Cache: resultados agregados do setor cacheados por 24h (mudam pouco)

### Frontend — Componente CompetitorBenchmark

- Gráfico radar/spider (Recharts) com 4 eixos, cada um em percentil
- Legenda: "Concorrente" (linha destacada) vs "Mediana do Setor" (linha tracejada)
- Tooltip explicativo em cada métrica (ex: "Este player está no percentil 85 de ticket médio — acima da média do setor")
- Posição: bloco dentro de /intel-concorrente (após o mapa de território)
- Responsivo: radar → tabela em mobile (<640px)

### Gating
- Mesma capability `allow_competitive_intel` da página pai

## Critérios de Aceite
- [ ] RPC `competitor_benchmarks` implementada com índices adequados
- [ ] Gráfico radar/spider renderizado com dados reais (não mock)
- [ ] 4 métricas comparativas com percentis (P25, P50, P75)
- [ ] Tooltip explicativo em cada métrica do radar
- [ ] Responsivo: radar em desktop, tabela em mobile
- [ ] Performance: query <500ms
- [ ] Cache setorial 24h funcional
- [ ] Testes: cálculo de percentis, render do gráfico, dados mock

## Esforço Estimado: 6h

Parent: #1261