### PR TITLE
fix(frontend): proxy /api/openapi.json to backend OpenAPI schema (#1806)

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -111,6 +111,18 @@ const nextConfig = {
     ];
   },
 
+  // Issue #1806: Rewrite /api/openapi.json to backend FastAPI OpenAPI schema.
+  // Next.js catches /api/* paths and looks for route handlers, but there is
+  // no app/api/openapi.json/ route — the backend serves it at /openapi.json.
+  async rewrites() {
+    return [
+      {
+        source: '/api/openapi.json',
+        destination: `${process.env.BACKEND_URL || 'http://localhost:8000'}/openapi.json`,
+      },
+    ];
+  },
+
   // SYS-019: Cache headers for static assets (CDN-ready)
   async headers() {
     return [


### PR DESCRIPTION
## Summary

Adiciona rewrite rule no `next.config.js` que faz proxy de `/api/openapi.json` para o backend FastAPI, resolvendo o problema de GET /api/openapi.json retornar 404.

## Problem
GET /api/openapi.json retorna 404 porque o Next.js captura a rota `/api/*` e procura por route handlers em `app/api/`, mas não existe handler para `openapi.json`. O backend FastAPI já serve o schema em `/openapi.json`.

## Solution
Adicionado `async rewrites()` no `next.config.js` que faz proxy de `/api/openapi.json` para `{BACKEND_URL}/openapi.json`, usando a variável de ambiente `BACKEND_URL` (default: `http://localhost:8000`).

## Files Changed
- `frontend/next.config.js` — Adicionado rewrite rule para `/api/openapi.json`

## Verification
- Backend já testa `GET /openapi.json → 200` via `test_openapi_schema_file_can_be_generated` em `backend/tests/test_openapi_schema.py`
- CORS já configurado globalmente no backend para todas as origens permitidas (incluindo frontend)
- Config syntax validada com Node.js

Closes #1806