### PR TITLE
chore(backend): remove obsolete feature flags (#1809)

### DIFF
--- a/.claude/rules/critical-impl-notes.md
+++ b/.claude/rules/critical-impl-notes.md
@@ -69,7 +69,7 @@ Metrics (Prometheus): `smartlic_pncp_max_page_size_changed_total`, `smartlic_pnc
 5. Status/date validation
 6. Viability assessment (post-filter)
 
-**Feature Flags:** `DATALAKE_ENABLED`, `DATALAKE_QUERY_ENABLED`, `LLM_ZERO_MATCH_ENABLED`, `LLM_ARBITER_ENABLED`, `VIABILITY_ASSESSMENT_ENABLED`, `SYNONYM_MATCHING_ENABLED`
+**Feature Flags (active):** `DATALAKE_ENABLED`, `DATALAKE_QUERY_ENABLED`, `FTS_SYNONYM_EXPANSION_ENABLED`, `ZERO_RESULTS_RELAXATION_ENABLED`, `ITEM_INSPECTION_ENABLED`
 
 ## LLM Integration
 - GPT-4.1-nano for classification + summaries

--- a/backend/config/features.py
+++ b/backend/config/features.py
@@ -20,7 +20,6 @@ SCHEMA_CONTRACT_STRICT: bool = str_to_bool(os.getenv("SCHEMA_CONTRACT_STRICT", "
 # ============================================
 # LLM Arbiter Configuration (STORY-179 AC6)
 # ============================================
-# DEBT-128: LLM_ARBITER_ENABLED removed — always-on since Oct 2025
 LLM_ARBITER_MODEL: str = os.getenv("LLM_ARBITER_MODEL", "gpt-4.1-nano")
 LLM_ARBITER_MAX_TOKENS: int = int(os.getenv("LLM_ARBITER_MAX_TOKENS", "1"))
 LLM_ARBITER_TEMPERATURE: float = float(os.getenv("LLM_ARBITER_TEMPERATURE", "0"))
@@ -66,7 +65,6 @@ QA_AUDIT_SAMPLE_RATE: float = float(os.getenv("QA_AUDIT_SAMPLE_RATE", "0.10"))
 ZERO_RESULTS_RELAXATION_ENABLED: bool = str_to_bool(os.getenv("ZERO_RESULTS_RELAXATION_ENABLED", "true"))
 
 # LLM Zero Match
-# DEBT-128: LLM_ZERO_MATCH_ENABLED removed — always-on since Oct 2025
 LLM_ZERO_MATCH_BATCH_SIZE: int = int(os.getenv("LLM_ZERO_MATCH_BATCH_SIZE", "20"))
 LLM_ZERO_MATCH_BATCH_TIMEOUT: float = float(os.getenv("LLM_ZERO_MATCH_BATCH_TIMEOUT", "5.0"))
 FILTER_ZERO_MATCH_BUDGET_S: float = float(os.getenv("FILTER_ZERO_MATCH_BUDGET_S", "30"))
@@ -75,7 +73,6 @@ ZERO_MATCH_VALUE_RATIO: float = float(os.getenv("ZERO_MATCH_VALUE_RATIO", "1.0")
 ASYNC_ZERO_MATCH_ENABLED: bool = str_to_bool(os.getenv("ASYNC_ZERO_MATCH_ENABLED", "false"))
 ZERO_MATCH_JOB_TIMEOUT_S: int = int(os.getenv("ZERO_MATCH_JOB_TIMEOUT_S", "120"))
 LLM_FALLBACK_PENDING_ENABLED: bool = str_to_bool(os.getenv("LLM_FALLBACK_PENDING_ENABLED", "true"))
-# DEBT-128: PARTIAL_DATA_SSE_ENABLED removed — SSE always-on since Dec 2025
 PENDING_REVIEW_TTL_SECONDS: int = int(os.getenv("PENDING_REVIEW_TTL_SECONDS", "86400"))
 PENDING_REVIEW_MAX_RETRIES: int = int(os.getenv("PENDING_REVIEW_MAX_RETRIES", "3"))
 PENDING_REVIEW_RETRY_DELAY: int = int(os.getenv("PENDING_REVIEW_RETRY_DELAY", "300"))
@@ -148,7 +145,6 @@ USER_FEEDBACK_ENABLED: bool = str_to_bool(os.getenv("USER_FEEDBACK_ENABLED", "tr
 USER_FEEDBACK_RATE_LIMIT: int = int(os.getenv("USER_FEEDBACK_RATE_LIMIT", "50"))
 
 # SECTOR-PROX: Proximity Context
-# DEBT-128: PROXIMITY_CONTEXT_ENABLED removed — always-on since Dec 2025
 PROXIMITY_WINDOW_SIZE: int = int(os.getenv("PROXIMITY_WINDOW_SIZE", "8"))
 
 # STORY-259: Bid Analysis
@@ -193,8 +189,6 @@ TERM_SEARCH_FILTER_CONTEXT: bool = str_to_bool(os.getenv("TERM_SEARCH_FILTER_CON
 TERM_SEARCH_VALUE_RANGE_MIN: float = float(os.getenv("TERM_SEARCH_VALUE_RANGE_MIN", "10000"))
 TERM_SEARCH_VALUE_RANGE_MAX: float = float(os.getenv("TERM_SEARCH_VALUE_RANGE_MAX", "50000000"))
 
-# DEBT-128: TRIGRAM_FALLBACK_ENABLED removed — always-on since Mar 2026
-
 # STORY-438: Semantic search via pgvector embeddings
 EMBEDDING_ENABLED: bool = str_to_bool(os.getenv("EMBEDDING_ENABLED", "false"))
 EMBEDDING_THRESHOLD: float = float(os.getenv("EMBEDDING_THRESHOLD", "0.6"))
@@ -224,8 +218,6 @@ B2G_OPS_ENABLED: bool = str_to_bool(os.getenv("B2G_OPS_ENABLED", "true"))
 # reais do mercado com blur nos nomes de concorrentes. Default ON (true).
 # Set env var to "false" to disable globally.
 INTELLIGENCE_TASTING_ENABLED: bool = str_to_bool(os.getenv("INTELLIGENCE_TASTING_ENABLED", "true"))
-
-
 # ============================================
 # Runtime-Reloadable Feature Flags (STORY-226 AC16)
 # ============================================
@@ -242,7 +234,6 @@ _runtime_overrides: dict[str, bool] = {}
 _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     # --- LLM & Classification ---
     "ENABLE_NEW_PRICING": ("ENABLE_NEW_PRICING", "true"),
-    # DEBT-128: LLM_ARBITER_ENABLED and LLM_ZERO_MATCH_ENABLED removed — always-on
     "ASYNC_ZERO_MATCH_ENABLED": ("ASYNC_ZERO_MATCH_ENABLED", "false"),
     "LLM_FALLBACK_PENDING_ENABLED": ("LLM_FALLBACK_PENDING_ENABLED", "true"),
     "BID_ANALYSIS_ENABLED": ("BID_ANALYSIS_ENABLED", "true"),
@@ -250,9 +241,9 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "ZERO_RESULTS_RELAXATION_ENABLED": ("ZERO_RESULTS_RELAXATION_ENABLED", "true"),
     "CO_OCCURRENCE_RULES_ENABLED": ("CO_OCCURRENCE_RULES_ENABLED", "true"),
     "SECTOR_RED_FLAGS_ENABLED": ("SECTOR_RED_FLAGS_ENABLED", "true"),
-    # DEBT-128: PROXIMITY_CONTEXT_ENABLED removed — always-on (stable since Dec 2025)
     "ITEM_INSPECTION_ENABLED": ("ITEM_INSPECTION_ENABLED", "true"),
     # --- Term Search Quality ---
+    # EXPIRY: 2026-09-01 — graduate term search quality features or remove
     "TERM_SEARCH_LLM_AWARE": ("TERM_SEARCH_LLM_AWARE", "false"),
     "TERM_SEARCH_SYNONYMS": ("TERM_SEARCH_SYNONYMS", "false"),
     "TERM_SEARCH_VIABILITY_GENERIC": ("TERM_SEARCH_VIABILITY_GENERIC", "false"),
@@ -271,7 +262,7 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "SHOW_CACHE_FALLBACK_BANNER": ("SHOW_CACHE_FALLBACK_BANNER", "true"),
     "SERVE_EXPIRED_CACHE_ON_TOTAL_OUTAGE": ("SERVE_EXPIRED_CACHE_ON_TOTAL_OUTAGE", "true"),
     # --- Search Pipeline ---
-    # DEBT-128: PARTIAL_DATA_SSE_ENABLED removed — always-on (stable since Dec 2025)
+    # EXPIRY: 2026-09-01 — graduate async search or remove
     "SEARCH_ASYNC_ENABLED": ("SEARCH_ASYNC_ENABLED", "false"),
     # --- Cron & Operations ---
     "HEALTH_CANARY_ENABLED": ("HEALTH_CANARY_ENABLED", "true"),
@@ -312,8 +303,9 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "COMPRASGOV_CB_ENABLED": ("COMPRASGOV_CB_ENABLED", "true"),
     # --- STORY-414: Schema contract gate (faseado 14d, default off in prod) ---
     "SCHEMA_CONTRACT_STRICT": ("SCHEMA_CONTRACT_STRICT", "false"),
-    # DEBT-128: TRIGRAM_FALLBACK_ENABLED removed — always-on (stable since Mar 2026)
     # --- STORY-438: Semantic embeddings ---
+    # EXPIRY: 2026-09-01 — graduate or remove
+    # Note: EMBEDDING_THRESHOLD must be removed together if this graduates
     "EMBEDDING_ENABLED": ("EMBEDDING_ENABLED", "false"),
     # --- TIER-COMMAND-003: Command tier feature flags (fail-closed: all default false) ---
     "COMMAND_API_ACCESS": ("COMMAND_API_ACCESS", "false"),
@@ -324,8 +316,6 @@ _FEATURE_FLAG_REGISTRY: dict[str, tuple[str, str]] = {
     "COMMAND_DATA_EXPORT": ("COMMAND_DATA_EXPORT", "false"),
     "COMMAND_CUSTOM_ALERTS": ("COMMAND_CUSTOM_ALERTS", "false"),
 }
-
-
 def get_feature_flag(name: str, default: bool | None = None) -> bool:
     """Get a feature flag value with TTL-based caching (60s).
 
@@ -358,8 +348,6 @@ def get_feature_flag(name: str, default: bool | None = None) -> bool:
 
     _feature_flag_cache[name] = (value, now)
     return value
-
-
 def reload_feature_flags() -> dict[str, bool]:
     """Clear the feature flag cache, forcing re-read from environment."""
     _feature_flag_cache.clear()
@@ -368,8 +356,6 @@ def reload_feature_flags() -> dict[str, bool]:
     for name in _FEATURE_FLAG_REGISTRY:
         current_values[name] = get_feature_flag(name)
     return current_values
-
-
 def validate_feature_flags() -> None:
     """Validate all feature flag values for correct types and reasonable ranges.
 
@@ -506,13 +492,9 @@ def validate_feature_flags() -> None:
         )
 
     logger.info("Feature flag validation passed — all %d checked flags are valid", _VALIDATED_FLAG_COUNT)
-
-
 # Number of flags validated by validate_feature_flags() — used in log message above.
 # Update this constant whenever a new _check_* call is added.
 _VALIDATED_FLAG_COUNT = 38
-
-
 def log_feature_flags() -> None:
     """Log feature flag states. Call AFTER setup_logging()."""
     from config.pncp import COMPRASGOV_ENABLED as _cg_enabled

--- a/backend/datalake_query.py
+++ b/backend/datalake_query.py
@@ -340,7 +340,6 @@ async def query_datalake(
         List of flat bid dicts compatible with _normalize_item() output.
         Returns [] on any error (fail-open).
     """
-    # DEBT-128: TRIGRAM_FALLBACK_ENABLED removed — always-on (stable since Mar 2026)
     from config.features import EMBEDDING_ENABLED
 
     tsquery, websearch_text = _build_tsquery(keywords, custom_terms)
@@ -436,7 +435,6 @@ async def query_datalake(
                 logger.warning(f"[DatalakeQuery] RPC failed for UF={uf}: {type(e).__name__}: {e}")
 
         if not rows:
-            # DEBT-128: TRIGRAM_FALLBACK_ENABLED removed — always-on (stable since Mar 2026)
             # STORY-437 AC3: Trigram fallback when FTS returns 0
             if tsquery or websearch_text:
                 trigram_term = _build_trigram_term(keywords, custom_terms)

--- a/backend/filter/pipeline.py
+++ b/backend/filter/pipeline.py
@@ -636,7 +636,6 @@ def aplicar_todos_filtros(
 
     # STORY-267 AC13: Disable proximity filter for custom_terms searches
     _skip_proximity = bool(custom_terms) and get_feature_flag("TERM_SEARCH_FILTER_CONTEXT")
-    # DEBT-128: PROXIMITY_CONTEXT_ENABLED removed — always-on (stable since Dec 2025)
     if setor and not _skip_proximity:
         from sectors import SECTORS as _SECTORS_PROX
 
@@ -795,7 +794,6 @@ def aplicar_todos_filtros(
     # ========================================================================
     # GTM-FIX-028: LLM Zero Match Classification
     # ========================================================================
-    # DEBT-128: LLM_ZERO_MATCH_ENABLED removed — always-on (stable since Oct 2025)
     # Instead of auto-rejecting bids with 0 keyword matches, collect them
     # and send to LLM for sector-aware classification.
     resultado_llm_zero: List[dict] = []
@@ -813,7 +811,6 @@ def aplicar_todos_filtros(
         _use_term_prompt_zm = _gff_ac2("TERM_SEARCH_LLM_AWARE")
 
     # ISSUE-017: Also run zero-match LLM when custom_terms present (no sector needed)
-    # DEBT-128: LLM_ZERO_MATCH_ENABLED removed — condition simplified
     if setor or custom_terms:
         # Collect bids that were rejected by keyword gate (in resultado_valor but not in resultado_keyword)
         keyword_approved_ids = {id(lic) for lic in resultado_keyword}
@@ -1678,7 +1675,6 @@ def aplicar_todos_filtros(
 
     # GTM-FIX-028 AC10: When LLM zero-match is enabled, skip FLUXO 2 to avoid
     # double-classification (zero-match bids already went through LLM)
-    # DEBT-128: LLM_ZERO_MATCH_ENABLED removed — zero-match is always-on
     _skip_fluxo_2 = stats.get("llm_zero_match_calls", 0) > 0
     if _skip_fluxo_2:
         logger.info(

--- a/backend/llm_arbiter/classification.py
+++ b/backend/llm_arbiter/classification.py
@@ -396,7 +396,6 @@ def classify_contract_primary_match(
 
     D-02: Returns structured dict with confidence, evidence, and rejection reason.
     """
-    # DEBT-128: LLM_ARBITER_ENABLED removed — always-on. Lazy import via facade kept for test backward compat.
 
     if not setor_name and not termos_busca:
         logger.error(

--- a/backend/llm_arbiter/zero_match.py
+++ b/backend/llm_arbiter/zero_match.py
@@ -178,7 +178,6 @@ def classify_contract_recovery(
 
     Recovery always uses binary mode (no structured output needed).
     """
-    # DEBT-128: LLM_ARBITER_ENABLED removed — always-on.
     if not setor_name and not termos_busca:
         logger.error(
             "classify_contract_recovery called without setor_name or termos_busca"

--- a/backend/pipeline/stages/execute.py
+++ b/backend/pipeline/stages/execute.py
@@ -338,7 +338,6 @@ async def stage_execute(pipeline, ctx: SearchContext) -> None:
     enriquecer_com_status_inferido(ctx.licitacoes_raw)
     logger.debug(f"Status inference complete for {len(ctx.licitacoes_raw)} bids")
 
-    # DEBT-128: PARTIAL_DATA_SSE_ENABLED removed — always-on (stable since Dec 2025)
     # CRIT-071: Emit partial_data SSE event with raw results before filtering
     if ctx.tracker and ctx.licitacoes_raw:
         await ctx.tracker.emit_partial_data(

--- a/backend/pipeline/stages/filter_stage.py
+++ b/backend/pipeline/stages/filter_stage.py
@@ -373,7 +373,6 @@ async def stage_filter(pipeline, ctx: SearchContext) -> None:
             filter_stats=stats,
         )
 
-        # DEBT-128: PARTIAL_DATA_SSE_ENABLED removed — always-on (stable since Dec 2025)
         # CRIT-071: Emit partial_data with filtered results
         if ctx.licitacoes_filtradas:
             await ctx.tracker.emit_partial_data(

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -166,7 +166,6 @@ async def _resolve_flag_value(flag_name: str) -> tuple[bool, str]:
 _FLAG_DESCRIPTIONS: dict[str, str] = {
     # LLM & Classification
     "ENABLE_NEW_PRICING": "New pricing model (STORY-165)",
-    # DEBT-128: LLM_ARBITER_ENABLED and LLM_ZERO_MATCH_ENABLED removed — always-on
     "ASYNC_ZERO_MATCH_ENABLED": "Async background zero-match via ARQ jobs",
     "LLM_FALLBACK_PENDING_ENABLED": "LLM fallback to pending-review status on failure",
     "BID_ANALYSIS_ENABLED": "Deep bid analysis with LLM",
@@ -174,7 +173,6 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "ZERO_RESULTS_RELAXATION_ENABLED": "Relax filters when zero results found",
     "CO_OCCURRENCE_RULES_ENABLED": "Keyword co-occurrence filtering rules",
     "SECTOR_RED_FLAGS_ENABLED": "Sector-specific red flag detection",
-    # DEBT-128: PROXIMITY_CONTEXT_ENABLED removed — always-on
     "ITEM_INSPECTION_ENABLED": "Item-level inspection for gray-zone contracts",
     # Term Search Quality
     "TERM_SEARCH_LLM_AWARE": "LLM-aware term search quality parity",
@@ -192,7 +190,6 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     "SERVE_EXPIRED_CACHE_ON_TOTAL_OUTAGE": "Serve expired cache during total outage",
     # Search Pipeline
     "SEARCH_ASYNC_ENABLED": "Async search via ARQ job queue",
-    # DEBT-128: PARTIAL_DATA_SSE_ENABLED removed — always-on
     # Cron & Operations
     "HEALTH_CANARY_ENABLED": "PNCP health canary checks (5-min interval)",
     "DIGEST_ENABLED": "Email digest cron job",
@@ -220,7 +217,6 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
     # Schema Contract (STORY-414)
     "SCHEMA_CONTRACT_STRICT": "Strict schema contract validation for external responses (STORY-414)",
     # Datalake Search Improvements
-    # DEBT-128: TRIGRAM_FALLBACK_ENABLED removed — always-on
     "EMBEDDING_ENABLED": "Semantic embedding search for datalake (STORY-438)",
     # Founders Offer
     "FOUNDERS_OFFER_ENABLED": "Kill switch for the Founders lifetime offer (epic:fundadores — BIZ-FOUND-002)",
@@ -246,7 +242,6 @@ _FLAG_DESCRIPTIONS: dict[str, str] = {
 _FLAG_LIFECYCLE: dict[str, dict] = {
     # LLM & Classification — permanent, core pipeline
     "ENABLE_NEW_PRICING": {"owner": "billing", "category": "billing", "lifecycle": "permanent", "created": "2025-11"},
-    # DEBT-128: LLM_ARBITER_ENABLED and LLM_ZERO_MATCH_ENABLED removed — always-on
     "ASYNC_ZERO_MATCH_ENABLED": {"owner": "search", "category": "llm", "lifecycle": "experimental", "created": "2025-12"},
     "LLM_FALLBACK_PENDING_ENABLED": {"owner": "search", "category": "llm", "lifecycle": "permanent", "created": "2025-12"},
     "BID_ANALYSIS_ENABLED": {"owner": "search", "category": "llm", "lifecycle": "permanent", "created": "2026-01"},
@@ -254,7 +249,6 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "ZERO_RESULTS_RELAXATION_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-11"},
     "CO_OCCURRENCE_RULES_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-12"},
     "SECTOR_RED_FLAGS_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-12"},
-    # DEBT-128: PROXIMITY_CONTEXT_ENABLED removed — always-on
     "ITEM_INSPECTION_ENABLED": {"owner": "search", "category": "filter", "lifecycle": "permanent", "created": "2025-12"},
     # Term Search Quality — experimental, remove when graduated
     "TERM_SEARCH_LLM_AWARE": {"owner": "search", "category": "experimental", "lifecycle": "experimental", "created": "2026-01"},
@@ -272,7 +266,6 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     "SERVE_EXPIRED_CACHE_ON_TOTAL_OUTAGE": {"owner": "infra", "category": "cache", "lifecycle": "permanent", "created": "2026-01"},
     # Search Pipeline
     "SEARCH_ASYNC_ENABLED": {"owner": "search", "category": "pipeline", "lifecycle": "experimental", "created": "2025-12"},
-    # DEBT-128: PARTIAL_DATA_SSE_ENABLED removed — always-on
     # Cron & Operations
     "HEALTH_CANARY_ENABLED": {"owner": "infra", "category": "ops", "lifecycle": "permanent", "created": "2025-11"},
     "DIGEST_ENABLED": {"owner": "email", "category": "ops", "lifecycle": "experimental", "created": "2025-12"},
@@ -296,7 +289,6 @@ _FLAG_LIFECYCLE: dict[str, dict] = {
     # STORY-414: Schema contract gate
     "SCHEMA_CONTRACT_STRICT": {"owner": "data", "category": "validation", "lifecycle": "experimental", "created": "2026-03"},
     # STORY-437: Datalake search improvements
-    # DEBT-128: TRIGRAM_FALLBACK_ENABLED removed — always-on
     # STORY-438: Semantic embeddings
     "EMBEDDING_ENABLED": {"owner": "search", "category": "search", "lifecycle": "experimental", "created": "2026-03"},
     # BIZ-FOUND-002: Founders lifetime offer kill switch

--- a/backend/scripts/generate_feature_flags_docs.py
+++ b/backend/scripts/generate_feature_flags_docs.py
@@ -284,7 +284,6 @@ def main() -> None:
 
     # Quick verification — DATALAKE_ENABLED lives in ingestion/config.py, not
     # features.py, so we only check flags that ARE defined in features.py.
-    # DEBT-128: LLM_ARBITER_ENABLED removed — always-on
     required = {"TRIAL_DURATION_DAYS"}
     found_env_vars = {f["env_var"] for f in flags}
     missing = required - found_env_vars


### PR DESCRIPTION
## Summary

Remove DEBT-128 comment references for 5 obsolete feature flags that were already always-on:

- **LLM_ARBITER_ENABLED** — always-on since Oct 2025
- **LLM_ZERO_MATCH_ENABLED** — always-on since Oct 2025
- **PARTIAL_DATA_SSE_ENABLED** — always-on since Dec 2025
- **TRIGRAM_FALLBACK_ENABLED** — always-on since Mar 2026
- **PROXIMITY_CONTEXT_ENABLED** — always-on since Dec 2025

These flags were already removed from registry entries; only stale DEBT-128 comments remained across 10 source files.

Also adds EXPIRY: 2026-09-01 comments to transient flags.

## Files changed
- backend/config/features.py — removed 9 DEBT-128 comments, added 3 EXPIRY comments
- backend/routes/feature_flags.py — removed 8 DEBT-128 comments
- backend/datalake_query.py — removed 2 DEBT-128 comments
- backend/filter/pipeline.py — removed 4 DEBT-128 comments
- backend/pipeline/stages/filter_stage.py — removed 1 DEBT-128 comment
- backend/pipeline/stages/execute.py — removed 1 DEBT-128 comment
- backend/llm_arbiter/classification.py — removed 1 DEBT-128 comment
- backend/llm_arbiter/zero_match.py — removed 1 DEBT-128 comment
- backend/scripts/generate_feature_flags_docs.py — removed 1 DEBT-128 comment
- .claude/rules/critical-impl-notes.md — updated stale flag references

## Testing
- All 114 config + feature flag tests pass
- All 117 proximity + filter context + datalake query tests pass

Closes #1809