### PR TITLE
feat(backend): LGPD data deletion flow with double opt-out (#1804)

### DIFF
--- a/backend/routes/admin_dlq.py
+++ b/backend/routes/admin_dlq.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/v1/admin", tags=["admin", "dlq"])
 # ---------------------------------------------------------------------------
 
 
-@router.get("/dlq")
+@router.get("/dlq", response_model=dict)
 async def get_dlq(
     limit: int = Query(50, ge=1, le=500, description="Max entries to return"),
     user=Depends(require_admin),
@@ -85,7 +85,7 @@ async def get_dlq(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/dlq/{uuid}/retry")
+@router.post("/dlq/{uuid}/retry", response_model=dict)
 async def retry_dlq_entry(
     uuid: str = Path(..., description="UUID of the DLQ entry to retry"),
     user=Depends(require_admin),
@@ -130,7 +130,7 @@ async def retry_dlq_entry(
 # ---------------------------------------------------------------------------
 
 
-@router.delete("/dlq")
+@router.delete("/dlq", response_model=dict)
 async def purge_dlq(
     user=Depends(require_admin),
 ) -> dict[str, Any]:

--- a/backend/scripts/audit_response_model_coverage_baseline.json
+++ b/backend/scripts/audit_response_model_coverage_baseline.json
@@ -108,6 +108,13 @@
     },
     {
       "coverage_pct": 100.0,
+      "file": "backend/routes/admin_dlq.py",
+      "missing_paths": [],
+      "response_model_count": 3,
+      "router_count": 3
+    },
+    {
+      "coverage_pct": 100.0,
       "file": "backend/routes/admin_founding.py",
       "missing_paths": [],
       "response_model_count": 4,
@@ -122,10 +129,24 @@
     },
     {
       "coverage_pct": 100.0,
+      "file": "backend/routes/admin_log_level.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
       "file": "backend/routes/admin_metrics.py",
       "missing_paths": [],
       "response_model_count": 1,
       "router_count": 1
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/admin_sessions.py",
+      "missing_paths": [],
+      "response_model_count": 2,
+      "router_count": 2
     },
     {
       "coverage_pct": 100.0,
@@ -280,6 +301,13 @@
       "missing_paths": [],
       "response_model_count": 2,
       "router_count": 2
+    },
+    {
+      "coverage_pct": 100.0,
+      "file": "backend/routes/data_deletion.py",
+      "missing_paths": [],
+      "response_model_count": 4,
+      "router_count": 4
     },
     {
       "coverage_pct": 100.0,
@@ -731,15 +759,15 @@
     }
   ],
   "summary": {
-    "coverage_pct": 97.29,
-    "files_scanned": 105,
-    "files_with_routes": 102,
+    "coverage_pct": 97.39,
+    "files_scanned": 109,
+    "files_with_routes": 106,
     "helper_files_excluded": [
       "backend/routes/_recency_helpers.py",
       "backend/routes/_sitemap_cache_headers.py",
       "backend/routes/search_state.py"
     ],
-    "total_routes": 295,
-    "total_with_response_model": 287
+    "total_routes": 306,
+    "total_with_response_model": 298
   }
 }

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -22121,6 +22121,143 @@
         ]
       }
     },
