### PR TITLE
fix(test): validate version headers on error responses properly (#1918)

### DIFF
--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -22,6 +22,7 @@ import io
 import pytest
 from httpx import AsyncClient, ASGITransport
 from fastapi import FastAPI
+from starlette.responses import JSONResponse
 
 from middleware import (RequestIDFilter, CorrelationIDMiddleware,
                          APIVersionHeaderMiddleware, request_id_var)
@@ -530,18 +531,21 @@ class TestAPIVersionHeaderMiddleware:
         async def error_endpoint():
             raise ValueError("Test error")
 
+        @app.exception_handler(ValueError)
+        async def value_error_handler(request, exc):
+            return JSONResponse(status_code=500, content={"error": "Test error"})
+
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            try:
-                await client.get("/error")
-            except Exception:
-                pass
+            response = await client.get("/error")
 
-        # We can't easily capture error response headers via httpx,
-        # but we verify the middleware class exists and is properly configured
-        middleware = APIVersionHeaderMiddleware(app)
-        assert middleware.API_VERSION == "v1"
-        assert middleware._DEPRECATED == "false"
+        assert response.status_code == 500
+        assert response.headers["x-api-version"] == "v1", (
+            "X-API-Version header must be present even on error responses"
+        )
+        assert response.headers["x-api-deprecated"] == "false", (
+            "X-API-Deprecated header must be present even on error responses"
+        )
 
     @pytest.mark.anyio
     async def test_headers_on_multiple_endpoints(self):


### PR DESCRIPTION
## Summary

Fixes the `test_headers_on_error_response` test identified in governance review of PR #1933.

**Problem:** The test claimed to verify "Version headers present even on error responses" but it caught the exception with `try/except` and only asserted class constants — it NEVER checked actual HTTP error response headers.

## Changes

- Replace `try/except` pattern with proper `@app.exception_handler(ValueError)` returning `JSONResponse(status_code=500)`
- Test now verifies actual HTTP 500 response headers contain `x-api-version: v1` and `x-api-deprecated: false`
- Added import: `from starlette.responses import JSONResponse`

## Validation

- `ruff check tests/test_middleware.py`: All checks passed
- `TestAPIVersionHeaderMiddleware`: 5/5 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)