### PR TITLE
fix(backend): add offset-based intra-day pagination for UF=SP truncation (#1746)

### DIFF
--- a/backend/datalake_query.py
+++ b/backend/datalake_query.py
@@ -121,6 +121,60 @@ def _record_sentry_truncation(uf: str) -> None:
         pass  # sentry_sdk not available (tests, local dev)
 
 
+async def _query_single_day_with_offset(
+    sb: Any,
+    sb_execute: Any,
+    uf_params: dict[str, Any],
+    uf: str,
+    date_str: str,
+) -> list[dict]:
+    """Fetch all rows for a single date using offset-based pagination.
+
+    TRUNC-002: When binary date-range splitting bottoms out at a single day
+    that still exceeds the PostgREST 1000-row cap, use p_offset to batch
+    through all rows deterministically.
+
+    Uses the search_datalake RPC with p_offset (added via migration
+    20260614022207_add_p_offset_to_search_datalake.sql).  Each call fetches
+    up to _POSTGREST_ROW_CAP rows; the loop continues until a page returns
+    fewer rows than the cap.
+    """
+    all_rows: list[dict] = []
+    offset = 0
+    max_pages = 20  # Safety cap: 20 pages × 1000 = 20k rows/day
+
+    while offset < max_pages * _POSTGREST_ROW_CAP:
+        page_params = {**uf_params, "p_offset": offset, "p_limit": _POSTGREST_ROW_CAP}
+        try:
+            result = await sb_execute(
+                sb.rpc("search_datalake", page_params), category="rpc"
+            )
+            page_rows = result.data or []
+        except Exception as e:
+            logger.warning(
+                f"[DatalakeQuery] Offset RPC failed for UF={uf} "
+                f"[{date_str}] offset={offset}: {type(e).__name__}: {e}"
+            )
+            break  # Return what we have so far (fail-open)
+
+        if not page_rows:
+            break
+
+        all_rows.extend(page_rows)
+
+        if len(page_rows) < _POSTGREST_ROW_CAP:
+            # Last page — got all rows
+            break
+
+        offset += _POSTGREST_ROW_CAP
+
+    logger.info(
+        f"[DatalakeQuery] UF={uf} [{date_str}] offset pagination complete: "
+        f"{len(all_rows)} rows in {(offset // _POSTGREST_ROW_CAP) + 1} pages"
+    )
+    return all_rows
+
+
 async def _query_uf_with_pagination(
     sb: Any,
     sb_execute: Any,
@@ -196,12 +250,21 @@ async def _query_uf_with_pagination(
 
     total_days = (d_end - d_start).days
     if total_days < 1:
-        # Single date — cannot split further; return partial
+        # TRUNC-002: Single-date still exceeds cap — use offset-based
+        # intra-day pagination instead of returning truncated data.
+        # PostgREST caps RPC results at 1000 rows; p_offset batches
+        # through all rows for a single date deterministically.
         logger.warning(
-            f"[DatalakeQuery] UF={uf} still exceeds cap at minimum granularity "
-            f"[{date_start}] — returning {len(uf_rows)} rows (possibly truncated)."
+            f"[DatalakeQuery] UF={uf} single-day overflow [{date_start}] — "
+            f"switching to offset-based intra-day pagination"
         )
-        return uf_rows
+        return await _query_single_day_with_offset(
+            sb=sb,
+            sb_execute=sb_execute,
+            uf_params=uf_params,
+            uf=uf,
+            date_str=date_start,
+        )
 
     # Compute midpoint
     mid = d_start + timedelta(days=total_days // 2)

--- a/backend/tests/test_datalake_query.py
+++ b/backend/tests/test_datalake_query.py
@@ -808,29 +808,56 @@ class TestQueryUfWithPagination:
         assert len(result) == 200
 
     @pytest.mark.asyncio
-    async def test_single_day_truncation_returns_partial(self):
-        """When truncation persists at minimum granularity, return partial."""
+    async def test_single_day_truncation_delegates_to_offset_pagination(self):
+        """TRUNC-002: Single-day overflow delegates to offset-based pagination."""
         from datalake_query import _query_uf_with_pagination, _POSTGREST_ROW_CAP
+        from unittest.mock import patch, AsyncMock
 
         sb = MagicMock()
         sb_execute = MagicMock()
 
+        # First call (full range) returns 1000 rows → triggers split
+        # After split, single day still returns 1000 → delegates to offset
+        delegate_result = [{"pncp_id": f"offset-row-{i}"} for i in range(2500)]
+
+        call_count = 0
+
         async def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
             result = MagicMock()
             result.data = [{"pncp_id": f"row-{i}"} for i in range(_POSTGREST_ROW_CAP)]
             return result
 
         sb_execute.side_effect = mock_execute
 
-        result = await _query_uf_with_pagination(
-            sb=sb, sb_execute=sb_execute,
-            rpc_params={}, uf="SP",
-            date_start="2026-03-01", date_end="2026-03-01",  # single day
-            depth=0,
-        )
+        with patch(
+            "datalake_query._query_single_day_with_offset",
+            new=AsyncMock(return_value=delegate_result),
+        ) as mock_offset:
+            result = await _query_uf_with_pagination(
+                sb=sb, sb_execute=sb_execute,
+                rpc_params={}, uf="SP",
+                date_start="2026-03-01", date_end="2026-03-01",  # single day
+                depth=0,
+            )
 
-        # Should return partial results (1000 rows) instead of crashing
-        assert len(result) == _POSTGREST_ROW_CAP
+            # Must delegate to offset pagination
+            mock_offset.assert_called_once()
+            call_kwargs = mock_offset.call_args.kwargs
+            assert call_kwargs["sb"] == sb
+            assert call_kwargs["sb_execute"] == sb_execute
+            assert call_kwargs["uf"] == "SP"
+            assert call_kwargs["date_str"] == "2026-03-01"
+            assert call_kwargs["uf_params"] == {
+                "p_ufs": ["SP"],
+                "p_date_start": "2026-03-01",
+                "p_date_end": "2026-03-01",
+            }
+
+            # Result must match the delegate return value
+            assert len(result) == 2500
+            assert result == delegate_result
 
     @pytest.mark.asyncio
     async def test_max_depth_exceeded_returns_empty(self):
@@ -867,6 +894,153 @@ class TestQueryUfWithPagination:
         )
 
         assert result == []
+
+
+class TestQuerySingleDayWithOffset:
+    """Tests for _query_single_day_with_offset() — TRUNC-002 intra-day pagination."""
+
+    @pytest.mark.asyncio
+    async def test_returns_all_rows_single_page(self):
+        """Single page (< cap rows) returns all rows, no extra calls."""
+        from datalake_query import _query_single_day_with_offset, _POSTGREST_ROW_CAP
+
+        sb = MagicMock()
+        sb.rpc.return_value = MagicMock()  # sb.rpc("search_datalake", ...)
+
+        rows = [{"pncp_id": f"row-{i}"} for i in range(500)]
+        mock_result = MagicMock()
+        mock_result.data = rows
+        sb_execute = AsyncMock(return_value=mock_result)
+
+        result = await _query_single_day_with_offset(
+            sb=sb, sb_execute=sb_execute,
+            uf_params={}, uf="SP", date_str="2026-03-01",
+        )
+
+        assert len(result) == 500
+        assert result == rows
+        # Only 1 RPC call for single page
+        assert sb_execute.call_count == 1
+        # Verify p_offset and p_limit in the params
+        # sb.rpc("search_datalake", page_params) — positional args
+        page_params = sb.rpc.call_args[0][1]
+        assert page_params["p_offset"] == 0
+        assert page_params["p_limit"] == _POSTGREST_ROW_CAP
+
+    @pytest.mark.asyncio
+    async def test_paginates_multiple_pages(self):
+        """Multiple pages of exactly _POSTGREST_ROW_CAP rows each."""
+        from datalake_query import _query_single_day_with_offset, _POSTGREST_ROW_CAP
+
+        sb = MagicMock()
+        sb_execute = AsyncMock()
+
+        # Page 1: 1000 rows, Page 2: 1000 rows, Page 3: 500 rows (< cap)
+        pages = [
+            [{"pncp_id": f"p1-{i}"} for i in range(_POSTGREST_ROW_CAP)],
+            [{"pncp_id": f"p2-{i}"} for i in range(_POSTGREST_ROW_CAP)],
+            [{"pncp_id": f"p3-{i}"} for i in range(500)],
+        ]
+        call_count = 0
+
+        async def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            result = MagicMock()
+            result.data = pages[call_count]
+            call_count += 1
+            return result
+
+        sb_execute.side_effect = mock_execute
+
+        result = await _query_single_day_with_offset(
+            sb=sb, sb_execute=sb_execute,
+            uf_params={}, uf="SP", date_str="2026-03-01",
+        )
+
+        assert len(result) == 2500  # 1000 + 1000 + 500
+        assert sb_execute.call_count == 3
+
+        # Verify offset progression
+        # sb.rpc("search_datalake", page_params) — positional args (arg 0, positional 1)
+        calls = sb.rpc.call_args_list
+        assert calls[0][0][1]["p_offset"] == 0
+        assert calls[1][0][1]["p_offset"] == _POSTGREST_ROW_CAP
+        assert calls[2][0][1]["p_offset"] == 2 * _POSTGREST_ROW_CAP
+
+    @pytest.mark.asyncio
+    async def test_empty_first_page_returns_empty(self):
+        """Empty first page → return [] immediately, no retry."""
+        from datalake_query import _query_single_day_with_offset
+
+        sb = MagicMock()
+        mock_result = MagicMock()
+        mock_result.data = []
+        sb_execute = AsyncMock(return_value=mock_result)
+
+        result = await _query_single_day_with_offset(
+            sb=sb, sb_execute=sb_execute,
+            uf_params={}, uf="SP", date_str="2026-03-01",
+        )
+
+        assert result == []
+        assert sb_execute.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_rpc_failure_returns_collected_rows(self):
+        """RPC failure mid-pagination returns rows collected so far (fail-open)."""
+        from datalake_query import _query_single_day_with_offset, _POSTGREST_ROW_CAP
+
+        sb = MagicMock()
+        sb_execute = AsyncMock()
+
+        first_page_rows = [{"pncp_id": f"row-{i}"} for i in range(_POSTGREST_ROW_CAP)]
+
+        call_count = 0
+
+        async def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                result = MagicMock()
+                result.data = first_page_rows
+                return result
+            raise RuntimeError("RPC gone")
+
+        sb_execute.side_effect = mock_execute
+
+        result = await _query_single_day_with_offset(
+            sb=sb, sb_execute=sb_execute,
+            uf_params={}, uf="SP", date_str="2026-03-01",
+        )
+
+        # Must return rows from first page (fail-open, don't crash)
+        assert len(result) == _POSTGREST_ROW_CAP
+        assert result == first_page_rows
+        assert sb_execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_respects_max_pages_safety_cap(self):
+        """Never exceed 20 pages (20 × 1000 = 20k rows)."""
+        from datalake_query import _query_single_day_with_offset, _POSTGREST_ROW_CAP
+
+        sb = MagicMock()
+        sb_execute = AsyncMock()
+
+        # Every call returns exactly _POSTGREST_ROW_CAP rows (never < cap)
+        # This would loop forever without the safety cap
+        page = [{"pncp_id": f"row-{i}"} for i in range(_POSTGREST_ROW_CAP)]
+        mock_result = MagicMock()
+        mock_result.data = page
+        sb_execute.return_value = mock_result
+
+        result = await _query_single_day_with_offset(
+            sb=sb, sb_execute=sb_execute,
+            uf_params={}, uf="SP", date_str="2026-03-01",
+        )
+
+        # max_pages = 20, so max rows = 20 × 1000 = 20000
+        assert len(result) == 20 * _POSTGREST_ROW_CAP
+        assert sb_execute.call_count == 20
 
 
 class TestRecordSentryTruncation:

--- a/supabase/migrations/20260614022207_add_p_offset_to_search_datalake.down.sql
+++ b/supabase/migrations/20260614022207_add_p_offset_to_search_datalake.down.sql
@@ -1,0 +1,96 @@
+-- Rollback: Remove p_offset from search_datalake, reverting to TRUNC-001 behavior
+-- (binary date-range splitting only, no offset-based intra-day pagination).
+
+CREATE OR REPLACE FUNCTION public.search_datalake(
+    p_ufs          TEXT[]            DEFAULT NULL,
+    p_date_start   DATE              DEFAULT NULL,
+    p_date_end     DATE              DEFAULT NULL,
+    p_tsquery      TEXT              DEFAULT NULL,
+    p_modalidades  INTEGER[]         DEFAULT NULL,
+    p_valor_min    NUMERIC           DEFAULT NULL,
+    p_valor_max    NUMERIC           DEFAULT NULL,
+    p_esferas      TEXT[]            DEFAULT NULL,
+    p_modo         TEXT              DEFAULT 'publicacao',
+    p_limit        INTEGER           DEFAULT 2000
+)
+RETURNS TABLE (
+    pncp_id              TEXT,
+    objeto_compra        TEXT,
+    valor_total_estimado NUMERIC,
+    modalidade_id        INTEGER,
+    modalidade_nome      TEXT,
+    situacao_compra      TEXT,
+    esfera_id            TEXT,
+    uf                   TEXT,
+    municipio            TEXT,
+    orgao_razao_social   TEXT,
+    orgao_cnpj           TEXT,
+    data_publicacao      TIMESTAMPTZ,
+    data_abertura        TIMESTAMPTZ,
+    data_encerramento    TIMESTAMPTZ,
+    link_pncp            TEXT,
+    ts_rank              REAL
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_ts_query TSQUERY;
+BEGIN
+    IF p_modo NOT IN ('publicacao', 'abertas') THEN
+        RAISE EXCEPTION 'p_modo must be ''publicacao'' or ''abertas'', got: %', p_modo;
+    END IF;
+
+    IF p_limit > 5000 THEN
+        p_limit := 5000;
+    END IF;
+
+    IF p_tsquery IS NOT NULL AND trim(p_tsquery) <> '' THEN
+        BEGIN
+            v_ts_query := to_tsquery('portuguese', p_tsquery);
+        EXCEPTION WHEN OTHERS THEN
+            v_ts_query := plainto_tsquery('portuguese', p_tsquery);
+        END;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        b.pncp_id, b.objeto_compra, b.valor_total_estimado,
+        b.modalidade_id, b.modalidade_nome, b.situacao_compra, b.esfera_id,
+        b.uf, b.municipio, b.orgao_razao_social, b.orgao_cnpj,
+        b.data_publicacao, b.data_abertura, b.data_encerramento, b.link_pncp,
+        CASE WHEN v_ts_query IS NOT NULL
+             THEN ts_rank(b.tsv, v_ts_query)
+             ELSE 0.0
+        END::REAL AS ts_rank
+    FROM public.pncp_raw_bids b
+    WHERE
+        b.is_active = true
+        AND (p_ufs IS NULL       OR b.uf = ANY(p_ufs))
+        AND (p_modalidades IS NULL OR b.modalidade_id = ANY(p_modalidades))
+        AND (p_esferas IS NULL   OR b.esfera_id = ANY(p_esferas))
+        AND (p_valor_min IS NULL OR b.valor_total_estimado >= p_valor_min)
+        AND (p_valor_max IS NULL OR b.valor_total_estimado <= p_valor_max)
+        AND (v_ts_query IS NULL OR b.tsv @@ v_ts_query)
+        AND (p_modo <> 'publicacao'
+            OR ((p_date_start IS NULL OR b.data_publicacao >= p_date_start::TIMESTAMPTZ)
+                AND (p_date_end IS NULL OR b.data_publicacao < (p_date_end + INTERVAL '1 day')::TIMESTAMPTZ)))
+        AND (p_modo <> 'abertas'
+            OR (b.data_encerramento > now()
+                AND (p_date_start IS NULL OR b.data_publicacao >= p_date_start::TIMESTAMPTZ)))
+    ORDER BY
+        CASE WHEN v_ts_query IS NOT NULL
+             THEN ts_rank(b.tsv, v_ts_query)
+             ELSE NULL
+        END DESC NULLS LAST,
+        b.data_publicacao DESC
+    LIMIT p_limit;
+END;
+$$;
+
+COMMENT ON FUNCTION public.search_datalake(TEXT[], DATE, DATE, TEXT, INTEGER[], NUMERIC, NUMERIC, TEXT[], TEXT, INTEGER) IS
+    'Full-featured datalake search using pre-computed tsv column (DEBT-DB-NEW-004).';
+
+GRANT EXECUTE ON FUNCTION public.search_datalake(TEXT[], DATE, DATE, TEXT, INTEGER[], NUMERIC, NUMERIC, TEXT[], TEXT, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.search_datalake(TEXT[], DATE, DATE, TEXT, INTEGER[], NUMERIC, NUMERIC, TEXT[], TEXT, INTEGER) TO service_role;

--- a/supabase/migrations/20260614022207_add_p_offset_to_search_datalake.sql
+++ b/supabase/migrations/20260614022207_add_p_offset_to_search_datalake.sql
@@ -1,0 +1,153 @@
+-- ============================================================================
+-- TRUNC-002: Add p_offset parameter to search_datalake RPC.
+--
+-- When binary date-range splitting reaches single-day granularity and the
+-- UF (e.g. SP) still has >1000 rows per day, the PostgREST hard cap cannot
+-- be avoided with date splits alone.  Adding p_offset allows the Python
+-- pagination layer to fetch all rows via offset-based batching.
+--
+-- Fixes: #1746 — UF=SP truncation, 147s query, 1000-row cap exceeded
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.search_datalake(
+    p_ufs          TEXT[]            DEFAULT NULL,
+    p_date_start   DATE              DEFAULT NULL,
+    p_date_end     DATE              DEFAULT NULL,
+    p_tsquery      TEXT              DEFAULT NULL,
+    p_modalidades  INTEGER[]         DEFAULT NULL,
+    p_valor_min    NUMERIC           DEFAULT NULL,
+    p_valor_max    NUMERIC           DEFAULT NULL,
+    p_esferas      TEXT[]            DEFAULT NULL,
+    p_modo         TEXT              DEFAULT 'publicacao',
+    p_limit        INTEGER           DEFAULT 2000,
+    p_offset       INTEGER           DEFAULT 0
+)
+RETURNS TABLE (
+    pncp_id              TEXT,
+    objeto_compra        TEXT,
+    valor_total_estimado NUMERIC,
+    modalidade_id        INTEGER,
+    modalidade_nome      TEXT,
+    situacao_compra      TEXT,
+    esfera_id            TEXT,
+    uf                   TEXT,
+    municipio            TEXT,
+    orgao_razao_social   TEXT,
+    orgao_cnpj           TEXT,
+    data_publicacao      TIMESTAMPTZ,
+    data_abertura        TIMESTAMPTZ,
+    data_encerramento    TIMESTAMPTZ,
+    link_pncp            TEXT,
+    ts_rank              REAL
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_ts_query TSQUERY;
+BEGIN
+    -- Validate modo parameter.
+    IF p_modo NOT IN ('publicacao', 'abertas') THEN
+        RAISE EXCEPTION 'p_modo must be ''publicacao'' or ''abertas'', got: %', p_modo;
+    END IF;
+
+    -- Cap limit to prevent runaway queries.
+    IF p_limit > 5000 THEN
+        p_limit := 5000;
+    END IF;
+
+    -- Parse tsquery once; NULL means no full-text filter.
+    IF p_tsquery IS NOT NULL AND trim(p_tsquery) <> '' THEN
+        BEGIN
+            v_ts_query := to_tsquery('portuguese', p_tsquery);
+        EXCEPTION WHEN OTHERS THEN
+            -- Malformed tsquery — fallback to plain text search.
+            v_ts_query := plainto_tsquery('portuguese', p_tsquery);
+        END;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        b.pncp_id,
+        b.objeto_compra,
+        b.valor_total_estimado,
+        b.modalidade_id,
+        b.modalidade_nome,
+        b.situacao_compra,
+        b.esfera_id,
+        b.uf,
+        b.municipio,
+        b.orgao_razao_social,
+        b.orgao_cnpj,
+        b.data_publicacao,
+        b.data_abertura,
+        b.data_encerramento,
+        b.link_pncp,
+        -- ts_rank uses pre-computed tsv column (no recomputation).
+        CASE
+            WHEN v_ts_query IS NOT NULL
+            THEN ts_rank(b.tsv, v_ts_query)
+            ELSE 0.0
+        END::REAL AS ts_rank
+    FROM public.pncp_raw_bids b
+    WHERE
+        b.is_active = true
+
+        -- UF filter: pass NULL to include all UFs.
+        AND (p_ufs IS NULL       OR b.uf = ANY(p_ufs))
+
+        -- Modality filter: pass NULL to include all modalities.
+        AND (p_modalidades IS NULL OR b.modalidade_id = ANY(p_modalidades))
+
+        -- Government sphere filter.
+        AND (p_esferas IS NULL   OR b.esfera_id = ANY(p_esferas))
+
+        -- Value range filters (inclusive).
+        AND (p_valor_min IS NULL OR b.valor_total_estimado >= p_valor_min)
+        AND (p_valor_max IS NULL OR b.valor_total_estimado <= p_valor_max)
+
+        -- Full-text match using pre-computed tsv column (GIN indexed).
+        AND (
+            v_ts_query IS NULL
+            OR b.tsv @@ v_ts_query
+        )
+
+        -- Date mode: 'publicacao' filters by publication date window.
+        AND (
+            p_modo <> 'publicacao'
+            OR (
+                (p_date_start IS NULL OR b.data_publicacao >= p_date_start::TIMESTAMPTZ)
+                AND
+                (p_date_end   IS NULL OR b.data_publicacao <  (p_date_end + INTERVAL '1 day')::TIMESTAMPTZ)
+            )
+        )
+
+        -- Date mode: 'abertas' — encerramento in the future, publicacao >= start.
+        AND (
+            p_modo <> 'abertas'
+            OR (
+                b.data_encerramento > now()
+                AND (p_date_start IS NULL OR b.data_publicacao >= p_date_start::TIMESTAMPTZ)
+            )
+        )
+
+    ORDER BY
+        -- When full-text query supplied, rank by relevance first.
+        CASE WHEN v_ts_query IS NOT NULL
+             THEN ts_rank(b.tsv, v_ts_query)
+             ELSE NULL
+        END DESC NULLS LAST,
+        b.data_publicacao DESC
+
+    LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+COMMENT ON FUNCTION public.search_datalake(TEXT[], DATE, DATE, TEXT, INTEGER[], NUMERIC, NUMERIC, TEXT[], TEXT, INTEGER, INTEGER) IS
+    'Full-featured datalake search with offset pagination support (TRUNC-002).'
+    ' p_offset=0 → first page; p_offset=1000 → next page. Used for UF=SP overflow when single-day rows exceed PostgREST 1000-row cap.';
+
+-- Permissions: match previous grants
+GRANT EXECUTE ON FUNCTION public.search_datalake(TEXT[], DATE, DATE, TEXT, INTEGER[], NUMERIC, NUMERIC, TEXT[], TEXT, INTEGER, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.search_datalake(TEXT[], DATE, DATE, TEXT, INTEGER[], NUMERIC, NUMERIC, TEXT[], TEXT, INTEGER, INTEGER) TO service_role;


### PR DESCRIPTION
## Summary

When binary date-range splitting bottoms out at a single day that still exceeds the PostgREST 1000-row cap (e.g. SP has >1000 bids/day), use offset-based intra-day pagination instead of returning truncated data. Previously this caused 147s queries (32+ recursive RPC calls) and silent data loss.

Migration adds `p_offset INTEGER DEFAULT 0` to `search_datalake` RPC. Python `_query_single_day_with_offset()` batches through all rows with a safety cap of 20 pages (20k rows/day).

## Changes

- `backend/datalake_query.py`: New `_query_single_day_with_offset()` function + modify single-day overflow case
- `supabase/migrations/20260614022207_add_p_offset_to_search_datalake.sql`: RPC migration with `LIMIT ... OFFSET p_offset`
- `supabase/migrations/20260614022207_add_p_offset_to_search_datalake.down.sql`: Rollback

## Testing Plan

- [ ] Manual: query UF=SP with single-day range → verify no truncation, <30s response
- [ ] CI: `pytest -k migration` validates migration syntax

Closes #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)