### PR TITLE
feat(backend): runtime log level toggle (#1814)

### DIFF
--- a/backend/routes/admin_log_level.py
+++ b/backend/routes/admin_log_level.py
@@ -1,0 +1,271 @@
+"""#1814: Runtime log level toggle for admin.
+
+POST /v1/admin/log-level -- altera log level em runtime (admin-only)
+GET  /v1/admin/log-level -- retorna niveis atuais de loggers modificados
+
+Mecanismo TTL: dict em memoria com timestamps. Background task (asyncio)
+verifica a cada 30s e reverte loggers expirados.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from admin import require_admin
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+# ---------------------------------------------------------------------------
+# In-memory state for log level overrides
+# ---------------------------------------------------------------------------
+# _log_level_overrides: dict[str, dict]
+#   key = logger_name (e.g. "ingestion", "*" for root logger)
+#   value = {
+#       "original_level": int,    # nivel antes da sobrescrita
+#       "current_level": int,     # nivel atual
+#       "set_by": str,            # user_id que alterou
+#       "set_at": str,            # ISO timestamp
+#       "ttl_until": float | None,# time.monotonic() expiry
+#   }
+_log_level_overrides: dict[str, dict] = {}
+
+_ROOT_LOGGER_KEY = "*"
+
+
+def _resolve_logger(name: str) -> logging.Logger:
+    """Resolve a logger name to a Python logger instance.
+
+    ``*`` or empty string returns the root logger.
+    """
+    if name == _ROOT_LOGGER_KEY or not name:
+        return logging.getLogger()
+    return logging.getLogger(name)
+
+
+def _level_name(level: int) -> str:
+    """Convert a logging level number to its name (e.g. 10 -> 'DEBUG')."""
+    name = logging.getLevelName(level)
+    if isinstance(name, str):
+        return name
+    return f"LEVEL_{level}"
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class SetLogLevelRequest(BaseModel):
+    """Request body for POST /v1/admin/log-level."""
+
+    level: str = Field(
+        ...,
+        description="Log level name: DEBUG, INFO, WARNING, ERROR, CRITICAL",
+        examples=["DEBUG"],
+    )
+    module: str = Field(
+        default="*",
+        description=(
+            "Logger name (e.g. 'ingestion', 'routes.search'). "
+            "Use '*' or omit for root logger."
+        ),
+        examples=["ingestion"],
+    )
+    ttl_minutes: int = Field(
+        default=15,
+        ge=1,
+        le=1440,
+        description="Auto-revert after N minutes (1-1440). Default 15.",
+        examples=[15],
+    )
+
+
+class LogLevelOverrideInfo(BaseModel):
+    """Single override entry returned by GET /v1/admin/log-level."""
+
+    logger: str
+    original_level: str
+    current_level: str
+    set_by: str
+    set_at: str
+    ttl_remaining_seconds: Optional[int] = None
+
+
+class LogLevelStatusResponse(BaseModel):
+    """Response for GET /v1/admin/log-level."""
+
+    overrides: list[LogLevelOverrideInfo]
+    count: int
+
+
+class SetLogLevelResponse(BaseModel):
+    """Response for POST /v1/admin/log-level."""
+
+    status: str
+    logger: str
+    original_level: str
+    current_level: str
+    ttl_minutes: int
+    detail: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/log-level", response_model=SetLogLevelResponse)
+async def set_log_level(
+    body: SetLogLevelRequest,
+    user: dict = Depends(require_admin),
+) -> SetLogLevelResponse:
+    """Set a logger's level at runtime (admin-only).
+
+    Altera o log level do *module* (ou root se omitido) para *level*.
+    Apos *ttl_minutes*, reverte automaticamente ao nivel original.
+    """
+    user_id = str(user.get("id", "unknown"))
+
+    # Validate level name
+    level_num = getattr(logging, body.level.upper(), None)
+    if not isinstance(level_num, int):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid log level: '{body.level}'. "
+                f"Use one of: DEBUG, INFO, WARNING, ERROR, CRITICAL"
+            ),
+        )
+
+    log_name = body.module.strip() if body.module.strip() else _ROOT_LOGGER_KEY
+    log_obj = _resolve_logger(log_name)
+
+    # Save original level only on first override for this logger
+    if log_name not in _log_level_overrides:
+        original_level = log_obj.level
+    else:
+        original_level = _log_level_overrides[log_name]["original_level"]
+
+    # Apply the new level
+    log_obj.setLevel(level_num)
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    now_mono = time.monotonic()
+
+    _log_level_overrides[log_name] = {
+        "original_level": original_level,
+        "current_level": level_num,
+        "set_by": user_id,
+        "set_at": now_iso,
+        "ttl_until": now_mono + (body.ttl_minutes * 60) if body.ttl_minutes > 0 else None,
+    }
+
+    # Audit via structured logging
+    logger.info(
+        "ADMIN LOG LEVEL CHANGE -- logger=%s from=%s to=%s ttl=%dmin set_by=%s",
+        log_name,
+        _level_name(original_level),
+        _level_name(level_num),
+        body.ttl_minutes,
+        user_id,
+    )
+
+    return SetLogLevelResponse(
+        status="ok",
+        logger=log_name,
+        original_level=_level_name(original_level),
+        current_level=_level_name(level_num),
+        ttl_minutes=body.ttl_minutes,
+        detail=(
+            f"Logger '{log_name}' changed from "
+            f"{_level_name(original_level)} to {_level_name(level_num)} "
+            f"(reverts in {body.ttl_minutes} min)"
+        ),
+    )
+
+
+@router.get("/log-level", response_model=LogLevelStatusResponse)
+async def get_log_levels(
+    user: dict = Depends(require_admin),
+) -> LogLevelStatusResponse:
+    """Return current log level overrides (admin-only)."""
+    now_mono = time.monotonic()
+    overrides: list[LogLevelOverrideInfo] = []
+
+    for log_name, state in list(_log_level_overrides.items()):
+        ttl_remaining: Optional[int] = None
+        if state["ttl_until"] is not None:
+            remaining = int(state["ttl_until"] - now_mono)
+            ttl_remaining = max(remaining, 0)
+
+        overrides.append(LogLevelOverrideInfo(
+            logger=log_name,
+            original_level=_level_name(state["original_level"]),
+            current_level=_level_name(state["current_level"]),
+            set_by=state["set_by"],
+            set_at=state["set_at"],
+            ttl_remaining_seconds=ttl_remaining,
+        ))
+
+    return LogLevelStatusResponse(overrides=overrides, count=len(overrides))
+
+
+# ---------------------------------------------------------------------------
+# Background TTL checker (registered in startup/lifespan.py)
+# ---------------------------------------------------------------------------
+
+
+async def _periodic_log_level_ttl_checker() -> None:
+    """Background task that checks every 30s and reverts expired overrides.
+
+    Registered in ``startup/lifespan.py`` via TaskRegistry with
+    ``is_coroutine=True``.
+    """
+    CHECK_INTERVAL = 30  # seconds
+
+    while True:
+        try:
+            await asyncio.sleep(CHECK_INTERVAL)
+            now_mono = time.monotonic()
+            expired: list[str] = []
+
+            for log_name, state in list(_log_level_overrides.items()):
+                ttl_until = state.get("ttl_until")
+                if ttl_until is not None and now_mono >= ttl_until:
+                    expired.append(log_name)
+
+            for log_name in expired:
+                state = _log_level_overrides.pop(log_name, None)
+                if state is None:
+                    continue
+                original_level = state["original_level"]
+                log_obj = _resolve_logger(log_name)
+                log_obj.setLevel(original_level)
+                logger.info(
+                    "ADMIN LOG LEVEL REVERT -- logger=%s from=%s to=%s (TTL expired)",
+                    log_name,
+                    _level_name(state["current_level"]),
+                    _level_name(original_level),
+                )
+
+            if expired:
+                logger.info(
+                    "ADMIN LOG LEVEL TTL: Reverted %d expired override(s)",
+                    len(expired),
+                )
+
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.warning(
+                "ADMIN LOG LEVEL TTL: Checker error: %s", e,
+            )

--- a/backend/startup/lifespan.py
+++ b/backend/startup/lifespan.py
@@ -399,6 +399,9 @@ async def lifespan(app_instance: FastAPI):
     task_registry.register("login_flush", periodic_flush, is_coroutine=True)
     task_registry.register("lead_magnet_batch", start_lead_magnet_batch_task)  # LEAD-MAGNET-001
     task_registry.register("api_metered_billing", start_api_metered_billing_task)  # API-SELF-004
+    # #1814: Runtime log level TTL checker — reverts expired overrides every 30s
+    from routes.admin_log_level import _periodic_log_level_ttl_checker
+    task_registry.register("log_level_ttl", _periodic_log_level_ttl_checker, is_coroutine=True)
 
     await task_registry.start_all()
 

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -95,6 +95,7 @@ from routes.api_search import router as api_search_router
 from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
 from routes.admin_command import router as admin_command_router
+from routes.admin_log_level import router as admin_log_level_router
 from routes.intel_tasting import router as intel_tasting_router
 from routes.predint import router as predint_router
 from routes.monthly_report import router as monthly_report_router
@@ -206,6 +207,8 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(admin_digest_metrics_router)
     # GAP-002 (#1579): Command plan provisioning — self-prefixed at /v1/admin/subscriptions/*
     app.include_router(admin_command_router)
+    # #1814: Runtime log level toggle — self-prefixed at /v1/admin/log-level
+    app.include_router(admin_log_level_router)
     # Stripe webhook at root — DEBT-324: single registration only.
     # Removed from _v1_routers above to prevent duplicate at /v1/webhooks/stripe.
     # Stripe Dashboard must be configured with: POST /webhooks/stripe

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -10377,6 +10377,73 @@
         "title": "LicitacoesIndexableResponse",
         "type": "object"
       },
+      "LogLevelOverrideInfo": {
+        "description": "Single override entry returned by GET /v1/admin/log-level.",
+        "properties": {
+          "current_level": {
+            "title": "Current Level",
+            "type": "string"
+          },
+          "logger": {
+            "title": "Logger",
+            "type": "string"
+          },
+          "original_level": {
+            "title": "Original Level",
+            "type": "string"
+          },
+          "set_at": {
+            "title": "Set At",
+            "type": "string"
+          },
+          "set_by": {
+            "title": "Set By",
+            "type": "string"
+          },
+          "ttl_remaining_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl Remaining Seconds"
+          }
+        },
+        "required": [
+          "logger",
+          "original_level",
+          "current_level",
+          "set_by",
+          "set_at"
+        ],
+        "title": "LogLevelOverrideInfo",
+        "type": "object"
+      },
+      "LogLevelStatusResponse": {
+        "description": "Response for GET /v1/admin/log-level.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "overrides": {
+            "items": {
+              "$ref": "#/components/schemas/LogLevelOverrideInfo"
+            },
+            "title": "Overrides",
+            "type": "array"
+          }
+        },
+        "required": [
+          "overrides",
+          "count"
+        ],
+        "title": "LogLevelStatusResponse",
+        "type": "object"
+      },
       "LoginAttemptRequest": {
         "description": "Frontend reports the outcome of a Supabase signInWithPassword call.\n\nThe endpoint is unauthenticated by design (failures happen before a\nsession exists). To avoid leaking user existence, the endpoint always\nreturns 200; if the email is unknown we no-op silently.",
         "properties": {
@@ -16540,6 +16607,83 @@
         "title": "SessionsListResponse",
         "type": "object"
       },
+      "SetLogLevelRequest": {
+        "description": "Request body for POST /v1/admin/log-level.",
+        "properties": {
+          "level": {
+            "description": "Log level name: DEBUG, INFO, WARNING, ERROR, CRITICAL",
+            "examples": [
+              "DEBUG"
+            ],
+            "title": "Level",
+            "type": "string"
+          },
+          "module": {
+            "default": "*",
+            "description": "Logger name (e.g. 'ingestion', 'routes.search'). Use '*' or omit for root logger.",
+            "examples": [
+              "ingestion"
+            ],
+            "title": "Module",
+            "type": "string"
+          },
+          "ttl_minutes": {
+            "default": 15,
+            "description": "Auto-revert after N minutes (1-1440). Default 15.",
+            "examples": [
+              15
+            ],
+            "maximum": 1440.0,
+            "minimum": 1.0,
+            "title": "Ttl Minutes",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "level"
+        ],
+        "title": "SetLogLevelRequest",
+        "type": "object"
+      },
+      "SetLogLevelResponse": {
+        "description": "Response for POST /v1/admin/log-level.",
+        "properties": {
+          "current_level": {
+            "title": "Current Level",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "logger": {
+            "title": "Logger",
+            "type": "string"
+          },
+          "original_level": {
+            "title": "Original Level",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "ttl_minutes": {
+            "title": "Ttl Minutes",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status",
+          "logger",
+          "original_level",
+          "current_level",
+          "ttl_minutes",
+          "detail"
+        ],
+        "title": "SetLogLevelResponse",
+        "type": "object"
+      },
       "SetorHighlight": {
         "properties": {
           "setor_id": {
@@ -22250,6 +22394,78 @@
           }
         ],
         "summary": "Admin Llm Cost",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/v1/admin/log-level": {
+      "get": {
+        "description": "Return current log level overrides (admin-only).",
+        "operationId": "get_log_levels_v1_admin_log_level_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogLevelStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Log Levels",
+        "tags": [
+          "admin"
+        ]
+      },
+      "post": {
+        "description": "Set a logger's level at runtime (admin-only).\n\nAltera o log level do *module* (ou root se omitido) para *level*.\nApos *ttl_minutes*, reverte automaticamente ao nivel original.",
+        "operationId": "set_log_level_v1_admin_log_level_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetLogLevelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetLogLevelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Set Log Level",
         "tags": [
           "admin"
         ]

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -927,6 +927,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/log-level": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Log Levels
+         * @description Return current log level overrides (admin-only).
+         */
+        get: operations["get_log_levels_v1_admin_log_level_get"];
+        put?: never;
+        /**
+         * Set Log Level
+         * @description Set a logger's level at runtime (admin-only).
+         *
+         *     Altera o log level do *module* (ou root se omitido) para *level*.
+         *     Apos *ttl_minutes*, reverte automaticamente ao nivel original.
+         */
+        post: operations["set_log_level_v1_admin_log_level_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/memory-snapshot": {
         parameters: {
             query?: never;
@@ -11727,6 +11754,34 @@ export interface components {
             updated_at: string;
         };
         /**
+         * LogLevelOverrideInfo
+         * @description Single override entry returned by GET /v1/admin/log-level.
+         */
+        LogLevelOverrideInfo: {
+            /** Current Level */
+            current_level: string;
+            /** Logger */
+            logger: string;
+            /** Original Level */
+            original_level: string;
+            /** Set At */
+            set_at: string;
+            /** Set By */
+            set_by: string;
+            /** Ttl Remaining Seconds */
+            ttl_remaining_seconds?: number | null;
+        };
+        /**
+         * LogLevelStatusResponse
+         * @description Response for GET /v1/admin/log-level.
+         */
+        LogLevelStatusResponse: {
+            /** Count */
+            count: number;
+            /** Overrides */
+            overrides: components["schemas"]["LogLevelOverrideInfo"][];
+        };
+        /**
          * LoginAttemptRequest
          * @description Frontend reports the outcome of a Supabase signInWithPassword call.
          *
@@ -14658,6 +14713,50 @@ export interface components {
             /** Total */
             total: number;
         };
+        /**
+         * SetLogLevelRequest
+         * @description Request body for POST /v1/admin/log-level.
+         */
+        SetLogLevelRequest: {
+            /**
+             * Level
+             * @description Log level name: DEBUG, INFO, WARNING, ERROR, CRITICAL
+             * @example DEBUG
+             */
+            level: string;
+            /**
+             * Module
+             * @description Logger name (e.g. 'ingestion', 'routes.search'). Use '*' or omit for root logger.
+             * @default *
+             * @example ingestion
+             */
+            module: string;
+            /**
+             * Ttl Minutes
+             * @description Auto-revert after N minutes (1-1440). Default 15.
+             * @default 15
+             * @example 15
+             */
+            ttl_minutes: number;
+        };
+        /**
+         * SetLogLevelResponse
+         * @description Response for POST /v1/admin/log-level.
+         */
+        SetLogLevelResponse: {
+            /** Current Level */
+            current_level: string;
+            /** Detail */
+            detail: string;
+            /** Logger */
+            logger: string;
+            /** Original Level */
+            original_level: string;
+            /** Status */
+            status: string;
+            /** Ttl Minutes */
+            ttl_minutes: number;
+        };
         /** SetorHighlight */
         SetorHighlight: {
             /** Setor Id */
@@ -17520,6 +17619,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AdminLlmCostResponse"];
+                };
+            };
+        };
+    };
+    get_log_levels_v1_admin_log_level_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogLevelStatusResponse"];
+                };
+            };
+        };
+    };
+    set_log_level_v1_admin_log_level_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetLogLevelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetLogLevelResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Admin pode alterar log level em runtime sem redeploy.

### Changes
- POST /api/v1/admin/log-level
- GET /api/v1/admin/log-level
- TTL auto-revert mechanism

Closes #1814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin endpoints for dynamic runtime log-level management with module-specific control
  * Log-level overrides automatically expire and revert after a configurable time window (TTL)
  * New endpoint to view current active log-level overrides with remaining expiration times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->