### PR TITLE
fix(backend): increase Supabase httpx pool default 20→25

### DIFF
--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -42,10 +42,12 @@ _supabase_client_lock = threading.Lock()
 # Default: 25 per worker (50 total), down from 50 per worker (100 total).
 # ============================================================================
 
-# DEBT-IO-BUDGET: Reduced from 25→10 per worker (20 total with 2 workers)
-# to stay under Supabase free tier limit of 20 direct connections.
-# Override via SUPABASE_POOL_MAX_CONNECTIONS env if upgraded to paid tier.
-_POOL_MAX_CONNECTIONS = int(os.getenv("SUPABASE_POOL_MAX_CONNECTIONS", "20"))
+# CRIT-046: Pool default 20→25 per worker. Semaphores (datalake=5, blog=3)
+# prevent actual concurrency > 8/worker, but httpx pool needs headroom for
+# keepalive connections + brief overshoot during semaphore handoff.
+# 25 pool slots × 2 workers = 50 max — well within Supabase 60-connection limit.
+# Override via SUPABASE_POOL_MAX_CONNECTIONS env.
+_POOL_MAX_CONNECTIONS = int(os.getenv("SUPABASE_POOL_MAX_CONNECTIONS", "25"))
 _POOL_MAX_KEEPALIVE = int(os.getenv("SUPABASE_POOL_MAX_KEEPALIVE", "10"))
 _POOL_TIMEOUT = float(os.getenv("SUPABASE_POOL_TIMEOUT", "30.0"))
 _POOL_CONNECT_TIMEOUT = 10.0

--- a/backend/tests/test_crit046_pool_exhaustion.py
+++ b/backend/tests/test_crit046_pool_exhaustion.py
@@ -476,9 +476,9 @@ class TestPoolConstants:
     """Verify CRIT-046 constants are correctly defined."""
 
     def test_pool_max_connections(self):
-        """POOL-001: raised default to 20 (env-tunable via SUPABASE_POOL_MAX_CONNECTIONS)."""
+        """POOL-001: raised default to 25 (env-tunable via SUPABASE_POOL_MAX_CONNECTIONS)."""
         from supabase_client import _POOL_MAX_CONNECTIONS
-        assert _POOL_MAX_CONNECTIONS == 20
+        assert _POOL_MAX_CONNECTIONS == 25
 
     def test_pool_max_keepalive(self):
         """POOL-001: raised default to 10 (env-tunable via SUPABASE_POOL_MAX_KEEPALIVE)."""


### PR DESCRIPTION
## Summary

Increase Supabase httpx connection pool default from 20 to 25 per worker. Semaphores (datalake=5, blog=3) already limit actual concurrency to 8/worker, but the pool needs headroom for keepalive connections and brief overshoot during semaphore handoff. 25 slots × 2 workers = 50 max — well within Supabase 60-connection limit.

## Changes

- `backend/supabase_client.py`: `_POOL_MAX_CONNECTIONS` default 20→25, updated comment explaining the math

## Testing Plan

- [ ] Manual: deploy, trigger ISR burst, verify CRIT-046 warning does not fire
- [ ] CI: existing tests cover supabase client initialization

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)