### PR TITLE
fix(backend): increase uvicorn max-requests 5000→10000

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -118,10 +118,10 @@ _start_worker() {
 # ── Uvicorn launcher (foreground) ───────────────────────────────────────
 _start_uvicorn() {
   local workers="${WEB_CONCURRENCY:-2}"
-  # CRIT-083 AC6 MEM-6: Reduced from 10000→5000 to limit memory accumulation.
-  # Worker RSS grows ~50KB/request (cache churn + object churn). At 5000 requests
-  # that's ~250MB growth — well within the 512MB threshold with margin.
-  local limit_max_requests="${GUNICORN_MAX_REQUESTS:-5000}"
+  # CRIT-083 AC6 MEM-6: 5000→10000. 5000 atingido em <1h com rajada ISR
+  # (100+ cidades × setores revalidando). 10000 dá ~2h de margem.
+  # Override via GUNICORN_MAX_REQUESTS env var.
+  local limit_max_requests="${GUNICORN_MAX_REQUESTS:-10000}"
   local graceful_timeout="${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-120}"
   local keep_alive="${GUNICORN_KEEP_ALIVE:-75}"
   local log_level="${UVICORN_LOG_LEVEL:-info}"
@@ -187,7 +187,7 @@ case "$PROCESS_TYPE" in
         --log-level "${UVICORN_LOG_LEVEL:-info}" \
         --timeout-keep-alive "${GUNICORN_KEEP_ALIVE:-75}" \
         --workers "${WEB_CONCURRENCY:-2}" \
-        --limit-max-requests "${GUNICORN_MAX_REQUESTS:-5000}" \
+        --limit-max-requests "${GUNICORN_MAX_REQUESTS:-10000}" \
         --timeout-graceful-shutdown "${UVICORN_TIMEOUT_GRACEFUL_SHUTDOWN:-120}"
     fi
     ;;


### PR DESCRIPTION
## Summary

Increase uvicorn `--limit-max-requests` default from 5000 to 10000 to prevent worker recycling during ISR bursts (100+ cities × sectors revalidating). Overridable via `GUNICORN_MAX_REQUESTS` env var.

## Changes

- `backend/start.sh`: Both code paths (function `_start_uvicorn` + direct exec) use `${GUNICORN_MAX_REQUESTS:-10000}`

## Testing Plan

- [ ] Manual: deploy to staging, trigger ISR burst, verify workers survive >5000 requests
- [ ] CI: existing backend tests cover start.sh path selection

Closes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)