### PR TITLE
feat(backend): data retention dry-run + admin dashboard + alert (#1877)

### DIFF
--- a/backend/jobs/cron/data_retention.py
+++ b/backend/jobs/cron/data_retention.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone, timedelta
 
 from jobs.cron.canary import _is_cb_or_connection_error
@@ -40,9 +41,18 @@ RETENTION_INGESTION_CHECKPOINTS = 30  # AC5: purge > 30 days
 # Purge interval: run daily
 PURGE_INTERVAL_SECONDS = 24 * 60 * 60
 
+# #1877 AC1: Dry-run mode — when True, only log what WOULD be deleted
+DATA_RETENTION_DRY_RUN = os.getenv("DATA_RETENTION_DRY_RUN", "").lower() in ("true", "1", "yes")
+
+# #1877 AC3: Redis key for consecutive failure counter
+_CONCLUSIVE_FAILURES_KEY = "data_retention:consecutive_failures"
+
 
 async def purge_trial_email_log() -> dict:
     """Purge trial_email_log rows older than RETENTION_TRIAL_EMAIL_LOG days.
+
+    When DATA_RETENTION_DRY_RUN is True, only logs what WOULD be deleted
+    without executing the DELETE query (#1877 AC1).
 
     Returns dict with count of deleted rows and any error message.
     """
@@ -50,6 +60,15 @@ async def purge_trial_email_log() -> dict:
         from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
         cutoff = (datetime.now(timezone.utc) - timedelta(days=RETENTION_TRIAL_EMAIL_LOG)).isoformat()
+
+        if DATA_RETENTION_DRY_RUN:
+            logger.info(
+                "GAP-005 [DRY-RUN]: Would purge trial_email_log rows older than "
+                "%d days (cutoff=%s) — skipping DELETE",
+                RETENTION_TRIAL_EMAIL_LOG, cutoff,
+            )
+            return {"deleted": 0, "table": "trial_email_log", "cutoff": cutoff, "dry_run": True}
+
         result = await sb_execute(
             sb.table("trial_email_log").delete().lt("sent_at", cutoff)
         )
@@ -73,6 +92,9 @@ async def purge_messages() -> dict:
     Also purges conversations whose last_message_at is older than the cutoff.
     Conversations that still have recent messages are preserved.
 
+    When DATA_RETENTION_DRY_RUN is True, only logs what WOULD be deleted
+    without executing the DELETE query (#1877 AC1).
+
     Uses a two-step approach:
       1. Delete old messages (created_at < cutoff)
       2. Delete conversations with last_message_at < cutoff
@@ -84,6 +106,21 @@ async def purge_messages() -> dict:
         from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
         cutoff = (datetime.now(timezone.utc) - timedelta(days=RETENTION_MESSAGES)).isoformat()
+
+        if DATA_RETENTION_DRY_RUN:
+            logger.info(
+                "GAP-005 [DRY-RUN]: Would purge messages + conversations older than "
+                "%d days (cutoff=%s) — skipping DELETE",
+                RETENTION_MESSAGES, cutoff,
+            )
+            return {
+                "table": "messages",
+                "messages_deleted": 0,
+                "conversations_deleted": 0,
+                "deleted": 0,
+                "cutoff": cutoff,
+                "dry_run": True,
+            }
 
         # Step 1: Delete old messages
         result = await sb_execute(
@@ -125,12 +162,30 @@ async def purge_ingestion_checkpoints() -> dict:
     Only deletes checkpoints with terminal status (completed, failed).
     Active/pending checkpoints are never purged.
 
+    When DATA_RETENTION_DRY_RUN is True, only logs what WOULD be deleted
+    without executing the DELETE query (#1877 AC1).
+
     Returns dict with count of deleted rows and any error message.
     """
     try:
         from supabase_client import get_supabase, sb_execute
         sb = get_supabase()
         cutoff = (datetime.now(timezone.utc) - timedelta(days=RETENTION_INGESTION_CHECKPOINTS)).isoformat()
+
+        if DATA_RETENTION_DRY_RUN:
+            logger.info(
+                "GAP-005 [DRY-RUN]: Would purge ingestion_checkpoints rows older than "
+                "%d days (cutoff=%s) — skipping DELETE",
+                RETENTION_INGESTION_CHECKPOINTS, cutoff,
+            )
+            return {
+                "table": "ingestion_checkpoints",
+                "deleted_completed_at": 0,
+                "deleted_started_at_fallback": 0,
+                "deleted": 0,
+                "cutoff": cutoff,
+                "dry_run": True,
+            }
 
         # Purge completed/failed checkpoints older than cutoff
         # completed_at is set when a checkpoint finishes; use it as the age metric.
@@ -174,11 +229,104 @@ async def purge_ingestion_checkpoints() -> dict:
         return {"deleted": 0, "table": "ingestion_checkpoints", "error": str(e)}
 
 
+async def _track_consecutive_failures(results: list[dict]) -> None:
+    """Track consecutive purge failures via Redis key (#1877 AC3).
+
+    Increments a Redis counter if ANY purge result has an ``error`` key.
+    Resets the counter to 0 if all results are error-free.
+
+    When consecutive failures >= 2, emits a Sentry ``capture_message``
+    with level="error" so on-call is alerted.
+
+    Graceful degradation: if Redis is unreachable, logs a warning and
+    continues without alerting (prevents alert-storm on transient Redis
+    downtime).
+    """
+    has_errors = any(r.get("error") for r in results)
+
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+
+        if has_errors:
+            count = await redis.incr(_CONCLUSIVE_FAILURES_KEY)
+            # Set a 24h TTL on every increment so the key auto-cleans
+            await redis.expire(_CONCLUSIVE_FAILURES_KEY, 86400)
+        else:
+            count = 0
+            await redis.set(_CONCLUSIVE_FAILURES_KEY, 0)
+            # TTL still useful: keep at 0 for 24h in case of transient blip
+            await redis.expire(_CONCLUSIVE_FAILURES_KEY, 86400)
+
+        if count >= 2:
+            import sentry_sdk
+            with sentry_sdk.push_scope() as scope:
+                scope.set_tag("data_retention", "consecutive_failures")
+                scope.set_extra("consecutive_failures", count)
+                sentry_sdk.capture_message(
+                    f"GAP-005: data retention purge failed {count}x consecutively (#1877)",
+                    level="error",
+                )
+    except Exception:
+        logger.warning(
+            "GAP-005: Could not track consecutive failures (Redis unavailable) — "
+            "consecutive-failure alert skipped",
+        )
+
+
+async def _persist_purge_results(
+    summary: dict,
+    trial_result: dict,
+    messages_result: dict,
+    checkpoints_result: dict,
+) -> None:
+    """Persist purge cycle results to Redis for the admin dashboard (#1877 AC2).
+
+    Writes per-table keys (last_run, last_rows, last_error) and a
+    global duration key. All keys have a 7-day TTL.
+
+    Graceful degradation: if Redis is unavailable, logs a warning and
+    continues — the admin dashboard will report ``redis_unavailable``.
+    """
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+        ttl = 7 * 86400  # 7 days
+
+        for tbl_result in (trial_result, messages_result, checkpoints_result):
+            tbl = tbl_result.get("table", "unknown")
+
+            await redis.setex(f"data_retention:last_run:{tbl}", ttl, summary.get("completed_at", ""))
+            await redis.setex(f"data_retention:last_rows:{tbl}", ttl, str(tbl_result.get("deleted", 0)))
+
+            error = tbl_result.get("error")
+            if error:
+                await redis.setex(f"data_retention:last_error:{tbl}", ttl, str(error))
+            else:
+                # Clear any stale error
+                await redis.delete(f"data_retention:last_error:{tbl}")
+
+        await redis.setex(
+            "data_retention:last_duration", ttl,
+            str(summary.get("duration_seconds", 0)),
+        )
+    except Exception:
+        logger.warning(
+            "GAP-005: Could not persist purge results to Redis — "
+            "admin dashboard will show redis_unavailable",
+        )
+
+
 async def run_data_retention_purge() -> dict:
     """Run all data retention purge steps and aggregate results.
 
     Each table is purged in its own try/except block so a failure in one
     table does not prevent the others from being cleaned.
+
+    Tracks consecutive failures via Redis and alerts Sentry at >=2
+    consecutive failures (#1877 AC3).
+
+    Persists per-table results to Redis for the admin dashboard (#1877 AC2).
 
     Returns a dict with per-table results and aggregated totals.
     """
@@ -228,6 +376,13 @@ async def run_data_retention_purge() -> dict:
         "GAP-005: Purge cycle complete — %d total rows purged in %.2fs",
         grand_total, duration,
     )
+
+    # #1877 AC3: Track consecutive failures for Sentry alert
+    await _track_consecutive_failures([trial_result, messages_result, checkpoints_result])
+
+    # #1877 AC2: Persist purge results to Redis for admin dashboard
+    await _persist_purge_results(summary, trial_result, messages_result, checkpoints_result)
+
     return summary
 
 

--- a/backend/routes/admin_data_retention.py
+++ b/backend/routes/admin_data_retention.py
@@ -1,0 +1,122 @@
+"""#1877 AC2: Data retention admin status endpoint.
+
+Provides a read-only admin endpoint to inspect the last purge run per table:
+
+    GET /v1/admin/data-retention/status
+
+Returns per-table purge stats including timestamps, row counts, and any
+errors from the most recent purge cycle.
+
+Data is read from Redis keys written by ``run_data_retention_purge()``.
+Falls back gracefully when Redis is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from admin import require_admin
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin", tags=["admin", "data_retention"])
+
+_REDIS_TTL = 7 * 86400  # 7 days — must match data_retention.py
+
+
+@router.get("/data-retention/status", response_model=dict)
+async def get_data_retention_status(
+    user=Depends(require_admin),
+) -> dict[str, Any]:
+    """Return the last purge status per table.
+
+    Reads data from Redis keys set by the data retention purge cycle.
+    Falls back gracefully when Redis is unavailable.
+
+    Returns::
+
+        {
+            "status": "ok",
+            "queried_at": "2026-06-16T12:00:00+00:00",
+            "tables": [
+                {
+                    "name": "trial_email_log",
+                    "last_purge_at": "2026-06-16T12:00:00+00:00",
+                    "rows_purged_last": 42,
+                    "status": "success"
+                },
+                ...
+            ],
+            "total_rows_purged_last": 123,
+            "last_cycle_duration_seconds": 5.23
+        }
+    """
+    queried_at = datetime.now(timezone.utc).isoformat()
+
+    try:
+        from redis_pool import get_redis_pool
+        redis = await get_redis_pool()
+
+        tables: list[dict[str, Any]] = []
+        total_rows = 0
+        status = "ok"
+
+        for tbl_name in ("trial_email_log", "messages", "ingestion_checkpoints"):
+            table_info: dict[str, Any] = {
+                "name": tbl_name,
+                "last_purge_at": None,
+                "rows_purged_last": 0,
+                "status": "unknown",
+            }
+
+            try:
+                last_run_raw = await redis.get(f"data_retention:last_run:{tbl_name}")
+                if last_run_raw:
+                    table_info["last_purge_at"] = last_run_raw.decode()
+
+                rows_raw = await redis.get(f"data_retention:last_rows:{tbl_name}")
+                if rows_raw:
+                    table_info["rows_purged_last"] = int(rows_raw.decode())
+
+                error_raw = await redis.get(f"data_retention:last_error:{tbl_name}")
+                if error_raw:
+                    table_info["status"] = "error"
+                    table_info["error"] = error_raw.decode()
+                else:
+                    table_info["status"] = "success"
+            except Exception:
+                table_info["status"] = "redis_unavailable"
+
+            total_rows += table_info["rows_purged_last"]
+            tables.append(table_info)
+
+        # Read overall cycle duration
+        duration = 0.0
+        try:
+            duration_raw = await redis.get("data_retention:last_duration")
+            if duration_raw:
+                duration = float(duration_raw.decode())
+        except Exception:
+            pass
+
+        return {
+            "status": status,
+            "queried_at": queried_at,
+            "tables": tables,
+            "total_rows_purged_last": total_rows,
+            "last_cycle_duration_seconds": round(duration, 2),
+        }
+    except Exception as exc:
+        logger.warning("GET /v1/admin/data-retention/status failed: %s", exc)
+        return {
+            "status": "error",
+            "queried_at": queried_at,
+            "tables": [],
+            "total_rows_purged_last": 0,
+            "last_cycle_duration_seconds": 0,
+            "detail": str(exc),
+        }

--- a/backend/routes/admin_data_retention.py
+++ b/backend/routes/admin_data_retention.py
@@ -76,16 +76,16 @@ async def get_data_retention_status(
             try:
                 last_run_raw = await redis.get(f"data_retention:last_run:{tbl_name}")
                 if last_run_raw:
-                    table_info["last_purge_at"] = last_run_raw.decode()
+                    table_info["last_purge_at"] = last_run_raw
 
                 rows_raw = await redis.get(f"data_retention:last_rows:{tbl_name}")
                 if rows_raw:
-                    table_info["rows_purged_last"] = int(rows_raw.decode())
+                    table_info["rows_purged_last"] = int(rows_raw)
 
                 error_raw = await redis.get(f"data_retention:last_error:{tbl_name}")
                 if error_raw:
                     table_info["status"] = "error"
-                    table_info["error"] = error_raw.decode()
+                    table_info["error"] = error_raw
                 else:
                     table_info["status"] = "success"
             except Exception:
@@ -99,7 +99,7 @@ async def get_data_retention_status(
         try:
             duration_raw = await redis.get("data_retention:last_duration")
             if duration_raw:
-                duration = float(duration_raw.decode())
+                duration = float(duration_raw)
         except Exception:
             pass
 
@@ -118,5 +118,4 @@ async def get_data_retention_status(
             "tables": [],
             "total_rows_purged_last": 0,
             "last_cycle_duration_seconds": 0,
-            "detail": str(exc),
         }

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -112,6 +112,7 @@ from routes.score import router as score_router
 from routes.subcontract_intel import router as subcontract_intel_router
 from routes.data_deletion import router as data_deletion_router
 from routes.admin_alerts import router as admin_alerts_router
+from routes.admin_data_retention import router as admin_data_retention_router
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
     features_router, messages_router,
@@ -221,6 +222,8 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(admin_synthetic_router)
     # #1865: Alert routing — self-prefixed at /v1/admin/test-alert
     app.include_router(admin_alerts_router)
+    # #1877 AC2: Data retention status — self-prefixed at /v1/admin/data-retention/status
+    app.include_router(admin_data_retention_router)
     # Stripe webhook at root — DEBT-324: single registration only.
     # Removed from _v1_routers above to prevent duplicate at /v1/webhooks/stripe.
     # Stripe Dashboard must be configured with: POST /webhooks/stripe

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -22399,6 +22399,36 @@
         ]
       }
     },
+    "/v1/admin/data-retention/status": {
+      "get": {
+        "description": "Return the last purge status per table.\n\nReads data from Redis keys set by the data retention purge cycle.\nFalls back gracefully when Redis is unavailable.\n\nReturns::\n\n    {\n        \"status\": \"ok\",\n        \"queried_at\": \"2026-06-16T12:00:00+00:00\",\n        \"tables\": [\n            {\n                \"name\": \"trial_email_log\",\n                \"last_purge_at\": \"2026-06-16T12:00:00+00:00\",\n                \"rows_purged_last\": 42,\n                \"status\": \"success\"\n            },\n            ...\n        ],\n        \"total_rows_purged_last\": 123,\n        \"last_cycle_duration_seconds\": 5.23\n    }",
+        "operationId": "get_data_retention_status_v1_admin_data_retention_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Data Retention Status V1 Admin Data Retention Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Data Retention Status",
+        "tags": [
+          "admin",
+          "data_retention"
+        ]
+      }
+    },
     "/v1/admin/dlq": {
       "delete": {
         "description": "Delete **all** entries from the ARQ Dead Letter Queue.\n\nReturns ``{\"status\": \"ok\", \"keys_deleted\": N}`` on success.\nReturns ``{\"status\": \"error\", \"detail\": \"...\"}`` on failure.",

--- a/backend/tests/test_data_retention_admin.py
+++ b/backend/tests/test_data_retention_admin.py
@@ -125,13 +125,13 @@ def test_admin_status_endpoint_returns_expected_shape(admin_client):
     mock_redis = AsyncMock()
     # Simulate Redis with some data
     mock_redis.get = AsyncMock(side_effect=lambda key: {
-        "data_retention:last_run:trial_email_log": b"2026-06-15T12:00:00",
-        "data_retention:last_rows:trial_email_log": b"42",
-        "data_retention:last_run:messages": b"2026-06-15T12:00:00",
-        "data_retention:last_rows:messages": b"10",
-        "data_retention:last_run:ingestion_checkpoints": b"2026-06-15T12:00:00",
-        "data_retention:last_rows:ingestion_checkpoints": b"5",
-        "data_retention:last_duration": b"3.14",
+        "data_retention:last_run:trial_email_log": "2026-06-15T12:00:00",
+        "data_retention:last_rows:trial_email_log": "42",
+        "data_retention:last_run:messages": "2026-06-15T12:00:00",
+        "data_retention:last_rows:messages": "10",
+        "data_retention:last_run:ingestion_checkpoints": "2026-06-15T12:00:00",
+        "data_retention:last_rows:ingestion_checkpoints": "5",
+        "data_retention:last_duration": "3.14",
     }.get(key, None))
 
     with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):

--- a/backend/tests/test_data_retention_admin.py
+++ b/backend/tests/test_data_retention_admin.py
@@ -1,0 +1,246 @@
+"""#1877: Tests for data retention enhancements — dry-run, admin dashboard, Sentry alert.
+
+Covers:
+1. Dry-run mode does not DELETE, only logs (#1877 AC1).
+2. Admin status endpoint returns expected shape (#1877 AC2).
+3. Consecutive failure tracking alerts Sentry at >=2 failures (#1877 AC3).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_fake")
+os.environ.setdefault("DATA_RETENTION_DRY_RUN", "true")
+
+from main import app  # noqa: E402
+from auth import require_auth  # noqa: E402
+from admin import require_admin  # noqa: E402
+from jobs.cron import data_retention  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_client():
+    """TestClient with admin auth override."""
+    fake_admin = {"id": "00000000-0000-0000-0000-00000000a001", "email": "admin@test"}
+    app.dependency_overrides[require_auth] = lambda: fake_admin
+    app.dependency_overrides[require_admin] = lambda: fake_admin
+    yield TestClient(app)
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+@pytest.fixture
+def regular_client():
+    """Logged-in non-admin user — should get 403 from require_admin."""
+    fake_user = {"id": "regular-user", "email": "user@test"}
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    yield TestClient(app)
+    app.dependency_overrides.pop(require_auth, None)
+
+
+@pytest.fixture(autouse=True)
+def _clear_dry_run_flag():
+    """Ensure DATA_RETENTION_DRY_RUN is set to true for all tests.
+
+    Individual tests can override by patching the module constant.
+    """
+    original = data_retention.DATA_RETENTION_DRY_RUN
+    data_retention.DATA_RETENTION_DRY_RUN = True
+    yield
+    data_retention.DATA_RETENTION_DRY_RUN = original
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_skips_delete_trial_email_log():
+    """AC1: Dry-run must log and skip actual DELETE for trial_email_log."""
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.delete.return_value.lt.return_value = "would_query"
+
+    with (
+        patch("supabase_client.get_supabase", return_value=mock_sb),
+        patch("supabase_client.sb_execute", new_callable=AsyncMock) as mock_exec,
+    ):
+        result = await data_retention.purge_trial_email_log()
+
+    # sb_execute must NOT be called in dry-run mode
+    mock_exec.assert_not_called()
+    assert result["deleted"] == 0
+    assert result.get("dry_run") is True
+    assert result["table"] == "trial_email_log"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_skips_delete_messages():
+    """AC1: Dry-run must log and skip actual DELETE for messages."""
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.delete.return_value.lt.return_value = "would_query"
+
+    with (
+        patch("supabase_client.get_supabase", return_value=mock_sb),
+        patch("supabase_client.sb_execute", new_callable=AsyncMock) as mock_exec,
+    ):
+        result = await data_retention.purge_messages()
+
+    mock_exec.assert_not_called()
+    assert result["deleted"] == 0
+    assert result.get("dry_run") is True
+    assert result["table"] == "messages"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_skips_delete_ingestion_checkpoints():
+    """AC1: Dry-run must log and skip actual DELETE for ingestion_checkpoints."""
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.delete.return_value.in_.return_value.lt.return_value = "would_query"
+
+    with (
+        patch("supabase_client.get_supabase", return_value=mock_sb),
+        patch("supabase_client.sb_execute", new_callable=AsyncMock) as mock_exec,
+    ):
+        result = await data_retention.purge_ingestion_checkpoints()
+
+    mock_exec.assert_not_called()
+    assert result["deleted"] == 0
+    assert result.get("dry_run") is True
+    assert result["table"] == "ingestion_checkpoints"
+
+
+def test_admin_status_endpoint_returns_expected_shape(admin_client):
+    """AC2: Admin status endpoint returns expected JSON structure."""
+    mock_redis = AsyncMock()
+    # Simulate Redis with some data
+    mock_redis.get = AsyncMock(side_effect=lambda key: {
+        "data_retention:last_run:trial_email_log": b"2026-06-15T12:00:00",
+        "data_retention:last_rows:trial_email_log": b"42",
+        "data_retention:last_run:messages": b"2026-06-15T12:00:00",
+        "data_retention:last_rows:messages": b"10",
+        "data_retention:last_run:ingestion_checkpoints": b"2026-06-15T12:00:00",
+        "data_retention:last_rows:ingestion_checkpoints": b"5",
+        "data_retention:last_duration": b"3.14",
+    }.get(key, None))
+
+    with patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis):
+        response = admin_client.get("/v1/admin/data-retention/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "queried_at" in body
+    assert len(body["tables"]) == 3
+    assert body["total_rows_purged_last"] == 57  # 42 + 10 + 5
+    assert body["last_cycle_duration_seconds"] == 3.14
+
+    # Verify per-table structure
+    trial_email = body["tables"][0]
+    assert trial_email["name"] == "trial_email_log"
+    assert trial_email["rows_purged_last"] == 42
+    assert trial_email["last_purge_at"] == "2026-06-15T12:00:00"
+    assert trial_email["status"] == "success"
+
+
+def test_admin_status_endpoint_requires_auth(regular_client):
+    """AC2: Non-admin users get 403 from status endpoint."""
+    response = regular_client.get("/v1/admin/data-retention/status")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failure_alert_at_threshold():
+    """AC3: Sentry alert when consecutive failures >= 2.
+
+    Simulates one error result and one clean result to verify the counter
+    only fires at >=2.
+    """
+    mock_redis = AsyncMock()
+    mock_redis.incr = AsyncMock(return_value=2)  # Second consecutive failure
+    mock_redis.expire = AsyncMock(return_value=True)
+
+    mock_scope = MagicMock()
+
+    with (
+        patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis),
+        patch("sentry_sdk.push_scope", return_value=mock_scope),
+        patch("sentry_sdk.capture_message") as mock_capture,
+    ):
+        results = [
+            {"table": "trial_email_log", "deleted": 0, "error": "test error"},
+            {"table": "messages", "deleted": 0, "error": "test error"},
+            {"table": "ingestion_checkpoints", "deleted": 0, "error": "test error"},
+        ]
+        await data_retention._track_consecutive_failures(results)
+
+    # Should have triggered sentry capture_message
+    mock_capture.assert_called_once()
+    call_args = mock_capture.call_args
+    assert "failed 2x consecutively" in call_args[0][0]
+    assert call_args[1]["level"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failure_no_alert_below_threshold():
+    """AC3: No Sentry alert when consecutive failures < 2.
+
+    Simulates a clean run (no errors) to verify counter resets to 0.
+    """
+    mock_redis = AsyncMock()
+    mock_redis.set = AsyncMock(return_value=True)
+    mock_redis.expire = AsyncMock(return_value=True)
+
+    with (
+        patch("redis_pool.get_redis_pool", new_callable=AsyncMock, return_value=mock_redis),
+        patch("sentry_sdk.capture_message") as mock_capture,
+    ):
+        results = [
+            {"table": "trial_email_log", "deleted": 10},
+            {"table": "messages", "deleted": 5},
+            {"table": "ingestion_checkpoints", "deleted": 3},
+        ]
+        await data_retention._track_consecutive_failures(results)
+
+    # Counter should have been reset to 0 — no sentry alert
+    mock_capture.assert_not_called()
+    mock_redis.set.assert_called_with("data_retention:consecutive_failures", 0)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_flag_off_deletes_normally():
+    """AC1: When dry-run is False, DELETE queries are executed."""
+    # Temporarily disable dry-run
+    original = data_retention.DATA_RETENTION_DRY_RUN
+    data_retention.DATA_RETENTION_DRY_RUN = False
+
+    mock_result = MagicMock()
+    mock_result.data = [{"id": 1}, {"id": 2}, {"id": 3}]
+
+    mock_sb = MagicMock()
+    mock_sb.table.return_value.delete.return_value.lt.return_value = "query"
+
+    try:
+        with (
+            patch("supabase_client.get_supabase", return_value=mock_sb),
+            patch("supabase_client.sb_execute", new_callable=AsyncMock, return_value=mock_result),
+            patch("redis_pool.get_redis_pool", new_callable=AsyncMock) as mock_redis_pool,
+        ):
+            mock_redis = AsyncMock()
+            mock_redis_pool.return_value = mock_redis
+            result = await data_retention.purge_trial_email_log()
+
+        assert result["deleted"] == 3
+        assert result.get("dry_run") is None
+    finally:
+        data_retention.DATA_RETENTION_DRY_RUN = original

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -767,6 +767,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/data-retention/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Data Retention Status
+         * @description Return the last purge status per table.
+         *
+         *     Reads data from Redis keys set by the data retention purge cycle.
+         *     Falls back gracefully when Redis is unavailable.
+         *
+         *     Returns::
+         *
+         *         {
+         *             "status": "ok",
+         *             "queried_at": "2026-06-16T12:00:00+00:00",
+         *             "tables": [
+         *                 {
+         *                     "name": "trial_email_log",
+         *                     "last_purge_at": "2026-06-16T12:00:00+00:00",
+         *                     "rows_purged_last": 42,
+         *                     "status": "success"
+         *                 },
+         *                 ...
+         *             ],
+         *             "total_rows_purged_last": 123,
+         *             "last_cycle_duration_seconds": 5.23
+         *         }
+         */
+        get: operations["get_data_retention_status_v1_admin_data_retention_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/dlq": {
         parameters: {
             query?: never;
@@ -17910,6 +17951,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AdminCronStatusResponse"];
+                };
+            };
+        };
+    };
+    get_data_retention_status_v1_admin_data_retention_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };


### PR DESCRIPTION
## Summary

Post-PR #1886 enhancements for data retention automation.

### Changes

- **Dry-run mode**: `DATA_RETENTION_DRY_RUN=true` logs what would be deleted without executing DELETE
- **Admin dashboard**: `GET /v1/admin/data-retention/status` returns per-table purge stats
- **Sentry alert**: Consecutive failure detection — alerts if purge fails ≥2x consecutively
- **Redis persistence**: Purge run metadata stored in Redis for admin dashboard

### Acceptance Criteria

- [x] Dry-run mode implemented (`DATA_RETENTION_DRY_RUN=true`)
- [x] Admin dashboard shows retention status per table
- [x] Sentry alert for consecutive purge failures
- [x] 8 new tests + 8 existing tests passing

Closes #1877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin endpoint to view data retention operation status with metrics including last purge timestamp, rows purged per table, and cycle duration.
  * Enabled dry-run mode for data retention operations to safely preview purge actions without executing deletions.

* **Tests**
  * Added comprehensive test coverage for dry-run functionality, admin endpoint access controls, and failure monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->