### PR TITLE
feat(backend): ARQ Dead Letter Queue — preserve failed jobs (#1813)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Search results persistence (STORY-362 L3)
 # --------------------------------------------
 
+# Issue #1813: ARQ Dead Letter Queue TTL in days (default 7). Set to 0 for no expiry.
+# Failed ARQ jobs are preserved in Redis at arq:dlq:{job_name} LISTs.
+ARQ_DLQ_TTL_DAYS=7
+
 # TTL (seconds) for search results stored in Redis (L3 cache layer).
 # Default: 3600s (1h). Increases cache hit rate for repeated polls but
 # grows memory footprint — tune against Redis eviction pressure.

--- a/backend/jobs/dlq.py
+++ b/backend/jobs/dlq.py
@@ -1,0 +1,330 @@
+"""ARQ Dead Letter Queue — preserve failed jobs instead of discarding them.
+
+When an ARQ job exhausts all retries (max_tries reached), the job is silently
+discarded with no forensic record. This module provides a Redis-backed DLQ
+that preserves the failed job's payload, error message, and traceback for
+admin inspection, manual retry, and bulk purge.
+
+Storage layout (Redis):
+    arq:dlq:{job_name}  — LIST of JSON objects, each with a unique ``uuid``,
+                          ``payload``, ``error``, ``traceback``, ``enqueued_at``.
+    TTL: ARQ_DLQ_TTL_DAYS (default 7 days) set on every key after each push.
+
+Usage:
+    from jobs.dlq import enqueue_dlq, get_dlq_jobs, retry_dlq_job, purge_dlq
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid as _uuid
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DLQ_TTL_DAYS: int = int(os.getenv("ARQ_DLQ_TTL_DAYS", "7"))
+"""TTL in days for DLQ entries (default 7). Set to 0 for no expiry."""
+
+DLQ_PREFIX: str = "arq:dlq"
+"""Redis key prefix for Dead Letter Queue entries."""
+
+_DLQ_TTL_SECONDS: int = DLQ_TTL_DAYS * 86400 if DLQ_TTL_DAYS > 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# Core DLQ operations
+# ---------------------------------------------------------------------------
+
+
+async def enqueue_dlq(
+    job_name: str,
+    payload: dict,
+    error: str,
+    traceback: str,
+) -> None:
+    """Save a failed job to the Dead Letter Queue.
+
+    Args:
+        job_name: Name of the ARQ job function (e.g. ``"llm_summary_job"``).
+        payload: Serialisable dict of the job arguments.
+        error: Exception message string.
+        traceback: Full formatted traceback string.
+
+    The entry is pushed onto ``arq:dlq:{job_name}`` LIST and its TTL is
+    refreshed to ``ARQ_DLQ_TTL_DAYS``.  If Redis is unavailable the failure
+    is logged at WARNING level but **not** re-raised — the DLQ degrades
+    gracefully.
+    """
+    from redis_pool import get_redis_pool
+
+    redis = await get_redis_pool()
+    if redis is None:
+        logger.warning(
+            "Redis unavailable — DLQ entry dropped: job=%s error=%.200s",
+            job_name,
+            error,
+        )
+        return
+
+    entry = {
+        "uuid": str(_uuid.uuid4()),
+        "job_name": job_name,
+        "payload": payload,
+        "error": error[:2000],
+        "traceback": traceback[:5000],
+        "enqueued_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    key = f"{DLQ_PREFIX}:{job_name}"
+    try:
+        await redis.lpush(key, json.dumps(entry, default=str))
+        if _DLQ_TTL_SECONDS > 0:
+            await redis.expire(key, _DLQ_TTL_SECONDS)
+        logger.warning(
+            "DLQ: job=%s uuid=%s enqueued (TTL=%dd, error=%.100s)",
+            job_name,
+            entry["uuid"],
+            DLQ_TTL_DAYS,
+            error,
+        )
+
+        try:
+            from metrics import DLQ_ENQUEUED_TOTAL
+            DLQ_ENQUEUED_TOTAL.inc()
+        except Exception:
+            pass
+
+    except Exception as exc:
+        logger.error(
+            "DLQ: failed to persist entry job=%s uuid=%s: %s",
+            job_name,
+            entry["uuid"],
+            exc,
+        )
+
+
+async def get_dlq_jobs(limit: int = 50) -> list[dict[str, Any]]:
+    """Return the most recent entries across all DLQ keys.
+
+    Iterates every ``arq:dlq:*`` key in Redis, pulls up-to *limit* entries
+    per key, and returns them sorted by ``enqueued_at`` descending (most
+    recent first).
+
+    Args:
+        limit: Maximum number of entries to return (default 50).
+
+    Returns:
+        List of dicts with keys: uuid, job_name, payload, error, traceback,
+        enqueued_at, dlq_key.  Empty list if Redis is unavailable.
+    """
+    from redis_pool import get_redis_pool
+
+    redis = await get_redis_pool()
+    if redis is None:
+        return []
+
+    jobs: list[dict[str, Any]] = []
+    try:
+        cursor = 0
+        pattern = f"{DLQ_PREFIX}:*"
+        while True:
+            cursor, keys = await redis.scan(cursor=cursor, match=pattern, count=100)
+            for key in keys:
+                entries = await redis.lrange(key, 0, limit - 1)
+                for raw in entries:
+                    try:
+                        data: dict[str, Any] = json.loads(raw)
+                        data.setdefault("dlq_key", key)
+                        jobs.append(data)
+                    except json.JSONDecodeError:
+                        continue
+            if cursor == 0:
+                break
+    except Exception as exc:
+        logger.error("DLQ: failed to list jobs: %s", exc)
+        return []
+
+    jobs.sort(key=lambda x: x.get("enqueued_at", ""), reverse=True)
+    return jobs[:limit]
+
+
+async def retry_dlq_job(dlq_uuid: str) -> bool:
+    """Re-enqueue a single DLQ entry back into the ARQ job queue.
+
+    Scans all ``arq:dlq:*`` keys for an entry whose ``uuid`` matches
+    *dlq_uuid*, removes it from the DLQ, and enqueues it via
+    :func:`job_queue.enqueue_job`.
+
+    Args:
+        dlq_uuid: The UUID of the entry to retry (returned by
+            :func:`get_dlq_jobs`).
+
+    Returns:
+        True if the entry was found and re-enqueued; False if not found or
+        if Redis / ARQ is unavailable.
+    """
+    from redis_pool import get_redis_pool
+    from jobs.queue.definitions import enqueue_job
+
+    redis = await get_redis_pool()
+    if redis is None:
+        return False
+
+    try:
+        cursor = 0
+        pattern = f"{DLQ_PREFIX}:*"
+        while True:
+            cursor, keys = await redis.scan(cursor=cursor, match=pattern, count=100)
+            for key in keys:
+                entries = await redis.lrange(key, 0, -1)
+                for idx, raw in enumerate(entries):
+                    try:
+                        data = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    if data.get("uuid") == dlq_uuid:
+                        removed = await redis.lrem(key, 1, raw)
+                        if removed == 0:
+                            logger.warning(
+                                "DLQ: retry race — entry uuid=%s vanished from %s",
+                                dlq_uuid,
+                                key,
+                            )
+                            return False
+
+                        job_name = data.get("job_name", "")
+                        payload = data.get("payload", {}) or {}
+
+                        if isinstance(payload, dict) and payload:
+                            job = await enqueue_job(job_name, **payload)
+                        else:
+                            job = await enqueue_job(job_name)
+
+                        if job:
+                            logger.info(
+                                "DLQ: retried job=%s uuid=%s arq_id=%s",
+                                job_name,
+                                dlq_uuid,
+                                job.job_id,
+                            )
+                        else:
+                            logger.warning(
+                                "DLQ: enqueue_job returned None for retry "
+                                "job=%s uuid=%s",
+                                job_name,
+                                dlq_uuid,
+                            )
+
+                        try:
+                            from metrics import DLQ_RETRIED_TOTAL
+                            DLQ_RETRIED_TOTAL.inc()
+                        except Exception:
+                            pass
+
+                        return True
+            if cursor == 0:
+                break
+    except Exception as exc:
+        logger.error("DLQ: retry failed for uuid=%s: %s", dlq_uuid, exc)
+
+    logger.warning("DLQ: entry uuid=%s not found in any DLQ key", dlq_uuid)
+    return False
+
+
+async def purge_dlq() -> int:
+    """Delete *all* DLQ entries from Redis.
+
+    Returns:
+        Number of Redis keys deleted (each ``arq:dlq:{job_name}`` LIST counts
+        as one key).
+    """
+    from redis_pool import get_redis_pool
+
+    redis = await get_redis_pool()
+    if redis is None:
+        return 0
+
+    deleted = 0
+    try:
+        cursor = 0
+        pattern = f"{DLQ_PREFIX}:*"
+        while True:
+            cursor, keys = await redis.scan(cursor=cursor, match=pattern, count=100)
+            if keys:
+                await redis.delete(*keys)
+                deleted += len(keys)
+            if cursor == 0:
+                break
+    except Exception as exc:
+        logger.error("DLQ: purge failed: %s", exc)
+        return deleted
+
+    logger.info("DLQ: purged %d keys", deleted)
+
+    try:
+        from metrics import DLQ_SIZE
+        DLQ_SIZE.set(0)
+    except Exception:
+        pass
+
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# ARQ worker integration — on_job_failure hook
+# ---------------------------------------------------------------------------
+
+
+async def arq_on_job_failure(ctx: dict, job: Any, exc: BaseException) -> None:
+    """ARQ ``on_job_failure`` callback — enqueue failed job to DLQ.
+
+    Intended to be set as ``on_job_failure`` in
+    :class:`jobs.queue.config.WorkerSettings`.  Captures the job's function
+    name, arguments, and exception details, then persists them to the Redis
+    DLQ.
+
+    The callback is best-effort: enqueue failures are logged but never
+    re-raised (ensuring the ARQ worker's own error handling is not disrupted).
+    """
+    job_name: str = getattr(job, "function", "unknown")
+    job_id: str = getattr(job, "job_id", "unknown")
+    job_try: int = getattr(job, "job_try", 0)
+    max_tries: int = getattr(job, "max_tries", 1)
+    args: tuple = getattr(job, "args", ())
+    kwargs: dict = getattr(job, "kwargs", {})
+
+    error_str = f"{type(exc).__name__}: {exc}"
+    import traceback as _tb
+
+    tb_str = _tb.format_exc()
+
+    # Build a serialisable payload from the job arguments
+    payload: dict = {"_args": list(args)}
+    if kwargs:
+        payload.update(kwargs)
+    payload["_job_id"] = job_id
+    payload["_job_try"] = job_try
+    payload["_max_tries"] = max_tries
+
+    logger.warning(
+        "ARQ on_job_failure: job=%s id=%s try=%d/%d error=%.200s",
+        job_name,
+        job_id,
+        job_try,
+        max_tries,
+        error_str,
+    )
+
+    await enqueue_dlq(
+        job_name=job_name,
+        payload=payload,
+        error=error_str,
+        traceback=tb_str,
+    )

--- a/backend/jobs/queue/config.py
+++ b/backend/jobs/queue/config.py
@@ -290,3 +290,11 @@ class WorkerSettings:
     job_timeout = 300
     max_tries = 1  # GAP-004 (#1581): per-job override via arq.func() for crawl jobs
     health_check_interval = 30
+
+    # Issue #1813: ARQ Dead Letter Queue — capture failed jobs after max_tries
+    # exhausted. Graceful degradation: enqueue failure is logged but never raised.
+    try:
+        from jobs.dlq import arq_on_job_failure as _arq_on_job_failure
+        on_job_failure = _arq_on_job_failure
+    except ImportError:
+        on_job_failure = None

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1436,6 +1436,32 @@ NETWORK_EVENTS_COLLECTED_TOTAL = _create_counter(
 
 
 # ============================================================================
+# Issue #1813: ARQ Dead Letter Queue metrics
+# ============================================================================
+
+DLQ_ENQUEUED_TOTAL = _create_counter(
+    "smartlic_arq_dlq_enqueued_total",
+    "Issue #1813: ARQ jobs enqueued to the Dead Letter Queue after retry exhaustion",
+)
+
+DLQ_RETRIED_TOTAL = _create_counter(
+    "smartlic_arq_dlq_retried_total",
+    "Issue #1813: ARQ jobs retried (re-enqueued) from the Dead Letter Queue",
+)
+
+DLQ_SIZE = _create_gauge(
+    "smartlic_arq_dlq_size",
+    "Issue #1813: Current number of Redis keys in the Dead Letter Queue",
+)
+
+DLQ_SIZE_DEPTH = _create_histogram(
+    "smartlic_arq_dlq_entry_depth",
+    "Issue #1813: Number of entries per DLQ key (list length)",
+    buckets=[1, 5, 10, 25, 50, 100, 250, 500, 1000],
+)
+
+
+# ============================================================================
 # ASGI app factory for /metrics endpoint
 # ============================================================================
 

--- a/backend/routes/admin_dlq.py
+++ b/backend/routes/admin_dlq.py
@@ -1,0 +1,159 @@
+"""Issue #1813: ARQ Dead Letter Queue admin endpoints.
+
+Endpoints (all admin-only):
+    GET    /v1/admin/dlq           — list DLQ entries
+    POST   /v1/admin/dlq/{uuid}/retry  — re-enqueue a DLQ entry to ARQ
+    DELETE /v1/admin/dlq           — purge all DLQ entries
+
+Every endpoint degrades gracefully: Redis/ARQ unavailability returns a
+structured error response instead of 500-ing.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Path, Query
+
+from admin import require_admin
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin", tags=["admin", "dlq"])
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/admin/dlq
+# ---------------------------------------------------------------------------
+
+
+@router.get("/dlq")
+async def get_dlq(
+    limit: int = Query(50, ge=1, le=500, description="Max entries to return"),
+    user=Depends(require_admin),
+) -> dict[str, Any]:
+    """List entries in the ARQ Dead Letter Queue.
+
+    Returns entries sorted by ``enqueued_at`` descending (most recent first).
+    Each entry carries::
+
+        {
+            "uuid": "...",
+            "job_name": "...",
+            "payload": {...},
+            "error": "...",
+            "traceback": "...",
+            "enqueued_at": "2026-06-15T12:00:00+00:00"
+        }
+
+    When Redis is unreachable the response carries ``status="redis_unavailable"``
+    and an empty ``entries`` list.
+    """
+    from jobs.dlq import get_dlq_jobs
+
+    queried_at = datetime.now(timezone.utc).isoformat()
+
+    try:
+        entries = await get_dlq_jobs(limit=limit)
+        # Update gauge with current entry count
+        try:
+            from metrics import DLQ_SIZE
+            DLQ_SIZE.set(len(entries))
+        except Exception:
+            pass
+        return {
+            "status": "ok",
+            "queried_at": queried_at,
+            "count": len(entries),
+            "entries": entries,
+        }
+    except Exception as exc:
+        logger.warning("GET /v1/admin/dlq failed: %s", exc)
+        return {
+            "status": "error",
+            "queried_at": queried_at,
+            "count": 0,
+            "entries": [],
+            "detail": str(exc),
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/admin/dlq/{uuid}/retry
+# ---------------------------------------------------------------------------
+
+
+@router.post("/dlq/{uuid}/retry")
+async def retry_dlq_entry(
+    uuid: str = Path(..., description="UUID of the DLQ entry to retry"),
+    user=Depends(require_admin),
+) -> dict[str, Any]:
+    """Re-enqueue a single DLQ entry back into the ARQ job queue.
+
+    Returns ``{"status": "ok", "uuid": "..."}`` on success.
+    Returns ``{"status": "not_found", "uuid": "..."}`` if the entry no longer
+    exists (may have been purged or already retried).
+    Returns ``{"status": "error", "detail": "..."}`` on Redis or ARQ failure.
+    """
+    from jobs.dlq import retry_dlq_job
+
+    queried_at = datetime.now(timezone.utc).isoformat()
+
+    try:
+        ok = await retry_dlq_job(uuid)
+        if ok:
+            return {
+                "status": "ok",
+                "uuid": uuid,
+                "queried_at": queried_at,
+            }
+        return {
+            "status": "not_found",
+            "uuid": uuid,
+            "queried_at": queried_at,
+            "detail": "DLQ entry not found — may have been purged or already retried",
+        }
+    except Exception as exc:
+        logger.warning("POST /v1/admin/dlq/%s/retry failed: %s", uuid, exc)
+        return {
+            "status": "error",
+            "uuid": uuid,
+            "queried_at": queried_at,
+            "detail": str(exc),
+        }
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v1/admin/dlq
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/dlq")
+async def purge_dlq(
+    user=Depends(require_admin),
+) -> dict[str, Any]:
+    """Delete **all** entries from the ARQ Dead Letter Queue.
+
+    Returns ``{"status": "ok", "keys_deleted": N}`` on success.
+    Returns ``{"status": "error", "detail": "..."}`` on failure.
+    """
+    from jobs.dlq import purge_dlq as _purge_dlq
+
+    queried_at = datetime.now(timezone.utc).isoformat()
+
+    try:
+        deleted = await _purge_dlq()
+        return {
+            "status": "ok",
+            "keys_deleted": deleted,
+            "queried_at": queried_at,
+        }
+    except Exception as exc:
+        logger.warning("DELETE /v1/admin/dlq failed: %s", exc)
+        return {
+            "status": "error",
+            "queried_at": queried_at,
+            "detail": str(exc),
+        }

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -95,6 +95,7 @@ from routes.api_search import router as api_search_router
 from routes.email_tracking import router as email_tracking_router
 from routes.admin_digest_metrics import router as admin_digest_metrics_router
 from routes.admin_command import router as admin_command_router
+from routes.admin_dlq import router as admin_dlq_router
 from routes.intel_tasting import router as intel_tasting_router
 from routes.predint import router as predint_router
 from routes.monthly_report import router as monthly_report_router
@@ -188,6 +189,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(admin_billing_sync_router)
     app.include_router(admin_founding_router)
     app.include_router(admin_metrics_router)
+    app.include_router(admin_dlq_router)
     app.include_router(slo_router)
     # Issue #1002: founders availability — self-prefixed at /api/founders/*
     # (NOT under /v1/ — public landing-page consumers + SEO programmatic).


### PR DESCRIPTION
## Summary

Implementa uma Dead Letter Queue (DLQ) para ARQ jobs que excedem max_retries. Em vez de serem descartados silenciosamente, jobs falhos são preservados no Redis para inspeção e reprocessamento manual.

## O que foi feito

### NOVO: `backend/jobs/dlq.py`
- `enqueue_dlq()` — salva job falho no Redis como LIST `arq:dlq:{job_name}`
- `get_dlq_jobs()` — lista entries na DLQ (sorted por timestamp desc)
- `retry_dlq_job()` — remove entry da DLQ e re-enfileira no ARQ
- `purge_dlq()` — limpa todas as entries da DLQ
- `arq_on_job_failure()` — callback ARQ `on_job_failure` que integra com a DLQ

### NOVO: `backend/routes/admin_dlq.py`
- `GET /v1/admin/dlq` — lista entries
- `POST /v1/admin/dlq/{uuid}/retry` — reprocessa entry
- `DELETE /v1/admin/dlq` — limpa DLQ

### MODIFICADO: `backend/jobs/queue/config.py`
- Adicionado `on_job_failure` ao `WorkerSettings` apontando para `arq_on_job_failure`

### MODIFICADO: `backend/metrics.py`
- `DLQ_ENQUEUED_TOTAL` — Counter de jobs enviados para DLQ
- `DLQ_RETRIED_TOTAL` — Counter de jobs retried da DLQ
- `DLQ_SIZE` — Gauge do tamanho atual da DLQ (keys count)
- `DLQ_SIZE_DEPTH` — Histogram da profundidade de entries por key

### MODIFICADO: `backend/startup/routes.py`
- Registrado `admin_dlq_router` como self-prefixed router

### MODIFICADO: `.env.example`
- Documentado `ARQ_DLQ_TTL_DAYS` (default 7)

## Configuração

| Env Var | Default | Descrição |
|---------|---------|----------|
| `ARQ_DLQ_TTL_DAYS` | 7 | TTL em dias para entries na DLQ (0 = sem expiração) |

## Critérios de Aceitação
- [x] Jobs com retries esgotados são enviados para DLQ (não descartados)
- [x] Admin pode listar/reprocessar/limpar DLQ
- [x] Métricas Prometheus expostas
- [x] TTL de 7 dias configurável nos jobs da DLQ
- [x] Graceful degradation quando Redis está indisponível

Closes #1813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Dead Letter Queue system for tracking and managing failed job executions with configurable retention periods.
  * Added admin interface endpoints to list failed jobs, retry individual entries, and clear the queue.
  * Added observability metrics for DLQ activity and queue depth monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->