### PR TITLE
fix(backend): move APIVersionHeaderMiddleware to outermost layer (#1918)

### DIFF
--- a/backend/startup/middleware_setup.py
+++ b/backend/startup/middleware_setup.py
@@ -89,10 +89,10 @@ def setup_middleware(app: FastAPI) -> None:
     app.add_middleware(CorrelationIDMiddleware)
     app.add_middleware(SecurityHeadersMiddleware)
     app.add_middleware(DeprecationMiddleware)
-    # Issue #1918: X-API-Version header on all responses — must be close to
-    # outermost so it covers even responses from other middlewares.
-    app.add_middleware(APIVersionHeaderMiddleware)
     app.add_middleware(RateLimitMiddleware)
+    # Issue #1918: X-API-Version header on all responses — outermost layer
+    # so ALL responses (including 429 rate-limit errors) get version headers.
+    app.add_middleware(APIVersionHeaderMiddleware)
 
     # RBAC-SEC-002: Inject rate limit headers stored in request.state by
     # require_rate_limit / rate_limit_public dependencies into every response.

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -464,7 +464,14 @@ class TestCorrelationIDMiddlewareAC5:
 
 
 class TestAPIVersionHeaderMiddleware:
-    """Issue #1918 AC2: Test that APIVersionHeaderMiddleware adds version headers."""
+    """Issue #1918 AC2: Test that APIVersionHeaderMiddleware adds version headers.
+
+    Note: these tests create isolated FastAPI apps so middleware registration
+    order within each test method is arbitrary. In production
+    (middleware_setup.py), APIVersionHeaderMiddleware is registered LAST
+    (= outermost) to ensure ALL responses — including 429 from
+    RateLimitMiddleware — receive X-API-Version and X-API-Deprecated headers.
+    """
 
     @pytest.mark.anyio
     async def test_api_version_header_present(self):


### PR DESCRIPTION
## Summary

Fixes middleware ordering issue identified in governance review of PR #1933.

**Problem:** APIVersionHeaderMiddleware was registered before RateLimitMiddleware, so 429 rate-limit responses didn't get X-API-Version and X-API-Deprecated headers.

**Fix:** Move APIVersionHeaderMiddleware to the outermost layer (after RateLimitMiddleware) so ALL responses — including error responses from other middleware — include version headers.

## Changes
- `backend/startup/middleware_setup.py`: Reorder middleware registration
- `backend/tests/test_middleware.py`: Update class docstring noting production ordering

## Validation
- ruff check: passes
- Backend tests: pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)