### PR TITLE
refactor(backend): reduce jobs-cron complexity — BaseCronLoop + CronLoopRegistry (#1781)

### DIFF
--- a/backend/job_queue.py
+++ b/backend/job_queue.py
@@ -28,11 +28,8 @@ arq_log_config = {
 # Pool state lives here so tests can mutate job_queue._arq_pool directly
 _arq_pool = None
 _pool_lock = asyncio.Lock()
-# Issue #1867 AC1: threading.Lock alongside asyncio.Lock for thread safety.
-# asyncio.Lock protects coroutine interleaving within the same event loop;
-# threading.Lock protects global state writes from thread-level races
-# (e.g., when get_arq_pool() is called via run_coroutine_threadsafe or
-# from thread pool executors). Dual-lock pattern is belt-and-suspenders.
+# Issue #1867 AC1 / Issue #1781 AC5.7: threading.Lock protects global state from
+# cross-event-loop / cross-thread access (e.g., lifespan vs colocated ARQ worker).
 _pool_thread_lock = threading.Lock()
 _worker_alive_cache: tuple[float, bool] = (0.0, False)
 _WORKER_CHECK_INTERVAL = 15
@@ -62,36 +59,32 @@ async def get_arq_pool():
     Tests can still directly mutate ``_arq_pool`` for injection.
     """
     global _arq_pool
-    # Fast path: pool is already connected and healthy
-    if _arq_pool is not None:
-        try:
-            await _arq_pool.ping()
-            return _arq_pool
-        except Exception:
-            # Issue #1867 AC1: thread lock protects the reset from thread races
-            with _pool_thread_lock:
-                _arq_pool = None
-
-    # Slow path: asyncio lock for coroutine serialization during creation
-    async with _pool_lock:
+    # Issue #1781 AC5.7: acquire thread lock before asyncio lock to protect
+    # _arq_pool from concurrent access across different event loops or threads
+    # (e.g., lifespan startup vs. colocated ARQ worker).
+    with _pool_thread_lock:
         if _arq_pool is not None:
-            return _arq_pool
-        for attempt in range(1, 4):
             try:
-                from arq import create_pool
-                pool = await create_pool(_get_redis_settings())
-                # Issue #1867 AC1: thread lock protects the global assignment
-                with _pool_thread_lock:
-                    _arq_pool = pool
-                logger.info(f"ARQ connection pool created (attempt {attempt})")
+                await _arq_pool.ping()
                 return _arq_pool
-            except Exception as e:
-                delay = 2 ** attempt
-                logger.warning(f"redis_pool_reconnect attempt={attempt}/3 delay={delay}s error={type(e).__name__}: {e}")
-                if attempt < 3:
-                    await asyncio.sleep(delay)
-        logger.warning("ARQ pool creation failed after all retries")
-        return None
+            except Exception:
+                _arq_pool = None
+        async with _pool_lock:
+            if _arq_pool is not None:
+                return _arq_pool
+            for attempt in range(1, 4):
+                try:
+                    from arq import create_pool
+                    _arq_pool = await create_pool(_get_redis_settings())
+                    logger.info(f"ARQ connection pool created (attempt {attempt})")
+                    return _arq_pool
+                except Exception as e:
+                    delay = 2 ** attempt
+                    logger.warning(f"redis_pool_reconnect attempt={attempt}/3 delay={delay}s error={type(e).__name__}: {e}")
+                    if attempt < 3:
+                        await asyncio.sleep(delay)
+            logger.warning("ARQ pool creation failed after all retries")
+            return None
 
 
 async def close_arq_pool() -> None:
@@ -100,14 +93,15 @@ async def close_arq_pool() -> None:
     Thread-safe: uses threading.Lock for the global variable reset.
     """
     global _arq_pool
-    if _arq_pool is not None:
-        try:
-            await _arq_pool.close()
-        except Exception as e:
-            logger.warning(f"Error closing ARQ pool: {e}")
-        with _pool_thread_lock:
+    # Issue #1781 AC5.7: protect _arq_pool with thread lock
+    with _pool_thread_lock:
+        if _arq_pool is not None:
+            try:
+                await _arq_pool.close()
+            except Exception as e:
+                logger.warning(f"Error closing ARQ pool: {e}")
             _arq_pool = None
-        logger.info("ARQ pool closed")
+            logger.info("ARQ pool closed")
 
 
 async def _check_worker_alive(pool) -> bool:

--- a/backend/jobs/cron/base.py
+++ b/backend/jobs/cron/base.py
@@ -1,0 +1,265 @@
+"""jobs.cron.base — BaseCronLoop ABC (Template Method pattern).
+
+All lifespan cron loops inherit from ``BaseCronLoop`` which provides:
+
+  * Uniform ``start()`` lifecycle (initial_delay → run_once → update_health → sleep)
+  * Redis-based health reporting (``loop:health:<name>`` hash) — AC5.8
+  * Prometheus metrics via ``metrics.py``
+  * Configurable ``handle_error()`` override
+  * CancelledError / infra-unavailable handling built in
+  * Lock helpers (``_acquire_lock`` / ``_release_lock``) available for subclasses
+
+Lock strategy (AC5.1 Template Method):
+  Each subclass's ``run_once()`` is responsible for its own Redis lock
+  acquisition using the provided helpers.  The ``start()`` lifecycle only
+  orchestrates scheduling and error handling — it does NOT acquire locks
+  automatically, so that tests calling ``run_once()`` directly get the
+  full business logic including lock behavior.
+
+Usage::
+
+    class MyLoop(BaseCronLoop):
+        name = "my_loop"
+        interval_seconds = 3600
+        lock_key = "smartlic:my_loop:lock"
+        lock_ttl = 600
+
+        async def run_once(self) -> dict:
+            locked = await self._acquire_lock()
+            if not locked:
+                return {"status": "skipped", "reason": "lock_held"}
+            try:
+                # business logic
+                return {"deleted": 42}
+            finally:
+                await self._release_lock()
+"""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCronLoop(abc.ABC):
+    """Template-method base class for all lifespan cron loops.
+
+    Subclasses MUST define:
+      * ``name``             — human-readable unique identifier (used for Redis
+                               health key and Prometheus labels).
+      * ``interval_seconds`` — sleep interval between successful runs.
+      * ``run_once()``       — the actual business logic; returns a dict result.
+
+    Subclasses MAY override:
+      * ``lock_key``         — Redis NX lock key (None = no locking).
+      * ``lock_ttl``         — lock TTL in seconds.
+      * ``initial_delay``    — seconds to sleep before first run.
+      * ``error_retry_seconds`` — sleep after an unhandled exception.
+      * ``handle_error()``   — custom error handling (default: log + sleep).
+    """
+
+    # --- Required overrides ---
+    name: str = ""
+    interval_seconds: int | float = 0
+
+    # --- Optional overrides ---
+    lock_key: str | None = None
+    lock_ttl: int | None = None
+    initial_delay: float = 0.0
+    error_retry_seconds: float = 300.0
+
+    # --- Internal state (updated by start()) ---
+    _last_run_at: float = 0.0     # monotonic clock
+    _last_status: str = "unknown"
+    _last_error: str | None = None
+
+    # ── Abstract ────────────────────────────────────────────────────────────
+
+    @abc.abstractmethod
+    async def run_once(self) -> dict:
+        """Execute one cycle of the loop (includes lock acquisition if used).
+
+        Returns:
+            A dict summarising the result (e.g. ``{"deleted": 42}``).
+            The dict is logged and stored in the Redis health hash.
+        """
+        ...
+
+    # ── Hooks ───────────────────────────────────────────────────────────────
+
+    async def on_startup(self) -> None:
+        """Called once before the main loop (optional hook).
+
+        Use for scheduling the first run (e.g. ``await asyncio.sleep(delay)``).
+        """
+        pass
+
+    async def handle_error(self, exc: Exception) -> None:
+        """Handle an exception from ``run_once()``.
+
+        Default: log the exception with circuit-breaker awareness and let
+        the loop retry after ``error_retry_seconds``.
+        """
+        _log_cb_aware(logger, self.name, exc)
+
+    # ── Lock helpers ────────────────────────────────────────────────────────
+
+    async def _acquire_lock(self) -> bool:
+        """Acquire a Redis NX lock. Returns True if acquired or Redis down."""
+        if not self.lock_key or not self.lock_ttl:
+            return True
+        try:
+            from redis_pool import get_redis_pool
+            redis = await get_redis_pool()
+            if redis:
+                acquired = await redis.set(
+                    self.lock_key,
+                    datetime.now(timezone.utc).isoformat(),
+                    nx=True,
+                    ex=self.lock_ttl,
+                )
+                if not acquired:
+                    return False
+        except Exception as e:
+            logger.warning("%s: lock check failed (proceeding): %s", self.name, e)
+        return True
+
+    async def _release_lock(self) -> None:
+        """Release a Redis lock (best-effort)."""
+        if not self.lock_key:
+            return
+        try:
+            from redis_pool import get_redis_pool
+            redis = await get_redis_pool()
+            if redis:
+                await redis.delete(self.lock_key)
+        except Exception:
+            pass
+
+    # ── Health reporting (AC5.8) ────────────────────────────────────────────
+
+    async def _report_health(
+        self,
+        status: str,
+        error: str | None = None,
+        extra: dict | None = None,
+    ) -> None:
+        """Write health state to Redis hash ``loop:health:<name>``.
+
+        Fields: ``last_run_at`` (ISO-8601), ``last_status``, ``last_error``,
+        and any extra keys provided.
+        """
+        self._last_status = status
+        self._last_error = error
+        if error:
+            self._last_run_at = 0.0
+        else:
+            self._last_run_at = time.monotonic()
+
+        try:
+            from redis_pool import get_redis_pool
+            redis = await get_redis_pool()
+            if redis:
+                mapping: dict[str, str] = {
+                    "last_run_at": datetime.now(timezone.utc).isoformat(),
+                    "last_status": status,
+                    "last_error": error or "",
+                }
+                if extra:
+                    mapping.update(extra)
+                await redis.hset(f"loop:health:{self.name}", mapping=mapping)  # type: ignore[arg-type]
+        except Exception:
+            pass
+
+    # ── Prometheus metrics ──────────────────────────────────────────────────
+
+    def _observe_duration(self, duration_s: float) -> None:
+        """Record loop duration to Prometheus (best-effort)."""
+        try:
+            from metrics import CRON_LOOP_DURATION
+            CRON_LOOP_DURATION.labels(loop=self.name).observe(duration_s)
+        except Exception:
+            pass
+
+    def _inc_status(self, status: str) -> None:
+        """Increment loop status counter (best-effort)."""
+        try:
+            from metrics import CRON_LOOP_STATUS
+            CRON_LOOP_STATUS.labels(loop=self.name, status=status).inc()
+        except Exception:
+            pass
+
+    # ── Main lifecycle ──────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Main loop lifecycle.
+
+        Sequence:
+          1. ``initial_delay`` sleep (if configured)
+          2. ``on_startup()`` hook
+          3. Infinite loop::
+               await run_once()
+               _report_health("completed")
+               await asyncio.sleep(interval_seconds)
+             On exception: handle_error() → _report_health("error") → sleep
+        """
+        await asyncio.sleep(self.initial_delay)
+
+        try:
+            await self.on_startup()
+        except Exception:
+            logger.exception("%s: on_startup hook failed, continuing", self.name)
+
+        while True:
+            start_ts = time.monotonic()
+            status = "completed"
+            error: str | None = None
+
+            try:
+                result = await self.run_once()
+                duration = time.monotonic() - start_ts
+                logger.info("%s: completed in %.2fs — %s", self.name, duration, result)
+                self._observe_duration(duration)
+                self._inc_status("completed")
+            except asyncio.CancelledError:
+                logger.info("%s: cancelled", self.name)
+                self._inc_status("cancelled")
+                break
+            except Exception as exc:
+                duration = time.monotonic() - start_ts
+                status = "error"
+                error = f"{type(exc).__name__}: {exc}"
+                self._observe_duration(duration)
+                self._inc_status("error")
+                await self.handle_error(exc)
+
+            # Report health (always — even on error, so cron_monitor sees the
+            # failure timestamp rather than a stale "completed" entry).
+            await self._report_health(status, error=error, extra={
+                "duration_s": f"{time.monotonic() - start_ts:.2f}",
+            })
+
+            if status == "error":
+                await asyncio.sleep(self.error_retry_seconds)
+            else:
+                await asyncio.sleep(self.interval_seconds)
+
+
+def _log_cb_aware(log: logging.Logger, name: str, exc: Exception) -> None:
+    """Log exception with awareness of circuit-breaker / connection errors."""
+    err_name = type(exc).__name__
+    err_str = str(exc)
+    if (
+        "CircuitBreaker" in err_name
+        or "ConnectionError" in err_name
+        or "ConnectError" in err_str
+        or "PGRST205" in err_str
+    ):
+        log.warning("%s: skipped (infra unavailable): %s", name, exc)
+    else:
+        log.error("%s: loop error: %s", name, exc, exc_info=True)

--- a/backend/jobs/cron/billing.py
+++ b/backend/jobs/cron/billing.py
@@ -1,12 +1,29 @@
-"""jobs.cron.billing — Billing reconciliation, dunning, revenue share, and plan sync crons."""
+"""jobs.cron.billing — Facade: billing cron functions (Issue #1781).
+
+All implementation has been moved to ``jobs.cron.billing_loops``. This module
+re-exports constants, loop classes, and ``start_*_task`` wrappers for backward
+compatibility.
+
+Legacy ``run_*`` and ``_*_loop`` functions delegate to the corresponding
+``BaseCronLoop`` subclasses so that existing tests and imports continue to work.
+"""
+from __future__ import annotations
+
 import asyncio
 import logging
 from datetime import datetime, timezone, timedelta
 
-from jobs.cron.canary import _is_cb_or_connection_error
+from jobs.cron.billing_loops import (
+    ReconciliationLoop,
+    PreDunningLoop,
+    RevenueShareLoop,
+    PlanReconciliationLoop,
+    StripeEventsPurgeLoop,
+)
 
 logger = logging.getLogger(__name__)
 
+# ── Lock keys / constants (re-exported) ─────────────────────────────────────
 RECONCILIATION_LOCK_KEY = "smartlic:reconciliation:lock"
 RECONCILIATION_LOCK_TTL = 30 * 60
 PRE_DUNNING_INTERVAL_SECONDS = 24 * 60 * 60
@@ -17,13 +34,14 @@ PLAN_RECONCILIATION_LOCK_TTL = 10 * 60
 PLAN_RECONCILIATION_INTERVAL = 12 * 60 * 60
 STRIPE_EVENTS_RETENTION_DAYS = 90
 STRIPE_PURGE_INTERVAL_SECONDS = 24 * 60 * 60
-
 _MONITORED_TABLES = [
     "search_results_cache", "search_results_store", "search_sessions",
     "stripe_webhook_events", "profiles", "user_subscriptions",
     "conversations", "messages", "alert_runs", "classification_feedback",
 ]
 
+
+# ── Lock / timing helpers (used by legacy imports — keep for backward compat) ─
 
 async def _acquire_lock(key: str, ttl: int) -> bool:
     """Acquire a Redis NX lock. Returns True if acquired (or Redis unavailable)."""
@@ -50,6 +68,7 @@ async def _release_lock(key: str) -> None:
 
 
 def _next_utc_hour(target_hour: int, max_delay: float = 86400.0) -> float:
+    """Compute seconds until next occurrence of ``target_hour`` UTC."""
     now = datetime.now(timezone.utc)
     next_run = now.replace(hour=target_hour, minute=0, second=0, microsecond=0)
     if now.hour >= target_hour:
@@ -57,216 +76,22 @@ def _next_utc_hour(target_hour: int, max_delay: float = 86400.0) -> float:
     return max(60.0, min((next_run - now).total_seconds(), max_delay))
 
 
+# ── Legacy run_* business functions (delegate to loop.run_once()) ────────────
+
 async def run_reconciliation() -> dict:
-    from services.stripe_reconciliation import reconcile_subscriptions, save_reconciliation_report, send_reconciliation_alert
-    if not await _acquire_lock(RECONCILIATION_LOCK_KEY, RECONCILIATION_LOCK_TTL):
-        logger.info("Reconciliation skipped — lock already held")
-        return {"status": "skipped", "reason": "lock_held"}
-    try:
-        result = await reconcile_subscriptions()
-        await save_reconciliation_report(result)
-        await send_reconciliation_alert(result)
-        return result
-    finally:
-        await _release_lock(RECONCILIATION_LOCK_KEY)
-
-
-async def _reconciliation_loop() -> None:
-    from config import RECONCILIATION_ENABLED, RECONCILIATION_HOUR_UTC
-    if not RECONCILIATION_ENABLED:
-        logger.info("Reconciliation disabled")
-        return
-    await asyncio.sleep(_next_utc_hour(RECONCILIATION_HOUR_UTC))
-    while True:
-        try:
-            result = await run_reconciliation()
-            logger.info("STORY-314 reconciliation cycle: checked=%d, divergences=%d", result.get("total_checked", 0), result.get("divergences_found", 0))
-            await asyncio.sleep(24 * 60 * 60)
-        except asyncio.CancelledError:
-            logger.info("Reconciliation task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("Reconciliation skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error(f"Reconciliation loop error: {e}", exc_info=True)
-            await asyncio.sleep(300)
+    return await ReconciliationLoop().run_once()
 
 
 async def check_pre_dunning_cards() -> dict:
-    import os
-    try:
-        import stripe
-        stripe_key = os.getenv("STRIPE_SECRET_KEY", "")
-        if not stripe_key:
-            return {"sent": 0, "skipped": 0, "errors": 0, "disabled": True}
-        from supabase_client import get_supabase, sb_execute
-        from services.dunning import send_pre_dunning_email
-        sb = get_supabase()
-        now = datetime.now(timezone.utc)
-        target_date = now + timedelta(days=7)
-        sent = skipped = errors = 0
-        subs_result = await sb_execute(sb.table("user_subscriptions").select("user_id, stripe_customer_id").eq("is_active", True).eq("subscription_status", "active").not_.is_("stripe_customer_id", "null"))
-        if not subs_result.data:
-            return {"sent": 0, "skipped": 0, "errors": 0}
-        for sub in subs_result.data:
-            try:
-                customer_id = sub.get("stripe_customer_id")
-                user_id = sub.get("user_id")
-                if not customer_id or not user_id:
-                    continue
-                customer = stripe.Customer.retrieve(customer_id, api_key=stripe_key, expand=["default_source", "invoice_settings.default_payment_method"])
-                pm = customer.get("invoice_settings", {}).get("default_payment_method")
-                card_info = None
-                if pm and hasattr(pm, "card"):
-                    card_info = pm.card
-                elif customer.get("default_source") and hasattr(customer.default_source, "exp_month"):
-                    card_info = customer.default_source
-                if not card_info:
-                    skipped += 1
-                    continue
-                exp_month = getattr(card_info, "exp_month", None) or card_info.get("exp_month")
-                exp_year = getattr(card_info, "exp_year", None) or card_info.get("exp_year")
-                last4 = getattr(card_info, "last4", None) or card_info.get("last4", "****")
-                if not exp_month or not exp_year:
-                    skipped += 1
-                    continue
-                if exp_year == target_date.year and exp_month == target_date.month:
-                    await send_pre_dunning_email(user_id, last4, exp_month, exp_year)
-                    sent += 1
-                else:
-                    skipped += 1
-            except Exception as e:
-                errors += 1
-                logger.debug(f"Pre-dunning check failed for customer: {e}")
-        logger.info(f"Pre-dunning check: sent={sent}, skipped={skipped}, errors={errors}")
-        return {"sent": sent, "skipped": skipped, "errors": errors}
-    except Exception as e:
-        if _is_cb_or_connection_error(e):
-            logger.warning("Pre-dunning check skipped (Supabase unavailable): %s", e)
-        else:
-            logger.error(f"Pre-dunning check failed: {e}", exc_info=True)
-        return {"sent": 0, "skipped": 0, "errors": 1, "error": str(e)}
-
-
-async def _pre_dunning_loop() -> None:
-    await asyncio.sleep(120)
-    while True:
-        try:
-            result = await check_pre_dunning_cards()
-            logger.info(f"Pre-dunning cycle: {result}")
-            await asyncio.sleep(PRE_DUNNING_INTERVAL_SECONDS)
-        except asyncio.CancelledError:
-            logger.info("Pre-dunning task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("Pre-dunning loop skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error(f"Pre-dunning loop error: {e}", exc_info=True)
-            await asyncio.sleep(60)
+    return await PreDunningLoop().run_once()
 
 
 async def run_revenue_share_report() -> dict:
-    if not await _acquire_lock(REVENUE_SHARE_LOCK_KEY, REVENUE_SHARE_LOCK_TTL):
-        logger.info("STORY-323: Revenue share report skipped — lock held")
-        return {"status": "skipped", "reason": "lock_held"}
-    try:
-        from services.partner_service import generate_monthly_revenue_report
-        now = datetime.now(timezone.utc)
-        report_year = now.year - 1 if now.month == 1 else now.year
-        report_month = 12 if now.month == 1 else now.month - 1
-        result = await generate_monthly_revenue_report(report_year, report_month)
-        logger.info("STORY-323: Revenue share report generated — %d/%d, %d partners, total_share=R$%.2f", report_month, report_year, len(result.get("partner_reports", [])), result.get("total_share", 0))
-        return result
-    finally:
-        await _release_lock(REVENUE_SHARE_LOCK_KEY)
-
-
-async def _revenue_share_loop() -> None:
-    now = datetime.now(timezone.utc)
-    if now.month == 12:
-        next_run = datetime(now.year + 1, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    else:
-        next_run = datetime(now.year, now.month + 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    initial_delay = max(60.0, min((next_run - now).total_seconds(), 31 * 86400.0))
-    logger.info("STORY-323: Revenue share report first run in %.0fs (target: %s)", initial_delay, next_run.isoformat())
-    await asyncio.sleep(initial_delay)
-    while True:
-        try:
-            result = await run_revenue_share_report()
-            logger.info("STORY-323 revenue share cycle: %s", result.get("total_share", "N/A"))
-            await asyncio.sleep(30 * 24 * 60 * 60)
-        except asyncio.CancelledError:
-            logger.info("STORY-323: Revenue share report task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("STORY-323: Revenue share skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error(f"STORY-323: Revenue share loop error: {e}", exc_info=True)
-            await asyncio.sleep(3600)
+    return await RevenueShareLoop().run_once()
 
 
 async def run_plan_reconciliation() -> dict:
-    from supabase_client import get_supabase, sb_execute
-    from metrics import PLAN_RECONCILIATION_RUNS, PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED
-    PLAN_RECONCILIATION_RUNS.inc()
-    if not await _acquire_lock(PLAN_RECONCILIATION_LOCK_KEY, PLAN_RECONCILIATION_LOCK_TTL):
-        logger.info("DEBT-010: Plan reconciliation skipped — lock held")
-        return {"status": "skipped", "reason": "lock_held"}
-    try:
-        sb = get_supabase()
-        profiles_result = await sb_execute(sb.table("profiles").select("id, plan_type"))
-        profiles = {p["id"]: p["plan_type"] for p in (profiles_result.data or [])}
-        subs_result = await sb_execute(sb.table("user_subscriptions").select("user_id, plan_id").eq("is_active", True))
-        subs = {s["user_id"]: s["plan_id"] for s in (subs_result.data or [])}
-        drift_details = []
-        auto_healed = 0
-        for user_id, plan_type in profiles.items():
-            sub_plan = subs.get(user_id)
-            if sub_plan is None:
-                if plan_type not in ("free_trial", "cancelled", None, ""):
-                    drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": None, "direction": "orphan_profile"})
-                    PLAN_RECONCILIATION_DRIFT.labels(direction="orphan_profile").inc()
-                    # Self-heal: orphan profile with a paid plan — reset to free_trial
-                    try:
-                        await sb_execute(
-                            sb.table("profiles").update({"plan_type": "free_trial"}).eq("id", user_id),
-                            category="write",
-                        )
-                        logger.info("DEBT-010: auto-healed orphan profile %s: %s -> free_trial", user_id[:8], plan_type)
-                        PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="orphan_profile").inc()
-                        auto_healed += 1
-                    except Exception as heal_err:
-                        logger.warning("DEBT-010: auto-heal failed for orphan profile %s: %s", user_id[:8], heal_err)
-            elif plan_type != sub_plan:
-                drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": sub_plan, "direction": "profiles_stale"})
-                PLAN_RECONCILIATION_DRIFT.labels(direction="profiles_stale").inc()
-                # Self-heal: profiles_stale — align profile plan with active subscription
-                try:
-                    await sb_execute(
-                        sb.table("profiles").update({"plan_type": sub_plan}).eq("id", user_id),
-                        category="write",
-                    )
-                    logger.info("DEBT-010: auto-healed profile for user %s: %s -> %s", user_id[:8], plan_type, sub_plan)
-                    PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="profiles_stale").inc()
-                    auto_healed += 1
-                except Exception as heal_err:
-                    logger.warning("DEBT-010: auto-heal failed for user %s: %s", user_id[:8], heal_err)
-        if drift_details:
-            logger.warning("DEBT-010: Plan reconciliation found %d drifts, auto-healed %d: %s", len(drift_details), auto_healed, drift_details[:5])
-        else:
-            logger.info("DEBT-010: Plan reconciliation clean — %d profiles, %d active subs", len(profiles), len(subs))
-        return {"status": "completed", "total_profiles": len(profiles), "total_active_subs": len(subs), "drift_count": len(drift_details), "auto_healed": auto_healed, "drift_details": drift_details[:20], "checked_at": datetime.now(timezone.utc).isoformat()}
-    except Exception as e:
-        if _is_cb_or_connection_error(e):
-            logger.warning("DEBT-010: Plan reconciliation skipped (Supabase unavailable): %s", e)
-        else:
-            logger.error("DEBT-010: Plan reconciliation error: %s", e, exc_info=True)
-        return {"status": "error", "error": str(e)}
-    finally:
-        await _release_lock(PLAN_RECONCILIATION_LOCK_KEY)
+    return await PlanReconciliationLoop().run_once()
 
 
 async def update_table_size_metrics() -> dict:
@@ -285,93 +110,73 @@ async def update_table_size_metrics() -> dict:
             except Exception as e:
                 logger.debug("DEBT-010: Table size query failed for %s: %s", table_name, e)
                 sizes[table_name] = -1
-        logger.info("DEBT-010: Table sizes updated — %d tables", len(sizes))
         return {"status": "ok", "sizes": sizes}
     except Exception as e:
-        if _is_cb_or_connection_error(e):
-            logger.warning("DEBT-010: Table size metrics skipped (Supabase unavailable): %s", e)
-        else:
-            logger.error("DEBT-010: Table size metrics error: %s", e, exc_info=True)
         return {"status": "error", "error": str(e)}
 
 
-async def _plan_reconciliation_loop() -> None:
-    await asyncio.sleep(300)
-    while True:
-        try:
-            await run_plan_reconciliation()
-            await update_table_size_metrics()
-            await asyncio.sleep(PLAN_RECONCILIATION_INTERVAL)
-        except asyncio.CancelledError:
-            logger.info("DEBT-010: Plan reconciliation task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("DEBT-010: Reconciliation loop skipped: %s", e)
-            else:
-                logger.error("DEBT-010: Reconciliation loop error: %s", e, exc_info=True)
-            await asyncio.sleep(300)
-
-
 async def purge_old_stripe_events() -> dict:
-    try:
-        from supabase_client import get_supabase, sb_execute
-        sb = get_supabase()
-        cutoff = (datetime.now(timezone.utc) - timedelta(days=STRIPE_EVENTS_RETENTION_DAYS)).isoformat()
-        result = await sb_execute(sb.table("stripe_webhook_events").delete().lt("processed_at", cutoff))
-        deleted = len(result.data) if result and result.data else 0
-        logger.info("HARDEN-028: Purged %d Stripe webhook events older than %d days", deleted, STRIPE_EVENTS_RETENTION_DAYS)
-        return {"deleted": deleted, "cutoff": cutoff}
-    except Exception as e:
-        if _is_cb_or_connection_error(e):
-            logger.warning("HARDEN-028: Stripe events purge skipped (Supabase unavailable): %s", e)
-        else:
-            logger.error("HARDEN-028: Stripe events purge error: %s", e, exc_info=True)
-        return {"deleted": 0, "error": str(e)}
+    return await StripeEventsPurgeLoop().run_once()
+
+
+# ── Legacy _*_loop functions (delegate to loop.start()) ─────────────────────
+
+async def _reconciliation_loop() -> None:
+    await ReconciliationLoop().start()
+
+
+async def _pre_dunning_loop() -> None:
+    await PreDunningLoop().start()
+
+
+async def _revenue_share_loop() -> None:
+    await RevenueShareLoop().start()
+
+
+async def _plan_reconciliation_loop() -> None:
+    await PlanReconciliationLoop().start()
 
 
 async def _stripe_events_purge_loop() -> None:
-    while True:
-        try:
-            result = await purge_old_stripe_events()
-            logger.info("HARDEN-028 purge cycle: %s", result)
-            await asyncio.sleep(STRIPE_PURGE_INTERVAL_SECONDS)
-        except asyncio.CancelledError:
-            logger.info("HARDEN-028: Stripe events purge task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("HARDEN-028 purge loop skipped: %s", e)
-            else:
-                logger.error("HARDEN-028 purge loop error: %s", e, exc_info=True)
-            await asyncio.sleep(300)
+    await StripeEventsPurgeLoop().start()
 
+
+# ── start_*_task factories (called by task_registry on lifespan startup) ──
 
 async def start_reconciliation_task() -> asyncio.Task:
-    task = asyncio.create_task(_reconciliation_loop(), name="stripe_reconciliation")
+    from config import RECONCILIATION_ENABLED
+    if not RECONCILIATION_ENABLED:
+        logger.info("Reconciliation disabled — starting noop task")
+        return asyncio.create_task(asyncio.sleep(0), name="reconciliation_noop")
+    loop = ReconciliationLoop()
+    task = asyncio.create_task(loop.start(), name="stripe_reconciliation")
     logger.info("STORY-314: Stripe reconciliation task started (daily at 03:00 BRT)")
     return task
 
 
 async def start_pre_dunning_task() -> asyncio.Task:
-    task = asyncio.create_task(_pre_dunning_loop(), name="pre_dunning")
+    loop = PreDunningLoop()
+    task = asyncio.create_task(loop.start(), name="pre_dunning")
     logger.info("Pre-dunning card expiry check started (interval: 24h)")
     return task
 
 
 async def start_revenue_share_task() -> asyncio.Task:
-    task = asyncio.create_task(_revenue_share_loop(), name="revenue_share_report")
+    loop = RevenueShareLoop()
+    task = asyncio.create_task(loop.start(), name="revenue_share_report")
     logger.info("STORY-323: Revenue share report task started (monthly, day 1, 09:00 BRT)")
     return task
 
 
 async def start_plan_reconciliation_task() -> asyncio.Task:
-    task = asyncio.create_task(_plan_reconciliation_loop(), name="plan_reconciliation")
+    loop = PlanReconciliationLoop()
+    task = asyncio.create_task(loop.start(), name="plan_reconciliation")
     logger.info("DEBT-010: Plan reconciliation task started (interval: 12h)")
     return task
 
 
 async def start_stripe_events_purge_task() -> asyncio.Task:
-    task = asyncio.create_task(_stripe_events_purge_loop(), name="stripe_events_purge")
+    loop = StripeEventsPurgeLoop()
+    task = asyncio.create_task(loop.start(), name="stripe_events_purge")
     logger.info("HARDEN-028: Stripe events purge task started (interval: 24h, retention: %dd)", STRIPE_EVENTS_RETENTION_DAYS)
     return task

--- a/backend/jobs/cron/billing_loops/__init__.py
+++ b/backend/jobs/cron/billing_loops/__init__.py
@@ -1,0 +1,25 @@
+"""jobs.cron.billing_loops — Individual cron loop classes for billing operations.
+
+Each module contains a single ``BaseCronLoop`` subclass that maps to one of the
+five original loops in ``jobs/cron/billing.py``:
+
+  * ``ReconciliationLoop``       — Stripe <-> DB reconciliation (daily)
+  * ``PreDunningLoop``            — Card expiry pre-dunning check (daily)
+  * ``RevenueShareLoop``          — Monthly partner revenue share report
+  * ``PlanReconciliationLoop``    — Profile/plan drift detection + auto-heal
+  * ``StripeEventsPurgeLoop``     — Old Stripe webhook event cleanup (daily)
+"""
+
+from jobs.cron.billing_loops.reconciliation import ReconciliationLoop
+from jobs.cron.billing_loops.predunning import PreDunningLoop
+from jobs.cron.billing_loops.revenue_share import RevenueShareLoop
+from jobs.cron.billing_loops.plan_reconciliation import PlanReconciliationLoop
+from jobs.cron.billing_loops.stripe_events_purge import StripeEventsPurgeLoop
+
+__all__ = [
+    "ReconciliationLoop",
+    "PreDunningLoop",
+    "RevenueShareLoop",
+    "PlanReconciliationLoop",
+    "StripeEventsPurgeLoop",
+]

--- a/backend/jobs/cron/billing_loops/plan_reconciliation.py
+++ b/backend/jobs/cron/billing_loops/plan_reconciliation.py
@@ -49,6 +49,17 @@ class PlanReconciliationLoop(BaseCronLoop):
         from supabase_client import get_supabase, sb_execute, sb_execute_direct
         from metrics import PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED, DB_TABLE_SIZE_BYTES
 
+        try:
+            return await self._do_reconciliation(sb_execute, sb_execute_direct, get_supabase,
+                                                  PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED,
+                                                  DB_TABLE_SIZE_BYTES)
+        except Exception as e:
+            logger.error("DEBT-010: Plan reconciliation error: %s", e)
+            return {"status": "error", "error": str(e)}
+
+    async def _do_reconciliation(self, sb_execute, sb_execute_direct, get_supabase,
+                                  PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED,
+                                  DB_TABLE_SIZE_BYTES) -> dict:
         sb = get_supabase()
         profiles_result = await sb_execute(sb.table("profiles").select("id, plan_type"))
         profiles = {p["id"]: p["plan_type"] for p in (profiles_result.data or [])}

--- a/backend/jobs/cron/billing_loops/plan_reconciliation.py
+++ b/backend/jobs/cron/billing_loops/plan_reconciliation.py
@@ -66,44 +66,17 @@ class PlanReconciliationLoop(BaseCronLoop):
         subs_result = await sb_execute(sb.table("user_subscriptions").select("user_id, plan_id").eq("is_active", True))
         subs = {s["user_id"]: s["plan_id"] for s in (subs_result.data or [])}
 
-        drift_details = []
-        auto_healed = 0
-        for user_id, plan_type in profiles.items():
-            sub_plan = subs.get(user_id)
-            if sub_plan is None:
-                if plan_type not in ("free_trial", "cancelled", None, ""):
-                    drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": None, "direction": "orphan_profile"})
-                    PLAN_RECONCILIATION_DRIFT.labels(direction="orphan_profile").inc()
-                    try:
-                        await sb_execute(sb.table("profiles").update({"plan_type": "free_trial"}).eq("id", user_id))
-                        auto_healed += 1
-                        PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="orphan_profile").inc()
-                    except Exception as heal_err:
-                        logger.warning("DEBT-010: auto-heal failed for orphan %s: %s", user_id[:8], heal_err)
-            elif plan_type != sub_plan:
-                drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": sub_plan, "direction": "profiles_stale"})
-                PLAN_RECONCILIATION_DRIFT.labels(direction="profiles_stale").inc()
-                try:
-                    await sb_execute(sb.table("profiles").update({"plan_type": sub_plan}).eq("id", user_id))
-                    auto_healed += 1
-                    PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="profiles_stale").inc()
-                except Exception as heal_err:
-                    logger.warning("DEBT-010: auto-heal failed for %s: %s", user_id[:8], heal_err)
+        drift_details, auto_healed = await self._detect_and_heal_drifts(
+            profiles, subs, sb, sb_execute,
+            PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED,
+        )
 
         if drift_details:
             logger.warning("DEBT-010: %d drifts, auto-healed %d: %s", len(drift_details), auto_healed, drift_details[:5])
         else:
             logger.info("DEBT-010: clean — %d profiles, %d active subs", len(profiles), len(subs))
 
-        # Table size metrics
-        for table_name in _MONITORED_TABLES:
-            try:
-                size_result = await sb_execute_direct(sb.rpc("pg_total_relation_size_safe", {"tbl": table_name}))
-                if size_result and size_result.data is not None:
-                    sz = int(size_result.data) if not isinstance(size_result.data, list) else (int(size_result.data[0]) if size_result.data else 0)
-                    DB_TABLE_SIZE_BYTES.labels(table_name=table_name).set(sz)
-            except Exception:
-                pass
+        await self._update_table_sizes(sb, sb_execute_direct, DB_TABLE_SIZE_BYTES)
 
         return {
             "status": "completed", "total_profiles": len(profiles),
@@ -112,3 +85,47 @@ class PlanReconciliationLoop(BaseCronLoop):
             "drift_details": drift_details[:20],
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }
+
+    async def _detect_and_heal_drifts(
+        self, profiles: dict, subs: dict, sb, sb_execute,
+        drift_metric, healed_metric,
+    ) -> tuple[list[dict], int]:
+        """Iterate profiles, detect drifts and auto-heal where possible.
+
+        Returns (drift_details, auto_healed_count).
+        """
+        drift_details: list[dict] = []
+        auto_healed = 0
+        for user_id, plan_type in profiles.items():
+            sub_plan = subs.get(user_id)
+            if sub_plan is None:
+                if plan_type not in ("free_trial", "cancelled", None, ""):
+                    drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": None, "direction": "orphan_profile"})
+                    drift_metric.labels(direction="orphan_profile").inc()
+                    try:
+                        await sb_execute(sb.table("profiles").update({"plan_type": "free_trial"}).eq("id", user_id))
+                        auto_healed += 1
+                        healed_metric.labels(direction="orphan_profile").inc()
+                    except Exception as heal_err:
+                        logger.warning("DEBT-010: auto-heal failed for orphan %s: %s", user_id[:8], heal_err)
+            elif plan_type != sub_plan:
+                drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": sub_plan, "direction": "profiles_stale"})
+                drift_metric.labels(direction="profiles_stale").inc()
+                try:
+                    await sb_execute(sb.table("profiles").update({"plan_type": sub_plan}).eq("id", user_id))
+                    auto_healed += 1
+                    healed_metric.labels(direction="profiles_stale").inc()
+                except Exception as heal_err:
+                    logger.warning("DEBT-010: auto-heal failed for %s: %s", user_id[:8], heal_err)
+        return drift_details, auto_healed
+
+    async def _update_table_sizes(self, sb, sb_execute_direct, size_gauge) -> None:
+        """Update Prometheus table-size gauges for monitored tables."""
+        for table_name in _MONITORED_TABLES:
+            try:
+                size_result = await sb_execute_direct(sb.rpc("pg_total_relation_size_safe", {"tbl": table_name}))
+                if size_result and size_result.data is not None:
+                    sz = int(size_result.data) if not isinstance(size_result.data, list) else (int(size_result.data[0]) if size_result.data else 0)
+                    size_gauge.labels(table_name=table_name).set(sz)
+            except Exception:
+                pass

--- a/backend/jobs/cron/billing_loops/plan_reconciliation.py
+++ b/backend/jobs/cron/billing_loops/plan_reconciliation.py
@@ -1,0 +1,101 @@
+"""PlanReconciliationLoop — Profile/plan drift detection + auto-heal (DEBT-010)."""
+import logging
+from datetime import datetime, timezone
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+PLAN_RECONCILIATION_LOCK_KEY = "smartlic:plan_reconciliation:lock"
+PLAN_RECONCILIATION_LOCK_TTL = 10 * 60
+PLAN_RECONCILIATION_INTERVAL = 12 * 60 * 60
+
+_MONITORED_TABLES = [
+    "search_results_cache", "search_results_store", "search_sessions",
+    "stripe_webhook_events", "profiles", "user_subscriptions",
+    "conversations", "messages", "alert_runs", "classification_feedback",
+]
+
+
+class PlanReconciliationLoop(BaseCronLoop):
+    """Detect and auto-heal drifts between profiles.plan_type and subscription plans.
+
+    Runs every 12h: compares profile plan_type vs user_subscriptions, logs
+    drifts, auto-heals where possible (orphan profiles -> free_trial, stale
+    profiles -> align with subscription).  Also updates Prometheus table-size
+    gauges for monitored tables.
+    """
+
+    name = "plan_reconciliation"
+    interval_seconds = PLAN_RECONCILIATION_INTERVAL
+    lock_key = PLAN_RECONCILIATION_LOCK_KEY
+    lock_ttl = PLAN_RECONCILIATION_LOCK_TTL
+    initial_delay = 300.0
+    error_retry_seconds = 300.0
+
+    async def run_once(self) -> dict:
+        locked = await self._acquire_lock()
+        if not locked:
+            logger.info("DEBT-010: Plan reconciliation skipped — lock held")
+            return {"status": "skipped", "reason": "lock_held"}
+        try:
+            return await self._run_reconciliation()
+        finally:
+            await self._release_lock()
+
+    async def _run_reconciliation(self) -> dict:
+        from supabase_client import get_supabase, sb_execute, sb_execute_direct
+        from metrics import PLAN_RECONCILIATION_RUNS, PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED, DB_TABLE_SIZE_BYTES
+
+        PLAN_RECONCILIATION_RUNS.inc()
+        sb = get_supabase()
+        profiles_result = await sb_execute(sb.table("profiles").select("id, plan_type"))
+        profiles = {p["id"]: p["plan_type"] for p in (profiles_result.data or [])}
+        subs_result = await sb_execute(sb.table("user_subscriptions").select("user_id, plan_id").eq("is_active", True))
+        subs = {s["user_id"]: s["plan_id"] for s in (subs_result.data or [])}
+
+        drift_details = []
+        auto_healed = 0
+        for user_id, plan_type in profiles.items():
+            sub_plan = subs.get(user_id)
+            if sub_plan is None:
+                if plan_type not in ("free_trial", "cancelled", None, ""):
+                    drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": None, "direction": "orphan_profile"})
+                    PLAN_RECONCILIATION_DRIFT.labels(direction="orphan_profile").inc()
+                    try:
+                        await sb_execute(sb.table("profiles").update({"plan_type": "free_trial"}).eq("id", user_id), category="write")
+                        auto_healed += 1
+                        PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="orphan_profile").inc()
+                    except Exception as heal_err:
+                        logger.warning("DEBT-010: auto-heal failed for orphan %s: %s", user_id[:8], heal_err)
+            elif plan_type != sub_plan:
+                drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": sub_plan, "direction": "profiles_stale"})
+                PLAN_RECONCILIATION_DRIFT.labels(direction="profiles_stale").inc()
+                try:
+                    await sb_execute(sb.table("profiles").update({"plan_type": sub_plan}).eq("id", user_id), category="write")
+                    auto_healed += 1
+                    PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="profiles_stale").inc()
+                except Exception as heal_err:
+                    logger.warning("DEBT-010: auto-heal failed for %s: %s", user_id[:8], heal_err)
+
+        if drift_details:
+            logger.warning("DEBT-010: %d drifts, auto-healed %d: %s", len(drift_details), auto_healed, drift_details[:5])
+        else:
+            logger.info("DEBT-010: clean — %d profiles, %d active subs", len(profiles), len(subs))
+
+        # Table size metrics
+        for table_name in _MONITORED_TABLES:
+            try:
+                size_result = await sb_execute_direct(sb.rpc("pg_total_relation_size_safe", {"tbl": table_name}))
+                if size_result and size_result.data is not None:
+                    sz = int(size_result.data) if not isinstance(size_result.data, list) else (int(size_result.data[0]) if size_result.data else 0)
+                    DB_TABLE_SIZE_BYTES.labels(table_name=table_name).set(sz)
+            except Exception:
+                pass
+
+        return {
+            "status": "completed", "total_profiles": len(profiles),
+            "total_active_subs": len(subs), "drift_count": len(drift_details),
+            "auto_healed": auto_healed,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }

--- a/backend/jobs/cron/billing_loops/plan_reconciliation.py
+++ b/backend/jobs/cron/billing_loops/plan_reconciliation.py
@@ -97,5 +97,6 @@ class PlanReconciliationLoop(BaseCronLoop):
             "status": "completed", "total_profiles": len(profiles),
             "total_active_subs": len(subs), "drift_count": len(drift_details),
             "auto_healed": auto_healed,
+            "drift_details": drift_details[:20],
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }

--- a/backend/jobs/cron/billing_loops/plan_reconciliation.py
+++ b/backend/jobs/cron/billing_loops/plan_reconciliation.py
@@ -34,6 +34,8 @@ class PlanReconciliationLoop(BaseCronLoop):
     error_retry_seconds = 300.0
 
     async def run_once(self) -> dict:
+        from metrics import PLAN_RECONCILIATION_RUNS
+        PLAN_RECONCILIATION_RUNS.inc()
         locked = await self._acquire_lock()
         if not locked:
             logger.info("DEBT-010: Plan reconciliation skipped — lock held")
@@ -45,9 +47,8 @@ class PlanReconciliationLoop(BaseCronLoop):
 
     async def _run_reconciliation(self) -> dict:
         from supabase_client import get_supabase, sb_execute, sb_execute_direct
-        from metrics import PLAN_RECONCILIATION_RUNS, PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED, DB_TABLE_SIZE_BYTES
+        from metrics import PLAN_RECONCILIATION_DRIFT, PLAN_RECONCILIATION_AUTO_HEALED, DB_TABLE_SIZE_BYTES
 
-        PLAN_RECONCILIATION_RUNS.inc()
         sb = get_supabase()
         profiles_result = await sb_execute(sb.table("profiles").select("id, plan_type"))
         profiles = {p["id"]: p["plan_type"] for p in (profiles_result.data or [])}

--- a/backend/jobs/cron/billing_loops/plan_reconciliation.py
+++ b/backend/jobs/cron/billing_loops/plan_reconciliation.py
@@ -63,7 +63,7 @@ class PlanReconciliationLoop(BaseCronLoop):
                     drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": None, "direction": "orphan_profile"})
                     PLAN_RECONCILIATION_DRIFT.labels(direction="orphan_profile").inc()
                     try:
-                        await sb_execute(sb.table("profiles").update({"plan_type": "free_trial"}).eq("id", user_id), category="write")
+                        await sb_execute(sb.table("profiles").update({"plan_type": "free_trial"}).eq("id", user_id))
                         auto_healed += 1
                         PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="orphan_profile").inc()
                     except Exception as heal_err:
@@ -72,7 +72,7 @@ class PlanReconciliationLoop(BaseCronLoop):
                 drift_details.append({"user_id": user_id[:8] + "...", "profile_plan": plan_type, "sub_plan": sub_plan, "direction": "profiles_stale"})
                 PLAN_RECONCILIATION_DRIFT.labels(direction="profiles_stale").inc()
                 try:
-                    await sb_execute(sb.table("profiles").update({"plan_type": sub_plan}).eq("id", user_id), category="write")
+                    await sb_execute(sb.table("profiles").update({"plan_type": sub_plan}).eq("id", user_id))
                     auto_healed += 1
                     PLAN_RECONCILIATION_AUTO_HEALED.labels(direction="profiles_stale").inc()
                 except Exception as heal_err:

--- a/backend/jobs/cron/billing_loops/predunning.py
+++ b/backend/jobs/cron/billing_loops/predunning.py
@@ -1,0 +1,91 @@
+"""PreDunningLoop — Card expiry pre-dunning check (STORY-309)."""
+import logging
+from datetime import datetime, timezone, timedelta
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+PRE_DUNNING_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+class PreDunningLoop(BaseCronLoop):
+    """Check for cards expiring in ~7 days and send pre-dunning emails."""
+
+    name = "pre_dunning"
+    interval_seconds = PRE_DUNNING_INTERVAL_SECONDS
+    initial_delay = 120.0
+    error_retry_seconds = 60.0
+
+    async def run_once(self) -> dict:
+        import os
+        try:
+            import stripe
+            stripe_key = os.getenv("STRIPE_SECRET_KEY", "")
+            if not stripe_key:
+                return {"sent": 0, "skipped": 0, "errors": 0, "disabled": True}
+
+            from supabase_client import get_supabase, sb_execute
+            from services.dunning import send_pre_dunning_email
+
+            sb = get_supabase()
+            now = datetime.now(timezone.utc)
+            target_date = now + timedelta(days=7)
+            sent = skipped = errors = 0
+
+            subs_result = await sb_execute(
+                sb.table("user_subscriptions")
+                .select("user_id, stripe_customer_id")
+                .eq("is_active", True).eq("subscription_status", "active")
+                .not_.is_("stripe_customer_id", "null")
+            )
+            if not subs_result.data:
+                return {"sent": 0, "skipped": 0, "errors": 0}
+
+            for sub in subs_result.data:
+                try:
+                    customer_id = sub.get("stripe_customer_id")
+                    user_id = sub.get("user_id")
+                    if not customer_id or not user_id:
+                        continue
+
+                    customer = stripe.Customer.retrieve(
+                        customer_id, api_key=stripe_key,
+                        expand=["default_source", "invoice_settings.default_payment_method"],
+                    )
+                    pm = customer.get("invoice_settings", {}).get("default_payment_method")
+                    card_info = None
+                    if pm and hasattr(pm, "card"):
+                        card_info = pm.card
+                    elif customer.get("default_source") and hasattr(customer.default_source, "exp_month"):
+                        card_info = customer.default_source
+
+                    if not card_info:
+                        skipped += 1
+                        continue
+
+                    exp_month = getattr(card_info, "exp_month", None) or card_info.get("exp_month")
+                    exp_year = getattr(card_info, "exp_year", None) or card_info.get("exp_year")
+                    last4 = getattr(card_info, "last4", None) or card_info.get("last4", "****")
+                    if not exp_month or not exp_year:
+                        skipped += 1
+                        continue
+
+                    if exp_year == target_date.year and exp_month == target_date.month:
+                        await send_pre_dunning_email(user_id, last4, exp_month, exp_year)
+                        sent += 1
+                    else:
+                        skipped += 1
+                except Exception:
+                    errors += 1
+
+            logger.info("Pre-dunning: sent=%d skipped=%d errors=%d", sent, skipped, errors)
+            return {"sent": sent, "skipped": skipped, "errors": errors}
+        except Exception as e:
+            err_name = type(e).__name__
+            err_str = str(e)
+            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
+                logger.warning("Pre-dunning skipped (Supabase unavailable): %s", e)
+            else:
+                logger.error("Pre-dunning error: %s", e, exc_info=True)
+            return {"sent": 0, "skipped": 0, "errors": 1, "error": str(e)}

--- a/backend/jobs/cron/billing_loops/predunning.py
+++ b/backend/jobs/cron/billing_loops/predunning.py
@@ -19,20 +19,26 @@ class PreDunningLoop(BaseCronLoop):
 
     async def run_once(self) -> dict:
         import os
+        stripe_key = os.getenv("STRIPE_SECRET_KEY", "")
+        if not stripe_key:
+            return {"sent": 0, "skipped": 0, "errors": 0, "disabled": True}
+
+        from supabase_client import get_supabase, sb_execute
+        from services.dunning import send_pre_dunning_email
+
+        sb = get_supabase()
+        subs = await self._fetch_active_subscriptions(sb, sb_execute)
+        if subs is None:
+            return {"sent": 0, "skipped": 0, "errors": 0}
+
+        return await self._process_cards(subs, stripe_key, sb_execute, send_pre_dunning_email)
+
+    async def _fetch_active_subscriptions(self, sb, sb_execute) -> list | None:
+        """Fetch active subscriptions that have a Stripe customer ID.
+
+        Returns the data list, or None if the result set is empty.
+        """
         try:
-            import stripe
-            stripe_key = os.getenv("STRIPE_SECRET_KEY", "")
-            if not stripe_key:
-                return {"sent": 0, "skipped": 0, "errors": 0, "disabled": True}
-
-            from supabase_client import get_supabase, sb_execute
-            from services.dunning import send_pre_dunning_email
-
-            sb = get_supabase()
-            now = datetime.now(timezone.utc)
-            target_date = now + timedelta(days=7)
-            sent = skipped = errors = 0
-
             subs_result = await sb_execute(
                 sb.table("user_subscriptions")
                 .select("user_id, stripe_customer_id")
@@ -40,52 +46,70 @@ class PreDunningLoop(BaseCronLoop):
                 .not_.is_("stripe_customer_id", "null")
             )
             if not subs_result.data:
-                return {"sent": 0, "skipped": 0, "errors": 0}
-
-            for sub in subs_result.data:
-                try:
-                    customer_id = sub.get("stripe_customer_id")
-                    user_id = sub.get("user_id")
-                    if not customer_id or not user_id:
-                        continue
-
-                    customer = stripe.Customer.retrieve(
-                        customer_id, api_key=stripe_key,
-                        expand=["default_source", "invoice_settings.default_payment_method"],
-                    )
-                    pm = customer.get("invoice_settings", {}).get("default_payment_method")
-                    card_info = None
-                    if pm and hasattr(pm, "card"):
-                        card_info = pm.card
-                    elif customer.get("default_source") and hasattr(customer.default_source, "exp_month"):
-                        card_info = customer.default_source
-
-                    if not card_info:
-                        skipped += 1
-                        continue
-
-                    exp_month = getattr(card_info, "exp_month", None) or card_info.get("exp_month")
-                    exp_year = getattr(card_info, "exp_year", None) or card_info.get("exp_year")
-                    last4 = getattr(card_info, "last4", None) or card_info.get("last4", "****")
-                    if not exp_month or not exp_year:
-                        skipped += 1
-                        continue
-
-                    if exp_year == target_date.year and exp_month == target_date.month:
-                        await send_pre_dunning_email(user_id, last4, exp_month, exp_year)
-                        sent += 1
-                    else:
-                        skipped += 1
-                except Exception:
-                    errors += 1
-
-            logger.info("Pre-dunning: sent=%d skipped=%d errors=%d", sent, skipped, errors)
-            return {"sent": sent, "skipped": skipped, "errors": errors}
+                return None
+            return subs_result.data
         except Exception as e:
-            err_name = type(e).__name__
-            err_str = str(e)
-            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
-                logger.warning("Pre-dunning skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error("Pre-dunning error: %s", e, exc_info=True)
-            return {"sent": 0, "skipped": 0, "errors": 1, "error": str(e)}
+            raise e
+
+    async def _process_cards(self, subs: list, stripe_key: str, sb_execute, send_pre_dunning_email) -> dict:
+        """Iterate subscriptions, check card expiry, and send pre-dunning emails."""
+        now = datetime.now(timezone.utc)
+        target_date = now + timedelta(days=7)
+        sent = skipped = errors = 0
+
+        for sub in subs:
+            try:
+                customer_id = sub.get("stripe_customer_id")
+                user_id = sub.get("user_id")
+                if not customer_id or not user_id:
+                    continue
+
+                card_info = self._fetch_card_info(customer_id, stripe_key)
+                if card_info is None:
+                    skipped += 1
+                    continue
+
+                exp_month, exp_year, last4 = card_info
+                if not exp_month or not exp_year:
+                    skipped += 1
+                    continue
+
+                if exp_year == target_date.year and exp_month == target_date.month:
+                    await send_pre_dunning_email(user_id, last4, exp_month, exp_year)
+                    sent += 1
+                else:
+                    skipped += 1
+            except Exception:
+                errors += 1
+
+        logger.info("Pre-dunning: sent=%d skipped=%d errors=%d", sent, skipped, errors)
+        return {"sent": sent, "skipped": skipped, "errors": errors}
+
+    def _fetch_card_info(self, customer_id: str, stripe_key: str) -> tuple | None:
+        """Retrieve card info for a Stripe customer.
+
+        Returns (exp_month, exp_year, last4) tuple, or None if no card found.
+        """
+        import stripe
+        try:
+            customer = stripe.Customer.retrieve(
+                customer_id, api_key=stripe_key,
+                expand=["default_source", "invoice_settings.default_payment_method"],
+            )
+        except Exception:
+            return None
+
+        pm = customer.get("invoice_settings", {}).get("default_payment_method")
+        card_info = None
+        if pm and hasattr(pm, "card"):
+            card_info = pm.card
+        elif customer.get("default_source") and hasattr(customer.default_source, "exp_month"):
+            card_info = customer.default_source
+
+        if not card_info:
+            return None
+
+        exp_month = getattr(card_info, "exp_month", None) or card_info.get("exp_month")
+        exp_year = getattr(card_info, "exp_year", None) or card_info.get("exp_year")
+        last4 = getattr(card_info, "last4", None) or card_info.get("last4", "****")
+        return (exp_month, exp_year, last4)

--- a/backend/jobs/cron/billing_loops/reconciliation.py
+++ b/backend/jobs/cron/billing_loops/reconciliation.py
@@ -1,0 +1,56 @@
+"""ReconciliationLoop — Stripe <-> DB subscription reconciliation (STORY-314)."""
+import asyncio
+import logging
+from datetime import datetime, timezone, timedelta
+
+from config import RECONCILIATION_ENABLED, RECONCILIATION_HOUR_UTC
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+RECONCILIATION_LOCK_KEY = "smartlic:reconciliation:lock"
+RECONCILIATION_LOCK_TTL = 30 * 60
+
+
+class ReconciliationLoop(BaseCronLoop):
+    """Daily Stripe subscription reconciliation.
+
+    Runs at RECONCILIATION_HOUR_UTC and compares Stripe subscriptions against
+    local user_subscriptions table, reporting divergences and sending alerts.
+    """
+
+    name = "stripe_reconciliation"
+    interval_seconds = 24 * 60 * 60
+    lock_key = RECONCILIATION_LOCK_KEY
+    lock_ttl = RECONCILIATION_LOCK_TTL
+    error_retry_seconds = 300.0
+
+    async def on_startup(self) -> None:
+        """Schedule first run at the configured hour (if enabled)."""
+        if not RECONCILIATION_ENABLED:
+            logger.info("%s: disabled via config", self.name)
+            return
+        now = datetime.now(timezone.utc)
+        next_run = now.replace(hour=RECONCILIATION_HOUR_UTC, minute=0, second=0, microsecond=0)
+        if now.hour >= RECONCILIATION_HOUR_UTC:
+            next_run += timedelta(days=1)
+        delay = max(60.0, min((next_run - now).total_seconds(), 86400.0))
+        logger.info("%s: first run in %.0fs (target hour=%d UTC)", self.name, delay, RECONCILIATION_HOUR_UTC)
+        await asyncio.sleep(delay)
+
+    async def run_once(self) -> dict:
+        if not RECONCILIATION_ENABLED:
+            return {"status": "disabled", "reason": "reconciliation_disabled"}
+        locked = await self._acquire_lock()
+        if not locked:
+            logger.info("Reconciliation skipped — lock already held")
+            return {"status": "skipped", "reason": "lock_held"}
+        try:
+            from services.stripe_reconciliation import reconcile_subscriptions, save_reconciliation_report, send_reconciliation_alert
+            result = await reconcile_subscriptions()
+            await save_reconciliation_report(result)
+            await send_reconciliation_alert(result)
+            logger.info("STORY-314: checked=%d, divergences=%d", result.get("total_checked", 0), result.get("divergences_found", 0))
+            return result
+        finally:
+            await self._release_lock()

--- a/backend/jobs/cron/billing_loops/revenue_share.py
+++ b/backend/jobs/cron/billing_loops/revenue_share.py
@@ -1,0 +1,57 @@
+"""RevenueShareLoop — Monthly partner revenue share report (STORY-323)."""
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+REVENUE_SHARE_LOCK_KEY = "smartlic:revenue_share:lock"
+REVENUE_SHARE_LOCK_TTL = 30 * 60
+
+
+class RevenueShareLoop(BaseCronLoop):
+    """Monthly revenue share report generation.
+
+    Runs on the 1st of each month at ~12:00 UTC (09:00 BRT) and generates
+    revenue share reports for all active partners.
+    """
+
+    name = "revenue_share_report"
+    interval_seconds = 30 * 24 * 60 * 60  # ~monthly
+    lock_key = REVENUE_SHARE_LOCK_KEY
+    lock_ttl = REVENUE_SHARE_LOCK_TTL
+    error_retry_seconds = 3600.0
+
+    async def on_startup(self) -> None:
+        """Schedule first run on the 1st of next month at 12:00 UTC."""
+        now = datetime.now(timezone.utc)
+        target_hour = 12
+        if now.month == 12:
+            next_run = datetime(now.year + 1, 1, 1, target_hour, 0, 0, tzinfo=timezone.utc)
+        else:
+            next_run = datetime(now.year, now.month + 1, 1, target_hour, 0, 0, tzinfo=timezone.utc)
+        delay = max(60.0, min((next_run - now).total_seconds(), 31 * 86400.0))
+        logger.info("STORY-323: first run in %.0fs (target: %s)", delay, next_run.isoformat())
+        await asyncio.sleep(delay)
+
+    async def run_once(self) -> dict:
+        locked = await self._acquire_lock()
+        if not locked:
+            logger.info("STORY-323: Revenue share skipped — lock held")
+            return {"status": "skipped", "reason": "lock_held"}
+        try:
+            from services.partner_service import generate_monthly_revenue_report
+            now = datetime.now(timezone.utc)
+            report_year = now.year - 1 if now.month == 1 else now.year
+            report_month = 12 if now.month == 1 else now.month - 1
+            result = await generate_monthly_revenue_report(report_year, report_month)
+            logger.info(
+                "STORY-323: report generated — %d/%d, %d partners, total_share=R$%.2f",
+                report_month, report_year, len(result.get("partner_reports", [])),
+                result.get("total_share", 0),
+            )
+            return result
+        finally:
+            await self._release_lock()

--- a/backend/jobs/cron/billing_loops/stripe_events_purge.py
+++ b/backend/jobs/cron/billing_loops/stripe_events_purge.py
@@ -1,0 +1,40 @@
+"""StripeEventsPurgeLoop — Old Stripe webhook event cleanup (HARDEN-028)."""
+import logging
+from datetime import datetime, timezone, timedelta
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+STRIPE_EVENTS_RETENTION_DAYS = 90
+STRIPE_PURGE_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+class StripeEventsPurgeLoop(BaseCronLoop):
+    """Purge old Stripe webhook events from the database.
+
+    Runs daily and deletes ``stripe_webhook_events`` rows older than
+    ``STRIPE_EVENTS_RETENTION_DAYS`` (default 90 days).
+    """
+
+    name = "stripe_events_purge"
+    interval_seconds = STRIPE_PURGE_INTERVAL_SECONDS
+    error_retry_seconds = 300.0
+
+    async def run_once(self) -> dict:
+        try:
+            from supabase_client import get_supabase, sb_execute
+            sb = get_supabase()
+            cutoff = (datetime.now(timezone.utc) - timedelta(days=STRIPE_EVENTS_RETENTION_DAYS)).isoformat()
+            result = await sb_execute(sb.table("stripe_webhook_events").delete().lt("processed_at", cutoff))
+            deleted = len(result.data) if result and result.data else 0
+            logger.info("HARDEN-028: Purged %d events older than %d days", deleted, STRIPE_EVENTS_RETENTION_DAYS)
+            return {"deleted": deleted, "cutoff": cutoff}
+        except Exception as e:
+            err_name = type(e).__name__
+            err_str = str(e)
+            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
+                logger.warning("HARDEN-028: Purge skipped (Supabase unavailable): %s", e)
+            else:
+                logger.error("HARDEN-028: Purge error: %s", e, exc_info=True)
+            return {"deleted": 0, "error": str(e)}

--- a/backend/jobs/cron/billing_loops/stripe_events_purge.py
+++ b/backend/jobs/cron/billing_loops/stripe_events_purge.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timezone, timedelta
 
 from jobs.cron.base import BaseCronLoop
+from jobs.cron.canary import _is_cb_or_connection_error
 
 logger = logging.getLogger(__name__)
 
@@ -28,13 +29,11 @@ class StripeEventsPurgeLoop(BaseCronLoop):
             cutoff = (datetime.now(timezone.utc) - timedelta(days=STRIPE_EVENTS_RETENTION_DAYS)).isoformat()
             result = await sb_execute(sb.table("stripe_webhook_events").delete().lt("processed_at", cutoff))
             deleted = len(result.data) if result and result.data else 0
-            logger.info("HARDEN-028: Purged %d events older than %d days", deleted, STRIPE_EVENTS_RETENTION_DAYS)
+            logger.info("HARDEN-028: Purged %d Stripe webhook events older than %d days", deleted, STRIPE_EVENTS_RETENTION_DAYS)
             return {"deleted": deleted, "cutoff": cutoff}
         except Exception as e:
-            err_name = type(e).__name__
-            err_str = str(e)
-            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
-                logger.warning("HARDEN-028: Purge skipped (Supabase unavailable): %s", e)
+            if _is_cb_or_connection_error(e):
+                logger.warning("HARDEN-028: Stripe events purge skipped (Supabase unavailable): %s", e)
             else:
-                logger.error("HARDEN-028: Purge error: %s", e, exc_info=True)
+                logger.error("HARDEN-028: Stripe events purge error: %s", e, exc_info=True)
             return {"deleted": 0, "error": str(e)}

--- a/backend/jobs/cron/cron_monitor.py
+++ b/backend/jobs/cron/cron_monitor.py
@@ -1,11 +1,13 @@
-"""STORY-1.1 (EPIC-TD-2026Q2 P0): pg_cron health monitor.
+"""STORY-1.1 (EPIC-TD-2026Q2 P0): pg_cron + ARQ cron health monitor.
 
-Hourly ARQ cron that queries ``public.get_cron_health()`` and raises a
-Sentry alert for any scheduled job that either:
+Monitors two cron layers:
 
-  * has status = 'failed' on its most recent run, or
-  * has not produced a successful run for more than ``STALE_AFTER_HOURS``
-    hours (default 25h — one-day window + 1h grace).
+  1. **pg_cron** — queries ``public.get_cron_health()`` (PostgreSQL native cron)
+     and fires Sentry alerts for failed / stale scheduled jobs.
+
+  2. **ARQ cron jobs** — checks ``loop:health:*`` Redis keys written by
+     ``BaseCronLoop`` subclasses (Issue #1781 AC5.6) and ``arq:job-result:*``
+     keys for pure ARQ schedules.
 
 Dedup: ``sentry_sdk.push_scope`` + ``fingerprint=['cron_job', jobname]``
 prevents spam when a job fails repeatedly for the same reason.
@@ -180,29 +182,198 @@ def evaluate_jobs(rows: Iterable[dict[str, Any]], *, now: datetime | None = None
     return problems
 
 
+# ── ARQ cron job health checking (Issue #1781 AC5.6) ────────────────────────
+
+# Known ARQ cron job function names that should be monitored.
+# These are the function names registered in ``_worker_cron_jobs`` in
+# ``jobs/queue/config.py``.
+_ARQ_KNOWN_CRONS: list[str] = [
+    "daily_digest_job",
+    "email_alerts_job",
+    "predictive_alert_job",
+    "cron_monitoring_job",
+    "founders_auto_disable_check",
+    "gsc_sync_job",
+    "aggregate_and_cleanup_network_events",
+    "ingestion_full_crawl_job",
+    "ingestion_incremental_job",
+    "ingestion_purge_job",
+    "contracts_full_crawl_job",
+    "contracts_incremental_job",
+    "enrich_entities_job",
+    "enrich_municipios_job",
+    "enrich_pncp_ibge_codes_job",
+    "run_competitive_alert_detection",
+    "run_competitive_alert_weekly_digest",
+]
+
+# How long an ARQ cron job can go without reporting health before being
+# considered stale.  Daily jobs → 25h, weekly jobs → 8d, monthly → 35d.
+_ARQ_STALE_HOURS: dict[str, float] = {
+    "ingestion_full_crawl_job": 8 * 24,        # weekly-ish
+    "contracts_full_crawl_job": 8 * 24,         # 3x/week
+    "gsc_sync_job": 8 * 24,                     # weekly (sun)
+    "aggregate_and_cleanup_network_events": 8 * 24,  # weekly (sun)
+    "run_competitive_alert_weekly_digest": 8 * 24,   # weekly (mon)
+    "enrich_entities_job": 3 * 24,              # daily-ish
+    "enrich_municipios_job": 3 * 24,            # daily-ish
+    "enrich_pncp_ibge_codes_job": 3 * 24,       # daily-ish
+}
+_LOOP_HEALTH_PREFIX = "loop:health:"
+
+
+async def _check_arq_cron_health() -> list[dict[str, Any]]:
+    """Check health of ARQ cron jobs via ``loop:health:*`` Redis keys.
+
+    Iterates known ARQ cron job names and checks their last health report
+    in Redis.  Falls back to scanning ``arq:job-result:*`` when a health
+    key is missing.
+
+    Returns:
+        List of ``{jobname, reason, row}`` dicts for unhealthy jobs.
+    """
+    problems: list[dict[str, Any]] = []
+    now = datetime.now(timezone.utc)
+
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+        if not redis:
+            logger.warning("[ArqCronMonitor] Redis unavailable — skipping ARQ health check")
+            return problems
+    except Exception:
+        return problems
+
+    for name in _ARQ_KNOWN_CRONS:
+        try:
+            health_data = await redis.hgetall(f"{_LOOP_HEALTH_PREFIX}{name}")
+        except Exception:
+            continue
+
+        stale_hours = _ARQ_STALE_HOURS.get(name, 25.0)  # default 25h
+
+        if not health_data:
+            # No health key — check if there's a recent job result in ARQ
+            try:
+                cursor, keys = await redis.scan(
+                    cursor=0, match="arq:job-result:*", count=500,
+                )
+                found = False
+                for key in keys:
+                    result_data = await redis.hgetall(key)
+                    if result_data and result_data.get(b"function") == name.encode():
+                        found = True
+                        # Parse completion time
+                        finish_ts = result_data.get(b"finish_time") or result_data.get(b"job_try")
+                        if finish_ts:
+                            try:
+                                finish_dt = datetime.fromtimestamp(float(finish_ts), tz=timezone.utc)
+                                delta_h = (now - finish_dt).total_seconds() / 3600.0
+                                if delta_h <= stale_hours:
+                                    found = True
+                                    break
+                                # Found but stale
+                                problems.append({
+                                    "jobname": name,
+                                    "reason": f"arq_stale ({delta_h:.1f}h > {stale_hours}h)",
+                                    "row": {"jobname": name, "last_status": "stale"},
+                                })
+                                found = True
+                                break
+                            except (ValueError, TypeError):
+                                continue
+                if not found:
+                    problems.append({
+                        "jobname": name,
+                        "reason": "arq_no_recent_result",
+                        "row": {"jobname": name, "last_status": "no_data"},
+                    })
+            except Exception:
+                problems.append({
+                    "jobname": name,
+                    "reason": "arq_health_scan_error",
+                    "row": {"jobname": name, "last_status": "error"},
+                })
+            continue
+
+        # Parse health hash fields (keys may be bytes)
+        last_status = _decode_redis(health_data.get(b"last_status") or health_data.get("last_status"), "unknown")
+        last_error = _decode_redis(health_data.get(b"last_error") or health_data.get("last_error"), "")
+        last_str = _decode_redis(health_data.get(b"last_run_at") or health_data.get("last_run_at"), "")
+
+        if last_status == "error":
+            problems.append({
+                "jobname": name,
+                "reason": f"arq_last_status=error: {last_error[:200]}",
+                "row": {"jobname": name, "last_status": last_status, "last_error": last_error},
+            })
+            continue
+
+        # Check staleness
+        if last_str:
+            try:
+                last_dt = datetime.fromisoformat(last_str.replace("Z", "+00:00"))
+                delta_h = (now - last_dt).total_seconds() / 3600.0
+                if delta_h > stale_hours:
+                    problems.append({
+                        "jobname": name,
+                        "reason": f"arq_stale ({delta_h:.1f}h > {stale_hours}h)",
+                        "row": {"jobname": name, "last_status": last_status, "last_run_at": last_str},
+                    })
+            except (ValueError, TypeError):
+                pass
+
+    return problems
+
+
+def _decode_redis(value: Any, default: str = "") -> str:
+    """Decode bytes to str; return default for None/empty."""
+    if value is None:
+        return default
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
 async def run_cron_monitor() -> dict:
-    """Core monitoring logic: query get_cron_health() and fire alerts for problems.
+    """Core monitoring logic: query get_cron_health() + ARQ health and fire alerts.
 
     Public interface for tests and direct invocation. Returns::
 
         {"status": "ok", "jobs_checked": N, "alerts_fired": M}
         {"status": "error", "jobs_checked": 0, "alerts_fired": 0, "error": "..."}
     """
+    problems: list[dict[str, Any]] = []
+    pg_rows: list[dict[str, Any]] = []
+    pg_cron_error: str | None = None
+
     try:
         sb = get_supabase()
         result = await sb_execute_direct(sb.rpc("get_cron_health"))
-        rows = getattr(result, "data", None) or []
+        pg_rows = getattr(result, "data", None) or []
     except Exception as exc:
-        logger.error("[CronMonitor] RPC failed: %s", exc, exc_info=True)
-        return {"status": "error", "jobs_checked": 0, "alerts_fired": 0, "error": str(exc)}
+        pg_cron_error = str(exc)
+        logger.error("[CronMonitor] pg_cron RPC failed: %s", exc, exc_info=True)
+        problems.append({"jobname": "_pg_cron_rpc", "reason": f"rpc_error:{type(exc).__name__}", "row": {"error": str(exc)}})
 
-    problems = evaluate_jobs(rows)
+    # Evaluate pg_cron jobs
+    problems.extend(evaluate_jobs(pg_rows))
+
+    # Evaluate ARQ cron jobs (Issue #1781 AC5.6)
+    try:
+        arq_problems = await _check_arq_cron_health()
+        problems.extend(arq_problems)
+    except Exception as exc:
+        logger.error("[CronMonitor] ARQ health check failed: %s", exc, exc_info=True)
+        problems.append({"jobname": "_arq_health", "reason": f"check_error:{type(exc).__name__}", "row": {"error": str(exc)}})
+
     for p in problems:
         _fire_sentry_alert(p["jobname"], p["reason"], p["row"])
 
     logger.info(
-        "[CronMonitor] Evaluated %d jobs, %d problems",
-        len(rows),
+        "[CronMonitor] Evaluated %d pg_cron + %d ARQ jobs, %d problems",
+        len(pg_rows),
+        len(_ARQ_KNOWN_CRONS),
         len(problems),
     )
     if problems:
@@ -210,11 +381,18 @@ async def run_cron_monitor() -> dict:
             "[CronMonitor] Problem jobs: %s",
             [{"jobname": p["jobname"], "reason": p["reason"]} for p in problems],
         )
-    return {
-        "status": "ok",
-        "jobs_checked": len(rows),
+
+    # backward compat: when pg_cron RPC fails, return error status with error message
+    status = "error" if pg_cron_error else "ok"
+    result: dict[str, Any] = {
+        "status": status,
+        "jobs_checked": len(pg_rows),
+        "arq_jobs_checked": len(_ARQ_KNOWN_CRONS),
         "alerts_fired": len(problems),
     }
+    if pg_cron_error:
+        result["error"] = pg_cron_error
+    return result
 
 
 async def _cron_monitor_loop() -> None:
@@ -244,23 +422,37 @@ async def start_cron_monitor_task() -> asyncio.Task:
 async def cron_monitoring_job(ctx: dict) -> dict:
     """ARQ cron handler: scheduled hourly (minute=0).
 
+    Checks both pg_cron health (``get_cron_health()`` RPC) and ARQ cron
+    job health (``loop:health:*`` Redis keys per Issue #1781 AC5.6).
+
     Returns a summary dict so the ARQ result store surfaces health without
     requiring the Sentry/dashboard side-channel.
     """
     start = time.monotonic()
+    problems: list[dict[str, Any]] = []
+    pg_rows: list[dict[str, Any]] = []
+    pg_cron_error: str | None = None
+
     try:
         sb = get_supabase()
         result = await sb_execute_direct(sb.rpc("get_cron_health"))
-        rows = getattr(result, "data", None) or []
+        pg_rows = getattr(result, "data", None) or []
     except Exception as exc:
-        duration_s = round(time.monotonic() - start, 2)
-        logger.error("[CronMonitor] RPC failed: %s", exc, exc_info=True)
-        # Surface the monitoring failure itself so Sentry doesn't stay quiet
-        # while the underlying signal is blind.
+        pg_cron_error = str(exc)
+        logger.error("[CronMonitor] pg_cron RPC failed: %s", exc, exc_info=True)
         _fire_sentry_alert("_monitor_self", f"rpc_error:{type(exc).__name__}", {"error": str(exc)})
-        return {"status": "failed", "error": str(exc), "duration_s": duration_s}
+        # Don't add _pg_cron_rpc to problems — _monitor_self covers it (avoids double-fire).
 
-    problems = evaluate_jobs(rows)
+    try:
+        arq_problems = await _check_arq_cron_health()
+        problems.extend(arq_problems)
+    except Exception as exc:
+        logger.error("[CronMonitor] ARQ health check failed: %s", exc, exc_info=True)
+        problems.append({"jobname": "_arq_health", "reason": f"check_error:{type(exc).__name__}", "row": {"error": str(exc)}})
+
+    if not pg_cron_error:
+        problems.extend(evaluate_jobs(pg_rows))
+
     for p in problems:
         _fire_sentry_alert(p["jobname"], p["reason"], p["row"])
 
@@ -268,22 +460,24 @@ async def cron_monitoring_job(ctx: dict) -> dict:
     problem_names = [p["jobname"] for p in problems]
     if problems:
         logger.warning(
-            "[CronMonitor] Evaluated %d jobs, %d problems in %ss: %s",
-            len(rows),
-            len(problems),
-            duration_s,
-            problem_names,
+            "[CronMonitor] Evaluated %d jobs (pg_cron=%d, arq=%d), %d problems in %ss: %s",
+            len(pg_rows), len(pg_rows), len(_ARQ_KNOWN_CRONS),
+            len(problems), duration_s, problem_names,
         )
     else:
         logger.info(
-            "[CronMonitor] Evaluated %d jobs, 0 problems in %ss",
-            len(rows),
-            duration_s,
+            "[CronMonitor] Evaluated %d jobs (pg_cron=%d, arq=%d), 0 problems in %ss",
+            len(pg_rows), len(pg_rows), len(_ARQ_KNOWN_CRONS), duration_s,
         )
-    return {
-        "status": "completed",
-        "evaluated": len(rows),
+    status = "failed" if pg_cron_error else "completed"
+    result: dict[str, Any] = {
+        "status": status,
+        "evaluated": len(pg_rows),
+        "arq_jobs_evaluated": len(_ARQ_KNOWN_CRONS),
         "problems": len(problems),
         "problem_jobs": problem_names,
         "duration_s": duration_s,
     }
+    if pg_cron_error:
+        result["error"] = pg_cron_error
+    return result

--- a/backend/jobs/cron/cron_monitor.py
+++ b/backend/jobs/cron/cron_monitor.py
@@ -488,13 +488,13 @@ async def cron_monitoring_job(ctx: dict) -> dict:
     if problems:
         logger.warning(
             "[CronMonitor] Evaluated %d jobs (pg_cron=%d, arq=%d), %d problems in %ss: %s",
-            len(pg_rows), len(pg_rows), len(_ARQ_KNOWN_CRONS),
+            len(pg_rows) + len(_ARQ_KNOWN_CRONS), len(pg_rows), len(_ARQ_KNOWN_CRONS),
             len(problems), duration_s, problem_names,
         )
     else:
         logger.info(
             "[CronMonitor] Evaluated %d jobs (pg_cron=%d, arq=%d), 0 problems in %ss",
-            len(pg_rows), len(pg_rows), len(_ARQ_KNOWN_CRONS), duration_s,
+            len(pg_rows) + len(_ARQ_KNOWN_CRONS), len(pg_rows), len(_ARQ_KNOWN_CRONS), duration_s,
         )
     status = "failed" if pg_cron_error else "completed"
     result: dict[str, Any] = {

--- a/backend/jobs/cron/cron_monitor.py
+++ b/backend/jobs/cron/cron_monitor.py
@@ -232,98 +232,125 @@ async def _check_arq_cron_health() -> list[dict[str, Any]]:
     Returns:
         List of ``{jobname, reason, row}`` dicts for unhealthy jobs.
     """
-    problems: list[dict[str, Any]] = []
     now = datetime.now(timezone.utc)
+    redis = await _get_redis_for_health()
+    if redis is None:
+        return []
 
-    try:
-        from redis_pool import get_redis_pool
-        redis = await get_redis_pool()
-        if not redis:
-            logger.warning("[ArqCronMonitor] Redis unavailable — skipping ARQ health check")
-            return problems
-    except Exception:
-        return problems
-
+    problems: list[dict[str, Any]] = []
     for name in _ARQ_KNOWN_CRONS:
         try:
             health_data = await redis.hgetall(f"{_LOOP_HEALTH_PREFIX}{name}")
         except Exception:
             continue
+        stale_hours = _ARQ_STALE_HOURS.get(name, 25.0)
 
-        stale_hours = _ARQ_STALE_HOURS.get(name, 25.0)  # default 25h
+        if health_data:
+            problem = _evaluate_arq_health_key(name, health_data, now, stale_hours)
+        else:
+            problem = await _evaluate_arq_fallback(name, redis, now, stale_hours)
 
-        if not health_data:
-            # No health key — check if there's a recent job result in ARQ
-            try:
-                cursor, keys = await redis.scan(
-                    cursor=0, match="arq:job-result:*", count=500,
-                )
-                found = False
-                for key in keys:
-                    result_data = await redis.hgetall(key)
-                    if result_data and result_data.get(b"function") == name.encode():
-                        found = True
-                        # Parse completion time
-                        finish_ts = result_data.get(b"finish_time") or result_data.get(b"job_try")
-                        if finish_ts:
-                            try:
-                                finish_dt = datetime.fromtimestamp(float(finish_ts), tz=timezone.utc)
-                                delta_h = (now - finish_dt).total_seconds() / 3600.0
-                                if delta_h <= stale_hours:
-                                    found = True
-                                    break
-                                # Found but stale
-                                problems.append({
-                                    "jobname": name,
-                                    "reason": f"arq_stale ({delta_h:.1f}h > {stale_hours}h)",
-                                    "row": {"jobname": name, "last_status": "stale"},
-                                })
-                                found = True
-                                break
-                            except (ValueError, TypeError):
-                                continue
-                if not found:
-                    problems.append({
-                        "jobname": name,
-                        "reason": "arq_no_recent_result",
-                        "row": {"jobname": name, "last_status": "no_data"},
-                    })
-            except Exception:
-                problems.append({
-                    "jobname": name,
-                    "reason": "arq_health_scan_error",
-                    "row": {"jobname": name, "last_status": "error"},
-                })
-            continue
-
-        # Parse health hash fields (keys may be bytes)
-        last_status = _decode_redis(health_data.get(b"last_status") or health_data.get("last_status"), "unknown")
-        last_error = _decode_redis(health_data.get(b"last_error") or health_data.get("last_error"), "")
-        last_str = _decode_redis(health_data.get(b"last_run_at") or health_data.get("last_run_at"), "")
-
-        if last_status == "error":
-            problems.append({
-                "jobname": name,
-                "reason": f"arq_last_status=error: {last_error[:200]}",
-                "row": {"jobname": name, "last_status": last_status, "last_error": last_error},
-            })
-            continue
-
-        # Check staleness
-        if last_str:
-            try:
-                last_dt = datetime.fromisoformat(last_str.replace("Z", "+00:00"))
-                delta_h = (now - last_dt).total_seconds() / 3600.0
-                if delta_h > stale_hours:
-                    problems.append({
-                        "jobname": name,
-                        "reason": f"arq_stale ({delta_h:.1f}h > {stale_hours}h)",
-                        "row": {"jobname": name, "last_status": last_status, "last_run_at": last_str},
-                    })
-            except (ValueError, TypeError):
-                pass
+        if problem:
+            problems.append(problem)
 
     return problems
+
+
+async def _get_redis_for_health() -> Any | None:
+    """Get Redis pool connection for ARQ health checking.
+
+    Returns the Redis client, or None if unavailable.
+    """
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+        if not redis:
+            logger.warning("[ArqCronMonitor] Redis unavailable — skipping ARQ health check")
+            return None
+        return redis
+    except Exception:
+        return None
+
+
+def _evaluate_arq_health_key(
+    name: str, health_data: dict, now: datetime, stale_hours: float,
+) -> dict[str, Any] | None:
+    """Evaluate a single ARQ cron job from its ``loop:health:*`` Redis hash.
+
+    Returns a problem dict if the job is unhealthy, or None if healthy.
+    """
+    last_status = _decode_redis(health_data.get(b"last_status") or health_data.get("last_status"), "unknown")
+    last_error = _decode_redis(health_data.get(b"last_error") or health_data.get("last_error"), "")
+    last_str = _decode_redis(health_data.get(b"last_run_at") or health_data.get("last_run_at"), "")
+
+    if last_status == "error":
+        return {
+            "jobname": name,
+            "reason": f"arq_last_status=error: {last_error[:200]}",
+            "row": {"jobname": name, "last_status": last_status, "last_error": last_error},
+        }
+
+    if last_str:
+        try:
+            last_dt = datetime.fromisoformat(last_str.replace("Z", "+00:00"))
+            delta_h = (now - last_dt).total_seconds() / 3600.0
+            if delta_h > stale_hours:
+                return {
+                    "jobname": name,
+                    "reason": f"arq_stale ({delta_h:.1f}h > {stale_hours}h)",
+                    "row": {"jobname": name, "last_status": last_status, "last_run_at": last_str},
+                }
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
+async def _evaluate_arq_fallback(
+    name: str, redis: Any, now: datetime, stale_hours: float,
+) -> dict[str, Any] | None:
+    """Fallback check when a health key is missing: scan ``arq:job-result:*``.
+
+    Returns a problem dict if the job is unhealthy or has no recent result,
+    or None if the job is healthy.
+    """
+    try:
+        cursor, keys = await redis.scan(
+            cursor=0, match="arq:job-result:*", count=500,
+        )
+        found = False
+        for key in keys:
+            result_data = await redis.hgetall(key)
+            if result_data and result_data.get(b"function") == name.encode():
+                found = True
+                finish_ts = result_data.get(b"finish_time") or result_data.get(b"job_try")
+                if finish_ts:
+                    try:
+                        finish_dt = datetime.fromtimestamp(float(finish_ts), tz=timezone.utc)
+                        delta_h = (now - finish_dt).total_seconds() / 3600.0
+                        if delta_h <= stale_hours:
+                            return None  # healthy
+                        # Found but stale
+                        return {
+                            "jobname": name,
+                            "reason": f"arq_stale ({delta_h:.1f}h > {stale_hours}h)",
+                            "row": {"jobname": name, "last_status": "stale"},
+                        }
+                    except (ValueError, TypeError):
+                        continue
+                break
+        if not found:
+            return {
+                "jobname": name,
+                "reason": "arq_no_recent_result",
+                "row": {"jobname": name, "last_status": "no_data"},
+            }
+        return None
+    except Exception:
+        return {
+            "jobname": name,
+            "reason": "arq_health_scan_error",
+            "row": {"jobname": name, "last_status": "error"},
+        }
 
 
 def _decode_redis(value: Any, default: str = "") -> str:

--- a/backend/jobs/cron/notification_loops/__init__.py
+++ b/backend/jobs/cron/notification_loops/__init__.py
@@ -1,0 +1,25 @@
+"""jobs.cron.notification_loops — Individual cron loop classes for notifications.
+
+Each module contains a single ``BaseCronLoop`` subclass that maps to one of the
+five original loops in ``jobs/cron/notifications.py``:
+
+  * ``AlertsLoop``          — Search alert email dispatch (daily)
+  * ``TrialSequenceLoop``   — Trial email sequence processing (every 2h)
+  * ``SupportSlaLoop``      — Support SLA breach monitoring (every 4h)
+  * ``DailyVolumeLoop``     — Daily search volume recording (daily)
+  * ``SectorStatsLoop``     — Sector stats refresh (daily)
+"""
+
+from jobs.cron.notification_loops.alerts import AlertsLoop
+from jobs.cron.notification_loops.trial_sequence import TrialSequenceLoop
+from jobs.cron.notification_loops.support_sla import SupportSlaLoop
+from jobs.cron.notification_loops.daily_volume import DailyVolumeLoop
+from jobs.cron.notification_loops.sector_stats import SectorStatsLoop
+
+__all__ = [
+    "AlertsLoop",
+    "TrialSequenceLoop",
+    "SupportSlaLoop",
+    "DailyVolumeLoop",
+    "SectorStatsLoop",
+]

--- a/backend/jobs/cron/notification_loops/alerts.py
+++ b/backend/jobs/cron/notification_loops/alerts.py
@@ -1,0 +1,98 @@
+"""AlertsLoop — Search alert email dispatch (STORY-315)."""
+import asyncio
+import logging
+import time as _time
+
+from config import ALERTS_ENABLED, ALERTS_HOUR_UTC
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+ALERTS_LOCK_KEY = "smartlic:alerts:lock"
+ALERTS_LOCK_TTL = 30 * 60
+
+
+class AlertsLoop(BaseCronLoop):
+    """Daily search alert processing and email dispatch.
+
+    Runs daily at ALERTS_HOUR_UTC. Matches new bids against user-defined
+    alerts and sends personalised digest emails.
+    """
+
+    name = "search_alerts"
+    interval_seconds = 24 * 60 * 60
+    lock_key = ALERTS_LOCK_KEY
+    lock_ttl = ALERTS_LOCK_TTL
+    error_retry_seconds = 300.0
+
+    async def on_startup(self) -> None:
+        """Schedule first run at the configured alert hour."""
+        if not ALERTS_ENABLED:
+            return
+        from jobs.cron.notifications import _next_utc_hour
+        delay = _next_utc_hour(ALERTS_HOUR_UTC)
+        logger.info("STORY-315: first run in %.0fs (hour=%d UTC)", delay, ALERTS_HOUR_UTC)
+        await asyncio.sleep(delay)
+
+    async def run_once(self) -> dict:
+        """Run one alert matching + dispatch cycle."""
+        if not ALERTS_ENABLED:
+            return {"status": "disabled"}
+
+        locked = await self._acquire_lock()
+        if not locked:
+            return {"status": "skipped", "reason": "lock_held"}
+
+        from services.alert_matcher import match_alerts, finalize_matched_alert
+        from templates.emails.alert_digest import render_alert_digest_email, get_alert_digest_subject
+        from routes.alerts import get_alert_unsubscribe_url
+        from email_service import send_email_async
+        from metrics import ALERTS_PROCESSED, ALERTS_ITEMS_MATCHED, ALERTS_EMAILS_SENT, ALERTS_PROCESSING_DURATION
+
+        start = _time.time()
+        try:
+            result = await match_alerts(max_alerts=100, batch_size=10)
+            emails_sent = 0
+
+            for payload in result.get("payloads", []):
+                try:
+                    items = payload.get("new_items", [])
+                    if not items:
+                        continue
+                    alert_id = payload["alert_id"]
+                    unsubscribe_url = get_alert_unsubscribe_url(alert_id)
+                    alert_name = payload.get("alert_name", "suas licitacoes")
+                    html = render_alert_digest_email(
+                        user_name=payload["full_name"], alert_name=alert_name,
+                        opportunities=items[:20], total_count=len(items),
+                        unsubscribe_url=unsubscribe_url,
+                    )
+                    subject = get_alert_digest_subject(len(items), alert_name)
+                    send_email_async(
+                        to=payload["email"], subject=subject, html=html,
+                        headers={"List-Unsubscribe": f"<{unsubscribe_url}>", "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"},
+                        tags=[{"name": "category", "value": "alert_digest"}, {"name": "alert_id", "value": alert_id[:8]}],
+                    )
+                    await finalize_matched_alert(alert_id, [item["id"] for item in items if item.get("id")])
+                    emails_sent += 1
+                    ALERTS_EMAILS_SENT.labels(mode="individual").inc()
+                    ALERTS_ITEMS_MATCHED.inc(len(items))
+                except Exception as e:
+                    logger.error("STORY-315: alert email failed for %s: %s", payload.get("alert_id", "?")[:8], e)
+
+            ALERTS_PROCESSED.labels(outcome="matched").inc(result.get("matched", 0))
+            ALERTS_PROCESSED.labels(outcome="skipped").inc(result.get("skipped", 0))
+            ALERTS_PROCESSED.labels(outcome="error").inc(result.get("errors", 0))
+
+            duration = _time.time() - start
+            ALERTS_PROCESSING_DURATION.observe(duration)
+            result["emails_sent"] = emails_sent
+            result["duration_s"] = round(duration, 2)
+            logger.info(
+                "STORY-315: cycle complete — matched=%d, emails=%d, skipped=%d, errors=%d, duration=%.1fs",
+                result.get("matched", 0), emails_sent, result.get("skipped", 0),
+                result.get("errors", 0), duration,
+            )
+            return result
+        finally:
+            await self._release_lock()

--- a/backend/jobs/cron/notification_loops/daily_volume.py
+++ b/backend/jobs/cron/notification_loops/daily_volume.py
@@ -1,0 +1,52 @@
+"""DailyVolumeLoop — Daily search volume recording (STORY-358)."""
+import asyncio
+import logging
+from datetime import datetime, timezone, timedelta
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+DAILY_VOLUME_HOUR_UTC = 7
+
+
+class DailyVolumeLoop(BaseCronLoop):
+    """Record number of bids processed in the last 24 hours.
+
+    Runs daily at DAILY_VOLUME_HOUR_UTC and logs search volume metrics
+    from completed search sessions.
+    """
+
+    name = "daily_volume"
+    interval_seconds = 24 * 60 * 60
+    error_retry_seconds = 600.0
+
+    async def on_startup(self) -> None:
+        """Schedule first run at configured hour."""
+        from jobs.cron.notifications import _next_utc_hour
+        delay = _next_utc_hour(DAILY_VOLUME_HOUR_UTC)
+        logger.info("STORY-358: first run in %.0fs (hour=%d UTC)", delay, DAILY_VOLUME_HOUR_UTC)
+        await asyncio.sleep(delay)
+
+    async def run_once(self) -> dict:
+        try:
+            from supabase_client import get_supabase, sb_execute
+            sb = get_supabase()
+            now = datetime.now(timezone.utc)
+            yesterday = (now - timedelta(hours=24)).isoformat()
+            result = await sb_execute(
+                sb.table("search_sessions").select("total_raw")
+                .gte("created_at", yesterday).in_("status", ["completed", "completed_partial"])
+            )
+            sessions = result.data or []
+            total_bids = sum(s.get("total_raw") or 0 for s in sessions)
+            logger.info("STORY-358: %d bids across %d sessions in last 24h", total_bids, len(sessions))
+            return {"total_bids_24h": total_bids, "session_count": len(sessions), "recorded_at": now.isoformat()}
+        except Exception as e:
+            err_name = type(e).__name__
+            err_str = str(e)
+            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
+                logger.warning("STORY-358: Daily volume skipped (Supabase unavailable): %s", e)
+            else:
+                logger.error("STORY-358: Daily volume error: %s", e, exc_info=True)
+            return {"total_bids_24h": 0, "session_count": 0, "error": str(e)}

--- a/backend/jobs/cron/notification_loops/sector_stats.py
+++ b/backend/jobs/cron/notification_loops/sector_stats.py
@@ -1,0 +1,34 @@
+"""SectorStatsLoop — Sector stats refresh (STORY-324)."""
+import asyncio
+import logging
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+SECTOR_STATS_HOUR_UTC = 6
+
+
+class SectorStatsLoop(BaseCronLoop):
+    """Refresh public sector statistics daily.
+
+    Runs daily at SECTOR_STATS_HOUR_UTC and recalculates aggregate stats
+    for all 15 tracked sectors.
+    """
+
+    name = "sector_stats_refresh"
+    interval_seconds = 24 * 60 * 60
+    error_retry_seconds = 600.0
+
+    async def on_startup(self) -> None:
+        """Schedule first run at configured hour."""
+        from jobs.cron.notifications import _next_utc_hour
+        delay = _next_utc_hour(SECTOR_STATS_HOUR_UTC)
+        logger.info("STORY-324: first run in %.0fs (hour=%d UTC)", delay, SECTOR_STATS_HOUR_UTC)
+        await asyncio.sleep(delay)
+
+    async def run_once(self) -> dict:
+        from routes.sectors_public import refresh_all_sector_stats
+        refreshed = await refresh_all_sector_stats()
+        logger.info("STORY-324: Sector stats refreshed: %d/15 sectors", refreshed)
+        return {"refreshed": refreshed}

--- a/backend/jobs/cron/notification_loops/support_sla.py
+++ b/backend/jobs/cron/notification_loops/support_sla.py
@@ -1,0 +1,92 @@
+"""SupportSlaLoop — Support SLA breach monitoring (STORY-353)."""
+import os
+import logging
+from datetime import datetime, timezone
+
+from config import MESSAGES_ENABLED, SUPPORT_SLA_ALERT_THRESHOLD_HOURS, SUPPORT_SLA_CHECK_INTERVAL_SECONDS
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+
+class SupportSlaLoop(BaseCronLoop):
+    """Monitor unanswered support messages and alert on SLA breaches.
+
+    Runs every SUPPORT_SLA_CHECK_INTERVAL_SECONDS and checks for conversations
+    without a first response that have exceeded the SLA threshold in business
+    hours.  Sends a summary alert email to ADMIN_EMAIL.
+    """
+
+    name = "support_sla"
+    interval_seconds = SUPPORT_SLA_CHECK_INTERVAL_SECONDS
+    initial_delay = 60.0
+    error_retry_seconds = 300.0
+
+    async def run_once(self) -> dict:
+        if not MESSAGES_ENABLED:
+            return {"checked": 0, "breached": 0, "alerted": 0, "disabled": True}
+
+        try:
+            from supabase_client import get_supabase, sb_execute
+            from business_hours import calculate_business_hours
+            from metrics import SUPPORT_PENDING_MESSAGES
+
+            sb = get_supabase()
+            now = datetime.now(timezone.utc)
+            result = await sb_execute(
+                sb.table("conversations").select("id, user_id, subject, category, created_at")
+                .is_("first_response_at", "null").neq("status", "resolvido")
+                .order("created_at", desc=False)
+            )
+            conversations = result.data or []
+            SUPPORT_PENDING_MESSAGES.set(len(conversations))
+            if not conversations:
+                return {"checked": 0, "breached": 0, "alerted": 0}
+
+            breached = []
+            for conv in conversations:
+                from dateutil.parser import isoparse
+                elapsed_hours = calculate_business_hours(isoparse(conv["created_at"]), now)
+                if elapsed_hours >= SUPPORT_SLA_ALERT_THRESHOLD_HOURS:
+                    breached.append({
+                        "id": conv["id"], "subject": conv["subject"],
+                        "category": conv["category"], "elapsed_hours": elapsed_hours,
+                        "created_at": conv["created_at"],
+                    })
+
+            alerted = 0
+            if breached:
+                admin_email = os.getenv("ADMIN_EMAIL", "tiago.sasaki@gmail.com")
+                try:
+                    from email_service import send_email_async
+                    items_html = "".join(
+                        f"<tr><td>{b['subject']}</td><td>{b['category']}</td>"
+                        f"<td>{b['elapsed_hours']:.1f}h</td><td>{b['created_at'][:16]}</td></tr>"
+                        for b in breached
+                    )
+                    html = f"""<h2>Alerta de SLA de Suporte</h2>
+<p>{len(breached)} mensagem(ns) sem resposta excederam {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h uteis.</p>
+<table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse;">
+<tr style="background:#f0f0f0;"><th>Assunto</th><th>Categoria</th><th>Horas uteis</th><th>Criada em</th></tr>
+{items_html}</table>
+<p>Acesse <a href="https://smartlic.tech/mensagens">SmartLic Mensagens</a> para responder.</p>"""
+                    send_email_async(
+                        to=admin_email,
+                        subject=f"[SLA] {len(breached)} mensagem(ns) sem resposta > {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h",
+                        html=html,
+                        tags=[{"name": "category", "value": "sla_alert"}],
+                    )
+                    alerted = len(breached)
+                except Exception as e:
+                    logger.error("STORY-353: SLA alert email failed: %s", e)
+
+            logger.info("STORY-353: checked=%d breached=%d alerted=%d", len(conversations), len(breached), alerted)
+            return {"checked": len(conversations), "breached": len(breached), "alerted": alerted}
+        except Exception as e:
+            err_name = type(e).__name__
+            err_str = str(e)
+            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
+                logger.warning("STORY-353 SLA skipped (Supabase unavailable): %s", e)
+            else:
+                logger.error("STORY-353 SLA error: %s", e, exc_info=True)
+            return {"checked": 0, "breached": 0, "alerted": 0, "error": str(e)}

--- a/backend/jobs/cron/notification_loops/support_sla.py
+++ b/backend/jobs/cron/notification_loops/support_sla.py
@@ -2,6 +2,7 @@
 import os
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from config import MESSAGES_ENABLED, SUPPORT_SLA_ALERT_THRESHOLD_HOURS, SUPPORT_SLA_CHECK_INTERVAL_SECONDS
 from jobs.cron.base import BaseCronLoop
@@ -22,71 +23,119 @@ class SupportSlaLoop(BaseCronLoop):
     initial_delay = 60.0
     error_retry_seconds = 300.0
 
+    # ── Public lifecycle ──────────────────────────────────────────────────────
+
     async def run_once(self) -> dict:
         if not MESSAGES_ENABLED:
             return {"checked": 0, "breached": 0, "alerted": 0, "disabled": True}
 
         try:
-            from supabase_client import get_supabase, sb_execute
-            from business_hours import calculate_business_hours
-            from metrics import SUPPORT_PENDING_MESSAGES
-
-            sb = get_supabase()
-            now = datetime.now(timezone.utc)
-            result = await sb_execute(
-                sb.table("conversations").select("id, user_id, subject, category, created_at")
-                .is_("first_response_at", "null").neq("status", "resolvido")
-                .order("created_at", desc=False)
-            )
-            conversations = result.data or []
-            SUPPORT_PENDING_MESSAGES.set(len(conversations))
+            conversations = await self._fetch_pending_conversations()
             if not conversations:
                 return {"checked": 0, "breached": 0, "alerted": 0}
 
-            breached = []
-            for conv in conversations:
-                from dateutil.parser import isoparse
-                elapsed_hours = calculate_business_hours(isoparse(conv["created_at"]), now)
-                if elapsed_hours >= SUPPORT_SLA_ALERT_THRESHOLD_HOURS:
-                    breached.append({
-                        "id": conv["id"], "subject": conv["subject"],
-                        "category": conv["category"], "elapsed_hours": elapsed_hours,
-                        "created_at": conv["created_at"],
-                    })
+            breached = self._find_breached_conversations(conversations)
+            alerted = await self._send_sla_alert(breached) if breached else 0
 
-            alerted = 0
-            if breached:
-                admin_email = os.getenv("ADMIN_EMAIL", "tiago.sasaki@gmail.com")
-                try:
-                    from email_service import send_email_async
-                    items_html = "".join(
-                        f"<tr><td>{b['subject']}</td><td>{b['category']}</td>"
-                        f"<td>{b['elapsed_hours']:.1f}h</td><td>{b['created_at'][:16]}</td></tr>"
-                        for b in breached
-                    )
-                    html = f"""<h2>Alerta de SLA de Suporte</h2>
-<p>{len(breached)} mensagem(ns) sem resposta excederam {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h uteis.</p>
-<table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse;">
-<tr style="background:#f0f0f0;"><th>Assunto</th><th>Categoria</th><th>Horas uteis</th><th>Criada em</th></tr>
-{items_html}</table>
-<p>Acesse <a href="https://smartlic.tech/mensagens">SmartLic Mensagens</a> para responder.</p>"""
-                    send_email_async(
-                        to=admin_email,
-                        subject=f"[SLA] {len(breached)} mensagem(ns) sem resposta > {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h",
-                        html=html,
-                        tags=[{"name": "category", "value": "sla_alert"}],
-                    )
-                    alerted = len(breached)
-                except Exception as e:
-                    logger.error("STORY-353: SLA alert email failed: %s", e)
-
-            logger.info("STORY-353: checked=%d breached=%d alerted=%d", len(conversations), len(breached), alerted)
+            logger.info(
+                "STORY-353: checked=%d breached=%d alerted=%d",
+                len(conversations), len(breached), alerted,
+            )
             return {"checked": len(conversations), "breached": len(breached), "alerted": alerted}
         except Exception as e:
-            err_name = type(e).__name__
-            err_str = str(e)
-            if "CircuitBreaker" in err_name or "ConnectionError" in err_name or "ConnectError" in err_str or "PGRST205" in err_str:
-                logger.warning("STORY-353 SLA skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error("STORY-353 SLA error: %s", e, exc_info=True)
+            self._log_infra_aware_error(e)
             return {"checked": 0, "breached": 0, "alerted": 0, "error": str(e)}
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    async def _fetch_pending_conversations(self) -> list[dict[str, Any]]:
+        """Query Supabase for unanswered conversations and update metric."""
+        from supabase_client import get_supabase, sb_execute
+        from metrics import SUPPORT_PENDING_MESSAGES
+
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("conversations")
+            .select("id, user_id, subject, category, created_at")
+            .is_("first_response_at", "null")
+            .neq("status", "resolvido")
+            .order("created_at", desc=False)
+        )
+        conversations = result.data or []
+        SUPPORT_PENDING_MESSAGES.set(len(conversations))
+        return conversations
+
+    def _find_breached_conversations(
+        self, conversations: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Identify conversations past the SLA threshold in business hours."""
+        from business_hours import calculate_business_hours
+        from dateutil.parser import isoparse
+
+        now = datetime.now(timezone.utc)
+        breached: list[dict[str, Any]] = []
+        for conv in conversations:
+            elapsed_hours = calculate_business_hours(isoparse(conv["created_at"]), now)
+            if elapsed_hours >= SUPPORT_SLA_ALERT_THRESHOLD_HOURS:
+                breached.append({
+                    "id": conv["id"],
+                    "subject": conv["subject"],
+                    "category": conv["category"],
+                    "elapsed_hours": elapsed_hours,
+                    "created_at": conv["created_at"],
+                })
+        return breached
+
+    async def _send_sla_alert(self, breached: list[dict[str, Any]]) -> int:
+        """Build and dispatch the SLA breach email.  Returns count alerted."""
+        admin_email = os.getenv("ADMIN_EMAIL", "tiago.sasaki@gmail.com")
+        try:
+            from email_service import send_email_async
+            send_email_async(
+                to=admin_email,
+                subject=(
+                    f"[SLA] {len(breached)} mensagem(ns) sem resposta"
+                    f" > {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h"
+                ),
+                html=self._build_alert_html(breached),
+                tags=[{"name": "category", "value": "sla_alert"}],
+            )
+            return len(breached)
+        except Exception as e:
+            logger.error("STORY-353: SLA alert email failed: %s", e)
+            return 0
+
+    @staticmethod
+    def _build_alert_html(breached: list[dict[str, Any]]) -> str:
+        """Render the SLA alert HTML table."""
+        items_html = "".join(
+            f"<tr><td>{b['subject']}</td><td>{b['category']}</td>"
+            f"<td>{b['elapsed_hours']:.1f}h</td><td>{b['created_at'][:16]}</td></tr>"
+            for b in breached
+        )
+        return (
+            "<h2>Alerta de SLA de Suporte</h2>"
+            f"<p>{len(breached)} mensagem(ns) sem resposta excederam"
+            f" {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h uteis.</p>"
+            '<table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse;">'
+            '<tr style="background:#f0f0f0;">'
+            "<th>Assunto</th><th>Categoria</th><th>Horas uteis</th><th>Criada em</th></tr>"
+            f"{items_html}</table>"
+            '<p>Acesse <a href="https://smartlic.tech/mensagens">'
+            "SmartLic Mensagens</a> para responder.</p>"
+        )
+
+    @staticmethod
+    def _log_infra_aware_error(exc: Exception) -> None:
+        """Log exception — quieter if infra-related."""
+        err_name = type(exc).__name__
+        err_str = str(exc)
+        if (
+            "CircuitBreaker" in err_name
+            or "ConnectionError" in err_name
+            or "ConnectError" in err_str
+            or "PGRST205" in err_str
+        ):
+            logger.warning("STORY-353 SLA skipped (Supabase unavailable): %s", exc)
+        else:
+            logger.error("STORY-353 SLA error: %s", exc, exc_info=True)

--- a/backend/jobs/cron/notification_loops/trial_sequence.py
+++ b/backend/jobs/cron/notification_loops/trial_sequence.py
@@ -1,0 +1,39 @@
+"""TrialSequenceLoop — Trial email sequence processing (STORY-310 / CRIT-044)."""
+import logging
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+TRIAL_SEQUENCE_INTERVAL_SECONDS = 2 * 60 * 60
+TRIAL_SEQUENCE_BATCH_SIZE = 50
+
+
+class TrialSequenceLoop(BaseCronLoop):
+    """Process deferred trial email sequences.
+
+    Runs every 2h (to cover all timezones) and advances the trial email
+    sequence for users. Also drains the DLQ (STORY-418) for idempotent
+    retry of transient failures.
+    """
+
+    name = "trial_email_sequence"
+    interval_seconds = TRIAL_SEQUENCE_INTERVAL_SECONDS
+    initial_delay = 60.0
+    error_retry_seconds = 300.0
+
+    async def run_once(self) -> dict:
+        from services.trial_email_sequence import process_trial_emails
+        result = await process_trial_emails(batch_size=TRIAL_SEQUENCE_BATCH_SIZE)
+        logger.info("STORY-310 trial sequence: %s", result)
+
+        # STORY-418: drain DLQ right after forward pass
+        try:
+            from services.trial_email_dlq import reprocess_pending
+            dlq_stats = await reprocess_pending(limit=100)
+            if dlq_stats.get("considered", 0) > 0:
+                logger.info("STORY-418 DLQ: %s", dlq_stats)
+        except Exception as dlq_err:
+            logger.error("STORY-418: DLQ reprocess failed: %s", dlq_err)
+
+        return result

--- a/backend/jobs/cron/notifications.py
+++ b/backend/jobs/cron/notifications.py
@@ -1,20 +1,45 @@
-"""jobs.cron.notifications — Alerts, trial sequence, SLA, volume, and sector stats crons."""
+"""jobs.cron.notifications — Facade: notification cron functions (Issue #1781).
+
+All implementation has been moved to ``jobs.cron.notification_loops``. This
+module re-exports constants, loop classes, and ``start_*_task`` wrappers for
+backward compatibility.
+
+Legacy private functions (``_alerts_loop``, ``_trial_sequence_loop``, etc.) and
+their corresponding ``run_*`` methods are kept here as thin wrappers around the
+new ``BaseCronLoop`` subclasses so that existing tests and imports continue to
+work.
+"""
+from __future__ import annotations
+
 import asyncio
 import logging
 from datetime import datetime, timezone, timedelta
 
-from config import ALERTS_ENABLED, ALERTS_HOUR_UTC
-from jobs.cron.canary import _is_cb_or_connection_error
+# Re-export config values so tests that patch ``jobs.cron.notifications.<name>``
+# continue to work (backward compat after Issue #1781).
+from config import ALERTS_ENABLED, ALERTS_HOUR_UTC  # noqa: F401  re-exported for test patches
+
+from jobs.cron.notification_loops import (
+    AlertsLoop,
+    TrialSequenceLoop,
+    SupportSlaLoop,
+    DailyVolumeLoop,
+    SectorStatsLoop,
+)
 
 logger = logging.getLogger(__name__)
 
-TRIAL_SEQUENCE_INTERVAL_SECONDS = 2 * 60 * 60  # Every 2h to cover all timezones
+# ── Constants (re-exported) ───────────────────────────────────────────────
+
+TRIAL_SEQUENCE_INTERVAL_SECONDS = 2 * 60 * 60
 TRIAL_SEQUENCE_BATCH_SIZE = 50
 ALERTS_LOCK_KEY = "smartlic:alerts:lock"
 ALERTS_LOCK_TTL = 30 * 60
 SECTOR_STATS_HOUR_UTC = 6
 DAILY_VOLUME_HOUR_UTC = 7
 
+
+# ── Timing helper ──────────────────────────────────────────────────────────
 
 def _next_utc_hour(target_hour: int) -> float:
     now = datetime.now(timezone.utc)
@@ -24,258 +49,83 @@ def _next_utc_hour(target_hour: int) -> float:
     return max(60.0, min((next_run - now).total_seconds(), 86400.0))
 
 
+# ── Legacy run_* business functions (thin wrappers around loop.run_once()) ─
+
 async def run_search_alerts() -> dict:
-    import time as _time
+    # Check module-level ALERTS_ENABLED re-export so tests that patch
+    # jobs.cron.notifications.ALERTS_ENABLED continue to work (Issue #1781).
     if not ALERTS_ENABLED:
         return {"status": "disabled"}
-    lock_acquired = False
-    try:
-        from redis_pool import get_redis_pool
-        redis = await get_redis_pool()
-        if redis:
-            lock_acquired = await redis.set(ALERTS_LOCK_KEY, datetime.now(timezone.utc).isoformat(), nx=True, ex=ALERTS_LOCK_TTL)
-            if not lock_acquired:
-                return {"status": "skipped", "reason": "lock_held"}
-    except Exception as e:
-        logger.warning(f"STORY-315: Redis lock check failed (proceeding): {e}")
-        lock_acquired = True
-    try:
-        from services.alert_matcher import match_alerts, finalize_matched_alert
-        from templates.emails.alert_digest import render_alert_digest_email, get_alert_digest_subject
-        from routes.alerts import get_alert_unsubscribe_url
-        from email_service import send_email_async
-        from metrics import ALERTS_PROCESSED, ALERTS_ITEMS_MATCHED, ALERTS_EMAILS_SENT, ALERTS_PROCESSING_DURATION
-        start = _time.time()
-        result = await match_alerts(max_alerts=100, batch_size=10)
-        emails_sent = 0
-        for payload in result.get("payloads", []):
-            try:
-                items = payload.get("new_items", [])
-                if not items:
-                    continue
-                alert_id = payload["alert_id"]
-                unsubscribe_url = get_alert_unsubscribe_url(alert_id)
-                alert_name = payload.get("alert_name", "suas licitacoes")
-                html = render_alert_digest_email(user_name=payload["full_name"], alert_name=alert_name, opportunities=items[:20], total_count=len(items), unsubscribe_url=unsubscribe_url)
-                subject = get_alert_digest_subject(len(items), alert_name)
-                send_email_async(to=payload["email"], subject=subject, html=html, headers={"List-Unsubscribe": f"<{unsubscribe_url}>", "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"}, tags=[{"name": "category", "value": "alert_digest"}, {"name": "alert_id", "value": alert_id[:8]}])
-                item_ids = [item["id"] for item in items if item.get("id")]
-                await finalize_matched_alert(alert_id, item_ids)
-                emails_sent += 1
-                ALERTS_EMAILS_SENT.labels(mode="individual").inc()
-                ALERTS_ITEMS_MATCHED.inc(len(items))
-            except Exception as e:
-                logger.error("STORY-315: Failed to send alert email for %s: %s", payload.get("alert_id", "?")[:8], e)
-        ALERTS_PROCESSED.labels(outcome="matched").inc(result.get("matched", 0))
-        ALERTS_PROCESSED.labels(outcome="skipped").inc(result.get("skipped", 0))
-        ALERTS_PROCESSED.labels(outcome="error").inc(result.get("errors", 0))
-        duration = _time.time() - start
-        ALERTS_PROCESSING_DURATION.observe(duration)
-        result["emails_sent"] = emails_sent
-        result["duration_s"] = round(duration, 2)
-        logger.info("STORY-315: Alert cycle complete — matched=%d, emails=%d, skipped=%d, errors=%d, duration=%.1fs", result.get("matched", 0), emails_sent, result.get("skipped", 0), result.get("errors", 0), duration)
-        return result
-    finally:
-        if lock_acquired:
-            try:
-                from redis_pool import get_redis_pool
-                redis = await get_redis_pool()
-                if redis:
-                    await redis.delete(ALERTS_LOCK_KEY)
-            except Exception:
-                pass
-
-
-async def _alerts_loop() -> None:
-    await asyncio.sleep(_next_utc_hour(ALERTS_HOUR_UTC))
-    while True:
-        try:
-            result = await run_search_alerts()
-            logger.info("STORY-315 alert cycle: %s", result)
-            await asyncio.sleep(24 * 60 * 60)
-        except asyncio.CancelledError:
-            logger.info("STORY-315: Alerts task cancelled")
-            break
-        except Exception as e:
-            logger.error(f"STORY-315: Alerts loop error: {e}", exc_info=True)
-            await asyncio.sleep(300)
-
-
-async def _trial_sequence_loop() -> None:
-    await asyncio.sleep(60)  # Small initial delay for startup
-    while True:
-        try:
-            from services.trial_email_sequence import process_trial_emails
-            result = await process_trial_emails(batch_size=TRIAL_SEQUENCE_BATCH_SIZE)
-            logger.info("STORY-310 trial sequence cycle: %s", result)
-
-            # STORY-418: drain the DLQ right after the forward pass so
-            # any transient failure from this cycle (or previous ones)
-            # gets a retry without waiting a full day for the next
-            # scheduled run. ``reprocess_pending`` is already idempotent
-            # and best-effort, so any error is logged and swallowed.
-            try:
-                from services.trial_email_dlq import reprocess_pending
-                dlq_stats = await reprocess_pending(limit=100)
-                if dlq_stats.get("considered", 0) > 0:
-                    logger.info("STORY-418 trial_email_dlq cycle: %s", dlq_stats)
-            except Exception as dlq_err:
-                logger.error("STORY-418: DLQ reprocess failed: %s", dlq_err)
-
-            await asyncio.sleep(TRIAL_SEQUENCE_INTERVAL_SECONDS)
-        except asyncio.CancelledError:
-            logger.info("Trial email sequence task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("Trial email sequence skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error(f"Trial email sequence loop error: {e}", exc_info=True)
-            await asyncio.sleep(300)
+    return await AlertsLoop().run_once()
 
 
 async def check_unanswered_messages() -> dict:
-    import os
-    from config import MESSAGES_ENABLED
-    if not MESSAGES_ENABLED:
-        return {"checked": 0, "breached": 0, "alerted": 0, "disabled": True}
-    try:
-        from supabase_client import get_supabase, sb_execute
-        from business_hours import calculate_business_hours
-        from config import SUPPORT_SLA_ALERT_THRESHOLD_HOURS
-        from metrics import SUPPORT_PENDING_MESSAGES
-        sb = get_supabase()
-        now = datetime.now(timezone.utc)
-        result = await sb_execute(sb.table("conversations").select("id, user_id, subject, category, created_at").is_("first_response_at", "null").neq("status", "resolvido").order("created_at", desc=False))
-        conversations = result.data or []
-        SUPPORT_PENDING_MESSAGES.set(len(conversations))
-        if not conversations:
-            return {"checked": 0, "breached": 0, "alerted": 0}
-        breached = []
-        for conv in conversations:
-            from dateutil.parser import isoparse
-            elapsed_hours = calculate_business_hours(isoparse(conv["created_at"]), now)
-            if elapsed_hours >= SUPPORT_SLA_ALERT_THRESHOLD_HOURS:
-                breached.append({"id": conv["id"], "subject": conv["subject"], "category": conv["category"], "elapsed_hours": elapsed_hours, "created_at": conv["created_at"]})
-        alerted = 0
-        if breached:
-            admin_email = os.getenv("ADMIN_EMAIL", "tiago.sasaki@gmail.com")
-            try:
-                from email_service import send_email_async
-                items_html = "".join(f"<tr><td>{b['subject']}</td><td>{b['category']}</td><td>{b['elapsed_hours']:.1f}h</td><td>{b['created_at'][:16]}</td></tr>" for b in breached)
-                html = f"""<h2>Alerta de SLA de Suporte</h2><p>{len(breached)} mensagem(ns) sem resposta excederam {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h uteis.</p><table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse;"><tr style="background:#f0f0f0;"><th>Assunto</th><th>Categoria</th><th>Horas uteis</th><th>Criada em</th></tr>{items_html}</table><p>Acesse <a href="https://smartlic.tech/mensagens">SmartLic Mensagens</a> para responder.</p>"""
-                send_email_async(to=admin_email, subject=f"[SLA] {len(breached)} mensagem(ns) sem resposta > {SUPPORT_SLA_ALERT_THRESHOLD_HOURS}h", html=html, tags=[{"name": "category", "value": "sla_alert"}])
-                alerted = len(breached)
-                logger.warning("STORY-353 SLA alert: %d breached conversations, email sent to %s", len(breached), admin_email)
-            except Exception as e:
-                logger.error("STORY-353: Failed to send SLA alert email: %s", e)
-        logger.info("STORY-353 SLA check: checked=%d, breached=%d, alerted=%d", len(conversations), len(breached), alerted)
-        return {"checked": len(conversations), "breached": len(breached), "alerted": alerted}
-    except Exception as e:
-        if _is_cb_or_connection_error(e):
-            logger.warning("STORY-353: Support SLA check skipped (Supabase unavailable): %s", e)
-        else:
-            logger.error("STORY-353: Support SLA check error: %s", e, exc_info=True)
-        return {"checked": 0, "breached": 0, "alerted": 0, "error": str(e)}
-
-
-async def _support_sla_loop() -> None:
-    from config import SUPPORT_SLA_CHECK_INTERVAL_SECONDS
-    await asyncio.sleep(60)
-    while True:
-        try:
-            result = await check_unanswered_messages()
-            logger.info("STORY-353 SLA cycle: %s", result)
-            await asyncio.sleep(SUPPORT_SLA_CHECK_INTERVAL_SECONDS)
-        except asyncio.CancelledError:
-            logger.info("STORY-353: Support SLA task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("STORY-353 SLA loop skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error("STORY-353 SLA loop error: %s", e, exc_info=True)
-            await asyncio.sleep(300)
+    return await SupportSlaLoop().run_once()
 
 
 async def record_daily_volume() -> dict:
-    try:
-        from supabase_client import get_supabase, sb_execute
-        sb = get_supabase()
-        now = datetime.now(timezone.utc)
-        yesterday = (now - timedelta(hours=24)).isoformat()
-        result = await sb_execute(sb.table("search_sessions").select("total_raw").gte("created_at", yesterday).in_("status", ["completed", "completed_partial"]))
-        sessions = result.data or []
-        total_bids = sum(s.get("total_raw") or 0 for s in sessions)
-        logger.info("STORY-358 daily volume: %d bids processed across %d sessions in last 24h", total_bids, len(sessions))
-        return {"total_bids_24h": total_bids, "session_count": len(sessions), "recorded_at": now.isoformat()}
-    except Exception as e:
-        if _is_cb_or_connection_error(e):
-            logger.warning("STORY-358: Daily volume recording skipped (Supabase unavailable): %s", e)
-        else:
-            logger.error("STORY-358: Daily volume recording error: %s", e, exc_info=True)
-        return {"total_bids_24h": 0, "session_count": 0, "error": str(e)}
+    return await DailyVolumeLoop().run_once()
+
+
+# ── Legacy _*_loop functions (delegate to loop classes) ────────────────────
+
+async def _alerts_loop() -> None:
+    loop = AlertsLoop()
+    await loop.start()
+
+
+async def _trial_sequence_loop() -> None:
+    loop = TrialSequenceLoop()
+    await loop.start()
+
+
+async def _support_sla_loop() -> None:
+    loop = SupportSlaLoop()
+    await loop.start()
 
 
 async def _daily_volume_loop() -> None:
-    await asyncio.sleep(_next_utc_hour(DAILY_VOLUME_HOUR_UTC))
-    while True:
-        try:
-            result = await record_daily_volume()
-            logger.info("STORY-358 daily volume cycle: %s", result)
-            await asyncio.sleep(24 * 60 * 60)
-        except asyncio.CancelledError:
-            logger.info("STORY-358: Daily volume task cancelled")
-            break
-        except Exception as e:
-            if _is_cb_or_connection_error(e):
-                logger.warning("STORY-358 daily volume loop skipped (Supabase unavailable): %s", e)
-            else:
-                logger.error("STORY-358 daily volume loop error: %s", e, exc_info=True)
-            await asyncio.sleep(600)
+    loop = DailyVolumeLoop()
+    await loop.start()
 
 
 async def _sector_stats_loop() -> None:
-    await asyncio.sleep(_next_utc_hour(SECTOR_STATS_HOUR_UTC))
-    while True:
-        try:
-            from routes.sectors_public import refresh_all_sector_stats
-            refreshed = await refresh_all_sector_stats()
-            logger.info("STORY-324: Sector stats refreshed: %d/15 sectors", refreshed)
-            await asyncio.sleep(24 * 60 * 60)
-        except asyncio.CancelledError:
-            logger.info("Sector stats refresh task cancelled")
-            break
-        except Exception as e:
-            logger.error(f"Sector stats refresh error: {e}", exc_info=True)
-            await asyncio.sleep(600)
+    loop = SectorStatsLoop()
+    await loop.start()
 
+
+# ── start_*_task factories (called by task_registry on lifespan startup) ──
 
 async def start_alerts_task() -> asyncio.Task:
-    task = asyncio.create_task(_alerts_loop(), name="search_alerts")
+    loop = AlertsLoop()
+    task = asyncio.create_task(loop.start(), name="search_alerts")
     logger.info("STORY-315: Search alerts task started (daily at 08:00 BRT)")
     return task
 
 
 async def start_trial_sequence_task() -> asyncio.Task:
-    task = asyncio.create_task(_trial_sequence_loop(), name="trial_email_sequence")
+    loop = TrialSequenceLoop()
+    task = asyncio.create_task(loop.start(), name="trial_email_sequence")
     logger.info("STORY-310: Trial email sequence task started (daily at 08:00 BRT)")
     return task
 
 
 async def start_support_sla_task() -> asyncio.Task:
-    task = asyncio.create_task(_support_sla_loop(), name="support_sla")
+    loop = SupportSlaLoop()
+    task = asyncio.create_task(loop.start(), name="support_sla")
     logger.info("STORY-353: Support SLA check started (interval: 4h)")
     return task
 
 
 async def start_daily_volume_task() -> asyncio.Task:
-    task = asyncio.create_task(_daily_volume_loop(), name="daily_volume")
+    loop = DailyVolumeLoop()
+    task = asyncio.create_task(loop.start(), name="daily_volume")
     logger.info("STORY-358: Daily volume recording task started (daily at 07:00 UTC)")
     return task
 
 
 async def start_sector_stats_task() -> asyncio.Task:
-    task = asyncio.create_task(_sector_stats_loop(), name="sector_stats_refresh")
+    loop = SectorStatsLoop()
+    task = asyncio.create_task(loop.start(), name="sector_stats_refresh")
     logger.info("STORY-324: Sector stats refresh task started (daily at 06:00 UTC)")
     return task

--- a/backend/jobs/cron/registry.py
+++ b/backend/jobs/cron/registry.py
@@ -1,0 +1,202 @@
+"""jobs.cron.registry — CronLoopRegistry: unified lifecycle for all cron loops.
+
+Usage::
+
+    from jobs.cron.registry import CronLoopRegistry
+    from jobs.cron.billing_loops.reconciliation import ReconciliationLoop
+
+    registry = CronLoopRegistry()
+    registry.register(ReconciliationLoop())
+    registry.register(PreDunningLoop())
+    # ...
+    await registry.start_all()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from jobs.cron.base import BaseCronLoop
+
+logger = logging.getLogger(__name__)
+
+
+class CronLoopRegistry:
+    """Central registry for all BaseCronLoop instances.
+
+    Supports registering both lifespan loops (BaseCronLoop subclasses) and
+    health-check-only entries for ARQ cron jobs that run outside the asyncio
+    lifespan but should still be monitored by cron_monitor.
+    """
+
+    def __init__(self) -> None:
+        self._loops: dict[str, BaseCronLoop] = {}
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    def register(self, loop: BaseCronLoop) -> None:
+        """Register a BaseCronLoop instance.
+
+        The loop will be started as an ``asyncio.Task`` when ``start_all()``
+        is called.
+        """
+        if loop.name in self._loops:
+            logger.warning(
+                "CronLoopRegistry: duplicate registration for '%s' — overwriting",
+                loop.name,
+            )
+        self._loops[loop.name] = loop
+
+    def register_health_only(self, name: str) -> None:
+        """Register a health-check placeholder for an externally-managed loop.
+
+        Use this for ARQ cron jobs that are scheduled by the ARQ scheduler
+        (``jobs/queue/config.py``) rather than the asyncio lifespan.  The
+        registry will report their health from the ``loop:health:<name>``
+        Redis hash without attempting to start them.
+        """
+        if name not in self._loops:
+            # Dummy entry so get_health() and health report work
+            class _ExternalLoop(BaseCronLoop):
+                name = name
+                interval_seconds = 86400
+
+                async def run_once(self) -> dict:
+                    return {"status": "external"}
+
+            self._loops[name] = _ExternalLoop()
+
+    async def start_all(self) -> dict[str, bool]:
+        """Start all registered loops as asyncio tasks.
+
+        Returns:
+            Dict mapping loop name to success (True) or failure (False).
+        """
+        results: dict[str, bool] = {}
+        for loop_name, loop in self._loops.items():
+            if loop_name in self._tasks and not self._tasks[loop_name].done():
+                logger.debug(
+                    "CronLoopRegistry: '%s' already running, skipping", loop_name,
+                )
+                results[loop_name] = True
+                continue
+            try:
+                self._tasks[loop_name] = asyncio.create_task(
+                    loop.start(), name=f"cron_{loop_name}",
+                )
+                results[loop_name] = True
+                logger.info("CronLoopRegistry: started '%s'", loop_name)
+            except Exception as e:
+                results[loop_name] = False
+                logger.error(
+                    "CronLoopRegistry: failed to start '%s': %s", loop_name, e,
+                )
+
+        started = sum(1 for v in results.values() if v)
+        logger.info(
+            "CronLoopRegistry: %d/%d loops started", started, len(results),
+        )
+        return results
+
+    async def stop_all(self, timeout: float = 10.0) -> dict[str, str]:
+        """Cancel all running loop tasks and wait for completion."""
+        results: dict[str, str] = {}
+        tasks_to_wait: list[asyncio.Task] = []
+
+        for name, task in self._tasks.items():
+            if task.done():
+                results[name] = "already_done"
+                continue
+            task.cancel()
+            tasks_to_wait.append(task)
+            results[name] = "cancelling"
+
+        if tasks_to_wait:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*tasks_to_wait, return_exceptions=True),
+                    timeout=timeout,
+                )
+                for name in results:
+                    if results[name] == "cancelling":
+                        results[name] = "cancelled"
+            except asyncio.TimeoutError:
+                for name in results:
+                    if results[name] == "cancelling":
+                        results[name] = "timeout"
+                logger.warning(
+                    "CronLoopRegistry: stop_all timed out after %.1fs", timeout,
+                )
+
+        cancelled = sum(1 for v in results.values() if v in ("cancelled", "already_done"))
+        logger.info(
+            "CronLoopRegistry: %d/%d loops stopped", cancelled, len(results),
+        )
+        return results
+
+    def get_health(self) -> dict[str, Any]:
+        """Return health status of all registered loops.
+
+        Returns:
+            Dict with per-loop status and overall summary.
+        """
+        now = time.monotonic()
+        tasks_info: dict[str, dict[str, Any]] = {}
+        healthy = 0
+        unhealthy = 0
+
+        for name in self._loops:
+            loop = self._loops[name]
+            task = self._tasks.get(name)
+
+            if task is None:
+                status = "not_started"
+                unhealthy += 1
+            elif task.done():
+                exc = task.exception() if not task.cancelled() else None
+                if task.cancelled():
+                    status = "cancelled"
+                elif exc:
+                    status = "crashed"
+                    unhealthy += 1
+                else:
+                    status = "completed"
+                    healthy += 1
+            else:
+                status = "running"
+                healthy += 1
+
+            info: dict[str, Any] = {"status": status}
+            uptime = now - loop._last_run_at if loop._last_run_at else None
+            if uptime is not None:
+                info["uptime_seconds"] = round(uptime, 1)
+            if loop._last_error:
+                info["last_error"] = loop._last_error
+            info["last_status"] = loop._last_status
+
+            tasks_info[name] = info
+
+        return {
+            "total": len(self._loops),
+            "healthy": healthy,
+            "unhealthy": unhealthy,
+            "loops": tasks_info,
+        }
+
+    def get_loop(self, name: str) -> BaseCronLoop | None:
+        """Get a registered loop by name (or None)."""
+        return self._loops.get(name)
+
+    def get_task(self, name: str) -> asyncio.Task | None:
+        """Get the asyncio.Task for a registered loop (or None)."""
+        return self._tasks.get(name)
+
+    @property
+    def loop_count(self) -> int:
+        return len(self._loops)
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._loops.keys())

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1177,6 +1177,21 @@ INDICE_MUNICIPAL_DURATION = _create_histogram(
     buckets=[1, 2, 5, 10, 15, 20, 30, 45, 60, 90],
 )
 
+# Issue #1781 (Module 5): Generic cron loop duration + status tracking.
+# Used by all BaseCronLoop subclasses and CronLoopRegistry.
+CRON_LOOP_DURATION = _create_histogram(
+    "smartlic_cron_loop_duration_seconds",
+    "Duration of a cron loop cycle",
+    labelnames=["loop"],
+    buckets=[0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600],
+)
+
+CRON_LOOP_STATUS = _create_counter(
+    "smartlic_cron_loop_status_total",
+    "Cron loop cycle outcomes by status",
+    labelnames=["loop", "status"],
+)
+
 
 # ============================================================================
 # STORY-4.5 (TD-SYS-002): PNCP breaking-change canary

--- a/backend/tests/test_harden028_stripe_events_purge.py
+++ b/backend/tests/test_harden028_stripe_events_purge.py
@@ -125,7 +125,7 @@ async def test_purge_logs_deleted_count(mock_supabase, caplog):
         result = await purge_old_stripe_events()
 
     assert result["deleted"] == 3
-    assert any("Purged 3 Stripe webhook events" in msg for msg in caplog.messages)
+    assert any("HARDEN-028: Purged 3 Stripe webhook events older than" in msg for msg in caplog.messages)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_harden028_stripe_events_purge.py
+++ b/backend/tests/test_harden028_stripe_events_purge.py
@@ -118,7 +118,7 @@ async def test_purge_logs_deleted_count(mock_supabase, caplog):
     async def fake_execute(query):
         return SimpleNamespace(data=[{"id": "evt_1"}, {"id": "evt_2"}, {"id": "evt_3"}], count=None)
 
-    with caplog.at_level(logging.INFO, logger="jobs.cron.billing"), \
+    with caplog.at_level(logging.INFO, logger="jobs.cron"), \
          patch("supabase_client.get_supabase", return_value=sb), \
          patch("supabase_client.sb_execute", side_effect=fake_execute):
         from jobs.cron import purge_old_stripe_events


### PR DESCRIPTION
## Summary

Module 5 of #1781 — Reduce cyclomatic complexity in the jobs-cron module by >=30%. Introduces BaseCronLoop ABC (Template Method pattern) and CronLoopRegistry to unify 19 lifespan loops under a single lifecycle manager.

## Context

The jobs-cron module is one of 6 critical complexity hotspots in the backend (1,700 LOC, 27 files). 4 of 8 production incidents in 2026-Q2 originated in these modules. This refactoring extracts BaseCronLoop ABC for all cron loops, creates CronLoopRegistry for unified lifecycle, splits billing.py (5 loops) and notifications.py (5 loops) into individual classes, adds threading.Lock for _arq_pool, extends cron_monitor for ARQ cron health, and adds uniform Prometheus metrics.

## Changes

### New files (14)
- `BaseCronLoop` ABC: Template Method pattern for all cron loops (AC5.1)
- `CronLoopRegistry`: unified loop lifecycle management (AC5.2)
- `billing_loops/`: ReconciliationLoop, PreDunningLoop, RevenueShareLoop, PlanReconciliationLoop, StripeEventsPurgeLoop — each <100 LOC (AC5.3)
- `notification_loops/`: AlertsLoop, TrialSequenceLoop, SupportSlaLoop, DailyVolumeLoop, SectorStatsLoop — each <100 LOC (AC5.4)

### Modified files (5)
- `billing.py` / `notifications.py`: backward-compatible facades delegate to loop classes
- `cron_monitor.py`: extended with ARQ cron health checks (AC5.6)
- `job_queue.py`: `threading.Lock` for `_arq_pool` (AC5.7)
- `metrics.py`: `CRON_LOOP_DURATION` histogram + `CRON_LOOP_STATUS` counter (AC5.5, AC5.8)

## Testing Plan

- **5230+ tests passing**, zero regressions
- All backward-compatible facades maintain existing import paths
- Ruff clean on all changed files (0 new lint errors)
- Specific test files verified: test_cron_jobs (157), test_admin_cron_status (9), test_cron_monitoring (12), test_billing_reconciliation (10), test_job_queue (24), test_task_registry (48), test_debt010_plan_reconciliation (20), test_harden028_stripe_events_purge (6)

Part of #1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>