### PR TITLE
feat(ops): database backup restore test — RTO/RPO validation (#1864)

### DIFF
--- a/scripts/backup-restore-test.sh
+++ b/scripts/backup-restore-test.sh
@@ -135,6 +135,11 @@ load_db_url() {
     echo ""
 }
 
+report_metric() {
+    mkdir -p "$REPORT_DIR"
+    echo "${1}=${2}" >> "$METRICS_FILE"
+}
+
 check_prereqs() {
     local missing=0
 
@@ -255,109 +260,24 @@ verify_fk_integrity() {
     # Get the count of FK constraints
     local fk_count
     fk_count=$(psql "$target_url" -X -t -A -c "
-        SELECT count(*)
+        SELECT count(*)::int
         FROM pg_constraint
         WHERE contype = 'f'
           AND connamespace = 'public'::regnamespace;
     " 2>/dev/null || echo "0")
 
-    log_info "Found $fk_count FK constraints in public schema."
+    log_info "FK constraint count: ${fk_count}"
+    report_metric "fk_constraint_count" "$fk_count"
 
     if [ "$fk_count" -eq 0 ]; then
         log_ok "No FK constraints to validate."
         return 0
     fi
 
-    # For each FK constraint, check for orphaned rows.
-    # Uses a DO block that queries each constraint's conkey/confkey to build
-    # the orphan-check query dynamically.
-    local violations
-    violations=$(psql "$target_url" -X -t -A -c "
-        WITH fk_list AS (
-            SELECT
-                conname,
-                conrelid::regclass::text AS child_table,
-                confrelid::regclass::text AS parent_table,
-                conkey,
-                confkey
-            FROM pg_constraint
-            WHERE contype = 'f'
-              AND connamespace = 'public'::regnamespace
-        ),
-        orphan_checks AS (
-            SELECT
-                conname,
-                child_table,
-                parent_table,
-                -- Build column references for the join condition
-                (
-                    SELECT string_agg(
-                        format('%I.%s', child_table, att.attname),
-                        ' AND '
-                    )
-                    FROM unnest(fk.conkey) WITH ORDINALITY AS ck(attnum, ord)
-                    JOIN pg_attribute att
-                        ON att.attrelid = fk.conrelid
-                        AND att.attnum = ck.attnum
-                ) AS child_cols,
-                (
-                    SELECT string_agg(
-                        format('%I.%s', parent_table, att.attname),
-                        ' AND '
-                    )
-                    FROM unnest(fk.confkey) WITH ORDINALITY AS cfk(attnum, ord)
-                    JOIN pg_attribute att
-                        ON att.attrelid = fk.confrelid
-                        AND att.attnum = cfk.attnum
-                ) AS parent_cols
-            FROM fk_list fk
-        )
-        SELECT
-            conname,
-            child_table,
-            parent_table
-        FROM orphan_checks
-        WHERE EXISTS (
-            -- Simplified: for each FK, check the first column pair
-            SELECT 1
-        );
-    " 2>/dev/null || true)
-
-    # More robust approach: use the built-in FK validation by running
-    # individual queries for each constraint, avoiding dynamic SQL issues
-    local row
-    while IFS='|' read -r _cname _child _parent _keys; do
-        # Use psql to check FK violations for each constraint via
-        # the pg_constraint system catalog validation
-        local orphaned
-        orphaned=$(psql "$target_url" -X -t -A -F'|' -c "
-            WITH fk_check AS (
-                SELECT
-                    con.conname,
-                    con.confrelid::regclass AS parent_table,
-                    con.conrelid::regclass AS child_table,
-                    pg_get_constraintdef(con.oid) AS constraint_def
-                FROM pg_constraint con
-                WHERE con.contype = 'f'
-                  AND con.conname = '$_cname'
-                  AND con.connamespace = 'public'::regnamespace
-                LIMIT 1
-            )
-            SELECT conname, parent_table, child_table, constraint_def
-            FROM fk_check;
-        " 2>/dev/null || true)
-
-        if [ -n "$orphaned" ]; then
-            local _name _pt _ct _def
-            IFS='|' read -r _name _pt _ct _def <<< "$orphaned"
-            log_ok "FK $_name ($_ct → $_pt): constraint definition present"
-        fi
-    done <<< "$violations"
-
-    # Final validation: check if constraint is NOT VALID
+    # Check for NOT VALID constraints
     local invalid_count
     invalid_count=$(psql "$target_url" -X -t -A -c "
-        SELECT count(*)
+        SELECT count(*)::int
         FROM pg_constraint
         WHERE contype = 'f'
           AND connamespace = 'public'::regnamespace
@@ -371,32 +291,97 @@ verify_fk_integrity() {
         log_ok "All FK constraints are validated."
     fi
 
-    # Check for actual orphaned rows using a safe heuristic:
-    # sample a subset of referenced values in the largest FK
-    local orphan_found
-    orphan_found=$(psql "$target_url" -X -t -A -c "
-        WITH fk_candidates AS (
-            SELECT
-                con.conname,
-                con.conrelid::regclass::text AS child_table,
-                con.confrelid::regclass::text AS parent_table
-            FROM pg_constraint con
-            WHERE con.contype = 'f'
-              AND con.connamespace = 'public'::regnamespace
-            ORDER BY (
-                SELECT c.reltuples FROM pg_class c WHERE c.oid = con.conrelid
-            ) DESC
-            LIMIT 5
-        ),
-        sampled AS (
-            SELECT
-                conname,
-                child_table,
-                parent_table
-            FROM fk_candidates
-        )
-        SELECT count(*) FROM sampled;
-    " 2>/dev/null || echo "0")
+    # Check for orphaned rows using PL/pgSQL dynamic query
+    # Iterates over each FK, builds the NOT EXISTS join from pg_attribute,
+    # and counts violations. Only runs on validated constraints to avoid
+    # false positives on intentionally unvalidated FKs.
+    log_info "Checking for orphaned rows across FK constraints..."
+    local total_orphans=0
+
+    # Create temporary function and execute in a single psql call
+    local orphan_check
+    orphan_check=$(psql "$target_url" -X -t -A 2>/dev/null <<SQL
+DO \$\$
+DECLARE
+    r RECORD;
+    orphan_count BIGINT;
+    total_orphans BIGINT := 0;
+    child_col TEXT;
+    parent_col TEXT;
+    join_cond TEXT;
+BEGIN
+    FOR r IN
+        SELECT
+            con.conname,
+            con.confrelid::regclass::text AS parent_table,
+            con.conrelid::regclass::text AS child_table,
+            con.conkey,
+            con.confkey
+        FROM pg_constraint con
+        WHERE con.contype = 'f'
+          AND con.connamespace = 'public'::regnamespace
+          AND con.convalidated
+    LOOP
+        -- Build join condition from column mappings
+        join_cond := '';
+        FOR i IN 1 .. array_length(r.conkey, 1) LOOP
+            IF i > 1 THEN join_cond := join_cond || ' AND '; END IF;
+
+            SELECT att.attname INTO child_col
+            FROM pg_attribute att
+            WHERE att.attrelid = (
+                SELECT conrelid FROM pg_constraint WHERE conname = r.conname
+                  AND connamespace = 'public'::regnamespace
+                LIMIT 1
+            ) AND att.attnum = r.conkey[i];
+
+            SELECT att.attname INTO parent_col
+            FROM pg_attribute att
+            WHERE att.attrelid = (
+                SELECT confrelid FROM pg_constraint WHERE conname = r.conname
+                  AND connamespace = 'public'::regnamespace
+                LIMIT 1
+            ) AND att.attnum = r.confkey[i];
+
+            IF child_col IS NOT NULL AND parent_col IS NOT NULL THEN
+                join_cond := join_cond || format('child.%I = parent.%I', child_col, parent_col);
+            END IF;
+        END LOOP;
+
+        IF join_cond != '' THEN
+            EXECUTE format(
+                'SELECT count(*) FROM %I child WHERE NOT EXISTS (SELECT 1 FROM %I parent WHERE %s)',
+                r.child_table, r.parent_table, join_cond
+            ) INTO orphan_count;
+
+            IF orphan_count > 0 THEN
+                RAISE WARNING 'FK %: % orphan(s) in % referencing %',
+                    r.conname, orphan_count, r.child_table, r.parent_table;
+                total_orphans := total_orphans + orphan_count;
+            END IF;
+        END IF;
+    END LOOP;
+
+    IF total_orphans > 0 THEN
+        RAISE NOTICE 'TOTAL_ORPHANS=%', total_orphans;
+    ELSE
+        RAISE NOTICE 'TOTAL_ORPHANS=0';
+    END IF;
+END;
+\$\$;
+SQL
+)
+
+    local orphans_detected
+    orphans_detected=$(echo "$orphan_check" | grep -Eo 'TOTAL_ORPHANS=[0-9]+' | cut -d= -f2 || echo "0")
+
+    if [ -n "$orphans_detected" ] && [ "$orphans_detected" -gt 0 ]; then
+        log_warn "Found $orphans_detected orphaned row(s) across FK constraints."
+        report_metric "fk_orphans" "$orphans_detected"
+    else
+        log_ok "No orphaned rows detected — FK referential integrity intact."
+        report_metric "fk_orphans" "0"
+    fi
 
     log_ok "FK constraint integrity verified across $fk_count constraints."
     return $failed
@@ -511,6 +496,7 @@ do_restore_from_live() {
     log_info "Source: (masked) $source_url" | sed 's|://[^@]*@|://***@|'
 
     local dump_start dump_end dump_elapsed
+    local dump_exit=0
     dump_start=$(date +%s)
 
     pg_dump \
@@ -520,9 +506,7 @@ do_restore_from_live() {
         --no-owner \
         --verbose \
         --file="$dump_file" \
-        "$source_url" 2>&1 | grep -E '^(pg_dump:|last|ERROR|WARNING)' || true
-
-    local dump_exit=$?
+        "$source_url" 2>&1 | grep -E '^(pg_dump:|last|ERROR|WARNING)' || dump_exit=${PIPESTATUS[0]}
     if [ $dump_exit -ne 0 ]; then
         log_error "pg_dump FAILED (exit code $dump_exit)."
         return 2
@@ -534,6 +518,7 @@ do_restore_from_live() {
     dump_size=$(du -sh "$dump_file" 2>/dev/null | cut -f1)
     log_ok "pg_dump completed in ${dump_elapsed}s, size=$dump_size"
 
+    local rs_exit=0
     RESTORE_START_EPOCH=$(date +%s)
 
     log_info "Step 2: pg_restore to target"
@@ -546,9 +531,7 @@ do_restore_from_live() {
         --no-owner \
         --verbose \
         --dbname="$target_url" \
-        "$dump_file" 2>&1 | grep -E '^(pg_restore:|ERROR|WARNING)' || true
-
-    local rs_exit=$?
+        "$dump_file" 2>&1 | grep -E '^(pg_restore:|ERROR|WARNING)' || rs_exit=${PIPESTATUS[0]}
     if [ $rs_exit -ne 0 ]; then
         log_error "pg_restore FAILED (exit code $rs_exit)."
         rm -f "$dump_file"
@@ -575,6 +558,7 @@ do_restore_from_file() {
     file_size=$(du -sh "$file_path" 2>/dev/null | cut -f1)
     log_info "Backup file: $(basename "$file_path") ($file_size)"
 
+    local rs_exit=0
     RESTORE_START_EPOCH=$(date +%s)
 
     pg_restore \
@@ -584,9 +568,7 @@ do_restore_from_file() {
         --no-owner \
         --verbose \
         --dbname="$target_url" \
-        "$file_path" 2>&1 | grep -E '^(pg_restore:|ERROR|WARNING)' || true
-
-    local rs_exit=$?
+        "$file_path" 2>&1 | grep -E '^(pg_restore:|ERROR|WARNING)' || rs_exit=${PIPESTATUS[0]}
     if [ $rs_exit -ne 0 ]; then
         log_error "pg_restore FAILED (exit code $rs_exit)."
         return 2
@@ -624,6 +606,7 @@ do_restore_from_s3() {
     file_size=$(du -sh "$dump_file" 2>/dev/null | cut -f1)
     log_ok "Downloaded in ${dl_elapsed}s, size=$file_size"
 
+    local rs_exit=0
     RESTORE_START_EPOCH=$(date +%s)
 
     pg_restore \
@@ -633,10 +616,9 @@ do_restore_from_s3() {
         --no-owner \
         --verbose \
         --dbname="$target_url" \
-        "$dump_file" 2>&1 | grep -E '^(pg_restore:|ERROR|WARNING)' || true
-
-    local rs_exit=$?
+        "$dump_file" 2>&1 | grep -E '^(pg_restore:|ERROR|WARNING)' || rs_exit=${PIPESTATUS[0]}
     RESTORE_END_EPOCH=$(date +%s)
+    BACKUP_SIZE_CAPTURED="${file_size:-unknown}"
     rm -f "$dump_file"
 
     if [ $rs_exit -ne 0 ]; then
@@ -647,6 +629,9 @@ do_restore_from_s3() {
     log_ok "Restore completed."
     return 0
 }
+
+# Global for backup size capture (set inside restore functions before file deletion)
+BACKUP_SIZE_CAPTURED=""
 
 cleanup_target() {
     section "AC8: Cleanup - Dropping Restored Schema"
@@ -806,7 +791,8 @@ main() {
     check_prereqs || exit 4
 
     # Verify target is NOT production
-    if [ -n "${SUPABASE_DB_URL:-}" ] && [ "$TARGET_URL" = "$SUPABASE_DB_URL" ]; then
+    if { [ -n "${SUPABASE_DB_URL:-}" ] && [ "$TARGET_URL" = "$SUPABASE_DB_URL" ]; } || \
+       { [ -n "${SOURCE_URL:-}" ] && [ "$TARGET_URL" = "$SOURCE_URL" ]; }; then
         log_error "TARGET URL IS THE SAME AS PRODUCTION. Aborting to protect production (AC8)."
         exit 4
     fi
@@ -830,7 +816,7 @@ main() {
     case "$MODE" in
         live)
             do_restore_from_live "$SOURCE_URL" "$TARGET_URL" "$dump_file" || overall_exit=$?
-            backup_size=$(du -sh "$dump_file" 2>/dev/null | cut -f1)
+            backup_size="${BACKUP_SIZE_CAPTURED:-$(du -sh "$dump_file" 2>/dev/null | cut -f1)}"
             ;;
         file)
             do_restore_from_file "$FROM_FILE" "$TARGET_URL" || overall_exit=$?
@@ -838,7 +824,7 @@ main() {
             ;;
         s3)
             do_restore_from_s3 "$FROM_S3_URI" "$TARGET_URL" "$dump_file" || overall_exit=$?
-            backup_size=$(du -sh "$dump_file" 2>/dev/null | cut -f1)
+            backup_size="${BACKUP_SIZE_CAPTURED:-$(du -sh "$dump_file" 2>/dev/null | cut -f1)}"
             ;;
     esac
 


### PR DESCRIPTION
## O que muda

Implementa **teste automatizado de restore de backup** do Supabase:

### Artefatos
- **`scripts/backup-restore-test.sh`** — Script automatizado com:
  - Restore do último backup em instância isolada
  - Verificação de row counts das 10 maiores tabelas
  - Verificação de integridade (FK constraints, indexes, sequences)
  - Métricas: tempo total, tempo por tabela, tamanho do backup
  - Alerta se restore > 30min
- **`.github/workflows/backup-restore-test.yml`** — CI semanal (Sunday 00:00 UTC)
- **`docs/operations/backup-dr-verified.md`** — Procedimento completo de disaster recovery com RTO/RPO validados

### Critérios de Aceitação
- [x] AC1 — Script `backup-restore-test.sh` funcional
- [x] AC2 — Verificação row counts 10 maiores tabelas
- [x] AC3 — FK constraints, indexes, sequences válidas
- [x] AC4 — Métricas de tempo e tamanho
- [x] AC5 — CI semanal agendado
- [x] AC6 — Alerta restore > 30min
- [x] AC7 — Documentação `backup-dr-verified.md`
- [x] AC8 — Restore em instância isolada (não afeta produção)

Closes #1864

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced foreign key validation to report orphaned-row metrics
  * Improved exit code capture for backup and restore operations
  * Strengthened production environment safety guards

* **Refactor**
  * Updated backup size measurement logic for restore operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->