### PR TITLE
feat(backend): webhook integrations — Slack + Teams + Email (#1522)

### DIFF
--- a/backend/routes/integrations.py
+++ b/backend/routes/integrations.py
@@ -1,0 +1,353 @@
+"""Webhook integration CRUD — B2GOPS-015 (#1522).
+
+Endpoints:
+    POST   /v1/integrations/webhooks         — create a new webhook
+    GET    /v1/integrations/webhooks         — list user's webhooks
+    PATCH  /v1/integrations/webhooks/{id}    — update a webhook
+    DELETE /v1/integrations/webhooks/{id}    — delete a webhook
+    POST   /v1/integrations/webhooks/{id}/test  — send test notification
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from auth import require_auth
+from schemas.integrations import (
+    WebhookChannel,
+    WebhookCreate,
+    WebhookEvent,
+    WebhookResponse,
+    WebhookTestResponse,
+    WebhookUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/integrations", tags=["integrations"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _user_id(user: dict) -> str:
+    return user.get("sub") or user.get("id", "")
+
+
+def _webhook_to_response(row: dict) -> WebhookResponse:
+    """Convert a DB row dict to a WebhookResponse schema."""
+    events_raw = row.get("events", []) or []
+    events = []
+    for e in events_raw:
+        try:
+            events.append(WebhookEvent(e))
+        except ValueError:
+            logger.warning("Unknown webhook event in DB: %s", e)
+
+    return WebhookResponse(
+        id=row.get("id", ""),
+        channel=WebhookChannel(row.get("channel", "email")),
+        label=row.get("label"),
+        webhook_url=row.get("webhook_url"),
+        email_target=row.get("email_target"),
+        events=events,
+        is_active=row.get("is_active", True),
+        last_triggered_at=row.get("last_triggered_at"),
+        created_at=row.get("created_at", _now_iso()),
+    )
+
+
+def _validate_webhook_create(body: WebhookCreate) -> None:
+    """Validate that the required fields are present for the chosen channel."""
+    if body.channel in (WebhookChannel.slack, WebhookChannel.teams):
+        if not body.webhook_url:
+            raise HTTPException(
+                status_code=422,
+                detail=f"webhook_url is required for {body.channel.value} channel",
+            )
+    elif body.channel == WebhookChannel.email:
+        if not body.email_target:
+            raise HTTPException(
+                status_code=422,
+                detail="email_target is required for email channel",
+            )
+
+
+# ---------------------------------------------------------------------------
+# CRUD Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/webhooks", response_model=WebhookResponse, status_code=201)
+async def create_webhook(
+    body: WebhookCreate,
+    user: dict = Depends(require_auth),
+):
+    """Create a new webhook integration (Slack, Teams, or Email)."""
+    _validate_webhook_create(body)
+
+    uid = _user_id(user)
+    events_str = [e.value for e in body.events]
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("integrations_webhooks")
+            .insert({
+                "user_id": uid,
+                "channel": body.channel.value,
+                "label": body.label,
+                "webhook_url": body.webhook_url,
+                "email_target": body.email_target,
+                "events": events_str,
+            })
+            .select("*"),
+            category="write",
+        )
+    except Exception as exc:
+        logger.error("Failed to create webhook: %s", exc)
+        raise HTTPException(status_code=500, detail="Erro ao criar webhook")
+
+    row = result.data[0] if result.data else {}
+    logger.info(
+        "Webhook created for user %s (channel=%s, id=%s)",
+        uid[:8], body.channel.value, row.get("id", "")[:8],
+    )
+    return _webhook_to_response(row)
+
+
+@router.get("/webhooks", response_model=list[WebhookResponse])
+async def list_webhooks(user: dict = Depends(require_auth)):
+    """List all webhooks for the authenticated user."""
+    uid = _user_id(user)
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        result = await sb_execute(
+            sb.table("integrations_webhooks")
+            .select("*")
+            .eq("user_id", uid)
+            .order("created_at", desc=True)
+        )
+    except Exception as exc:
+        logger.error("Failed to list webhooks: %s", exc)
+        raise HTTPException(status_code=500, detail="Erro ao listar webhooks")
+
+    return [_webhook_to_response(r) for r in (result.data or [])]
+
+
+@router.patch("/webhooks/{webhook_id}", response_model=WebhookResponse)
+async def update_webhook(
+    webhook_id: UUID,
+    body: WebhookUpdate,
+    user: dict = Depends(require_auth),
+):
+    """Update a webhook configuration."""
+    uid = _user_id(user)
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+
+        # Verify ownership
+        check = await sb_execute(
+            sb.table("integrations_webhooks")
+            .select("id, user_id")
+            .eq("id", str(webhook_id))
+            .limit(1)
+        )
+        if not check.data:
+            raise HTTPException(status_code=404, detail="Webhook não encontrado")
+
+        row = check.data[0]
+        if row.get("user_id") != uid:
+            raise HTTPException(
+                status_code=403,
+                detail="Você não tem permissão para modificar este webhook",
+            )
+
+        # Build update payload
+        update_data = {}
+        if body.label is not None:
+            update_data["label"] = body.label
+        if body.webhook_url is not None:
+            update_data["webhook_url"] = body.webhook_url
+        if body.email_target is not None:
+            update_data["email_target"] = body.email_target
+        if body.events is not None:
+            update_data["events"] = [e.value for e in body.events]
+        if body.is_active is not None:
+            update_data["is_active"] = body.is_active
+        update_data["updated_at"] = _now_iso()
+
+        result = await sb_execute(
+            sb.table("integrations_webhooks")
+            .update(update_data)
+            .eq("id", str(webhook_id))
+            .eq("user_id", uid)
+            .select("*"),
+            category="write",
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to update webhook %s: %s", str(webhook_id)[:8], exc)
+        raise HTTPException(status_code=500, detail="Erro ao atualizar webhook")
+
+    updated = result.data[0] if result.data else {}
+    logger.info(
+        "Webhook %s updated for user %s",
+        str(webhook_id)[:8], uid[:8],
+    )
+    return _webhook_to_response(updated)
+
+
+@router.delete("/webhooks/{webhook_id}", status_code=204, response_model=None)
+async def delete_webhook(
+    webhook_id: UUID,
+    user: dict = Depends(require_auth),
+):
+    """Delete a webhook integration."""
+    uid = _user_id(user)
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+
+        # Verify ownership
+        check = await sb_execute(
+            sb.table("integrations_webhooks")
+            .select("id, user_id")
+            .eq("id", str(webhook_id))
+            .limit(1)
+        )
+        if not check.data:
+            raise HTTPException(status_code=404, detail="Webhook não encontrado")
+
+        row = check.data[0]
+        if row.get("user_id") != uid:
+            raise HTTPException(
+                status_code=403,
+                detail="Você não tem permissão para excluir este webhook",
+            )
+
+        await sb_execute(
+            sb.table("integrations_webhooks")
+            .delete()
+            .eq("id", str(webhook_id))
+            .eq("user_id", uid),
+            category="write",
+        )
+
+        logger.info("Webhook %s deleted by user %s", str(webhook_id)[:8], uid[:8])
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to delete webhook %s: %s", str(webhook_id)[:8], exc)
+        raise HTTPException(status_code=500, detail="Erro ao excluir webhook")
+
+
+@router.post("/webhooks/{webhook_id}/test", response_model=WebhookTestResponse)
+async def test_webhook(
+    webhook_id: UUID,
+    user: dict = Depends(require_auth),
+):
+    """Send a test notification to verify the webhook configuration."""
+    uid = _user_id(user)
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+
+        # Fetch webhook
+        check = await sb_execute(
+            sb.table("integrations_webhooks")
+            .select("*")
+            .eq("id", str(webhook_id))
+            .limit(1)
+        )
+        if not check.data:
+            raise HTTPException(status_code=404, detail="Webhook não encontrado")
+
+        webhook = check.data[0]
+        if webhook.get("user_id") != uid:
+            raise HTTPException(
+                status_code=403,
+                detail="Você não tem permissão para testar este webhook",
+            )
+
+        # Send test notification (bypass rate limiting for test)
+
+        test_payload = {
+            "title": "🔔 Teste de Notificação SmartLic",
+            "description": (
+                "Esta é uma notificação de teste para verificar "
+                "a configuração do seu webhook."
+            ),
+            "url": "https://smartlic.tech/conta/integracoes",
+            "color": "#4CAF50",
+        }
+
+        # Force dispatch without rate limit check for tests
+        channel = webhook.get("channel", "")
+        success = False
+        target: Optional[str] = None
+
+        if channel == "slack":
+            from services.webhook_dispatcher import _send_slack
+
+            success = await _send_slack(
+                webhook.get("webhook_url", ""), "test", test_payload,
+            )
+            target = webhook.get("webhook_url", "")[:50]
+        elif channel == "teams":
+            from services.webhook_dispatcher import _send_teams
+
+            success = await _send_teams(
+                webhook.get("webhook_url", ""), "test", test_payload,
+            )
+            target = webhook.get("webhook_url", "")[:50]
+        elif channel == "email":
+            from services.webhook_dispatcher import _send_email
+
+            success = await _send_email(
+                webhook.get("email_target", ""), "test", test_payload,
+            )
+            target = webhook.get("email_target", "")
+
+        if not success:
+            raise HTTPException(
+                status_code=502,
+                detail="Falha ao enviar notificação de teste. Verifique a URL do webhook.",
+            )
+
+        return WebhookTestResponse(
+            message="Notificação de teste enviada com sucesso",
+            channel=WebhookChannel(channel),
+            target=target,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to test webhook %s: %s", str(webhook_id)[:8], exc)
+        raise HTTPException(status_code=500, detail="Erro ao testar webhook")

--- a/backend/schemas/integrations.py
+++ b/backend/schemas/integrations.py
@@ -1,0 +1,79 @@
+"""Pydantic schemas for webhook integrations — B2GOPS-015 (#1522)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "WebhookChannel",
+    "WebhookEvent",
+    "WebhookCreate",
+    "WebhookUpdate",
+    "WebhookResponse",
+    "WebhookTestResponse",
+]
+
+
+class WebhookChannel(str, Enum):
+    """Supported notification channels."""
+
+    slack = "slack"
+    teams = "teams"
+    email = "email"
+
+
+class WebhookEvent(str, Enum):
+    """Notification event types for webhook dispatch."""
+
+    new_edital = "new_edital"
+    deadline_24h = "deadline_24h"
+    deadline_6h = "deadline_6h"
+    deadline_1h = "deadline_1h"
+    pregao_started = "pregao_started"
+    result_published = "result_published"
+
+
+class WebhookCreate(BaseModel):
+    """Request body for POST /v1/integrations/webhooks."""
+
+    channel: WebhookChannel
+    label: Optional[str] = None
+    webhook_url: Optional[str] = Field(None, description="Incoming webhook URL (required for slack/teams)")
+    email_target: Optional[str] = Field(None, description="Email address (required for email channel)")
+    events: list[WebhookEvent] = []
+
+
+class WebhookUpdate(BaseModel):
+    """Request body for PATCH /v1/integrations/webhooks/{id}."""
+
+    label: Optional[str] = None
+    webhook_url: Optional[str] = None
+    email_target: Optional[str] = None
+    events: Optional[list[WebhookEvent]] = None
+    is_active: Optional[bool] = None
+
+
+class WebhookResponse(BaseModel):
+    """Public webhook representation returned by the API."""
+
+    id: str
+    channel: WebhookChannel
+    label: Optional[str] = None
+    webhook_url: Optional[str] = None
+    email_target: Optional[str] = None
+    events: list[WebhookEvent]
+    is_active: bool
+    last_triggered_at: Optional[datetime] = None
+    created_at: datetime
+
+
+class WebhookTestResponse(BaseModel):
+    """Response from the test notification endpoint."""
+
+    message: str
+    channel: WebhookChannel
+    target: Optional[str] = None

--- a/backend/schemas/integrations.py
+++ b/backend/schemas/integrations.py
@@ -1,12 +1,29 @@
-"""Pydantic schemas for webhook integrations — B2GOPS-015 (#1522)."""
+"""Pydantic schemas for webhook integrations — B2GOPS-015 (#1522).
+
+SSRF hardening: webhook_url fields enforce HTTPS-only + block internal/private
+IPs via custom field_validator. See security/SSRF-001.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
 from typing import Optional
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Hosts that are never allowed as webhook targets (SSRF prevention).
+# Covers localhost, loopback, cloud metadata endpoints, and common
+# private IP ranges checked at parse time.
+_BLOCKED_SSRF_HOSTS: set[str] = {
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "169.254.169.254",  # AWS/GCP/Azure metadata
+    "metadata.google.internal",  # GCP metadata
+    "100.100.100.200",  # Alicloud metadata
+}
 
 __all__ = [
     "WebhookChannel",
@@ -15,7 +32,69 @@ __all__ = [
     "WebhookUpdate",
     "WebhookResponse",
     "WebhookTestResponse",
+    "validate_webhook_url",
 ]
+
+
+def validate_webhook_url(v: Optional[str]) -> Optional[str]:
+    """Validate a webhook URL for SSRF safety.
+
+    Checks performed:
+    1. None is always allowed (field is optional).
+    2. Must be HTTPS (not HTTP or other schemes).
+    3. Hostname must not be in the blocked-SSRF set.
+    4. Hostname must not be a private/reserved IP (10.x, 172.16-31.x,
+       192.168.x, 127.x.x.x).
+
+    Returns the original value (passthrough) if valid, raises ValueError
+    with a specific message otherwise.
+    """
+    if v is None:
+        return v
+
+    parsed = urlparse(v)
+
+    # Scheme enforcement -- only HTTPS is safe for webhooks
+    if parsed.scheme != "https":
+        raise ValueError(
+            f"Webhook URL scheme must be 'https', got '{parsed.scheme}'"
+        )
+
+    hostname = (parsed.hostname or "").lower()
+
+    # Block known internal/metadata hosts
+    if hostname in _BLOCKED_SSRF_HOSTS:
+        raise ValueError(
+            f"Webhook URL host not allowed: {hostname}"
+        )
+
+    # Block private/reserved IP ranges
+    if hostname.startswith("10.") or hostname.startswith("192.168."):
+        raise ValueError(
+            f"Webhook URL host is a private IP range: {hostname}"
+        )
+
+    # 172.16.0.0 - 172.31.255.255
+    # The try/except only guards the int() parsing of the second octet;
+    # the ValueError for private range is raised OUTSIDE the handler so
+    # it is not accidentally swallowed.
+    if hostname.startswith("172."):
+        try:
+            second_octet = int(hostname.split(".")[1])
+        except (IndexError, ValueError):
+            second_octet = -1
+        if 16 <= second_octet <= 31:
+            raise ValueError(
+                f"Webhook URL host is a private IP range: {hostname}"
+            )
+
+    # Block link-local (169.254.x.x)
+    if hostname.startswith("169.254."):
+        raise ValueError(
+            f"Webhook URL host is a link-local address: {hostname}"
+        )
+
+    return v
 
 
 class WebhookChannel(str, Enum):
@@ -46,6 +125,8 @@ class WebhookCreate(BaseModel):
     email_target: Optional[str] = Field(None, description="Email address (required for email channel)")
     events: list[WebhookEvent] = []
 
+    _validate_webhook_url = field_validator("webhook_url")(validate_webhook_url)
+
 
 class WebhookUpdate(BaseModel):
     """Request body for PATCH /v1/integrations/webhooks/{id}."""
@@ -55,6 +136,8 @@ class WebhookUpdate(BaseModel):
     email_target: Optional[str] = None
     events: Optional[list[WebhookEvent]] = None
     is_active: Optional[bool] = None
+
+    _validate_webhook_url = field_validator("webhook_url")(validate_webhook_url)
 
 
 class WebhookResponse(BaseModel):

--- a/backend/services/webhook_dispatcher.py
+++ b/backend/services/webhook_dispatcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,54 @@ RATE_LIMIT_WINDOW = timedelta(hours=1)
 # ---------------------------------------------------------------------------
 # Rate limiting
 # ---------------------------------------------------------------------------
+
+
+
+# ---------------------------------------------------------------------------
+# SSRF defense-in-depth
+# ---------------------------------------------------------------------------
+
+
+def _validate_ssrf(url: str) -> None:
+    """Defense-in-depth SSRF check before making any outbound HTTP call.
+
+    This duplicates the Pydantic-level validation as a safety net at the
+    HTTP dispatch boundary, so that even if a webhook_url bypasses schema
+    validation (e.g. direct DB write, future code path), the request is
+    still blocked before hitting the network.
+
+    Raises ValueError if the URL targets an internal/private host.
+    """
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+
+    # Block known internal/metadata hosts
+    blocked_hosts = {
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",
+        "169.254.169.254",
+        "metadata.google.internal",
+        "100.100.100.200",
+    }
+    if hostname in blocked_hosts:
+        raise ValueError(f"Webhook URL host not allowed: {hostname}")
+
+    # Block private IP ranges
+    if hostname.startswith("10.") or hostname.startswith("192.168."):
+        raise ValueError(f"Webhook URL host is a private IP range: {hostname}")
+
+    if hostname.startswith("172."):
+        try:
+            second = int(hostname.split(".")[1])
+        except (IndexError, ValueError):
+            second = -1
+        if 16 <= second <= 31:
+            raise ValueError(f"Webhook URL host is a private IP range: {hostname}")
+
+    if hostname.startswith("169.254."):
+        raise ValueError(f"Webhook URL host is a link-local address: {hostname}")
+
 
 
 def _is_rate_limited(webhook: dict) -> bool:
@@ -175,7 +224,20 @@ def _format_email_subject(event: str, payload: dict) -> str:
 
 
 async def _send_webhook_post(url: str, json_data: dict) -> bool:
-    """Send a POST request to a webhook URL. Returns True on success."""
+    """Send a POST request to a webhook URL. Returns True on success.
+
+    SSRF guard: validates the URL against internal/private targets before
+    making any outbound HTTP call (defense-in-depth layer on top of
+    Pydantic schema validation).
+    """
+    try:
+        from schemas.integrations import validate_webhook_url
+
+        validate_webhook_url(url)
+    except ValueError:
+        logger.error("SSRF block: webhook URL %s rejected", url[:50])
+        return False
+
     try:
         import httpx
 

--- a/backend/services/webhook_dispatcher.py
+++ b/backend/services/webhook_dispatcher.py
@@ -1,0 +1,280 @@
+"""Webhook notification dispatcher — B2GOPS-015 (#1522).
+
+Dispatches notifications to Slack, Microsoft Teams, and Email channels
+with rate limiting (1 notification per event per hour).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+RATE_LIMIT_WINDOW = timedelta(hours=1)
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+def _is_rate_limited(webhook: dict) -> bool:
+    """Check if the webhook exceeds the 1-per-hour rate limit.
+
+    Returns True if the last trigger was within the rate limit window.
+    """
+    last_triggered = webhook.get("last_triggered_at")
+    if not last_triggered:
+        return False
+    if isinstance(last_triggered, str):
+        last_triggered = datetime.fromisoformat(last_triggered.replace("Z", "+00:00"))
+    age = datetime.now(timezone.utc) - last_triggered
+    return age < RATE_LIMIT_WINDOW
+
+
+async def _update_last_triggered(webhook_id: str) -> None:
+    """Update last_triggered_at to now for the given webhook."""
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        sb = get_supabase()
+        await sb_execute(
+            sb.table("integrations_webhooks")
+            .update({"last_triggered_at": datetime.now(timezone.utc).isoformat()})
+            .eq("id", webhook_id),
+            category="write",
+        )
+    except Exception as exc:
+        logger.warning("Failed to update last_triggered_at for webhook %s: %s", webhook_id[:8], exc)
+
+
+# ---------------------------------------------------------------------------
+# Message formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_slack_message(event: str, payload: dict) -> dict:
+    """Format a notification as a Slack incoming webhook message."""
+    title = payload.get("title", "SmartLic Notification")
+    description = payload.get("description", "")
+    url = payload.get("url", "")
+    color = payload.get("color", "#1E88E5")
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": f"📢 {title}"},
+        },
+    ]
+    if description:
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": description},
+        })
+    if url:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"<{url}|Abrir no SmartLic>",
+            },
+        })
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {
+                "type": "mrkdwn",
+                "text": f"Evento: `{event}` | SmartLic",
+            }
+        ],
+    })
+
+    return {
+        "text": f"📢 {title}",
+        "attachments": [
+            {
+                "color": color,
+                "blocks": blocks,
+            }
+        ],
+    }
+
+
+def _format_teams_message(event: str, payload: dict) -> dict:
+    """Format a notification as a Teams incoming webhook message (MessageCard)."""
+    title = payload.get("title", "SmartLic Notification")
+    description = payload.get("description", "")
+    url = payload.get("url", "")
+
+    sections = []
+    if description:
+        sections.append({
+            "text": description,
+        })
+    if url:
+        sections.append({
+            "text": f"[Abrir no SmartLic]({url})",
+        })
+
+    return {
+        "@type": "MessageCard",
+        "@context": "https://schema.org/extensions",
+        "summary": title,
+        "title": f"📢 {title}",
+        "sections": sections,
+        "potentialAction": (
+            [
+                {
+                    "@type": "OpenUri",
+                    "name": "Abrir no SmartLic",
+                    "targets": [{"os": "default", "uri": url}],
+                }
+            ]
+            if url
+            else []
+        ),
+    }
+
+
+def _format_email_html(event: str, payload: dict) -> str:
+    """Format a notification as HTML email body."""
+    title = payload.get("title", "SmartLic Notification")
+    description = payload.get("description", "")
+    url = payload.get("url", "")
+
+    rows = f"<p><strong>{title}</strong></p>"
+    if description:
+        rows += f"<p>{description}</p>"
+    if url:
+        rows += f'<p><a href="{url}" style="display:inline-block;padding:12px 24px;background-color:#1E88E5;color:#fff;text-decoration:none;border-radius:4px;">Abrir no SmartLic</a></p>'
+
+    return f"""<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;">
+    <div style="background-color:#f8f9fa;border-radius:8px;padding:24px;">
+        {rows}
+        <hr style="border:none;border-top:1px solid #e0e0e0;margin:16px 0;">
+        <p style="font-size:12px;color:#666;">
+            Evento: {event} | SmartLic
+        </p>
+    </div>
+</body>
+</html>"""
+
+
+def _format_email_subject(event: str, payload: dict) -> str:
+    """Format the email subject line."""
+    title = payload.get("title", "SmartLic Notification")
+    return f"📢 {title}"
+
+
+# ---------------------------------------------------------------------------
+# HTTP dispatchers
+# ---------------------------------------------------------------------------
+
+
+async def _send_webhook_post(url: str, json_data: dict) -> bool:
+    """Send a POST request to a webhook URL. Returns True on success."""
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(url, json=json_data)
+            resp.raise_for_status()
+            return True
+    except Exception as exc:
+        logger.warning("Webhook POST failed to %s: %s", url[:50], exc)
+        return False
+
+
+async def _send_slack(webhook_url: str, event: str, payload: dict) -> bool:
+    """Send notification to a Slack incoming webhook."""
+    message = _format_slack_message(event, payload)
+    return await _send_webhook_post(webhook_url, message)
+
+
+async def _send_teams(webhook_url: str, event: str, payload: dict) -> bool:
+    """Send notification to a Teams incoming webhook."""
+    message = _format_teams_message(event, payload)
+    return await _send_webhook_post(webhook_url, message)
+
+
+async def _send_email(
+    email_target: str, event: str, payload: dict
+) -> bool:
+    """Send notification via Resend email."""
+    try:
+        from email_service import send_email
+
+        html = _format_email_html(event, payload)
+        subject = _format_email_subject(event, payload)
+
+        email_id = send_email(
+            to=email_target,
+            subject=subject,
+            html=html,
+            tags=[{"name": "category", "value": f"webhook:{event}"}],
+        )
+        if email_id:
+            logger.info("Webhook email sent to %s: id=%s", email_target, email_id)
+            return True
+        logger.warning("Webhook email failed to send to %s", email_target)
+        return False
+    except Exception as exc:
+        logger.warning("Webhook email exception for %s: %s", email_target, exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_notification(
+    webhook: dict, event: str, payload: dict
+) -> bool:
+    """Dispatch a notification to the configured webhook channel.
+
+    Applies rate limiting: 1 notification per event per hour.
+    Returns True if the notification was sent, False if rate-limited or failed.
+
+    Args:
+        webhook: Webhook config dict with keys: id, channel, webhook_url,
+                 email_target, last_triggered_at, is_active.
+        event: Event type string (e.g. 'new_edital', 'deadline_24h').
+        payload: Dict with keys: title, description, url, color (optional).
+
+    Returns:
+        True if sent successfully, False otherwise.
+    """
+    if not webhook.get("is_active", True):
+        logger.debug("Webhook %s is inactive — skipping", webhook.get("id", "")[:8])
+        return False
+
+    if _is_rate_limited(webhook):
+        logger.info(
+            "Webhook %s rate limited for event %s — skipping",
+            webhook.get("id", "")[:8],
+            event,
+        )
+        return False
+
+    channel = webhook.get("channel", "")
+    webhook_id = webhook.get("id", "")
+
+    success = False
+    if channel == "slack":
+        success = await _send_slack(webhook.get("webhook_url", ""), event, payload)
+    elif channel == "teams":
+        success = await _send_teams(webhook.get("webhook_url", ""), event, payload)
+    elif channel == "email":
+        success = await _send_email(webhook.get("email_target", ""), event, payload)
+    else:
+        logger.warning("Unknown webhook channel: %s", channel)
+        return False
+
+    if success:
+        await _update_last_triggered(webhook_id)
+
+    return success

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -114,6 +114,7 @@ from routes.data_deletion import router as data_deletion_router
 from routes.admin_alerts import router as admin_alerts_router
 from routes.admin_circuit_breakers import router as admin_circuit_breakers_router
 from routes.admin_data_retention import router as admin_data_retention_router
+from routes.integrations import router as integrations_router
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
     features_router, messages_router,
@@ -180,6 +181,7 @@ _v1_routers = [
     score_router,
     subcontract_intel_router,
     data_deletion_router,
+    integrations_router,
 ]
 def register_routes(app: FastAPI) -> None:
     """Register all application routers onto *app*."""

--- a/backend/tests/test_admin_log_level.py
+++ b/backend/tests/test_admin_log_level.py
@@ -18,7 +18,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-from admin import require_admin
+from admin import require_admin_ops
 from auth import require_auth
 from main import app
 
@@ -55,10 +55,10 @@ def admin_client():
     """
     fake_admin = {"id": "00000000-0000-0000-0000-00000000a001", "email": "admin@test"}
     app.dependency_overrides[require_auth] = lambda: fake_admin
-    app.dependency_overrides[require_admin] = lambda: fake_admin
+    app.dependency_overrides[require_admin_ops] = lambda: fake_admin
     yield TestClient(app)
     app.dependency_overrides.pop(require_auth, None)
-    app.dependency_overrides.pop(require_admin, None)
+    app.dependency_overrides.pop(require_admin_ops, None)
 
 
 @pytest.fixture

--- a/backend/tests/test_integrations_webhooks.py
+++ b/backend/tests/test_integrations_webhooks.py
@@ -195,6 +195,159 @@ class TestWebhookCreate:
         assert body.events == []
 
 
+
+class TestValidateWebhookUrl:
+    """Tests for SSRF validation on webhook_url."""
+
+    def test_valid_https_passes(self):
+        """Valid HTTPS URLs pass validation."""
+        from schemas.integrations import validate_webhook_url
+
+        urls = [
+            "https://hooks.slack.com/services/T00/B00/xxx",
+            "https://outlook.office.com/webhook/xxx",
+            "https://example.com/webhook",
+            "https://sub.domain.com/path?query=1",
+        ]
+        for url in urls:
+            assert validate_webhook_url(url) == url
+
+    def test_none_passes(self):
+        """None is allowed (field is optional)."""
+        from schemas.integrations import validate_webhook_url
+
+        assert validate_webhook_url(None) is None
+
+    def test_http_rejected(self):
+        """HTTP URLs are rejected."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="scheme must be 'https'"):
+            validate_webhook_url("http://hooks.slack.com/xxx")
+
+    def test_localhost_rejected(self):
+        """localhost is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="host not allowed"):
+            validate_webhook_url("https://localhost:5432/webhook")
+
+    def test_loopback_rejected(self):
+        """127.0.0.1 is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="host not allowed"):
+            validate_webhook_url("https://127.0.0.1:8000/webhook")
+
+    def test_metadata_ip_rejected(self):
+        """Cloud metadata IP 169.254.169.254 is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="host not allowed"):
+            validate_webhook_url("https://169.254.169.254/latest/meta-data/")
+
+    def test_private_10_rejected(self):
+        """10.x.x.x private range is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="private IP range"):
+            validate_webhook_url("https://10.0.0.1/webhook")
+
+    def test_private_192_168_rejected(self):
+        """192.168.x.x private range is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="private IP range"):
+            validate_webhook_url("https://192.168.1.1/webhook")
+
+    def test_private_172_16_rejected(self):
+        """172.16-31.x.x private range is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="private IP range"):
+            validate_webhook_url("https://172.16.0.1/webhook")
+
+    def test_private_172_31_rejected(self):
+        """172.31.x.x private range is blocked (upper bound)."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="private IP range"):
+            validate_webhook_url("https://172.31.255.255/webhook")
+
+    def test_public_172_allowed(self):
+        """172.32.x.x (public) is allowed."""
+        from schemas.integrations import validate_webhook_url
+
+        assert validate_webhook_url("https://172.32.0.1/webhook") == "https://172.32.0.1/webhook"
+
+    def test_link_local_rejected(self):
+        """169.254.x.x (link-local) is blocked."""
+        from schemas.integrations import validate_webhook_url
+
+        with pytest.raises(ValueError, match="link-local"):
+            validate_webhook_url("https://169.254.1.1/webhook")
+
+    def test_webhook_create_rejects_localhost(self):
+        """WebhookCreate schema rejects localhost webhook_url via field_validator."""
+        with pytest.raises(ValueError, match="host not allowed"):
+            WebhookCreate(
+                channel=WebhookChannel.slack,
+                webhook_url="https://localhost:5432/webhook",
+                events=[WebhookEvent.new_edital],
+            )
+
+    def test_webhook_update_rejects_private_ip(self):
+        """WebhookUpdate schema rejects private IP webhook_url via field_validator."""
+        with pytest.raises(ValueError, match="private IP range"):
+            WebhookUpdate(
+                webhook_url="https://10.0.0.1/webhook",
+            )
+
+    def test_api_create_rejects_http(self, client):
+        """API endpoint returns 422 for HTTP webhook URLs."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        check_result = MagicMock()
+        check_result.data = []
+
+        chain.select.return_value = chain
+        chain.insert.return_value = chain
+        chain.update.return_value = chain
+        chain.delete.return_value = chain
+        chain.eq.return_value = chain
+        chain.order.return_value = chain
+        chain.limit.return_value = chain
+        chain.is_.return_value = chain
+        chain.execute.return_value = check_result
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.post(
+                "/v1/integrations/webhooks",
+                json={
+                    "channel": "slack",
+                    "label": "SSRF Test",
+                    "webhook_url": "http://hooks.slack.com/xxx",
+                    "events": ["new_edital"],
+                },
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        # Should fail validation at Pydantic level -> 422
+        assert resp.status_code == 422
+
+    def test_dispatcher_blocks_ssrf(self):
+        """_send_webhook_post returns False for blocked URLs (defense-in-depth)."""
+        from services.webhook_dispatcher import _send_webhook_post
+
+        import asyncio
+        result = asyncio.run(
+            _send_webhook_post("https://169.254.169.254/latest/meta-data/", {"test": True})
+        )
+        assert result is False
+
 class TestWebhookResponse:
     def test_fields(self):
         resp = WebhookResponse(

--- a/backend/tests/test_integrations_webhooks.py
+++ b/backend/tests/test_integrations_webhooks.py
@@ -1,0 +1,888 @@
+"""Tests for B2GOPS-015 — integrations webhooks CRUD + dispatch (#1522)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from schemas.integrations import (
+    WebhookChannel,
+    WebhookCreate,
+    WebhookEvent,
+    WebhookResponse,
+    WebhookUpdate,
+)
+
+# ---------------------------------------------------------------------------
+# UUID constants for testing
+# ---------------------------------------------------------------------------
+
+UUID_SLACK = "a1b2c3d4-0001-4000-8000-000000000001"
+UUID_TEAMS = "b2c3d4e5-0002-4000-8000-000000000002"
+UUID_EMAIL = "c3d4e5f6-0003-4000-8000-000000000003"
+UUID_UPDATE = "d4e5f6a7-0004-4000-8000-000000000004"
+UUID_DELETE = "e5f6a7b8-0005-4000-8000-000000000005"
+UUID_OTHER = "f6a7b8c9-0006-4000-8000-000000000006"
+UUID_TEST = "a7b8c9d0-0007-4000-8000-000000000007"
+
+USER_ID = "user-test-123"
+OTHER_USER_ID = "user-other-456"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_user() -> dict:
+    return {
+        "id": USER_ID,
+        "sub": USER_ID,
+        "email": "test@smartlic.tech",
+        "role": "authenticated",
+    }
+
+
+def _sample_slack_webhook_row(**overrides) -> dict:
+    row = {
+        "id": UUID_SLACK,
+        "user_id": USER_ID,
+        "channel": "slack",
+        "label": "Meu Slack",
+        "webhook_url": "https://hooks.slack.com/services/T00/B00/xxx",
+        "email_target": None,
+        "events": ["new_edital", "deadline_24h"],
+        "is_active": True,
+        "last_triggered_at": None,
+        "created_at": "2026-06-17T00:00:00Z",
+        "updated_at": "2026-06-17T00:00:00Z",
+    }
+    row.update(overrides)
+    return row
+
+
+def _sample_teams_webhook_row(**overrides) -> dict:
+    row = {
+        "id": UUID_TEAMS,
+        "user_id": USER_ID,
+        "channel": "teams",
+        "label": "Meu Teams",
+        "webhook_url": "https://outlook.office.com/webhook/xxx",
+        "email_target": None,
+        "events": ["new_edital"],
+        "is_active": True,
+        "last_triggered_at": None,
+        "created_at": "2026-06-17T00:00:00Z",
+        "updated_at": "2026-06-17T00:00:00Z",
+    }
+    row.update(overrides)
+    return row
+
+
+def _sample_email_webhook_row(**overrides) -> dict:
+    row = {
+        "id": UUID_EMAIL,
+        "user_id": USER_ID,
+        "channel": "email",
+        "label": "Meu Email",
+        "webhook_url": None,
+        "email_target": "notify@example.com",
+        "events": ["result_published"],
+        "is_active": True,
+        "last_triggered_at": None,
+        "created_at": "2026-06-17T00:00:00Z",
+        "updated_at": "2026-06-17T00:00:00Z",
+    }
+    row.update(overrides)
+    return row
+
+
+def _make_supabase_mock(initial_data: list[dict] | None = None):
+    """Create a mock Supabase client with configurable results.
+
+    If initial_data is provided, the first .execute() returns those rows.
+    For multi-call scenarios, use side_effect_list.
+    """
+    sb = MagicMock()
+    chain = MagicMock()
+    result = MagicMock()
+    result.data = initial_data or []
+
+    # Chain methods return self
+    chain.select.return_value = chain
+    chain.insert.return_value = chain
+    chain.update.return_value = chain
+    chain.delete.return_value = chain
+    chain.eq.return_value = chain
+    chain.order.return_value = chain
+    chain.limit.return_value = chain
+    chain.is_.return_value = chain
+    chain.execute.return_value = result
+
+    sb.table.return_value = chain
+    return sb
+
+
+@pytest.fixture
+def client():
+    """TestClient with mocked auth."""
+    from main import app
+    from auth import require_auth
+
+    app.dependency_overrides[require_auth] = _mock_user
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookChannel:
+    def test_slack(self):
+        assert WebhookChannel.slack.value == "slack"
+
+    def test_teams(self):
+        assert WebhookChannel.teams.value == "teams"
+
+    def test_email(self):
+        assert WebhookChannel.email.value == "email"
+
+
+class TestWebhookEvent:
+    def test_new_edital(self):
+        assert WebhookEvent.new_edital.value == "new_edital"
+
+    def test_all_events_defined(self):
+        expected = {
+            "new_edital", "deadline_24h", "deadline_6h",
+            "deadline_1h", "pregao_started", "result_published",
+        }
+        actual = {e.value for e in WebhookEvent}
+        assert actual == expected
+
+
+class TestWebhookCreate:
+    def test_valid_slack(self):
+        body = WebhookCreate(
+            channel=WebhookChannel.slack,
+            webhook_url="https://hooks.slack.com/xxx",
+            events=[WebhookEvent.new_edital],
+        )
+        assert body.channel == WebhookChannel.slack
+        assert body.webhook_url == "https://hooks.slack.com/xxx"
+        assert body.events == [WebhookEvent.new_edital]
+
+    def test_valid_email(self):
+        body = WebhookCreate(
+            channel=WebhookChannel.email,
+            email_target="user@example.com",
+        )
+        assert body.email_target == "user@example.com"
+        assert body.events == []
+
+    def test_default_events_empty(self):
+        body = WebhookCreate(
+            channel=WebhookChannel.slack,
+            webhook_url="https://hooks.slack.com/xxx",
+        )
+        assert body.events == []
+
+
+class TestWebhookResponse:
+    def test_fields(self):
+        resp = WebhookResponse(
+            id="uuid-1",
+            channel=WebhookChannel.slack,
+            label="My Webhook",
+            events=[WebhookEvent.new_edital],
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+        )
+        data = resp.model_dump()
+        assert data["id"] == "uuid-1"
+        assert data["channel"] == "slack"
+        assert data["is_active"] is True
+
+    def test_optional_fields(self):
+        resp = WebhookResponse(
+            id="uuid-1",
+            channel=WebhookChannel.email,
+            events=[],
+            is_active=False,
+            created_at=datetime.now(timezone.utc),
+        )
+        assert resp.label is None
+        assert resp.webhook_url is None
+        assert resp.email_target is None
+        assert resp.last_triggered_at is None
+
+    def test_model_dump_serializable(self):
+        """Ensure the response can be serialized to JSON."""
+        resp = WebhookResponse(
+            id="uuid-1",
+            channel=WebhookChannel.slack,
+            label="Test",
+            events=[WebhookEvent.new_edital, WebhookEvent.deadline_24h],
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+        )
+        resp.model_dump_json()
+
+
+class TestWebhookUpdate:
+    def test_partial_update(self):
+        body = WebhookUpdate(label="New Label")
+        assert body.label == "New Label"
+        assert body.is_active is None
+
+    def test_all_fields_optional(self):
+        body = WebhookUpdate()
+        assert body.label is None
+        assert body.webhook_url is None
+        assert body.email_target is None
+        assert body.events is None
+        assert body.is_active is None
+
+    def test_toggle_active(self):
+        body = WebhookUpdate(is_active=False)
+        assert body.is_active is False
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/integrations/webhooks
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWebhook:
+    def test_create_slack(self, client):
+        """POST creates a Slack webhook and returns WebhookResponse."""
+        sb = _make_supabase_mock([_sample_slack_webhook_row()])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.post(
+                "/v1/integrations/webhooks",
+                json={
+                    "channel": "slack",
+                    "label": "Meu Slack",
+                    "webhook_url": "https://hooks.slack.com/services/T00/B00/xxx",
+                    "events": ["new_edital", "deadline_24h"],
+                },
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["channel"] == "slack"
+        assert data["label"] == "Meu Slack"
+        assert data["events"] == ["new_edital", "deadline_24h"]
+
+    def test_create_teams(self, client):
+        """POST creates a Teams webhook."""
+        sb = _make_supabase_mock([_sample_teams_webhook_row()])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.post(
+                "/v1/integrations/webhooks",
+                json={
+                    "channel": "teams",
+                    "label": "Meu Teams",
+                    "webhook_url": "https://outlook.office.com/webhook/xxx",
+                    "events": ["new_edital"],
+                },
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["channel"] == "teams"
+        assert data["label"] == "Meu Teams"
+
+    def test_create_email(self, client):
+        """POST creates an Email webhook."""
+        sb = _make_supabase_mock([_sample_email_webhook_row()])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.post(
+                "/v1/integrations/webhooks",
+                json={
+                    "channel": "email",
+                    "label": "Meu Email",
+                    "email_target": "notify@example.com",
+                    "events": ["result_published"],
+                },
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["channel"] == "email"
+        assert data["email_target"] == "notify@example.com"
+
+    def test_slack_requires_webhook_url(self, client):
+        """Slack webhook must include webhook_url."""
+        resp = client.post(
+            "/v1/integrations/webhooks",
+            json={"channel": "slack", "label": "No URL"},
+            headers={"Authorization": "Bearer fake"},
+        )
+        assert resp.status_code == 422
+
+    def test_email_requires_target(self, client):
+        """Email webhook must include email_target."""
+        resp = client.post(
+            "/v1/integrations/webhooks",
+            json={"channel": "email", "label": "No Target"},
+            headers={"Authorization": "Bearer fake"},
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_channel(self, client):
+        """Invalid channel value returns 422."""
+        resp = client.post(
+            "/v1/integrations/webhooks",
+            json={"channel": "pagerduty", "label": "Invalid"},
+            headers={"Authorization": "Bearer fake"},
+        )
+        assert resp.status_code == 422
+
+    def test_requires_auth(self):
+        """Request without auth returns 401."""
+        from main import app
+
+        original = dict(app.dependency_overrides)
+        app.dependency_overrides.clear()
+        unauth_client = TestClient(app)
+        resp = unauth_client.post(
+            "/v1/integrations/webhooks",
+            json={"channel": "slack", "webhook_url": "https://hooks.slack.com/xxx"},
+        )
+        app.dependency_overrides.update(original)
+        assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/integrations/webhooks
+# ---------------------------------------------------------------------------
+
+
+class TestListWebhooks:
+    def test_lists_user_webhooks(self, client):
+        """GET returns all webhooks for the authenticated user."""
+        sb = _make_supabase_mock([
+            _sample_slack_webhook_row(),
+            _sample_email_webhook_row(),
+        ])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.get(
+                "/v1/integrations/webhooks",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+    def test_empty_list(self, client):
+        """Returns empty list when user has no webhooks."""
+        sb = _make_supabase_mock([])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.get(
+                "/v1/integrations/webhooks",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# PATCH /v1/integrations/webhooks/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWebhook:
+    def test_update_label(self, client):
+        """PATCH updates webhook label."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        # Ownership check result
+        check_result = MagicMock()
+        check_result.data = [{"id": UUID_UPDATE, "user_id": USER_ID}]
+        # Update result
+        update_result = MagicMock()
+        update_result.data = [_sample_slack_webhook_row(
+            id=UUID_UPDATE,
+            label="Updated Label",
+        )]
+
+        chain.select.return_value = chain
+        chain.insert.return_value = chain
+        chain.update.return_value = chain
+        chain.delete.return_value = chain
+        chain.order.return_value = chain
+        chain.limit.return_value = chain
+        chain.is_.return_value = chain
+
+        # First execute = ownership check, second = update
+        chain.execute.side_effect = [check_result, update_result]
+
+        # .eq() after .update().eq() needs to return chain for chaining
+        # Simpler: make eq return chain always
+        chain.eq.return_value = chain
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.patch(
+                f"/v1/integrations/webhooks/{UUID_UPDATE}",
+                json={"label": "Updated Label"},
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["label"] == "Updated Label"
+
+    def test_update_events(self, client):
+        """PATCH updates event subscriptions."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        check_result = MagicMock()
+        check_result.data = [{"id": UUID_UPDATE, "user_id": USER_ID}]
+        update_result = MagicMock()
+        update_result.data = [_sample_slack_webhook_row(
+            id=UUID_UPDATE,
+            events=["new_edital", "pregao_started", "result_published"],
+        )]
+
+        chain.select.return_value = chain
+        chain.insert.return_value = chain
+        chain.update.return_value = chain
+        chain.delete.return_value = chain
+        chain.order.return_value = chain
+        chain.limit.return_value = chain
+        chain.is_.return_value = chain
+        chain.eq.return_value = chain
+        chain.execute.side_effect = [check_result, update_result]
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.patch(
+                f"/v1/integrations/webhooks/{UUID_UPDATE}",
+                json={
+                    "events": [
+                        "new_edital",
+                        "pregao_started",
+                        "result_published",
+                    ],
+                },
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "new_edital" in data["events"]
+        assert "pregao_started" in data["events"]
+
+    def test_update_not_found(self, client):
+        """PATCH returns 404 for non-existent webhook."""
+        sb = _make_supabase_mock([])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.patch(
+                f"/v1/integrations/webhooks/{UUID_UPDATE}",
+                json={"label": "Noop"},
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_cannot_update_other_users_webhook(self, client):
+        """User cannot update another user's webhook."""
+        sb = MagicMock()
+        chain = MagicMock()
+        check_result = MagicMock()
+        check_result.data = [{"id": UUID_OTHER, "user_id": OTHER_USER_ID}]
+
+        chain.select.return_value = chain
+        chain.insert.return_value = chain
+        chain.update.return_value = chain
+        chain.delete.return_value = chain
+        chain.order.return_value = chain
+        chain.limit.return_value = chain
+        chain.is_.return_value = chain
+        chain.eq.return_value = chain
+        chain.execute.return_value = check_result
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.patch(
+                f"/v1/integrations/webhooks/{UUID_OTHER}",
+                json={"label": "Hacked"},
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v1/integrations/webhooks/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteWebhook:
+    def test_deletes_own_webhook(self, client):
+        """User can delete their own webhook."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        check_result = MagicMock()
+        check_result.data = [{"id": UUID_DELETE, "user_id": USER_ID}]
+
+        chain.select.return_value = chain
+        chain.delete.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = check_result
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.delete(
+                f"/v1/integrations/webhooks/{UUID_DELETE}",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 204
+
+    def test_delete_not_found(self, client):
+        """DELETE returns 404 for non-existent webhook."""
+        sb = _make_supabase_mock([])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.delete(
+                f"/v1/integrations/webhooks/{UUID_DELETE}",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_cannot_delete_others_webhook(self, client):
+        """User cannot delete another user's webhook."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        check_result = MagicMock()
+        check_result.data = [{"id": UUID_OTHER, "user_id": OTHER_USER_ID}]
+
+        chain.select.return_value = chain
+        chain.delete.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = check_result
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.delete(
+                f"/v1/integrations/webhooks/{UUID_OTHER}",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/integrations/webhooks/{id}/test — Test notification
+# ---------------------------------------------------------------------------
+
+
+class TestTestWebhook:
+    def test_test_slack(self, client):
+        """POST test sends test notification to Slack webhook."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        fetch_result = MagicMock()
+        fetch_result.data = [_sample_slack_webhook_row(id=UUID_TEST)]
+
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = fetch_result
+
+        sb.table.return_value = chain
+
+        with (
+            patch("supabase_client.get_supabase", return_value=sb),
+            patch(
+                "services.webhook_dispatcher._send_slack",
+                return_value=True,
+            ),
+        ):
+            resp = client.post(
+                f"/v1/integrations/webhooks/{UUID_TEST}/test",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sucesso" in data["message"]
+        assert data["channel"] == "slack"
+
+    def test_test_email(self, client):
+        """POST test sends test notification via email."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        fetch_result = MagicMock()
+        fetch_result.data = [_sample_email_webhook_row(id=UUID_TEST)]
+
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = fetch_result
+
+        sb.table.return_value = chain
+
+        with (
+            patch("supabase_client.get_supabase", return_value=sb),
+            patch(
+                "services.webhook_dispatcher._send_email",
+                return_value=True,
+            ),
+        ):
+            resp = client.post(
+                f"/v1/integrations/webhooks/{UUID_TEST}/test",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["channel"] == "email"
+        assert data["target"] == "notify@example.com"
+
+    def test_test_not_found(self, client):
+        """Test endpoint returns 404 for missing webhook."""
+        sb = _make_supabase_mock([])
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.post(
+                f"/v1/integrations/webhooks/{UUID_TEST}/test",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_test_other_user_forbidden(self, client):
+        """User cannot test another user's webhook."""
+        sb = MagicMock()
+        chain = MagicMock()
+
+        fetch_result = MagicMock()
+        fetch_result.data = [_sample_slack_webhook_row(
+            id=UUID_OTHER,
+            user_id=OTHER_USER_ID,
+        )]
+
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = fetch_result
+
+        sb.table.return_value = chain
+
+        with patch("supabase_client.get_supabase", return_value=sb):
+            resp = client.post(
+                f"/v1/integrations/webhooks/{UUID_OTHER}/test",
+                headers={"Authorization": "Bearer fake"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_rate_limited_skip(self):
+        """_is_rate_limited returns True when last trigger < 1h ago."""
+        from services.webhook_dispatcher import _is_rate_limited
+
+        recent = datetime.now(timezone.utc) - timedelta(minutes=5)
+        webhook = {"last_triggered_at": recent.isoformat()}
+        assert _is_rate_limited(webhook) is True
+
+    def test_rate_limit_expired(self):
+        """_is_rate_limited returns False when last trigger > 1h ago."""
+        from services.webhook_dispatcher import _is_rate_limited
+
+        old = datetime.now(timezone.utc) - timedelta(hours=2)
+        webhook = {"last_triggered_at": old.isoformat()}
+        assert _is_rate_limited(webhook) is False
+
+    def test_rate_limit_no_history(self):
+        """_is_rate_limited returns False when never triggered."""
+        from services.webhook_dispatcher import _is_rate_limited
+
+        webhook: dict = {}
+        assert _is_rate_limited(webhook) is False
+
+    def test_dispatch_respects_rate_limit(self):
+        """dispatch_notification skips when rate limited."""
+        from services.webhook_dispatcher import dispatch_notification
+
+        recent = datetime.now(timezone.utc) - timedelta(minutes=30)
+        webhook = {
+            "id": "rate-test-id",
+            "channel": "slack",
+            "webhook_url": "https://hooks.slack.com/xxx",
+            "is_active": True,
+            "last_triggered_at": recent.isoformat(),
+        }
+
+        import asyncio
+        result = asyncio.run(
+            dispatch_notification(webhook, "new_edital", {"title": "Test"})
+        )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Webhook dispatcher — message formatters
+# ---------------------------------------------------------------------------
+
+
+class TestSlackFormatter:
+    def test_basic_format(self):
+        from services.webhook_dispatcher import _format_slack_message
+
+        msg = _format_slack_message(
+            "new_edital",
+            {"title": "Novo Edital", "description": "Descricao", "url": "https://smartlic.tech"},
+        )
+        assert "Novo Edital" in msg["text"]
+        assert len(msg["attachments"]) == 1
+        blocks = msg["attachments"][0]["blocks"]
+        assert any("Novo Edital" in json.dumps(b) for b in blocks)
+
+    def test_without_url(self):
+        from services.webhook_dispatcher import _format_slack_message
+
+        msg = _format_slack_message(
+            "new_edital",
+            {"title": "Novo Edital", "description": "Descricao"},
+        )
+        assert "Novo Edital" in msg["text"]
+
+
+class TestTeamsFormatter:
+    def test_basic_format(self):
+        from services.webhook_dispatcher import _format_teams_message
+
+        msg = _format_teams_message(
+            "new_edital",
+            {"title": "Novo Edital", "description": "Descricao", "url": "https://smartlic.tech"},
+        )
+        assert msg["@type"] == "MessageCard"
+        assert "Novo Edital" in msg["title"]
+
+    def test_without_url(self):
+        from services.webhook_dispatcher import _format_teams_message
+
+        msg = _format_teams_message(
+            "new_edital",
+            {"title": "Novo Edital"},
+        )
+        assert msg["potentialAction"] == []
+
+
+class TestEmailFormatter:
+    def test_html_format(self):
+        from services.webhook_dispatcher import _format_email_html
+
+        html = _format_email_html(
+            "new_edital",
+            {"title": "Novo Edital", "description": "Descricao", "url": "https://smartlic.tech"},
+        )
+        assert "Novo Edital" in html
+        assert "smartlic.tech" in html
+        assert "<!DOCTYPE html>" in html
+
+    def test_subject_format(self):
+        from services.webhook_dispatcher import _format_email_subject
+
+        subject = _format_email_subject(
+            "new_edital",
+            {"title": "Novo Edital"},
+        )
+        assert "Novo Edital" in subject
+
+
+# ---------------------------------------------------------------------------
+# Cross-user isolation
+# ---------------------------------------------------------------------------
+
+
+class TestCrossUserIsolation:
+    def test_other_user_sees_no_overlap(self):
+        """Webhooks from different users don't overlap."""
+        user_a_uuid = "00000000-0000-0000-0000-0000000000a1"
+        user_b_uuid = "00000000-0000-0000-0000-0000000000b2"
+
+        user_a_keys = [
+            _sample_slack_webhook_row(id=user_a_uuid),
+        ]
+        user_b_uuid = "00000000-0000-0000-0000-0000000000b2"
+
+        from main import app
+        from auth import require_auth
+
+        # User A
+        sb_a = _make_supabase_mock(user_a_keys)
+        with patch("supabase_client.get_supabase", return_value=sb_a):
+            app.dependency_overrides[require_auth] = lambda: {
+                "id": "user-a", "sub": "user-a",
+                "email": "a@test.com", "role": "authenticated",
+            }
+            c = TestClient(app)
+            resp_a = c.get("/v1/integrations/webhooks", headers={"Authorization": "Bearer fake"})
+            app.dependency_overrides.clear()
+
+        assert resp_a.status_code == 200
+        ids_a = [w["id"] for w in resp_a.json()]
+        assert user_a_uuid in ids_a
+        assert user_b_uuid not in ids_a
+
+    def test_send_email_dispatches(self):
+        """send_email in webhook_dispatcher calls email_service.send_email."""
+        from services.webhook_dispatcher import _send_email
+
+        with patch("email_service.send_email") as mock_send:
+            mock_send.return_value = "email-id-123"
+            import asyncio
+            result = asyncio.run(
+                _send_email(
+                    "user@example.com",
+                    "test",
+                    {"title": "Test", "description": "Test body"},
+                )
+            )
+            assert result is True
+            mock_send.assert_called_once()

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -4440,6 +4440,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/integrations/webhooks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Webhooks
+         * @description List all webhooks for the authenticated user.
+         */
+        get: operations["list_webhooks_v1_integrations_webhooks_get"];
+        put?: never;
+        /**
+         * Create Webhook
+         * @description Create a new webhook integration (Slack, Teams, or Email).
+         */
+        post: operations["create_webhook_v1_integrations_webhooks_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/integrations/webhooks/{webhook_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Webhook
+         * @description Delete a webhook integration.
+         */
+        delete: operations["delete_webhook_v1_integrations_webhooks__webhook_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Webhook
+         * @description Update a webhook configuration.
+         */
+        patch: operations["update_webhook_v1_integrations_webhooks__webhook_id__patch"];
+        trace?: never;
+    };
+    "/v1/integrations/webhooks/{webhook_id}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test Webhook
+         * @description Send a test notification to verify the webhook configuration.
+         */
+        post: operations["test_webhook_v1_integrations_webhooks__webhook_id__test_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/intel-concorrente/benchmarks": {
         parameters: {
             query?: never;
@@ -16827,6 +16895,95 @@ export interface components {
             /** Success */
             success: boolean;
         };
+        /**
+         * WebhookChannel
+         * @description Supported notification channels.
+         * @enum {string}
+         */
+        WebhookChannel: "slack" | "teams" | "email";
+        /**
+         * WebhookCreate
+         * @description Request body for POST /v1/integrations/webhooks.
+         */
+        WebhookCreate: {
+            channel: components["schemas"]["WebhookChannel"];
+            /**
+             * Email Target
+             * @description Email address (required for email channel)
+             */
+            email_target?: string | null;
+            /**
+             * Events
+             * @default []
+             */
+            events: components["schemas"]["WebhookEvent"][];
+            /** Label */
+            label?: string | null;
+            /**
+             * Webhook Url
+             * @description Incoming webhook URL (required for slack/teams)
+             */
+            webhook_url?: string | null;
+        };
+        /**
+         * WebhookEvent
+         * @description Notification event types for webhook dispatch.
+         * @enum {string}
+         */
+        WebhookEvent: "new_edital" | "deadline_24h" | "deadline_6h" | "deadline_1h" | "pregao_started" | "result_published";
+        /**
+         * WebhookResponse
+         * @description Public webhook representation returned by the API.
+         */
+        WebhookResponse: {
+            channel: components["schemas"]["WebhookChannel"];
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Email Target */
+            email_target?: string | null;
+            /** Events */
+            events: components["schemas"]["WebhookEvent"][];
+            /** Id */
+            id: string;
+            /** Is Active */
+            is_active: boolean;
+            /** Label */
+            label?: string | null;
+            /** Last Triggered At */
+            last_triggered_at?: string | null;
+            /** Webhook Url */
+            webhook_url?: string | null;
+        };
+        /**
+         * WebhookTestResponse
+         * @description Response from the test notification endpoint.
+         */
+        WebhookTestResponse: {
+            channel: components["schemas"]["WebhookChannel"];
+            /** Message */
+            message: string;
+            /** Target */
+            target?: string | null;
+        };
+        /**
+         * WebhookUpdate
+         * @description Request body for PATCH /v1/integrations/webhooks/{id}.
+         */
+        WebhookUpdate: {
+            /** Email Target */
+            email_target?: string | null;
+            /** Events */
+            events?: components["schemas"]["WebhookEvent"][] | null;
+            /** Is Active */
+            is_active?: boolean | null;
+            /** Label */
+            label?: string | null;
+            /** Webhook Url */
+            webhook_url?: string | null;
+        };
         /** WeeklyDigestResponse */
         WeeklyDigestResponse: {
             /** Avg Value */
@@ -22690,6 +22847,154 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IndiceResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_webhooks_v1_integrations_webhooks_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookResponse"][];
+                };
+            };
+        };
+    };
+    create_webhook_v1_integrations_webhooks_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WebhookCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_webhook_v1_integrations_webhooks__webhook_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                webhook_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_webhook_v1_integrations_webhooks__webhook_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                webhook_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WebhookUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    test_webhook_v1_integrations_webhooks__webhook_id__test_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                webhook_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookTestResponse"];
                 };
             };
             /** @description Validation Error */

--- a/supabase/migrations/20260617000000_integrations_webhooks.down.sql
+++ b/supabase/migrations/20260617000000_integrations_webhooks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS integrations_webhooks;

--- a/supabase/migrations/20260617000000_integrations_webhooks.sql
+++ b/supabase/migrations/20260617000000_integrations_webhooks.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS integrations_webhooks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    channel TEXT NOT NULL CHECK (channel IN ('slack', 'teams', 'email')),
+    label TEXT,
+    webhook_url TEXT,
+    email_target TEXT,
+    events TEXT[] DEFAULT '{}',
+    is_active BOOLEAN DEFAULT true,
+    last_triggered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE integrations_webhooks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can CRUD own webhooks" ON integrations_webhooks
+    FOR ALL USING (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_integrations_webhooks_user ON integrations_webhooks(user_id);
+
+COMMENT ON TABLE integrations_webhooks IS 'Webhook integrations for Slack, Teams, Email notification channels (#1522)';
+COMMENT ON COLUMN integrations_webhooks.channel IS 'Notification channel: slack, teams, or email';
+COMMENT ON COLUMN integrations_webhooks.webhook_url IS 'Incoming webhook URL for Slack/Teams channels';
+COMMENT ON COLUMN integrations_webhooks.email_target IS 'Target email address for email channel';
+COMMENT ON COLUMN integrations_webhooks.events IS 'Array of event types to notify for: new_edital, deadline_24h, deadline_6h, deadline_1h, pregao_started, result_published';
+COMMENT ON COLUMN integrations_webhooks.last_triggered_at IS 'Timestamp of last notification sent (used for rate limiting)';


### PR DESCRIPTION
## Context
Integração de webhooks para notificações em Slack, Microsoft Teams e Email. Permite que usuários configurem endpoints de notificação para eventos de alertas e atualizações de editais.

## Changes
- Migration: integrations_webhooks table with RLS
- CRUD endpoints for webhook configuration
- Webhook dispatch service (Slack, Teams, Resend Email)
- Rate limiting: 1 notification per event per hour
- Test notification endpoint
- 46 tests covering CRUD, rate limit, cross-user isolation

## Issue
Closes #1522
Part of EPIC-B2GOPS (#1262)

🤖 Generated with [Claude Code](https://claude.com/claude-code)