### PR TITLE
feat(backend): COMPINT-014 — Dossie Competitivo PDF (route registration fix)

### DIFF
--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -104,6 +104,7 @@ from routes.intel_vitrine import router as intel_vitrine_router
 from routes.pseo_intel_feed import router as pseo_intel_feed_router
 from routes.widget_compint import router as widget_compint_router
 from routes.consultoria import router as consultoria_router
+from routes.competitive_intel import router as competitive_intel_router
 
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
@@ -165,6 +166,7 @@ _v1_routers = [
     pseo_intel_feed_router,
     widget_compint_router,
     consultoria_router,
+    competitive_intel_router,
 ]
 
 

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -3355,6 +3355,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/consultoria/clients": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List consultant's clients (CONSULT-001) */
+        get: operations["list_clients_v1_consultoria_clients_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/consultoria/clients/{client_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke client access (CONSULT-001) */
+        delete: operations["revoke_client_v1_consultoria_clients__client_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/consultoria/invite-client": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate invite link for a client (CONSULT-001) */
+        post: operations["invite_client_v1_consultoria_invite_client_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/consultoria/share/{client_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Share a resource with a client (CONSULT-001) */
+        post: operations["share_resource_v1_consultoria_share__client_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/consultoria/shared/{client_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List shared resources for a client (CONSULT-001) */
+        get: operations["get_shared_resources_v1_consultoria_shared__client_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/conta/api-usage": {
         parameters: {
             query?: never;
@@ -4043,6 +4128,108 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/intel-concorrente/benchmarks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Sector Benchmarks — competitive performance comparison */
+        get: operations["get_competitor_benchmarks_v1_intel_concorrente_benchmarks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/dossie/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate Competitive Dossie PDF */
+        post: operations["generate_competitive_dossie_v1_intel_concorrente_dossie__cnpj__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/dossie/{cnpj}/{job_id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download the generated Dossie PDF */
+        get: operations["download_dossie_v1_intel_concorrente_dossie__cnpj___job_id__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/dossie/{cnpj}/{job_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Check Dossie generation status */
+        get: operations["get_dossie_status_v1_intel_concorrente_dossie__cnpj___job_id__status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/landscape": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Competitive Landscape — top players in a sector */
+        get: operations["get_competitive_landscape_v1_intel_concorrente_landscape_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel-concorrente/territory/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Territory Map — competitor geographic presence */
+        get: operations["get_competitor_territory_v1_intel_concorrente_territory__cnpj__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/intel-reports/": {
         parameters: {
             query?: never;
@@ -4162,6 +4349,26 @@ export interface paths {
         };
         /** Intelligence Tasting — aggregated supplier data for trial upsell (DEGUST-001) */
         get: operations["intel_tasting_v1_intel_tasting_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/intel/vitrine/{cnpj}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Public company intelligence vitrine
+         * @description Retorna dados agregados de contratos públicos para um CNPJ. Endpoint público — sem autenticação necessária. Cache: 6h. Rate limit: 30 req/min por IP.
+         */
+        get: operations["intel_vitrine_v1_intel_vitrine__cnpj__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5025,6 +5232,93 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/predint/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Predictive Alerts */
+        get: operations["list_predictive_alerts_v1_predint_alerts_get"];
+        put?: never;
+        /** Create Predictive Alert */
+        post: operations["create_predictive_alert_v1_predint_alerts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/predint/alerts/{alert_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Predictive Alert */
+        delete: operations["delete_predictive_alert_v1_predint_alerts__alert_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Predictive Alert */
+        patch: operations["update_predictive_alert_v1_predint_alerts__alert_id__patch"];
+        trace?: never;
+    };
+    "/v1/predint/forecast": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Demand Forecast — monthly contract volume over time */
+        get: operations["get_demand_forecast_v1_predint_forecast_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/predint/renewals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Renewal Alerts — contracts approaching estimated expiry */
+        get: operations["get_renewal_alerts_v1_predint_renewals_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/predint/seasonality/{sector_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Seasonal Pattern — average monthly contract distribution */
+        get: operations["get_seasonal_pattern_v1_predint_seasonality__sector_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/products": {
         parameters: {
             query?: never;
@@ -5131,6 +5425,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/profile/network-analytics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update Network Analytics
+         * @description NETINT-006: Update user's network analytics opt-in preference.
+         *
+         *     Sets ``profiles.allow_network_analytics`` to true or false.
+         *     Null (undecided) is treated as opt-out — this PATCH is how users
+         *     explicitly opt in.
+         *
+         *     SYS-023: Uses user-scoped Supabase client. RLS on profiles ensures
+         *     users can only update their own profile row.
+         */
+        put: operations["update_network_analytics_v1_profile_network_analytics_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/profile/sector-affinity": {
         parameters: {
             query?: never;
@@ -5176,6 +5497,23 @@ export interface paths {
          *     Unmute: restores pre-mute value. Never deletes the row or sets affinity to 0 permanently.
          */
         patch: operations["mute_unmute_sector_v1_profile_sector_affinity__sector_id__patch"];
+        trace?: never;
+    };
+    "/v1/pseo/intel-feed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Compact market intelligence feed for a sector (EmbedIntelFeed widget) */
+        get: operations["get_intel_feed_v1_pseo_intel_feed_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/v1/pseo/recent-editais": {
@@ -5312,6 +5650,74 @@ export interface paths {
          *     Persistence failure -> 500. Email failure -> 200 with email_queued=False.
          */
         post: operations["request_relatorio_v1_relatorio_2026_t1_request_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/report-mensal/cancel/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel monthly report subscription (REPORT-MONTHLY-001) */
+        post: operations["cancel_subscription_v1_report_mensal_cancel__id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/report-mensal/preview/{setor}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Preview monthly report data for a sector (REPORT-MONTHLY-001) */
+        get: operations["preview_monthly_report_v1_report_mensal_preview__setor__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/report-mensal/subscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Subscribe to monthly report (REPORT-MONTHLY-001) */
+        post: operations["subscribe_monthly_report_v1_report_mensal_subscribe_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/report-mensal/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List monthly report subscriptions (REPORT-MONTHLY-001) */
+        get: operations["list_subscriptions_v1_report_mensal_subscriptions_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -7087,6 +7493,27 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * BenchmarkPercentile
+         * @description A single percentile value for a metric.
+         */
+        BenchmarkPercentile: {
+            /**
+             * P25
+             * @description Percentil 25
+             */
+            p25: number;
+            /**
+             * P50
+             * @description Percentil 50 (mediana)
+             */
+            p50: number;
+            /**
+             * P75
+             * @description Percentil 75
+             */
+            p75: number;
+        };
+        /**
          * BillingPlansResponse
          * @description Response for GET /plans (billing.py).
          */
@@ -8103,6 +8530,144 @@ export interface components {
             /** Uf */
             uf: string | null;
         };
+        /**
+         * CompetitiveLandscapeResponse
+         * @description Top-level response for GET /v1/intel-concorrente/landscape.
+         */
+        CompetitiveLandscapeResponse: {
+            /**
+             * Gerado Em
+             * @description Timestamp de geracao
+             */
+            gerado_em?: string;
+            /**
+             * Periodo
+             * @description Periodo analisado
+             * @default Ultimos 12 meses
+             */
+            periodo: string;
+            /**
+             * Setor Id
+             * @description ID do setor
+             */
+            setor_id: string;
+            /**
+             * Setor Nome
+             * @description Nome do setor
+             */
+            setor_nome: string;
+            /**
+             * Top Concorrentes
+             * @description Top concorrentes
+             */
+            top_concorrentes?: components["schemas"]["CompetitorItem"][];
+            /**
+             * Total Concorrentes
+             * @description Total de concorrentes identificados
+             * @default 0
+             */
+            total_concorrentes: number;
+            /**
+             * Total Contratado
+             * @description Valor total contratado no setor
+             */
+            total_contratado: number;
+            /**
+             * Total Contratos
+             * @description Total de contratos
+             * @default 0
+             */
+            total_contratos: number;
+            /**
+             * Uf
+             * @description UF filtrada (opcional)
+             */
+            uf?: string | null;
+        };
+        /**
+         * CompetitorBenchmark
+         * @description Benchmark comparison for a single metric.
+         */
+        CompetitorBenchmark: {
+            /** @description Benchmark do setor (P25/P50/P75) */
+            benchmark_setor: components["schemas"]["BenchmarkPercentile"];
+            /**
+             * Descricao
+             * @description Tooltip explicativo
+             * @default
+             */
+            descricao: string;
+            /**
+             * Label
+             * @description Label amigavel para exibicao
+             */
+            label: string;
+            /**
+             * Metrica
+             * @description Nome da metrica (ex: taxa_vitoria, ticket_medio)
+             */
+            metrica: string;
+            /**
+             * Percentil Concorrente
+             * @description Percentil do concorrente (0-100)
+             */
+            percentil_concorrente: number;
+            /**
+             * Valor Concorrente
+             * @description Valor do concorrente na metrica
+             */
+            valor_concorrente: number;
+        };
+        /**
+         * CompetitorItem
+         * @description A single competitor in the leaderboard.
+         */
+        CompetitorItem: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Market Share
+             * @description Market share percentual (0-100)
+             * @default 0
+             */
+            market_share: number;
+            /**
+             * Numero Contratos
+             * @description Numero de contratos no periodo
+             * @default 0
+             */
+            numero_contratos: number;
+            /**
+             * Razao Social
+             * @description Nome / razao social
+             */
+            razao_social: string;
+            /**
+             * Tendencia
+             * @description Tendencia: crescimento/estavel/retracao
+             * @default estavel
+             */
+            tendencia: string;
+            /**
+             * Ticket Medio
+             * @description Ticket medio por contrato
+             * @default 0
+             */
+            ticket_medio: number;
+            /**
+             * Total Contratado
+             * @description Valor total contratado no periodo
+             */
+            total_contratado: number;
+            /**
+             * Ufs Atuacao
+             * @description UFs onde atua
+             */
+            ufs_atuacao?: string[];
+        };
         /** ComplianceProfileResponse */
         ComplianceProfileResponse: {
             /** Aviso Legal */
@@ -8123,6 +8688,74 @@ export interface components {
             total_sancoes_ceis: number;
             /** Total Sancoes Cnep */
             total_sancoes_cnep: number;
+        };
+        /**
+         * ConsultantClientListResponse
+         * @description Wrapper for list of consultant clients.
+         */
+        ConsultantClientListResponse: {
+            /** Active Count */
+            active_count: number;
+            /** Clients */
+            clients: components["schemas"]["ConsultantClientResponse"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * ConsultantClientResponse
+         * @description Response model for a consultant-client relationship.
+         */
+        ConsultantClientResponse: {
+            /** Client Email */
+            client_email?: string | null;
+            /** Client Id */
+            client_id?: string | null;
+            /** Consultant Id */
+            consultant_id: string;
+            /** Created At */
+            created_at: string;
+            /** Id */
+            id: string;
+            /** Status */
+            status: string;
+        };
+        /**
+         * ConsultantInviteResponse
+         * @description Response with invite link details.
+         */
+        ConsultantInviteResponse: {
+            /** Expires At */
+            expires_at: string;
+            /** Invite Url */
+            invite_url: string;
+        };
+        /**
+         * ConsultantShareCreate
+         * @description Request to share a resource with a client.
+         */
+        ConsultantShareCreate: {
+            /** Resource Id */
+            resource_id: string;
+            /** Resource Type */
+            resource_type: string;
+        };
+        /**
+         * ConsultantShareResponse
+         * @description Response model for a shared resource.
+         */
+        ConsultantShareResponse: {
+            /** Client Id */
+            client_id: string;
+            /** Consultant Id */
+            consultant_id: string;
+            /** Id */
+            id: string;
+            /** Resource Id */
+            resource_id: string;
+            /** Resource Type */
+            resource_type: string;
+            /** Shared At */
+            shared_at: string;
         };
         /** ContratoPublico */
         ContratoPublico: {
@@ -8874,6 +9507,56 @@ export interface components {
             success: boolean;
         };
         /**
+         * DemandForecastItem
+         * @description A single month in the demand forecast time series.
+         */
+        DemandForecastItem: {
+            /**
+             * Bid Count
+             * @description Number of bids/contracts in this month
+             */
+            bid_count: number;
+            /**
+             * Month
+             * @description Month in YYYY-MM format
+             */
+            month: string;
+            /**
+             * Total Value
+             * @description Total value of contracts in this month
+             */
+            total_value: number;
+        };
+        /**
+         * DemandForecastResponse
+         * @description Response from the demand forecast endpoint.
+         */
+        DemandForecastResponse: {
+            /**
+             * Feature Enabled
+             * @default true
+             */
+            feature_enabled: boolean;
+            /** Forecast */
+            forecast: components["schemas"]["DemandForecastItem"][];
+            /** Months */
+            months: number;
+            /** Sector */
+            sector?: string | null;
+            /**
+             * Total Contracts
+             * @default 0
+             */
+            total_contracts: number;
+            /**
+             * Total Value
+             * @default 0
+             */
+            total_value: number;
+            /** Uf */
+            uf?: string | null;
+        };
+        /**
          * DiagnosticoRequest
          * @description Request body for PDF diagnostico report generation.
          */
@@ -8966,6 +9649,105 @@ export interface components {
             total_searches?: number | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * DistribuicaoItem
+         * @description Item de distribuição por UF, ano, ou modalidade.
+         */
+        DistribuicaoItem: {
+            /** Chave */
+            chave: string;
+            /** Quantidade */
+            quantidade: number;
+            /** Valor Total */
+            valor_total: number;
+        };
+        /**
+         * DossieRequest
+         * @description Request parameters for dossie generation.
+         */
+        DossieRequest: {
+            /**
+             * Include Llm Summary
+             * @description Incluir sumario executivo gerado por IA
+             * @default true
+             */
+            include_llm_summary: boolean;
+            /**
+             * Setor Id
+             * @description Setor para contextualizacao
+             */
+            setor_id?: string | null;
+        };
+        /**
+         * DossieResponse
+         * @description Response for dossie generation request.
+         */
+        DossieResponse: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Download Url
+             * @description URL para download do PDF quando pronto
+             */
+            download_url?: string | null;
+            /**
+             * Job Id
+             * @description ID do job ARQ para acompanhamento
+             */
+            job_id: string;
+            /**
+             * Message
+             * @description Mensagem de status
+             * @default Dossie sendo gerado em background.
+             */
+            message: string;
+            /**
+             * Status
+             * @description Status do job: queued/processing/done/error
+             * @default queued
+             */
+            status: string;
+        };
+        /**
+         * DossieStatusResponse
+         * @description Status polling response for dossie generation.
+         */
+        DossieStatusResponse: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Download Url
+             * @description URL de download quando concluido
+             */
+            download_url?: string | null;
+            /**
+             * Error
+             * @description Mensagem de erro se aplicavel
+             */
+            error?: string | null;
+            /**
+             * Job Id
+             * @description ID do job
+             */
+            job_id: string;
+            /**
+             * Progress
+             * @description Progresso percentual (0-100)
+             * @default 0
+             */
+            progress: number;
+            /**
+             * Status
+             * @description Status atual: queued/processing/done/error
+             */
+            status: string;
         };
         /** EditaisAmostra */
         EditaisAmostra: {
@@ -10233,6 +11015,33 @@ export interface components {
             uf_nome: string;
         };
         /**
+         * IntelFeedResponse
+         * @description Full response payload for the intel feed endpoint.
+         */
+        IntelFeedResponse: {
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            /** Sector */
+            sector: string;
+            /** Signals */
+            signals: components["schemas"]["IntelFeedSignal"][];
+        };
+        /**
+         * IntelFeedSignal
+         * @description Single market signal displayed in the widget.
+         */
+        IntelFeedSignal: {
+            /** Label */
+            label: string;
+            /** Trend */
+            trend?: string | null;
+            /** Value */
+            value: string;
+        };
+        /**
          * IntelReportCheckoutRequest
          * @description Request body for POST /v1/intel-reports/checkout.
          */
@@ -10316,6 +11125,69 @@ export interface components {
             total_winners: number;
             /** Uf */
             uf?: string | null;
+        };
+        /**
+         * IntelVitrineResponse
+         * @description Resposta completa da vitrine de inteligência pública.
+         */
+        IntelVitrineResponse: {
+            /**
+             * Aviso Legal
+             * @default Dados públicos do Portal Nacional de Contratações Públicas (PNCP). Os valores refletem contratos registrados — podem não representar o total faturado pela empresa no período.
+             */
+            aviso_legal: string;
+            /** Cnpj */
+            cnpj: string;
+            /**
+             * Distribuicao Ano
+             * @default []
+             */
+            distribuicao_ano: components["schemas"]["DistribuicaoItem"][];
+            /**
+             * Distribuicao Modalidade
+             * @default []
+             */
+            distribuicao_modalidade: components["schemas"]["DistribuicaoItem"][];
+            /**
+             * Distribuicao Uf
+             * @default []
+             */
+            distribuicao_uf: components["schemas"]["DistribuicaoItem"][];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            /** Nome Fantasia */
+            nome_fantasia?: string | null;
+            ranking?: components["schemas"]["RankingInfo"] | null;
+            /** Razao Social */
+            razao_social: string;
+            /** Setor Nome */
+            setor_nome?: string | null;
+            /** Setor Principal */
+            setor_principal?: string | null;
+            /**
+             * Top Orgaos
+             * @default []
+             */
+            top_orgaos: components["schemas"]["OrgaoInfo"][];
+            /** Total Contratos 12M */
+            total_contratos_12m: number;
+            /** Total Contratos Alltime */
+            total_contratos_alltime: number;
+            /** Valor Total 12M */
+            valor_total_12m: number;
+            /** Valor Total Alltime */
+            valor_total_alltime: number;
+        };
+        /**
+         * InviteClientRequest
+         * @description Request payload for inviting a client by email.
+         */
+        InviteClientRequest: {
+            /** Client Email */
+            client_email: string;
         };
         /** InviteMemberRequest */
         InviteMemberRequest: {
@@ -10811,6 +11683,79 @@ export interface components {
             pct: number;
         };
         /**
+         * MonthlyReportPreviewResponse
+         * @description Preview data for a sector's monthly report (sample data).
+         */
+        MonthlyReportPreviewResponse: {
+            /** Avg Value */
+            avg_value: number;
+            /** Executive Summary */
+            executive_summary: string;
+            /** Period */
+            period: string;
+            /**
+             * Sample Pdf Available
+             * @default false
+             */
+            sample_pdf_available: boolean;
+            /** Sector Id */
+            sector_id: string;
+            /** Sector Name */
+            sector_name: string;
+            /** Top Opportunities */
+            top_opportunities: {
+                [key: string]: unknown;
+            }[];
+            /** Top Winners */
+            top_winners: {
+                [key: string]: unknown;
+            }[];
+            /** Total Licitacoes */
+            total_licitacoes: number;
+            /** Total Value */
+            total_value: number;
+        };
+        /**
+         * MonthlyReportSubscribeRequest
+         * @description Request body for POST /v1/report-mensal/subscribe.
+         */
+        MonthlyReportSubscribeRequest: {
+            /** Sector Id */
+            sector_id: string;
+            /** Stripe Price Id */
+            stripe_price_id?: string | null;
+        };
+        /**
+         * MonthlyReportSubscriptionResponse
+         * @description Response model for a monthly report subscription.
+         */
+        MonthlyReportSubscriptionResponse: {
+            /** Created At */
+            created_at: string;
+            /** Id */
+            id: string;
+            /** Sector Id */
+            sector_id: string;
+            /** Status */
+            status: string;
+            /** Stripe Sub Id */
+            stripe_sub_id?: string | null;
+            /** User Id */
+            user_id: string;
+        };
+        /**
+         * MonthlyReportSubscriptionsListResponse
+         * @description Wrapper for list of subscriptions.
+         */
+        MonthlyReportSubscriptionsListResponse: {
+            /** Active Count */
+            active_count: number;
+            /** Subscriptions */
+            subscriptions: components["schemas"]["MonthlyReportSubscriptionResponse"][];
+            /** Total */
+            total: number;
+        };
+        /**
          * MrrHistoryEntry
          * @description Single month entry in the MRR time series.
          */
@@ -10867,6 +11812,21 @@ export interface components {
             uf: string;
             /** Valor Total Licitacoes */
             valor_total_licitacoes: number;
+        };
+        /** NetworkAnalyticsRequest */
+        NetworkAnalyticsRequest: {
+            /** Allow Network Analytics */
+            allow_network_analytics: boolean;
+        };
+        /** NetworkAnalyticsResponse */
+        NetworkAnalyticsResponse: {
+            /** Allow Network Analytics */
+            allow_network_analytics: boolean;
+            /**
+             * Success
+             * @default true
+             */
+            success: boolean;
         };
         /** NewBidsCountResponse */
         NewBidsCountResponse: {
@@ -11032,6 +11992,20 @@ export interface components {
             total_contracts: number;
             /** Total Value */
             total_value: number;
+        };
+        /**
+         * OrgaoInfo
+         * @description Órgão comprador com total de contratos e valor.
+         */
+        OrgaoInfo: {
+            /** Cnpj */
+            cnpj: string;
+            /** Nome */
+            nome: string;
+            /** Total Contratos */
+            total_contratos: number;
+            /** Valor Total */
+            valor_total: number;
         };
         /** OrgaoRank */
         OrgaoRank: {
@@ -11624,6 +12598,63 @@ export interface components {
          * @enum {string}
          */
         PorteEmpresa: "MEI" | "ME" | "EPP" | "MEDIO" | "GRANDE";
+        /** PredictiveAlertCreate */
+        PredictiveAlertCreate: {
+            /** Alert Type */
+            alert_type: string;
+            /** Sector Id */
+            sector_id: string;
+            /**
+             * Threshold Value
+             * @default 0
+             */
+            threshold_value: number;
+            /** Uf */
+            uf?: string | null;
+        };
+        /** PredictiveAlertListResponse */
+        PredictiveAlertListResponse: {
+            /** Alerts */
+            alerts: components["schemas"]["PredictiveAlertResponse"][];
+            /** Total */
+            total: number;
+        };
+        /** PredictiveAlertResponse */
+        PredictiveAlertResponse: {
+            /** Alert Type */
+            alert_type: string;
+            /** Created At */
+            created_at: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Id */
+            id: string;
+            /** Last Triggered At */
+            last_triggered_at?: string | null;
+            /** Sector Id */
+            sector_id: string;
+            /** Threshold Value */
+            threshold_value: number;
+            /** Uf */
+            uf?: string | null;
+            /** Updated At */
+            updated_at: string;
+            /** User Id */
+            user_id: string;
+        };
+        /** PredictiveAlertUpdate */
+        PredictiveAlertUpdate: {
+            /** Alert Type */
+            alert_type?: string | null;
+            /** Enabled */
+            enabled?: boolean | null;
+            /** Sector Id */
+            sector_id?: string | null;
+            /** Threshold Value */
+            threshold_value?: number | null;
+            /** Uf */
+            uf?: string | null;
+        };
         /**
          * PreferenciasRequest
          * @description Request body for PATCH /conta/preferencias — frequency toggle.
@@ -11726,6 +12757,20 @@ export interface components {
             timestamp?: string | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * RankingInfo
+         * @description Posição da empresa no ranking setorial.
+         */
+        RankingInfo: {
+            /** Percentil */
+            percentil: number;
+            /** Posicao */
+            posicao: number;
+            /** Texto Contexto */
+            texto_contexto: string;
+            /** Total Empresas Setor */
+            total_empresas_setor: number;
         };
         /** RankingResponse */
         RankingResponse: {
@@ -12139,6 +13184,60 @@ export interface components {
             download_url: string;
             /** Email Queued */
             email_queued: boolean;
+        };
+        /**
+         * RenewalAlertItem
+         * @description A single contract approaching renewal.
+         */
+        RenewalAlertItem: {
+            /**
+             * Contract Id
+             * @description Contract ID from pncp_supplier_contracts
+             */
+            contract_id: number;
+            /**
+             * Estimated Expiry
+             * Format: date
+             * @description Estimated expiry date (data_assinatura + 1 year heuristic)
+             */
+            estimated_expiry: string;
+            /**
+             * Orgao
+             * @description Name of the contracting public agency
+             */
+            orgao: string;
+            /**
+             * Value
+             * @description Estimated contract value
+             */
+            value: number;
+        };
+        /**
+         * RenewalAlertResponse
+         * @description Response from the renewal alerts endpoint.
+         */
+        RenewalAlertResponse: {
+            /** Alerts */
+            alerts: components["schemas"]["RenewalAlertItem"][];
+            /** Days */
+            days: number;
+            /**
+             * Feature Enabled
+             * @default true
+             */
+            feature_enabled: boolean;
+            /** Sector */
+            sector?: string | null;
+            /**
+             * Total Count
+             * @default 0
+             */
+            total_count: number;
+            /**
+             * Total Value
+             * @default 0
+             */
+            total_value: number;
         };
         /**
          * ReplyRequest
@@ -12797,6 +13896,47 @@ export interface components {
             uf: string;
         };
         /**
+         * SeasonalPatternItem
+         * @description A single month's seasonal average (Jan-Dec).
+         */
+        SeasonalPatternItem: {
+            /**
+             * Avg Count
+             * @description Average number of contracts in this month over the period
+             */
+            avg_count: number;
+            /**
+             * Avg Value
+             * @description Average contract value in this month
+             */
+            avg_value: number;
+            /**
+             * Month Num
+             * @description Month number (1=January, 12=December)
+             */
+            month_num: number;
+        };
+        /**
+         * SeasonalPatternResponse
+         * @description Response from the seasonal pattern endpoint.
+         */
+        SeasonalPatternResponse: {
+            /**
+             * Feature Enabled
+             * @default true
+             */
+            feature_enabled: boolean;
+            /** Patterns */
+            patterns: components["schemas"]["SeasonalPatternItem"][];
+            /**
+             * Peak Month
+             * @description Month with highest average contract count
+             */
+            peak_month?: number | null;
+            /** Sector */
+            sector?: string | null;
+        };
+        /**
          * SectorAffinityResponse
          * @description FEEDBACK-004: User affinity score for a sector.
          *
@@ -12837,6 +13977,42 @@ export interface components {
             sector_name: string;
             /** Total Value */
             total_value: number;
+        };
+        /**
+         * SectorBenchmarkResponse
+         * @description Top-level response for GET /v1/intel-concorrente/benchmarks.
+         */
+        SectorBenchmarkResponse: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Gerado Em
+             * @description Timestamp de geracao
+             */
+            gerado_em?: string;
+            /**
+             * Metricas
+             * @description Metricas comparativas
+             */
+            metricas?: components["schemas"]["CompetitorBenchmark"][];
+            /**
+             * Razao Social
+             * @description Nome / razao social
+             */
+            razao_social: string;
+            /**
+             * Setor Id
+             * @description ID do setor
+             */
+            setor_id: string;
+            /**
+             * Setor Nome
+             * @description Nome do setor
+             */
+            setor_nome: string;
         };
         /** SectorBlogStats */
         SectorBlogStats: {
@@ -13560,6 +14736,77 @@ export interface components {
             /** Total Won */
             total_won: number;
         };
+        /**
+         * TerritoryData
+         * @description Territory map data for a single competitor.
+         */
+        TerritoryData: {
+            /**
+             * Cnpj
+             * @description CNPJ do concorrente
+             */
+            cnpj: string;
+            /**
+             * Razao Social
+             * @description Nome / razao social
+             */
+            razao_social: string;
+            /**
+             * Total Contratado
+             * @description Valor total contratado
+             */
+            total_contratado: number;
+            /**
+             * Total Contratos
+             * @description Total de contratos
+             * @default 0
+             */
+            total_contratos: number;
+            /**
+             * Ufs
+             * @description Dados por UF
+             */
+            ufs?: components["schemas"]["TerritoryUfData"][];
+        };
+        /**
+         * TerritoryUfData
+         * @description Territory data for a single UF.
+         */
+        TerritoryUfData: {
+            /**
+             * Market Share
+             * @description Market share do concorrente na UF (0-100)
+             * @default 0
+             */
+            market_share: number;
+            /**
+             * Numero Contratos
+             * @description Numero de contratos na UF
+             * @default 0
+             */
+            numero_contratos: number;
+            /**
+             * Orgaos Principais
+             * @description Principais orgaos compradores
+             */
+            orgaos_principais?: string[];
+            /**
+             * Tendencia
+             * @description Tendencia na UF
+             * @default estavel
+             */
+            tendencia: string;
+            /**
+             * Total Contratado
+             * @description Valor total contratado na UF
+             */
+            total_contratado: number;
+            /**
+             * Uf
+             * @description Sigla da UF
+             */
+            uf: string;
+        };
         /** TimeSeriesDataPoint */
         TimeSeriesDataPoint: {
             /** Label */
@@ -14122,6 +15369,11 @@ export interface components {
          *     necessary plan information for UI rendering.
          */
         UserProfileResponse: {
+            /**
+             * Allow Network Analytics
+             * @description NETINT-001/006: User consent for anonymized network analytics collection. NULL = undecided (treated as opt-out), true = opted in, false = opted out.
+             */
+            allow_network_analytics?: boolean | null;
             /**
              * Capabilities
              * @description Plan capabilities (max_history_days, allow_excel, etc.)
@@ -18797,6 +20049,171 @@ export interface operations {
             };
         };
     };
+    list_clients_v1_consultoria_clients_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by status: active, revoked */
+                status_filter?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsultantClientListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_client_v1_consultoria_clients__client_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    invite_client_v1_consultoria_invite_client_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteClientRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsultantInviteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    share_resource_v1_consultoria_share__client_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConsultantShareCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsultantShareResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_shared_resources_v1_consultoria_shared__client_id__get: {
+        parameters: {
+            query?: {
+                /** @description Filter by resource type */
+                resource_type?: string | null;
+            };
+            header?: never;
+            path: {
+                client_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_api_usage_v1_conta_api_usage_get: {
         parameters: {
             query?: never;
@@ -19640,6 +21057,206 @@ export interface operations {
             };
         };
     };
+    get_competitor_benchmarks_v1_intel_concorrente_benchmarks_get: {
+        parameters: {
+            query: {
+                /** @description CNPJ do concorrente */
+                cnpj: string;
+                /** @description ID do setor para benchmark */
+                setor: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SectorBenchmarkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_competitive_dossie_v1_intel_concorrente_dossie__cnpj__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CNPJ do concorrente */
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DossieRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DossieResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_dossie_v1_intel_concorrente_dossie__cnpj___job_id__download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_dossie_status_v1_intel_concorrente_dossie__cnpj___job_id__status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DossieStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_competitive_landscape_v1_intel_concorrente_landscape_get: {
+        parameters: {
+            query: {
+                /** @description ID do setor (ex: ti, saude, construcao) */
+                setor: string;
+                /** @description UF (2 letras, opcional) */
+                uf?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CompetitiveLandscapeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_competitor_territory_v1_intel_concorrente_territory__cnpj__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description CNPJ do concorrente (com ou sem mascara) */
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TerritoryData"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_intel_report_purchases_v1_intel_reports__get: {
         parameters: {
             query?: never;
@@ -19778,6 +21395,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IntelTastingResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    intel_vitrine_v1_intel_vitrine__cnpj__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                cnpj: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelVitrineResponse"];
                 };
             };
             /** @description Validation Error */
@@ -20922,6 +22570,237 @@ export interface operations {
             };
         };
     };
+    list_predictive_alerts_v1_predint_alerts_get: {
+        parameters: {
+            query?: {
+                enabled_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PredictiveAlertListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_predictive_alert_v1_predint_alerts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PredictiveAlertCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PredictiveAlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_predictive_alert_v1_predint_alerts__alert_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_predictive_alert_v1_predint_alerts__alert_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                alert_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PredictiveAlertUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PredictiveAlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_demand_forecast_v1_predint_forecast_get: {
+        parameters: {
+            query?: {
+                /** @description Sector ID (e.g., 'alimentos'). If omitted, returns all sectors. */
+                sector?: string | null;
+                /** @description UF filter (2-letter). If omitted, returns national aggregation. */
+                uf?: string | null;
+                /** @description Lookback period in months (1-120, default 12) */
+                months?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DemandForecastResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_renewal_alerts_v1_predint_renewals_get: {
+        parameters: {
+            query?: {
+                /** @description Sector ID. If omitted, returns alerts for all sectors. */
+                sector?: string | null;
+                /** @description Lookahead window in days (1-365, default 90) */
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RenewalAlertResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_seasonal_pattern_v1_predint_seasonality__sector_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sector_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SeasonalPatternResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_products_v1_products_get: {
         parameters: {
             query?: never;
@@ -21068,6 +22947,39 @@ export interface operations {
             };
         };
     };
+    update_network_analytics_v1_profile_network_analytics_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NetworkAnalyticsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NetworkAnalyticsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_sector_affinity_v1_profile_sector_affinity_get: {
         parameters: {
             query?: never;
@@ -21110,6 +23022,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SectorAffinityResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_intel_feed_v1_pseo_intel_feed_get: {
+        parameters: {
+            query: {
+                /** @description Sector URL slug, e.g. 'engenharia' */
+                sector: string;
+                /** @description Optional UF filter (e.g. 'SP') */
+                uf?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelFeedResponse"];
                 };
             };
             /** @description Validation Error */
@@ -21293,6 +23239,121 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_subscription_v1_report_mensal_cancel__id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_monthly_report_v1_report_mensal_preview__setor__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                setor: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MonthlyReportPreviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    subscribe_monthly_report_v1_report_mensal_subscribe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MonthlyReportSubscribeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MonthlyReportSubscriptionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_subscriptions_v1_report_mensal_subscriptions_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MonthlyReportSubscriptionsListResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Fixes the COMPINT-014 implementation by registering the competitive_intel router in `startup/routes.py`.

## Changes

- **`backend/startup/routes.py`**: Added import for `competitive_intel_router` and registered it in the `_v1_routers` list, enabling the following endpoints:
  - `POST /v1/intel-concorrente/dossie/{cnpj}` — Generate competitive dossie PDF
  - `GET /v1/intel-concorrente/dossie/{cnpj}/{job_id}/status` — Check generation status
  - `GET /v1/intel-concorrente/dossie/{cnpj}/{job_id}/download` — Download generated PDF

## Validation

- `ruff check`: All checks passed
- `pytest tests/test_competitive_dossie.py -v`: 5/5 passed

Related: #1669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Competitive intelligence endpoints now available for sector benchmarks, competitor analysis, and business landscape insights.
  * Client management capabilities including invitations, resource sharing, and access control.
  * Predictive alert system for demand forecasts and renewal tracking.
  * Monthly report subscription and preview functionality.
  * Public company intelligence lookup and market intelligence feeds.
  * User preference settings for network analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->