### PR TITLE
fix(backend): Redis graceful degradation - fail-open on Redis DOWN (#1801)

### DIFF
--- a/backend/redis_pool.py
+++ b/backend/redis_pool.py
@@ -14,24 +14,34 @@ and https://github.com/redis/redis-py/issues/3454 — redis-py async applies
 socket_timeout to the ENTIRE response parse, not per-read. 5s was incompatible
 with any operation > 5s (XREAD BLOCK, large SCAN, slow XADD under load).
 
+#1801: Redis resilience — ``get_redis_pool()`` wraps the live connection in
+``ResilientRedis`` (from ``redis_resilience``) which applies per-operation
+timeouts (0.5s reads, 1s writes) via ``safe_redis_call``, preventing hangs
+when Redis is slow. When Redis is unavailable, returns None — existing
+``if redis:`` and ``if redis is None:`` checks continue to work unchanged.
+
 Usage:
     from redis_pool import get_redis_pool, get_fallback_cache, is_redis_available
 
     # In async context:
     redis = await get_redis_pool()
     if redis:
-        await redis.get("key")
+        await redis.get("key")    # protected by 500ms timeout (#1801)
     else:
         cache = get_fallback_cache()
         cache.get("key")
 """
 
+import asyncio
 import logging
 import os
 import time
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+
+# #1801: Redis resilience — per-operation timeouts and graceful fallback
+from redis_resilience import ResilientRedis
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +70,8 @@ INMEMORY_MAX_ENTRIES = 5_000
 # Singleton state
 _redis_pool = None
 _pool_initialized = False
+# #1801: Cache the resilient wrapper (separate from raw pool for shutdown/pool_stats)
+_resilient_pool = None
 
 
 class InMemoryCache:
@@ -184,14 +196,22 @@ async def get_redis_pool():
     Lazy initialization — creates pool on first call.
     Thread-safe within a single event loop.
 
+    #1801: Returns a ``ResilientRedis`` proxy when Redis is alive (adds per-operation
+    timeouts of 0.5-3s). Returns ``None`` when Redis is unavailable — existing
+    ``if redis:`` and ``if redis is None:`` checks continue to work unchanged.
+
     Returns:
-        redis.asyncio.Redis instance if available, None otherwise.
+        ResilientRedis instance if available, None otherwise.
         When None, callers should use get_fallback_cache().
     """
-    global _redis_pool, _pool_initialized
+    global _redis_pool, _pool_initialized, _resilient_pool
 
     if _pool_initialized:
-        return _redis_pool
+        # #1801: Return the cached resilient wrapper if pool exists,
+        # None if pool was never initialized (keeps backward compat).
+        if _redis_pool is None:
+            return None
+        return _resilient_pool
 
     redis_url = os.getenv("REDIS_URL")
     if not redis_url:
@@ -213,8 +233,9 @@ async def get_redis_pool():
             socket_connect_timeout=POOL_SOCKET_CONNECT_TIMEOUT,
         )
 
-        # Async ping — safe inside running event loop (no asyncio.run!)
-        await _redis_pool.ping()
+        # #1801: Add timeout to init ping (2s) so a dead Redis on startup
+        # doesn't hang the entire lifespan.
+        await asyncio.wait_for(_redis_pool.ping(), timeout=2.0)
         logger.info(
             "Redis pool connected: %s (max_connections=%d)",
             redis_url.split("@")[-1],
@@ -222,13 +243,16 @@ async def get_redis_pool():
         )
         _pool_initialized = True
         _mark_redis_connected()
-        return _redis_pool
+        # #1801: Wrap in ResilientRedis for per-operation timeout protection
+        _resilient_pool = ResilientRedis(_redis_pool)
+        return _resilient_pool
 
     except Exception as e:
         logger.warning(
             "Redis connection failed: %s — using InMemoryCache fallback", e
         )
         _redis_pool = None
+        _resilient_pool = None
         _pool_initialized = True
         _mark_fallback_started()
         return None
@@ -357,6 +381,10 @@ async def is_redis_available() -> bool:
     """Check if Redis pool is available and healthy (AC10, AC11).
 
     STORY-332: Also updates Prometheus metrics and emits periodic warnings.
+
+    #1801: ``pool.ping()`` goes through ``safe_redis_call`` with 500ms timeout
+    and returns ``False`` on failure (rather than raising). We check the return
+    value instead of catching exceptions.
     """
     pool = await get_redis_pool()
     if pool is None:
@@ -364,9 +392,13 @@ async def is_redis_available() -> bool:
         _emit_fallback_warning_if_needed()
         return False
     try:
-        await pool.ping()
-        _update_redis_metrics(available=True)
-        return True
+        ok = await pool.ping()
+        if ok:
+            _update_redis_metrics(available=True)
+            return True
+        _update_redis_metrics(available=False)
+        _emit_fallback_warning_if_needed()
+        return False
     except Exception:
         _update_redis_metrics(available=False)
         _emit_fallback_warning_if_needed()
@@ -389,6 +421,10 @@ async def shutdown_redis() -> None:
     """
     global _redis_pool, _pool_initialized, _sse_redis_pool, _sse_pool_initialized
     global _sync_redis, _sync_redis_initialized
+    global _resilient_pool
+
+    # #1801: Clear resilient wrapper
+    _resilient_pool = None
 
     # Close SSE pool first (depends on main pool as fallback)
     if _sse_redis_pool and _sse_redis_pool is not _redis_pool:

--- a/backend/redis_resilience.py
+++ b/backend/redis_resilience.py
@@ -1,0 +1,292 @@
+"""Redis resilience utilities — safe calls with timeout + graceful fallback.
+
+Every Redis operation in the codebase should go through ``safe_redis_call``
+to ensure the system degrades gracefully when Redis is unavailable.
+
+Timeout defaults (per operation category):
+    - Read (get, exists, ttl, ping): 500ms
+    - Write (set, setex, incr, expire): 1s
+    - Scan (keys, scan, mget): 3s
+    - Complex (eval, pipeline): 3s
+    - Health (ping): 500ms
+"""
+
+import asyncio
+import logging
+from typing import Any, Coroutine, Optional
+
+logger = logging.getLogger(__name__)
+
+# Timeout defaults (seconds) — conservative for shared Railway Redis
+TIMEOUT_READ_S: float = 0.5
+TIMEOUT_WRITE_S: float = 1.0
+TIMEOUT_SCAN_S: float = 3.0
+TIMEOUT_COMPLEX_S: float = 3.0
+TIMEOUT_HEALTH_S: float = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Categories of Redis commands for timeout selection
+# ---------------------------------------------------------------------------
+_READ_COMMANDS = frozenset({
+    "get", "mget", "hget", "hgetall", "hmget",
+    "exists", "hexists",
+    "ttl", "pttl",
+    "ping",
+    "lrange", "llen",
+    "smembers", "scard",
+    "zcard", "zrange", "zrevrange", "zrank", "zscore",
+    "getset",
+    "type",
+    "strlen",
+    "xlen",
+    "xrange", "xrevrange", "xread",
+})
+
+_WRITE_COMMANDS = frozenset({
+    "set", "setex", "psetex", "setnx",
+    "incr", "incrby", "incrbyfloat",
+    "decr", "decrby",
+    "expire", "expireat", "pexpire",
+    "delete", "del",
+    "lpush", "rpush", "ltrim", "lrem", "lpop", "rpop",
+    "sadd", "srem",
+    "zadd", "zrem", "zremrangebyscore",
+    "hset", "hdel",
+    "xadd", "xtrim",
+    "flushdb", "flushall",
+    "rename",
+})
+
+_SCAN_COMMANDS = frozenset({
+    "keys", "scan", "sscan", "hscan", "zscan",
+})
+
+_COMPLEX_COMMANDS = frozenset({
+    "eval", "evalsha",
+    "pipeline",
+    "script",
+    "sort",
+    "multi", "exec",
+})
+
+
+def _infer_timeout(method_name: str) -> float:
+    """Infer appropriate timeout based on Redis command name."""
+    if method_name in _READ_COMMANDS:
+        return TIMEOUT_READ_S
+    elif method_name in _WRITE_COMMANDS:
+        return TIMEOUT_WRITE_S
+    elif method_name in _SCAN_COMMANDS:
+        return TIMEOUT_SCAN_S
+    elif method_name in _COMPLEX_COMMANDS:
+        return TIMEOUT_COMPLEX_S
+    return TIMEOUT_WRITE_S
+
+
+def _infer_fallback(method_name: str) -> Any:
+    """Return a sensible no-op/zero fallback for common Redis command names.
+
+    Callers that need specific fallback logic (e.g. rate limiter fail-open)
+    should continue to handle None from ``get_redis_pool()`` explicitly.
+    This provides a safe default that prevents AttributeError crashes.
+    """
+    ml = method_name.lower()
+
+    # --- Read operations ---
+    if ml in ("get", "hget", "hgetall", "hmget", "getset", "zscore", "zrank", "type", "strlen"):
+        return None
+    if ml in ("mget",):
+        return []
+    if ml in ("lrange", "zrange", "zrevrange", "xrange", "xrevrange", "xread"):
+        return []
+    if ml in ("smembers",):
+        return set()
+    if ml in ("keys", "sort"):
+        return []
+    if ml in ("llen", "xlen", "scard"):
+        return 0
+
+    # --- Check operations ---
+    if ml in ("exists", "hexists"):
+        return False
+    if ml in ("ping",):
+        return False
+
+    # --- Time operations ---
+    if ml in ("ttl", "pttl"):
+        return -2  # Key does not exist
+
+    # --- Write operations (fire-and-forget) ---
+    if ml in (
+        "set", "setex", "psetex", "setnx",
+        "expire", "expireat", "pexpire",
+        "lpush", "rpush", "ltrim", "lrem", "lpop", "rpop",
+        "sadd", "srem",
+        "xadd", "xtrim",
+        "hset", "hdel",
+        "flushdb", "flushall",
+        "rename",
+    ):
+        return True
+
+    # --- Delete ---
+    if ml in ("delete", "del"):
+        return 0  # Nothing deleted
+
+    # --- Count operations ---
+    if ml in ("incr", "incrby"):
+        return 1
+    if ml in ("incrbyfloat",):
+        return 1.0
+    if ml in ("decr", "decrby"):
+        return -1
+    if ml in ("zcard",):
+        return 0
+    if ml in ("zrem", "zremrangebyscore", "hdel"):
+        return 0
+
+    # --- Scan ---
+    if ml in ("scan", "sscan", "hscan", "zscan"):
+        return (0, [])
+
+    # --- Complex ---
+    if ml in ("eval", "evalsha"):
+        return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cache for fallback values by method name (avoids repeated dict lookups)
+# ---------------------------------------------------------------------------
+_FALLBACK_CACHE: dict[str, Any] = {}
+
+
+def _cached_fallback(method_name: str) -> Any:
+    """Cached version of _infer_fallback."""
+    if method_name not in _FALLBACK_CACHE:
+        _FALLBACK_CACHE[method_name] = _infer_fallback(method_name)
+    return _FALLBACK_CACHE[method_name]
+
+
+async def safe_redis_call(
+    coro: Coroutine,
+    fallback: Any = None,
+    timeout_s: Optional[float] = None,
+    method_name: str = "redis_operation",
+    logger_warning: bool = True,
+) -> Any:
+    """Execute a Redis coroutine with timeout and fallback.
+
+    The Swiss-army-knife wrapper for all Redis operations.
+    Never raises — always returns ``fallback`` on any failure.
+
+    Args:
+        coro: The Redis coroutine to execute (e.g. ``redis.get("key")``).
+        fallback: Value to return on failure. If None, inferred from
+            ``method_name`` via ``_infer_fallback``.
+        timeout_s: Timeout in seconds. If None, inferred from method_name.
+        method_name: Human-readable name for logging (default: "redis_operation").
+        logger_warning: Whether to log a warning on failure (default: True).
+
+    Returns:
+        The Redis result on success, or ``fallback`` on failure.
+
+    Example::
+
+        # Redis DOWN -> returns None (safe for cache miss), never raises
+        data = await safe_redis_call(redis.get("key"), method_name="get")
+
+        # Redis DOWN -> returns default empty list
+        items = await safe_redis_call(
+            redis.lrange("k", 0, -1), fallback=[], method_name="lrange"
+        )
+
+        # Rate limiter: Redis DOWN -> allow request (fail-open)
+        count = await safe_redis_call(
+            redis.incr("key"), fallback=0, method_name="incr"
+        )
+    """
+    if fallback is None:
+        fallback = _cached_fallback(method_name)
+    if timeout_s is None:
+        timeout_s = _infer_timeout(method_name)
+
+    try:
+        return await asyncio.wait_for(coro, timeout=timeout_s)
+    except asyncio.TimeoutError:
+        if logger_warning:
+            logger.warning(
+                "Redis %s timed out after %.1fs - using fallback",
+                method_name, timeout_s,
+            )
+        return fallback
+    except (ConnectionError, OSError) as exc:
+        # ConnectionError: Redis connection refused/reset
+        # OSError: socket errors
+        if logger_warning:
+            logger.warning(
+                "Redis %s failed (%s: %s) - using fallback",
+                method_name, type(exc).__name__, exc,
+            )
+        return fallback
+    except Exception as exc:
+        # Catch-all: any other Redis error (data errors, type errors, etc.)
+        if logger_warning:
+            logger.warning(
+                "Redis %s unexpected error (%s: %s) - using fallback",
+                method_name, type(exc).__name__, exc,
+            )
+        return fallback
+
+
+class ResilientRedis:
+    """Proxy that wraps a Redis client with ``safe_redis_call`` for every method.
+
+    If the underlying ``_redis`` is None, all method calls return safe defaults
+    without any network attempt - the system continues in degraded mode.
+
+    Usage::
+
+        from redis_resilience import ResilientRedis
+
+        redis_raw = await get_redis_pool()       # may be None
+        safe = ResilientRedis(redis_raw)
+        data = await safe.get("key")             # never raises
+    """
+
+    def __init__(self, redis: Any):
+        self._redis = redis
+        self._alive = redis is not None
+
+    def is_alive(self) -> bool:
+        """Return True if the underlying Redis client is available."""
+        return self._alive
+
+    def __getattr__(self, name: str) -> Any:
+        """Dynamically proxy any Redis method with safe_redis_call."""
+        if name.startswith("_"):
+            raise AttributeError(f"ResilientRedis has no attribute {name!r}")
+
+        # If Redis is dead, return a function that returns fallback immediately
+        if not self._alive:
+            async def _dead_method(*args: Any, **kwargs: Any) -> Any:
+                return _cached_fallback(name)
+            return _dead_method
+
+        # Real Redis is alive - proxy with safe_redis_call
+        real_method = getattr(self._redis, name, None)
+        if real_method is None:
+            async def _missing_method(*args: Any, **kwargs: Any) -> Any:
+                return _cached_fallback(name)
+            return _missing_method
+
+        async def _safe_method(*args: Any, **kwargs: Any) -> Any:
+            coro = real_method(*args, **kwargs)
+            return await safe_redis_call(
+                coro,
+                method_name=name,
+            )
+
+        return _safe_method

--- a/backend/routes/conta.py
+++ b/backend/routes/conta.py
@@ -522,17 +522,17 @@ async def get_api_usage(
     # 4. Get daily usage from Redis (faster than DB for daily granularity)
     try:
         from redis_pool import get_redis_pool
-        redis = get_redis_pool()
+        redis = await get_redis_pool()
         if redis:
             # Scan Redis keys for daily usage: api_key_daily:{key_id}:{YYYY-MM-DD}
             for key_id in key_ids:
                 cursor = 0
                 pattern = f"api_key_daily:{key_id}:{current_month}-*"
                 while True:
-                    cursor, keys = redis.scan(cursor, match=pattern, count=100)
+                    cursor, keys = await redis.scan(cursor, match=pattern, count=100)
                     for k in keys:
                         day_str = k.decode().rsplit(":", 1)[-1]  # YYYY-MM-DD
-                        count = int(redis.get(k) or 0)
+                        count = int(await redis.get(k) or 0)
                         daily_usage_map[day_str] = daily_usage_map.get(day_str, 0) + count
                     if cursor == 0:
                         break

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -3105,6 +3105,24 @@
         "title": "CalculadoraDadosResponse",
         "type": "object"
       },
+      "CancelDeletionResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "detail"
+        ],
+        "title": "CancelDeletionResponse",
+        "type": "object"
+      },
       "CancelFeedbackRequest": {
         "description": "Post-cancellation feedback (UX-308 AC6).",
         "properties": {
@@ -4216,6 +4234,20 @@
           "valor_total_contratado"
         ],
         "title": "ConcorrenteInfo",
+        "type": "object"
+      },
+      "ConfirmDeletionRequest": {
+        "properties": {
+          "token": {
+            "description": "Raw token do email de confirma\u00e7\u00e3o",
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "title": "ConfirmDeletionRequest",
         "type": "object"
       },
       "ConsultantClientListResponse": {
@@ -6128,6 +6160,24 @@
           "message"
         ],
         "title": "DeleteAccountResponse",
+        "type": "object"
+      },
+      "DeletionRequestResponse": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "detail"
+        ],
+        "title": "DeletionRequestResponse",
         "type": "object"
       },
       "DemandForecastItem": {
@@ -22071,6 +22121,143 @@
         ]
       }
     },
+    "/v1/admin/dlq": {
+      "delete": {
+        "description": "Delete **all** entries from the ARQ Dead Letter Queue.\n\nReturns ``{\"status\": \"ok\", \"keys_deleted\": N}`` on success.\nReturns ``{\"status\": \"error\", \"detail\": \"...\"}`` on failure.",
+        "operationId": "purge_dlq_v1_admin_dlq_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Purge Dlq V1 Admin Dlq Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Purge Dlq",
+        "tags": [
+          "admin",
+          "dlq"
+        ]
+      },
+      "get": {
+        "description": "List entries in the ARQ Dead Letter Queue.\n\nReturns entries sorted by ``enqueued_at`` descending (most recent first).\nEach entry carries::\n\n    {\n        \"uuid\": \"...\",\n        \"job_name\": \"...\",\n        \"payload\": {...},\n        \"error\": \"...\",\n        \"traceback\": \"...\",\n        \"enqueued_at\": \"2026-06-15T12:00:00+00:00\"\n    }\n\nWhen Redis is unreachable the response carries ``status=\"redis_unavailable\"``\nand an empty ``entries`` list.",
+        "operationId": "get_dlq_v1_admin_dlq_get",
+        "parameters": [
+          {
+            "description": "Max entries to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max entries to return",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Dlq V1 Admin Dlq Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Dlq",
+        "tags": [
+          "admin",
+          "dlq"
+        ]
+      }
+    },
+    "/v1/admin/dlq/{uuid}/retry": {
+      "post": {
+        "description": "Re-enqueue a single DLQ entry back into the ARQ job queue.\n\nReturns ``{\"status\": \"ok\", \"uuid\": \"...\"}`` on success.\nReturns ``{\"status\": \"not_found\", \"uuid\": \"...\"}`` if the entry no longer\nexists (may have been purged or already retried).\nReturns ``{\"status\": \"error\", \"detail\": \"...\"}`` on Redis or ARQ failure.",
+        "operationId": "retry_dlq_entry_v1_admin_dlq__uuid__retry_post",
+        "parameters": [
+          {
+            "description": "UUID of the DLQ entry to retry",
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "description": "UUID of the DLQ entry to retry",
+              "title": "Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Retry Dlq Entry V1 Admin Dlq  Uuid  Retry Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Retry Dlq Entry",
+        "tags": [
+          "admin",
+          "dlq"
+        ]
+      }
+    },
     "/v1/admin/feature-flags": {
       "get": {
         "description": "List all registered feature flags with current values and sources.\n\nReturns each flag's effective value, where it comes from (redis override,\nenv var, or default), its description, and registry metadata.\n\nAdmin only.",
@@ -30129,6 +30316,128 @@
         ]
       }
     },
+    "/v1/me/admin/{user_id}": {
+      "delete": {
+        "description": "Admin for\u00e7a exclus\u00e3o de um usu\u00e1rio (bypass double opt-out).",
+        "operationId": "admin_delete_user_v1_me_admin__user_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Admin Delete User",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/me/cancel-deletion": {
+      "post": {
+        "description": "Cancela uma solicita\u00e7\u00e3o de exclus\u00e3o pendente.",
+        "operationId": "cancel_deletion_v1_me_cancel_deletion_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelDeletionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Cancel Deletion",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
+    "/v1/me/confirm-deletion": {
+      "post": {
+        "description": "Confirma exclus\u00e3o com token do email. Anonimiza perfil (soft-delete).",
+        "operationId": "confirm_deletion_v1_me_confirm_deletion_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmDeletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Confirm Deletion",
+        "tags": [
+          "data-deletion"
+        ]
+      }
+    },
     "/v1/me/export": {
       "get": {
         "description": "Export all user data as JSON file (LGPD Art. 18 V \u2014 data portability).\n\nUses admin client (get_db) because it queries across multiple tables\nand needs unrestricted access to gather all user data for export.\n\nReturns a downloadable JSON file containing:\n- Profile information\n- Search history (sessions)\n- Subscription history\n- Messages",
@@ -30151,6 +30460,33 @@
         "summary": "Export User Data",
         "tags": [
           "user"
+        ]
+      }
+    },
+    "/v1/me/request-deletion": {
+      "post": {
+        "description": "Solicita exclus\u00e3o de dados. Envia email de confirma\u00e7\u00e3o (double opt-out).\n\nIdempotente: se j\u00e1 existe pending, retorna 200 sem criar novo token.",
+        "operationId": "request_deletion_v1_me_request_deletion_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletionRequestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Request Deletion",
+        "tags": [
+          "data-deletion"
         ]
       }
     },

--- a/docs/architecture/redis-failure-modes.md
+++ b/docs/architecture/redis-failure-modes.md
@@ -1,0 +1,134 @@
+# Redis Failure Modes — Graceful Degradation (#1801)
+
+## Overview
+
+Redis is used across multiple critical paths: cache, rate limiter, SSE state
+tracking, ARQ job queue, distributed locks, and circuit breaker state. If Redis
+goes offline, the system must degrade gracefully rather than crash.
+
+This document describes the behavior of each subsystem when Redis is
+unavailable.
+
+## Failure Mode: Redis DOWN
+
+When `get_redis_pool()` returns `None` (Redis URL not configured or connection
+failed at startup), all callers that check the return value see `None` and take
+their fallback path.
+
+When Redis is **alive but slow**, the `ResilientRedis` proxy (from
+`redis_resilience.py`) wraps each operation with `asyncio.wait_for()` and
+per-operation timeouts:
+
+| Operation Type | Timeout | Fallback |
+|---|---|---|
+| Read (get, exists, ttl, ping) | 500ms | None / False / -2 |
+| Write (set, incr, expire, delete) | 1s | True / 1 / 0 |
+| Scan (keys, scan) | 3s | ([], 0) |
+| Complex (eval, pipeline) | 3s | None |
+
+### Affected Functionalities
+
+| Feature | Redis DOWN Behavior | Impact |
+|---------|-------------------|--------|
+| Rate limiter | Fail-open: all requests allowed. In-memory fallback in `RateLimiter._check_memory()`. | No rate limiting during outage. Bot protection degraded. |
+| Auth cache (L2) | L1 memory cache continues. L2 Redis skip = cache miss, re-fetch from Supabase. | Slightly slower auth (every request hits Supabase). |
+| Search results cache | L1 InMemoryCache continues (4h TTL). SWR revalidation via Supabase L3. | No impact if data in L1. Cache misses fall through to DataLake (<100ms). |
+| SSE progress tracking | Events tracked in-memory only. Late subscribers lose history. | SSE still works for active sessions. Replay via Last-Event-ID degraded. |
+| ARQ job queue (distributed locks) | `_acquire_lock` returns True (proceed). Risk of duplicate job execution. | Acceptable — jobs are idempotent (upsert semantics). |
+| ARQ queue itself | ARQ uses its own Redis connection. If same Redis: queue unavailable. | Background jobs (summaries, Excel) deferred until Redis recovers. |
+| Circuit breaker (PNCP, PCP) | Falls back to local in-memory state. | CB still functions within a single process, but state is not shared across workers. |
+| LLM budget tracking | `track_llm_cost` returns 0.0 (no-op). `is_budget_exceeded` returns False. | Budget enforcement disabled. Alert dedup disabled. |
+| LLM batch API | Batch meta not persisted. Pending batch detection falls back to empty list. | Batch jobs not tracked across restarts. |
+| Login activity tracking | Falls back to in-memory buffer. | Login data not persisted to DB. Recovered when Redis is back. |
+| PNCP canary | Failure counting disabled. Alerting disabled. | No auto-detection of PNCP API breaking changes. |
+| Feature flags | Redis overrides unavailable. Falls back to env-var + in-memory defaults. | Flag overrides not applied until Redis recovers. |
+| Negative cache (blog_stats) | Falls back to InMemoryCache. | Slightly more DB queries under bot crawl storms. |
+| Products / Founders / Orgao cache | Falls back to InMemoryCache or direct DB query. | Slightly slower on cache miss. |
+| Metrics cache | Computes metrics directly instead of reading from Redis. | More DB/API calls on each metrics request. |
+| Stripe webhook dedup | Dedup window lost. Risk of double-processing webhook events. | Stripe events may be processed twice (idempotency keys protect). |
+| Admin session revoke | Revoke not propagated across workers. | Revoke takes effect only on next auth cache refresh (5 min). |
+| Reports/Contracts crawler checkpoint | Checkpoint not saved. Progress may regress on worker restart. | Acceptable — crawler resumes from last DB checkpoint on next cycle. |
+| Billing cron (distributed locks) | Lock acquisition succeeds. Multiple workers may process billing. | Acceptable — billing is idempotent (upsert + dedup). |
+| Quota tracking (lead magnet) | Fail-open: quota check passes. | More lead magnets sent than the daily limit. |
+
+### Behavior per Component Type
+
+**Rate Limiter** (`rate_limiter.py`, `api_key_rate_limit.py`):
+- `get_redis_pool()` returns `None` -> `RateLimiter._check_memory()` takes over
+- `RedisRateLimiter` in circuit breaker also falls back to memory
+- **Fail-open**: all requests allowed (no 429s), bot protection degraded
+
+**Cache** (`cache_module.py`, `cache/redis.py`):
+- `None` from `get_redis_pool()` triggers `get_fallback_cache()` (InMemoryCache)
+- All Redis operations wrapped in try/except with InMemoryCache fallback
+
+**Auth** (`auth.py`):
+- L1 memory cache (5 min TTL) continues serving
+- L2 Redis lookup skipped -> cache miss -> re-fetch from Supabase
+- `_check_session_revoked`: returns `False` (fail-open, allows request)
+
+**ARQ/Locks** (`cron/_loop.py`, `jobs/cron/*`):
+- `_acquire_lock`: returns `True` if Redis unavailable (proceed without lock)
+- Risk: duplicate execution of cron jobs across workers
+
+**SSE** (`progress.py`, `routes/search_sse.py`):
+- `progress._publish_to_redis`: returns early, events stay in-memory only
+- SSE stream still works from in-memory queue
+- XREAD polling in SSE route: uses separate `get_sse_redis_pool()`
+
+### Health Check
+
+The health endpoint (`backend/health.py::get_system_health()`) reports Redis as:
+
+| Redis State | Status | Overall |
+|-------------|--------|---------|
+| Connected + ping OK | `up` | Depends on other components |
+| URL configured but connection failed | `down` | `unhealthy` |
+| URL not configured | `down` | `unhealthy` |
+
+The readiness probe (`backend/health.py::check_redis`) is advisory — it reports
+degraded but does NOT remove the instance from the load balancer.
+
+### Recovery Procedure
+
+1. **Check Redis connectivity** from Railway dashboard or directly:
+   ```bash
+   railway run redis-cli -u $REDIS_URL ping
+   ```
+
+2. **If Redis is up but connection pool is saturated:**
+   ```bash
+   railway run redis-cli -u $REDIS_URL CLIENT LIST | wc -l
+   ```
+
+3. **Monitor** Prometheus gauges:
+   - `smartlic_redis_available` (0/1)
+   - `smartlic_redis_fallback_duration_seconds` (seconds since fallback)
+   - `smartlic_redis_pool_connections_used` / `max`
+
+4. **After recovery**: verify:
+   - Auth cache repopulates on next request
+   - Rate limiter returns to Redis mode
+   - ARQ jobs resume (may need `railway redeploy --service worker`)
+
+### Design Decisions
+
+1. **Why not mark as unhealthy when Redis is down?**
+   Redis is a cache/accelerator, not a source of truth. The system functions
+   without it (degraded). Marking unhealthy would cause Railway to kill and
+   restart the instance, which doesn't help.
+
+2. **Why fail-open rate limiter?**
+   A false positive (blocking a legitimate user) is worse than a false negative
+   (allowing a bot). During an outage, it's better to serve traffic without
+   protection than to block all traffic.
+
+3. **Why allow duplicate cron jobs?**
+   Cron jobs handle their own idempotency (upsert semantics, `ON CONFLICT DO
+   NOTHING`). The risk of double-processing is low and the impact is limited to
+   extra API calls, not data corruption.
+
+4. **Why not crash on Redis pipeline None?**
+   Pipeline operations are wrapped in try/except in `check_api_key_rate_limit`
+   and circuit breaker. If pipeline creation fails, the exception handler takes
+   the fail-open path.

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -710,6 +710,73 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/dlq": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dlq
+         * @description List entries in the ARQ Dead Letter Queue.
+         *
+         *     Returns entries sorted by ``enqueued_at`` descending (most recent first).
+         *     Each entry carries::
+         *
+         *         {
+         *             "uuid": "...",
+         *             "job_name": "...",
+         *             "payload": {...},
+         *             "error": "...",
+         *             "traceback": "...",
+         *             "enqueued_at": "2026-06-15T12:00:00+00:00"
+         *         }
+         *
+         *     When Redis is unreachable the response carries ``status="redis_unavailable"``
+         *     and an empty ``entries`` list.
+         */
+        get: operations["get_dlq_v1_admin_dlq_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Purge Dlq
+         * @description Delete **all** entries from the ARQ Dead Letter Queue.
+         *
+         *     Returns ``{"status": "ok", "keys_deleted": N}`` on success.
+         *     Returns ``{"status": "error", "detail": "..."}`` on failure.
+         */
+        delete: operations["purge_dlq_v1_admin_dlq_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/dlq/{uuid}/retry": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Retry Dlq Entry
+         * @description Re-enqueue a single DLQ entry back into the ARQ job queue.
+         *
+         *     Returns ``{"status": "ok", "uuid": "..."}`` on success.
+         *     Returns ``{"status": "not_found", "uuid": "..."}`` if the entry no longer
+         *     exists (may have been purged or already retried).
+         *     Returns ``{"status": "error", "detail": "..."}`` on Redis or ARQ failure.
+         */
+        post: operations["retry_dlq_entry_v1_admin_dlq__uuid__retry_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/feature-flags": {
         parameters: {
             query?: never;
@@ -17571,6 +17638,96 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AdminCronStatusResponse"];
+                };
+            };
+        };
+    };
+    get_dlq_v1_admin_dlq_get: {
+        parameters: {
+            query?: {
+                /** @description Max entries to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    purge_dlq_v1_admin_dlq_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+    };
+    retry_dlq_entry_v1_admin_dlq__uuid__retry_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the DLQ entry to retry */
+                uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Implementa graceful degradation para Redis DOWN (#1801). Redis é usado em cache, rate limiter, SSE state, ARQ queue, distributed locks e circuit breaker. Se Redis ficar offline, o sistema degrada graciosamente em vez de crashar.

## Changes

### NOVO: backend/redis_resilience.py
- safe_redis_call(coro, fallback, timeout_s) — wrapper com timeout + fallback.
- ResilientRedis(redis) — proxy que envolve Redis real com timeouts.
- Timeouts: 0.5s leitura, 1s escrita, 3s scan/complexo.

### MODIFICADO: backend/redis_pool.py
- get_redis_pool() retorna ResilientRedis (timeout protection), None quando morto.
- is_redis_available() verifica retorno do ping.
- Ping de init com timeout 2s.

### CORRIGIDO: backend/routes/conta.py
- get_redis_pool() sem await (coroutine object).
- redis.scan() e redis.get() sem await.

### NOVO: docs/architecture/redis-failure-modes.md
- Comportamento de cada subsistema com Redis offline.
- Tabela completa, procedimento de recuperação.

## Testes
- 108 Redis-specific tests pass
- 6501 backend tests pass (1 pre-existing: OpenAPI snapshot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin Dead Letter Queue (DLQ) management endpoints: list, purge, and retry capabilities.

* **Improvements**
  * Enhanced Redis resilience with automatic operation timeouts and graceful fallbacks when Redis is unavailable.

* **Documentation**
  * Added architecture documentation detailing Redis failure modes and system behavior during outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->