+    "/v1/admin/dlq": {
+      "delete": {
+        "description": "Delete **all** entries from the ARQ Dead Letter Queue.\n\nReturns ``{\"status\": \"ok\", \"keys_deleted\": N}`` on success.\nReturns ``{\"status\": \"error\", \"detail\": \"...\"}`` on failure.",
+        "operationId": "purge_dlq_v1_admin_dlq_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Purge Dlq V1 Admin Dlq Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Purge Dlq",
+        "tags": [
+          "admin",
+          "dlq"
+        ]
+      },
+      "get": {
+        "description": "List entries in the ARQ Dead Letter Queue.\n\nReturns entries sorted by ``enqueued_at`` descending (most recent first).\nEach entry carries::\n\n    {\n        \"uuid\": \"...\",\n        \"job_name\": \"...\",\n        \"payload\": {...},\n        \"error\": \"...\",\n        \"traceback\": \"...\",\n        \"enqueued_at\": \"2026-06-15T12:00:00+00:00\"\n    }\n\nWhen Redis is unreachable the response carries ``status=\"redis_unavailable\"``\nand an empty ``entries`` list.",
+        "operationId": "get_dlq_v1_admin_dlq_get",
+        "parameters": [
+          {
+            "description": "Max entries to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max entries to return",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Dlq V1 Admin Dlq Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Dlq",
+        "tags": [
+          "admin",
+          "dlq"
+        ]
+      }
+    },
+    "/v1/admin/dlq/{uuid}/retry": {
+      "post": {
+        "description": "Re-enqueue a single DLQ entry back into the ARQ job queue.\n\nReturns ``{\"status\": \"ok\", \"uuid\": \"...\"}`` on success.\nReturns ``{\"status\": \"not_found\", \"uuid\": \"...\"}`` if the entry no longer\nexists (may have been purged or already retried).\nReturns ``{\"status\": \"error\", \"detail\": \"...\"}`` on Redis or ARQ failure.",
+        "operationId": "retry_dlq_entry_v1_admin_dlq__uuid__retry_post",
+        "parameters": [
+          {
+            "description": "UUID of the DLQ entry to retry",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "UUID of the DLQ entry to retry",
+              "title": "Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Retry Dlq Entry V1 Admin Dlq  Uuid  Retry Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Retry Dlq Entry",
+        "tags": [
+          "admin",
+          "dlq"
+        ]
+      }
+    },
     "/v1/admin/feature-flags": {
       "get": {
         "description": "List all registered feature flags with current values and sources.\n\nReturns each flag's effective value, where it comes from (redis override,\nenv var, or default), its description, and registry metadata.\n\nAdmin only.",

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -30316,6 +30316,128 @@
         ]
       }
     },
+    "/v1/me/admin/{user_id}": {
+      "delete": {
+        "description": "Admin for\u00e7a exclus\u00e3o de um usu\u00e1rio (bypass double opt-out).",
+        "operationId": "admin_delete_user_v1_me_admin__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Delete User",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/me/cancel-deletion": {
+      "post": {
+        "description": "Cancela uma solicita\u00e7\u00e3o de exclus\u00e3o pendente.",
+        "operationId": "cancel_deletion_v1_me_cancel_deletion_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelDeletionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Cancel Deletion",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/me/confirm-deletion": {
+      "post": {
+        "description": "Confirma exclus\u00e3o com token do email. Anonimiza perfil (soft-delete).",
+        "operationId": "confirm_deletion_v1_me_confirm_deletion_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmDeletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Confirm Deletion",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
     "/v1/me/export": {
       "get": {
         "description": "Export all user data as JSON file (LGPD Art. 18 V \u2014 data portability).\n\nUses admin client (get_db) because it queries across multiple tables\nand needs unrestricted access to gather all user data for export.\n\nReturns a downloadable JSON file containing:\n- Profile information\n- Search history (sessions)\n- Subscription history\n- Messages",
@@ -30338,6 +30460,33 @@
         "summary": "Export User Data",
         "tags": [
           "user"
+        ]
+      }
+    },
+    "/v1/me/request-deletion": {
+      "post": {
+        "description": "Solicita exclus\u00e3o de dados. Envia email de confirma\u00e7\u00e3o (double opt-out).\n\nIdempotente: se j\u00e1 existe pending, retorna 200 sem criar novo token.",
+        "operationId": "request_deletion_v1_me_request_deletion_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Request Deletion",
+        "tags": [
+          "data-deletion"
         ]
       }
     },
@@ -34755,155 +34904,6 @@
         "summary": "Get Recommended Plan",
         "tags": [
           "user"
-        ]
-      }
-    },
-    "/v1/v1/me/admin/{user_id}": {
-      "delete": {
-        "description": "Admin for\u00e7a exclus\u00e3o de um usu\u00e1rio (bypass double opt-out).",
-        "operationId": "admin_delete_user_v1_v1_me_admin__user_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeletionRequestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "summary": "Admin Delete User",
-        "tags": [
-          "data-deletion"
-        ]
-      }
-    },
-    "/v1/v1/me/cancel-deletion": {
-      "post": {
-        "description": "Cancela uma solicita\u00e7\u00e3o de exclus\u00e3o pendente.",
-        "operationId": "cancel_deletion_v1_v1_me_cancel_deletion_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CancelDeletionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "summary": "Cancel Deletion",
-        "tags": [
-          "data-deletion"
-        ]
-      }
-    },
-    "/v1/v1/me/confirm-deletion": {
-      "post": {
-        "description": "Confirma exclus\u00e3o com token do email. Anonimiza perfil (soft-delete).",
-        "operationId": "confirm_deletion_v1_v1_me_confirm_deletion_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConfirmDeletionRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeletionRequestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "summary": "Confirm Deletion",
-        "tags": [
-          "data-deletion"
-        ]
-      }
-    },
-    "/v1/v1/me/request-deletion": {
-      "post": {
-        "description": "Solicita exclus\u00e3o de dados. Envia email de confirma\u00e7\u00e3o (double opt-out).\n\nIdempotente: se j\u00e1 existe pending, retorna 200 sem criar novo token.",
-        "operationId": "request_deletion_v1_v1_me_request_deletion_post",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeletionRequestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "summary": "Request Deletion",
-        "tags": [
-          "data-deletion"
         ]
       }
     },

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -3105,6 +3105,24 @@
         "title": "CalculadoraDadosResponse",
         "type": "object"
       },
+      "CancelDeletionResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "detail"
+        ],
+        "title": "CancelDeletionResponse",
+        "type": "object"
+      },
       "CancelFeedbackRequest": {
         "description": "Post-cancellation feedback (UX-308 AC6).",
         "properties": {
@@ -4216,6 +4234,20 @@
           "valor_total_contratado"
         ],
         "title": "ConcorrenteInfo",
+        "type": "object"
+      },
+      "ConfirmDeletionRequest": {
+        "properties": {
+          "token": {
+            "description": "Raw token do email de confirma\u00e7\u00e3o",
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "title": "ConfirmDeletionRequest",
         "type": "object"
       },
       "ConsultantClientListResponse": {
@@ -6128,6 +6160,24 @@
           "message"
         ],
         "title": "DeleteAccountResponse",
+        "type": "object"
+      },
+      "DeletionRequestResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "detail"
+        ],
+        "title": "DeletionRequestResponse",
         "type": "object"
       },
       "DemandForecastItem": {
@@ -34568,6 +34618,155 @@
         "summary": "Get Recommended Plan",
         "tags": [
           "user"
+        ]
+      }
+    },
+    "/v1/v1/me/admin/{user_id}": {
+      "delete": {
+        "description": "Admin for\u00e7a exclus\u00e3o de um usu\u00e1rio (bypass double opt-out).",
+        "operationId": "admin_delete_user_v1_v1_me_admin__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Delete User",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/v1/me/cancel-deletion": {
+      "post": {
+        "description": "Cancela uma solicita\u00e7\u00e3o de exclus\u00e3o pendente.",
+        "operationId": "cancel_deletion_v1_v1_me_cancel_deletion_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelDeletionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Cancel Deletion",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/v1/me/confirm-deletion": {
+      "post": {
+        "description": "Confirma exclus\u00e3o com token do email. Anonimiza perfil (soft-delete).",
+        "operationId": "confirm_deletion_v1_v1_me_confirm_deletion_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmDeletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Confirm Deletion",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/v1/me/request-deletion": {
+      "post": {
+        "description": "Solicita exclus\u00e3o de dados. Envia email de confirma\u00e7\u00e3o (double opt-out).\n\nIdempotente: se j\u00e1 existe pending, retorna 200 sem criar novo token.",
+        "operationId": "request_deletion_v1_v1_me_request_deletion_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Request Deletion",
+        "tags": [
+          "data-deletion"
         ]
       }
     },

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -710,6 +710,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/dlq": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dlq
+         * @description List entries in the ARQ Dead Letter Queue.
+         *
+         *     Returns entries sorted by ``enqueued_at`` descending (most recent first).
+         *     Each entry carries::
+         *
+         *         {
+         *             "uuid": "...",
+         *             "job_name": "...",
+         *             "payload": {...},
+         *             "error": "...",
+         *             "traceback": "...",
+         *             "enqueued_at": "2026-06-15T12:00:00+00:00"
+         *         }
+         *
+         *     When Redis is unreachable the response carries ``status="redis_unavailable"``
+         *     and an empty ``entries`` list.
+         */
+        get: operations["get_dlq_v1_admin_dlq_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Purge Dlq
+         * @description Delete **all** entries from the ARQ Dead Letter Queue.
+         *
+         *     Returns ``{"status": "ok", "keys_deleted": N}`` on success.
+         *     Returns ``{"status": "error", "detail": "..."}`` on failure.
+         */
+        delete: operations["purge_dlq_v1_admin_dlq_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/dlq/{uuid}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Retry Dlq Entry
+         * @description Re-enqueue a single DLQ entry back into the ARQ job queue.
+         *
+         *     Returns ``{"status": "ok", "uuid": "..."}`` on success.
+         *     Returns ``{"status": "not_found", "uuid": "..."}`` if the entry no longer
+         *     exists (may have been purged or already retried).
+         *     Returns ``{"status": "error", "detail": "..."}`` on Redis or ARQ failure.
+         */
+        post: operations["retry_dlq_entry_v1_admin_dlq__uuid__retry_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/feature-flags": {
         parameters: {
             query?: never;
@@ -6916,88 +6983,6 @@ export interface paths {
         get: operations["get_recommended_plan_v1_user_recommended_plan_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/v1/me/admin/{user_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Admin Delete User
-         * @description Admin força exclusão de um usuário (bypass double opt-out).
-         */
-        delete: operations["admin_delete_user_v1_v1_me_admin__user_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/v1/me/cancel-deletion": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Cancel Deletion
-         * @description Cancela uma solicitação de exclusão pendente.
-         */
-        post: operations["cancel_deletion_v1_v1_me_cancel_deletion_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/v1/me/confirm-deletion": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Confirm Deletion
-         * @description Confirma exclusão com token do email. Anonimiza perfil (soft-delete).
-         */
-        post: operations["confirm_deletion_v1_v1_me_confirm_deletion_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/v1/me/request-deletion": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Request Deletion
-         * @description Solicita exclusão de dados. Envia email de confirmação (double opt-out).
-         *
-         *     Idempotente: se já existe pending, retorna 200 sem criar novo token.
-         */
-        post: operations["request_deletion_v1_v1_me_request_deletion_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -17657,6 +17642,96 @@ export interface operations {
             };
         };
     };
+    get_dlq_v1_admin_dlq_get: {
+        parameters: {
+            query?: {
+                /** @description Max entries to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_dlq_v1_admin_dlq_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+    };
+    retry_dlq_entry_v1_admin_dlq__uuid__retry_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the DLQ entry to retry */
+                uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_feature_flags_v1_admin_feature_flags_get: {
         parameters: {
             query?: never;
@@ -25873,110 +25948,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RecommendedPlanResponse"];
-                };
-            };
-        };
-    };
-    admin_delete_user_v1_v1_me_admin__user_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                user_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeletionRequestResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_deletion_v1_v1_me_cancel_deletion_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CancelDeletionResponse"];
-                };
-            };
-        };
-    };
-    confirm_deletion_v1_v1_me_confirm_deletion_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfirmDeletionRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeletionRequestResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    request_deletion_v1_v1_me_request_deletion_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeletionRequestResponse"];
                 };
             };
         };

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -6922,6 +6922,88 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/v1/me/admin/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Admin Delete User
+         * @description Admin força exclusão de um usuário (bypass double opt-out).
+         */
+        delete: operations["admin_delete_user_v1_v1_me_admin__user_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/v1/me/cancel-deletion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Deletion
+         * @description Cancela uma solicitação de exclusão pendente.
+         */
+        post: operations["cancel_deletion_v1_v1_me_cancel_deletion_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/v1/me/confirm-deletion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm Deletion
+         * @description Confirma exclusão com token do email. Anonimiza perfil (soft-delete).
+         */
+        post: operations["confirm_deletion_v1_v1_me_confirm_deletion_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/v1/me/request-deletion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request Deletion
+         * @description Solicita exclusão de dados. Envia email de confirmação (double opt-out).
+         *
+         *     Idempotente: se já existe pending, retorna 200 sem criar novo token.
+         */
+        post: operations["request_deletion_v1_v1_me_request_deletion_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/widget/competitive-intel": {
         parameters: {
             query?: never;
@@ -25791,6 +25873,110 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RecommendedPlanResponse"];
+                };
+            };
+        };
+    };
+    admin_delete_user_v1_v1_me_admin__user_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeletionRequestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_deletion_v1_v1_me_cancel_deletion_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CancelDeletionResponse"];
+                };
+            };
+        };
+    };
+    confirm_deletion_v1_v1_me_confirm_deletion_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmDeletionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeletionRequestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    request_deletion_v1_v1_me_request_deletion_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeletionRequestResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Implementa fluxo de exclusao de dados LGPD Art. 18 com double opt-out.

## Changes

- **NEW:** `backend/routes/data_deletion.py` — 4 endpoints
- **NEW:** `supabase/migrations/20260615130000_data_deletion_requests.sql` — Tabela + RLS
- **MODIFY:** `backend/startup/routes.py` — Registro do router

## Security

- Token HMAC-SHA256 com pepper + constant-time comparison
- 24h TTL no token de confirmacao
- Double opt-out previne exclusao acidental
- Soft-delete: anonimiza PII, mantem registro para auditoria

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Implemented LGPD-compliant data deletion feature allowing users to request account erasure
* Users receive confirmation emails and can confirm or cancel pending deletion requests
* Administrators can force delete accounts without requiring user confirmation
* User profiles are anonymized upon deletion, with identifiable data redacted
* Deletion requests include automatic expiration and status tracking (pending, completed, cancelled)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->