### PR TITLE
fix(frontend): graceful degradation — read-only mode when backend DOWN (#1791)

### DIFF
--- a/frontend/__tests__/degradation-banner.test.tsx
+++ b/frontend/__tests__/degradation-banner.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * ISSUE-1791: Tests for graceful degradation components.
+ *
+ * Tests:
+ * 1. DegradationBanner renders when backend offline
+ * 2. DegradationBanner hides when backend online
+ * 3. DegradationBanner is dismissible
+ * 4. DegradationBanner shows "recuperando" state
+ * 5. DegradationBanner has Recarregar button when offline
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DegradationBanner } from "../app/components/DegradationBanner";
+
+// ============================================================================
+// Mock BackendStatusIndicator
+// ============================================================================
+
+const mockStatus: { status: "online" | "offline" | "recovering"; isPolling: boolean; checkHealth: jest.Mock } = {
+  status: "online",
+  isPolling: false,
+  checkHealth: jest.fn(),
+};
+
+jest.mock("../app/components/BackendStatusIndicator", () => {
+  function MockProvider({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+  }
+  function MockIndicator() {
+    return null;
+  }
+  return {
+    useBackendStatusContext: () => ({
+      status: mockStatus.status,
+      isPolling: mockStatus.isPolling,
+      checkHealth: mockStatus.checkHealth,
+    }),
+    useBackendStatus: () => ({
+      status: mockStatus.status,
+      isPolling: mockStatus.isPolling,
+      checkHealth: mockStatus.checkHealth,
+    }),
+    BackendStatusProvider: MockProvider,
+    BackendStatusIndicator: MockIndicator,
+  };
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("DegradationBanner", () => {
+  beforeEach(() => {
+    mockStatus.status = "online";
+    mockStatus.isPolling = false;
+    try {
+      sessionStorage.clear();
+    } catch { /* noop */ }
+  });
+
+  it("renders nothing when backend is online", () => {
+    const { container } = render(<DegradationBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders offline banner when backend is offline", () => {
+    mockStatus.status = "offline";
+    render(<DegradationBanner />);
+
+    expect(screen.getByTestId("degradation-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Backend temporariamente indisponivel/i)).toBeInTheDocument();
+    expect(screen.getByText(/Algumas funcionalidades podem estar limitadas/i)).toBeInTheDocument();
+  });
+
+  it("renders recovering banner when backend is recovering", () => {
+    mockStatus.status = "recovering";
+    render(<DegradationBanner />);
+
+    expect(screen.getByTestId("degradation-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Backend recuperado/i)).toBeInTheDocument();
+  });
+
+  it("is dismissible via Dispensar button", () => {
+    mockStatus.status = "offline";
+    render(<DegradationBanner />);
+    expect(screen.getByTestId("degradation-banner")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Dispensar"));
+
+    expect(screen.queryByTestId("degradation-banner")).not.toBeInTheDocument();
+  });
+
+  it("persists dismissal across re-renders via sessionStorage", () => {
+    mockStatus.status = "offline";
+    const { unmount } = render(<DegradationBanner />);
+    expect(screen.getByTestId("degradation-banner")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Dispensar"));
+    expect(screen.queryByTestId("degradation-banner")).not.toBeInTheDocument();
+
+    unmount();
+    render(<DegradationBanner />);
+    expect(screen.queryByTestId("degradation-banner")).not.toBeInTheDocument();
+  });
+
+  it("shows Recarregar button when offline", () => {
+    mockStatus.status = "offline";
+    render(<DegradationBanner />);
+    expect(screen.getByText("Recarregar")).toBeInTheDocument();
+  });
+
+  it("does not show Recarregar button when recovering", () => {
+    mockStatus.status = "recovering";
+    render(<DegradationBanner />);
+    expect(screen.queryByText("Recarregar")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/use-backend-health.test.tsx
+++ b/frontend/__tests__/use-backend-health.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * ISSUE-1791: Tests for useBackendHealth hook.
+ *
+ * Tests:
+ * 1. Exposes isOnline=true when status is "online"
+ * 2. Exposes isDegraded=true when status is "offline"
+ * 3. Exposes isRecovering=true when status is "recovering"
+ * 4. Allows triggering checkHealth
+ */
+
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ============================================================================
+// Mock BackendStatusIndicator
+// ============================================================================
+
+const mockCheckHealth = jest.fn(() => Promise.resolve(true));
+const mockStatus = { status: "online" as const, isPolling: false, checkHealth: mockCheckHealth };
+
+jest.mock("../app/components/BackendStatusIndicator", () => {
+  const actual = jest.requireActual("../app/components/BackendStatusIndicator");
+  return {
+    ...actual,
+    useBackendStatusContext: () => mockStatus,
+    useBackendStatus: () => mockStatus,
+    BackendStatusProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+// ============================================================================
+// Test helper component
+// ============================================================================
+
+function TestHealthConsumer({
+  children,
+}: {
+  children: (state: import("../app/hooks/useBackendHealth").BackendHealthState) => React.ReactNode;
+}) {
+  const { useBackendHealth } = require("../app/hooks/useBackendHealth");
+  const health = useBackendHealth();
+  return <div data-testid="health-result">{children(health)}</div>;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("useBackendHealth", () => {
+  beforeEach(() => {
+    mockStatus.status = "online";
+    mockCheckHealth.mockResolvedValue(true);
+  });
+
+  it("exposes isOnline=true when backend is online", () => {
+    render(
+      <TestHealthConsumer>
+        {(h) => (h.isOnline ? "online" : "offline")}
+      </TestHealthConsumer>
+    );
+    expect(screen.getByTestId("health-result")).toHaveTextContent("online");
+  });
+
+  it("exposes isDegraded=true when backend is offline", () => {
+    mockStatus.status = "offline";
+    render(
+      <TestHealthConsumer>
+        {(h) => (h.isDegraded ? "degradado" : "ok")}
+      </TestHealthConsumer>
+    );
+    expect(screen.getByTestId("health-result")).toHaveTextContent("degradado");
+  });
+
+  it("exposes isRecovering=true when backend is recovering", () => {
+    mockStatus.status = "recovering";
+    render(
+      <TestHealthConsumer>
+        {(h) => (h.isRecovering ? "recuperando" : "normal")}
+      </TestHealthConsumer>
+    );
+    expect(screen.getByTestId("health-result")).toHaveTextContent("recuperando");
+  });
+
+  it("returns correct status string", () => {
+    mockStatus.status = "offline";
+    render(
+      <TestHealthConsumer>
+        {(h) => h.status}
+      </TestHealthConsumer>
+    );
+    expect(screen.getByTestId("health-result")).toHaveTextContent("offline");
+  });
+
+  it("calls checkHealth from backend context", async () => {
+    mockCheckHealth.mockResolvedValueOnce(true);
+
+    function TestComponent() {
+      const { useBackendHealth } = require("../app/hooks/useBackendHealth");
+      const health = useBackendHealth();
+      return <button onClick={() => health.checkHealth()}>check</button>;
+    }
+    render(<TestComponent />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("check"));
+    });
+
+    expect(mockCheckHealth).toHaveBeenCalled();
+  });
+});

--- a/frontend/app/components/DegradationBanner.tsx
+++ b/frontend/app/components/DegradationBanner.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { useBackendStatusContext } from "./BackendStatusIndicator";
+
+// ============================================================================
+// DegradationBanner — Global banner for backend offline / recovering.
+//
+// Renders a sticky banner at the top of the viewport when the backend is
+// detected as offline or recovering. Fully dismissible for the current
+// session (re-appears on next navigation or page reload).
+//
+// Integrates with BackendStatusProvider's shared polling (CRIT-018 AC7).
+// ============================================================================
+
+const BANNER_DISMISS_KEY = "degradation-banner-dismissed";
+
+interface DegradationBannerButtonProps {
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function DegradationBannerButton({ onClick, children }: DegradationBannerButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="
+        inline-flex items-center gap-1.5 shrink-0
+        px-3 py-1.5 rounded-button text-sm font-medium
+        border border-current/30
+        hover:bg-white/20 dark:hover:bg-black/20
+        transition-colors focus-visible:outline-none focus-visible:ring-2
+        focus-visible:ring-offset-2 focus-visible:ring-white/50
+      "
+    >
+      {children}
+    </button>
+  );
+}
+
+export function DegradationBanner() {
+  const { status } = useBackendStatusContext();
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return sessionStorage.getItem(BANNER_DISMISS_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  // Only show when offline or recovering
+  if (status === "online" || dismissed) return null;
+
+  const isOffline = status === "offline";
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try {
+      sessionStorage.setItem(BANNER_DISMISS_KEY, "true");
+    } catch { /* noop */ }
+  };
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      data-testid="degradation-banner"
+      className={[
+        "sticky top-0 z-50 w-full px-4 py-3 text-sm",
+        "backdrop-blur-md shadow-md",
+        "transition-all duration-300 animate-fade-in-down",
+        isOffline
+          ? "bg-red-600/90 text-white dark:bg-red-800/90"
+          : "bg-amber-500/90 text-white dark:bg-amber-700/90",
+      ].join(" ")}
+    >
+      <div className="max-w-7xl mx-auto flex items-start sm:items-center gap-3">
+        {/* Icon */}
+        <svg
+          className="w-5 h-5 shrink-0 mt-0.5 sm:mt-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          {isOffline ? (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+            />
+          ) : (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          )}
+        </svg>
+
+        {/* Message */}
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold">
+            {isOffline
+              ? "Backend temporariamente indisponivel"
+              : "Backend recuperado — normalizando"}
+          </p>
+          <p className="text-xs opacity-90 mt-0.5">
+            {isOffline
+              ? "Algumas funcionalidades podem estar limitadas. Dados em cache ainda estao disponiveis. Reconexao automatica em andamento."
+              : "Servico restabelecido. Funcionalidades voltando ao normal."}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 shrink-0">
+          {isOffline && (
+            <DegradationBannerButton onClick={() => window.location.reload()}>
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Recarregar
+            </DegradationBannerButton>
+          )}
+          <DegradationBannerButton onClick={handleDismiss}>
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Dispensar
+          </DegradationBannerButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DegradationBanner;

--- a/frontend/app/hooks/useBackendHealth.ts
+++ b/frontend/app/hooks/useBackendHealth.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useBackendStatusContext } from "../components/BackendStatusIndicator";
+
+// ============================================================================
+// useBackendHealth — convenience hook for graceful degradation
+// Thin wrapper around BackendStatusIndicator's shared polling context.
+// Exposes isOnline / isDegraded semantics for feature-level gating.
+// ============================================================================
+
+export interface BackendHealthState {
+  /** Backend is fully operational */
+  isOnline: boolean;
+  /** Backend is offline (consecutive failures detected) */
+  isDegraded: boolean;
+  /** Backend is recovering (just came back, transitional state) */
+  isRecovering: boolean;
+  /** Summary status */
+  status: "online" | "offline" | "recovering";
+  /** Timestamp of last health check attempt */
+  lastCheck: number | null;
+  /** Trigger an immediate health check */
+  checkHealth: () => Promise<boolean>;
+}
+
+/**
+ * useBackendHealth — convenience wrapper around useBackendStatusContext.
+ *
+ * Adds `isOnline` / `isDegraded` booleans and `lastCheck` timestamp
+ * for simpler consumption in feature gating (e.g. read-only mode).
+ *
+ * Shares the single polling instance from BackendStatusProvider — does
+ * NOT create a duplicate polling loop.
+ *
+ * @example
+ * ```tsx
+ * const { isOnline, isDegraded } = useBackendHealth();
+ * if (isDegraded) return <DegradationBanner />;
+ * ```
+ */
+export function useBackendHealth(): BackendHealthState {
+  const { status, isPolling, checkHealth } = useBackendStatusContext();
+
+  return {
+    isOnline: status === "online",
+    isDegraded: status === "offline",
+    isRecovering: status === "recovering",
+    status,
+    lastCheck: isPolling ? Date.now() : null,
+    checkHealth,
+  };
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -12,6 +12,7 @@ import { PaymentFailedBanner } from "../components/billing/PaymentFailedBanner";
 import { NavigationShell } from "../components/NavigationShell";
 import { TrialProgressBar } from "../components/TrialProgressBar";
 import { BackendStatusProvider } from "./components/BackendStatusIndicator";
+import { DegradationBanner } from "./components/DegradationBanner";
 import { SWRProvider } from "../components/SWRProvider";
 import { UserProvider } from "../contexts/UserContext";
 import { FoundersTopBanner } from "../components/banners/FoundersTopBanner";
@@ -216,6 +217,7 @@ export default async function RootLayout({
             <ThemeProvider>
               <NProgressProvider>
                 <BackendStatusProvider>
+                  <DegradationBanner />
                   <SessionExpiredBanner />
                   <PaymentFailedBanner />
                   <FoundersTopBanner />

--- a/frontend/app/pipeline/page.tsx
+++ b/frontend/app/pipeline/page.tsx
@@ -20,6 +20,7 @@ import { safeGetItem, safeSetItem } from "../../lib/storage";
 import { useAnalytics } from "../../hooks/useAnalytics";
 import { useTrialPhase } from "../../hooks/useTrialPhase";
 import { PageErrorBoundary } from "../../components/PageErrorBoundary";
+import { useBackendStatusContext } from "../components/BackendStatusIndicator";
 
 // @dnd-kit is code-split into PipelineKanban to reduce initial bundle size
 const _KanbanSkeleton = (
@@ -74,6 +75,7 @@ const PIPELINE_TOUR_STEPS: TourStepDef[] = [
 
 export default function PipelinePage() {
   const { session, loading: authLoading } = useAuth();
+  const { status: backendStatus } = useBackendStatusContext();
   const { planInfo } = usePlan();
   const { trackEvent } = useAnalytics();
   const { phase: trialPhase } = useTrialPhase();
@@ -234,7 +236,11 @@ export default function PipelinePage() {
         {/* AC8+AC14: Error state with retry when initial load fails (no data at all) */}
         {initialLoadFailed && !loading && items.length === 0 ? (
           <ErrorStateWithRetry
-            message="Não foi possível carregar seu pipeline."
+            message={
+              backendStatus === "offline"
+                ? "Backend indisponível. Tente novamente mais tarde."
+                : "Não foi possível carregar seu pipeline."
+            }
             onRetry={wrappedFetchItems}
           />
         ) : loading && items.length === 0 ? (
@@ -299,11 +305,14 @@ export default function PipelinePage() {
         ) : isReadOnlyError ? (
           /* AC9: Read-only mode when error occurs but stale data exists.
              ReadOnlyKanban uses DndContext with no sensors — disables drag-and-drop
-             while still providing context for useDroppable inside PipelineColumn. */
+             while still providing context for useDroppable inside PipelineColumn.
+             ISSUE-1791: backend status detection for specific messaging. */
           <>
             <div className="mb-4 p-3 bg-[var(--error-subtle)] border border-[var(--error)]/20 rounded-card flex items-center justify-between" role="alert">
               <p className="text-sm text-[var(--error)]">
-                Pipeline em modo leitura. Arraste desabilitado temporariamente.
+                {backendStatus === "offline"
+                  ? "Backend indisponível. Pipeline em modo leitura com dados em cache."
+                  : "Pipeline em modo leitura. Arraste desabilitado temporariamente."}
               </p>
               <button
                 onClick={wrappedFetchItems}

--- a/frontend/components/SWRProvider.tsx
+++ b/frontend/components/SWRProvider.tsx
@@ -8,6 +8,14 @@ import { fetcher } from "../lib/fetcher";
  * - revalidateOnFocus disabled (avoid unnecessary API calls on tab switch)
  * - dedupingInterval 5s (prevent duplicate concurrent requests)
  * - errorRetryCount 3 (built-in retry with exponential backoff)
+ * - errorRetryInterval 5s (backoff between retries — ISSUE-1791 graceful degradation)
+ *
+ * Graceful degradation behavior (ISSUE-1791):
+ * SWR keeps serving stale (cached) data when revalidation fails.
+ * This means if the backend goes DOWN, pages that have previously loaded
+ * data via SWR will continue to display that data while retrying in the
+ * background. Combined with DegradationBanner, users see stale data +
+ * a visual indicator rather than a white screen or error flash.
  */
 export function SWRProvider({ children }: { children: React.ReactNode }) {
   return (
@@ -17,6 +25,7 @@ export function SWRProvider({ children }: { children: React.ReactNode }) {
         revalidateOnFocus: false,
         dedupingInterval: 5000,
         errorRetryCount: 3,
+        errorRetryInterval: 5000,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

Frontend graceful degradation: quando backend DOWN, mostra DegradationBanner global + dados cacheados via SWR stale-while-revalidate.

## Changes

- **NEW:** `frontend/app/hooks/useBackendHealth.ts` — Hook de saúde do backend
- **NEW:** `frontend/app/components/DegradationBanner.tsx` — Banner global sticky
- **NEW:** `frontend/__tests__/degradation-banner.test.tsx` — 7 testes
- **NEW:** `frontend/__tests__/use-backend-health.test.tsx` — 5 testes
- **MODIFY:** `frontend/app/layout.tsx` — DegradationBanner em todas as páginas
- **MODIFY:** `frontend/components/SWRProvider.tsx` — errorRetryInterval 5s
- **MODIFY:** `frontend/app/pipeline/page.tsx` — Mensagem read-only quando offline

## Behavior
- Backend DOWN → banner vermelho sticky com botão Recarregar
- Backend recovering → banner ambar com botão Dispensar
- SWR serve stale data quando fetch falha
- Pipeline mostra mensagem de modo leitura

Closes #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)