### PR TITLE
fix(frontend): guard exit-intent popup during active search (#1761)

### DIFF
--- a/frontend/app/buscar/hooks/useSearchOrchestration.ts
+++ b/frontend/app/buscar/hooks/useSearchOrchestration.ts
@@ -99,6 +99,16 @@ export function useSearchOrchestration() {
     prevLoadingRef.current = search.loading;
   }, [search.loading, search.result, search.searchId, broadcastSearchComplete]);
 
+  // ISSUE-1761: Dispatch custom events so ExitIntentPopup can guard against
+  // false positives when the user is waiting for search results, not leaving.
+  useEffect(() => {
+    if (search.loading) {
+      window.dispatchEvent(new CustomEvent('smartlic:search-start'));
+    } else {
+      window.dispatchEvent(new CustomEvent('smartlic:search-end'));
+    }
+  }, [search.loading]);
+
   useEffect(() => {
     if (search.quotaError === "trial_expired") {
       billing.setShowTrialConversion(true);

--- a/frontend/app/components/ExitIntentPopup.tsx
+++ b/frontend/app/components/ExitIntentPopup.tsx
@@ -49,10 +49,26 @@ export function ExitIntentPopup() {
   // Track whether user has already seen the popup this session
   const [dismissed, setDismissed] = useState(false);
 
+  // ISSUE-1761: Guard against false positive during active search
+  const [searchActive, setSearchActive] = useState(false);
+
+  useEffect(() => {
+    const onSearchStart = () => setSearchActive(true);
+    const onSearchEnd = () => setSearchActive(false);
+
+    window.addEventListener('smartlic:search-start', onSearchStart);
+    window.addEventListener('smartlic:search-end', onSearchEnd);
+
+    return () => {
+      window.removeEventListener('smartlic:search-start', onSearchStart);
+      window.removeEventListener('smartlic:search-end', onSearchEnd);
+    };
+  }, []);
+
   const show = useCallback(() => {
-    if (getExitCookie() || dismissed) return;
+    if (getExitCookie() || dismissed || searchActive) return;
     setVisible(true);
-  }, [dismissed]);
+  }, [dismissed, searchActive]);
 
   const hide = useCallback(() => {
     setVisible(false);

--- a/frontend/app/components/landing/ExitIntentPopup.tsx
+++ b/frontend/app/components/landing/ExitIntentPopup.tsx
@@ -23,6 +23,22 @@ export default function ExitIntentPopup() {
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [dismissed, setDismissed] = useState(false);
   const checkDoneRef = useRef(false);
+  // ISSUE-1761: Guard against false positive during active search
+  const searchActiveRef = useRef(false);
+
+  // ISSUE-1761: Listen for search state changes
+  useEffect(() => {
+    const onSearchStart = () => { searchActiveRef.current = true; };
+    const onSearchEnd = () => { searchActiveRef.current = false; };
+
+    window.addEventListener('smartlic:search-start', onSearchStart);
+    window.addEventListener('smartlic:search-end', onSearchEnd);
+
+    return () => {
+      window.removeEventListener('smartlic:search-start', onSearchStart);
+      window.removeEventListener('smartlic:search-end', onSearchEnd);
+    };
+  }, []);
 
   // Check localStorage on mount
   useEffect(() => {
@@ -34,7 +50,7 @@ export default function ExitIntentPopup() {
 
   // Desktop: mouse leaving the viewport (top edge)
   const handleMouseLeave = useCallback((e: MouseEvent) => {
-    if (checkDoneRef.current) return;
+    if (checkDoneRef.current || searchActiveRef.current) return;
     if (e.clientY <= 0) {
       checkDoneRef.current = true;
       setVisible(true);
@@ -43,7 +59,7 @@ export default function ExitIntentPopup() {
 
   // Mobile: scroll-up detection — user scrolls back toward top after scrolling down
   const handleScroll = useCallback(() => {
-    if (checkDoneRef.current) return;
+    if (checkDoneRef.current || searchActiveRef.current) return;
     // Only trigger on mobile-ish widths (below 768px)
     if (window.innerWidth >= 768) return;
     // If user has scrolled down at least 400px and then scrolls back up past 300px


### PR DESCRIPTION
## Summary

Guard the exit-intent popup to prevent it from appearing while a search is actively in progress, avoiding disruptive UX during searches.

### Changes
- Add active search check in `frontend/app/buscar/hooks/useSearchOrchestration.ts`
- Update `frontend/app/components/ExitIntentPopup.tsx` to respect search state
- Update `frontend/app/components/landing/ExitIntentPopup.tsx` (landing variant)
- 3 files changed, 46 insertions, 4 deletions

### Testing
- All frontend tests passing
- Lint clean

Closes #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)