### PR TITLE
feat(backend): admin audit log with immutable trail (#1974)

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -64,7 +64,7 @@ from log_sanitizer import sanitize_dict, log_admin_action, log_admin_action_db
 from authorization import require_data_access, require_user_manager  # noqa: F401 — kept for backward compat
 from rbac_granular import (
     require_admin_role, require_admin_users, require_admin_billing,
-    require_admin_data, require_admin_ops, require_admin_seo,
+    require_admin_data, require_admin_ops, require_admin_seo,  # noqa: F401 — kept for backward compat
 )
 from filter.stats import filter_stats_tracker
 

--- a/backend/admin.py
+++ b/backend/admin.py
@@ -60,7 +60,7 @@ from schemas import (
     AdminUpdateCreditsResponse, MemorySnapshot, TraceMallocEntry,
     UserSegmentsResponse,
 )
-from log_sanitizer import sanitize_dict, log_admin_action
+from log_sanitizer import sanitize_dict, log_admin_action, log_admin_action_db
 from authorization import require_data_access, require_user_manager  # noqa: F401 — kept for backward compat
 from rbac_granular import (
     require_admin_role, require_admin_users, require_admin_billing,
@@ -367,6 +367,7 @@ async def list_users(
 
 @router.post("/users", response_model=AdminCreateUserResponse)
 async def create_user(
+    request: Request,
     req: CreateUserRequest,
     admin: dict = Depends(require_admin_users),
 ):
@@ -416,12 +417,22 @@ async def create_user(
         target_user_id=user_id,
         details={"plan": req.plan_id},
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin['id'],
+        action="create_user",
+        entity_type="user",
+        entity_id=user_id,
+        details={"plan": req.plan_id},
+    )
+    request.state.admin_audit_logged = True
 
     return {"user_id": user_id, "email": req.email, "plan_id": req.plan_id}
 
 
 @router.delete("/users/{user_id}", response_model=AdminDeleteUserResponse)
 async def delete_user(
+    request: Request,
     user_id: str = Path(..., description="User UUID to delete"),
     admin: dict = Depends(require_admin_users),
 ):
@@ -453,12 +464,21 @@ async def delete_user(
         action="delete-user",
         target_user_id=user_id,
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin['id'],
+        action="delete_user",
+        entity_type="user",
+        entity_id=user_id,
+    )
+    request.state.admin_audit_logged = True
 
     return {"deleted": True, "user_id": user_id}
 
 
 @router.put("/users/{user_id}", response_model=AdminUpdateUserResponse)
 async def update_user(
+    request: Request,
     req: UpdateUserRequest,
     user_id: str = Path(..., description="User UUID to update"),
     admin: dict = Depends(require_admin_users),
@@ -500,6 +520,15 @@ async def update_user(
         target_user_id=user_id,
         details=sanitize_dict(updates),
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin['id'],
+        action="update_user",
+        entity_type="user",
+        entity_id=user_id,
+        details=sanitize_dict(updates),
+    )
+    request.state.admin_audit_logged = True
     return {"updated": True, "user_id": user_id}
 
 
@@ -535,11 +564,20 @@ async def reset_user_password(
         action="reset-password",
         target_user_id=user_id,
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin['id'],
+        action="reset_password",
+        entity_type="user",
+        entity_id=user_id,
+    )
+    request.state.admin_audit_logged = True
     return {"success": True, "user_id": user_id}
 
 
 @router.post("/users/{user_id}/assign-plan", response_model=AdminAssignPlanResponse)
 async def assign_plan(
+    request: Request,
     user_id: str = Path(..., description="User UUID to assign plan to"),
     plan_id: str = Query(..., description="Plan ID to assign"),
     admin: dict = Depends(require_admin_users),
@@ -586,6 +624,15 @@ async def assign_plan(
         target_user_id=user_id,
         details={"plan_id": plan_id},
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin['id'],
+        action="assign_plan",
+        entity_type="user",
+        entity_id=user_id,
+        details={"plan_id": plan_id},
+    )
+    request.state.admin_audit_logged = True
     return {"assigned": True, "user_id": user_id, "plan_id": plan_id}
 
 
@@ -596,6 +643,7 @@ class UpdateCreditsRequest(BaseModel):
 
 @router.put("/users/{user_id}/credits", response_model=AdminUpdateCreditsResponse)
 async def update_user_credits(
+    request: Request,
     req: UpdateCreditsRequest,
     user_id: str = Path(..., description="User UUID to update credits for"),
     admin: dict = Depends(require_admin_users),
@@ -655,6 +703,15 @@ async def update_user_credits(
             target_user_id=user_id,
             details={"old_credits": old_credits, "new_credits": req.credits},
         )
+        # #1974: Persist to admin_audit_log
+        await log_admin_action_db(
+            admin_id=admin['id'],
+            action="update_credits",
+            entity_type="user",
+            entity_id=user_id,
+            details={"old_credits": old_credits, "new_credits": req.credits},
+        )
+        request.state.admin_audit_logged = True
 
         return {
             "success": True,
@@ -698,6 +755,15 @@ async def update_user_credits(
             target_user_id=user_id,
             details={"plan_id": plan_id, "credits": req.credits},
         )
+        # #1974: Persist to admin_audit_log
+        await log_admin_action_db(
+            admin_id=admin['id'],
+            action="create_subscription_with_credits",
+            entity_type="user",
+            entity_id=user_id,
+            details={"plan_id": plan_id, "credits": req.credits},
+        )
+        request.state.admin_audit_logged = True
 
         return {
             "success": True,
@@ -805,6 +871,7 @@ async def inspect_cache_entry_endpoint(
 
 @router.delete("/cache/{params_hash}")
 async def delete_cache_entry_endpoint(
+    request: Request,
     params_hash: str = Path(..., min_length=8, max_length=128, description="Cache entry hash"),
     admin: dict = Depends(require_admin_ops),
 ):
@@ -827,6 +894,15 @@ async def delete_cache_entry_endpoint(
         target_user_id=admin["id"],
         details={"params_hash": params_hash[:12], "deleted_levels": result["deleted_levels"]},
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin["id"],
+        action="invalidate_cache_entry",
+        entity_type="cache",
+        entity_id=params_hash,
+        details={"deleted_levels": result["deleted_levels"]},
+    )
+    request.state.admin_audit_logged = True
 
     return result
 
@@ -859,6 +935,15 @@ async def delete_all_cache_endpoint(
         target_user_id=admin["id"],
         details=result["deleted_counts"],
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin["id"],
+        action="invalidate_all_cache",
+        entity_type="cache",
+        entity_id="all",
+        details=result["deleted_counts"],
+    )
+    request.state.admin_audit_logged = True
 
     return result
 
@@ -895,6 +980,7 @@ async def get_reconciliation_history(
 
 @router.post("/reconciliation/trigger")
 async def trigger_reconciliation(
+    request: Request,
     admin: dict = Depends(require_admin_billing),
 ):
     """AC13: Manually trigger a reconciliation run.
@@ -910,6 +996,14 @@ async def trigger_reconciliation(
         target_user_id=admin["id"],
         details={},
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin["id"],
+        action="trigger_reconciliation",
+        entity_type="reconciliation",
+        entity_id=admin["id"],
+    )
+    request.state.admin_audit_logged = True
 
     result = await run_reconciliation()
 

--- a/backend/admin_audit_middleware.py
+++ b/backend/admin_audit_middleware.py
@@ -1,0 +1,225 @@
+"""#1974: Admin audit middleware — auto-log POST/PATCH/DELETE to admin_audit_log.
+
+Intercepts requests to ``/v1/admin/*`` paths and registers a basic audit entry
+in the ``admin_audit_log`` table. Routes that already call
+``log_admin_action_db()`` explicitly with rich context set
+``request.state.admin_audit_logged = True`` to prevent duplicate logging.
+
+Graceful degradation: if the DB write fails, the error is logged at warning
+level and the request proceeds uninterrupted.
+"""
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+
+# Admin path prefix patterns — any path starting with one of these or
+# containing a known admin segment triggers auto-logging.
+_ADMIN_PATH_PATTERNS = (
+    "/v1/admin/",
+    "/v1/admin",
+)
+
+# Self-prefixed admin routers (registered at /v1/admin/, not under /v1/):
+# admin_trace, admin_cron, admin_cnae_mapping, admin_llm_cost,
+# admin_calibration, admin_billing_sync, admin_founding, admin_metrics,
+# admin_dlq, admin_sessions, admin_log_level, admin_synthetic,
+# admin_alerts, admin_data_retention, admin_circuit_breakers, admin_db_pool
+_ADMIN_SELF_PREFIX = "/v1/admin/"
+
+
+def _is_admin_path(path: str) -> bool:
+    """Check if a request path targets an admin endpoint."""
+    return path.startswith(_ADMIN_SELF_PREFIX)
+
+
+def _infer_entity_type(path: str, action: str) -> str:
+    """Infer entity_type from the URL path.
+
+    Examples:
+        /v1/admin/users/{id}        -> user
+        /v1/admin/cache/{hash}      -> cache
+        /v1/admin/feature-flags/... -> feature_flag
+        /v1/admin/reconciliation/... -> reconciliation
+        /v1/admin/filter-stats       -> filter_stats
+        /v1/admin/cron-status        -> cron
+        /v1/admin/support-sla        -> support_sla
+        /v1/admin/trial-metrics      -> trial
+        /v1/admin/at-risk-trials     -> trial
+        /v1/admin/memory-snapshot    -> memory
+        /v1/admin/users/segments     -> user
+        /v1/admin/audit-log          -> audit_log
+    """
+    # Strip /v1/admin/ prefix and get the first meaningful segment
+    rest = path.removeprefix(_ADMIN_SELF_PREFIX).strip("/")
+    segments = rest.split("/") if rest else []
+
+    if not segments:
+        return "admin"
+
+    # Entity type inference from first URL segment
+    first = segments[0].lower()
+    # Maps URL segment -> entity_type
+    entity_map = {
+        "users": "user",
+        "cache": "cache",
+        "feature-flags": "feature_flag",
+        "reconciliation": "reconciliation",
+        "filter-stats": "filter_stats",
+        "cron-status": "cron",
+        "support-sla": "support_sla",
+        "trial-metrics": "trial",
+        "at-risk-trials": "trial",
+        "memory-snapshot": "memory",
+        "audit-log": "audit_log",
+        "subscriptions": "subscription",
+        "circuit-breakers": "circuit_breaker",
+        "data-retention": "data_retention",
+        "db-pool": "db_pool",
+        "log-level": "log_level",
+        "synthetic": "synthetic",
+        "test-alert": "alert",
+        "digest-metrics": "digest",
+        "billing-sync": "billing",
+        "llm-cost": "llm_cost",
+        "calibration": "calibration",
+        "cnae-mapping": "cnae",
+        "founding": "founding",
+        "metrics": "metrics",
+        "command": "command",
+        "search-trace": "search_trace",
+    }
+    return entity_map.get(first, first)
+
+
+def _infer_action(method: str, path: str) -> str:
+    """Infer action name from HTTP method and URL path.
+
+    Examples:
+        POST /v1/admin/users          -> create_user
+        DELETE /v1/admin/users/{id}   -> delete_user
+        PATCH /v1/admin/feature-flags/{name} -> update_feature_flag
+    """
+    rest = path.removeprefix(_ADMIN_SELF_PREFIX).strip("/")
+    segments = rest.split("/") if rest else []
+    first = segments[0].lower() if segments else ""
+
+    method_lower = method.lower()
+
+    # Heuristic: POST/PATCH/DELETE + entity knowledge
+    if method_lower == "post":
+        return f"create_{first}" if first else "admin_action"
+    elif method_lower == "patch":
+        return f"update_{first}" if first else "admin_action"
+    elif method_lower == "delete":
+        return f"delete_{first}" if first else "admin_action"
+    elif method_lower == "put":
+        return f"update_{first}" if first else "admin_action"
+    return f"{method_lower}_{first}" if first else "admin_action"
+
+
+def _infer_entity_id(path: str, admin_id: str) -> str:
+    """Infer entity_id from URL path. Falls back to admin_id if not found."""
+    rest = path.removeprefix(_ADMIN_SELF_PREFIX).strip("/")
+    segments = rest.split("/") if rest else []
+    # entity ID is typically the second segment (e.g. /v1/admin/users/{id})
+    if len(segments) >= 2:
+        candidate = segments[1]
+        # Skip known sub-resources (feature-flags is the entity, {name} is the ID)
+        if segments[0].lower() == "feature-flags" and len(segments) >= 3:
+            return segments[2]
+        return candidate
+    return admin_id
+
+
+class AdminAuditMiddleware(BaseHTTPMiddleware):
+    """#1974: Auto-log all POST/PATCH/DELETE requests to admin endpoints.
+
+    Operates as a response-side middleware: captures the request BEFORE the
+    handler runs and writes the audit entry AFTER the response is generated,
+    so the entry includes only the context available from the request path.
+
+    Routes that already call ``log_admin_action_db()`` with richer context
+    should set ``request.state.admin_audit_logged = True`` to prevent the
+    middleware from creating a duplicate entry.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        path = request.url.path
+        method = request.method
+
+        # Only intercept mutating requests to admin paths
+        if method not in ("POST", "PATCH", "PUT", "DELETE") or not _is_admin_path(path):
+            return await call_next(request)
+
+        # Extract admin_id from auth if available — will be None for unauthenticated requests
+        admin_id = _extract_admin_id(request)
+        if not admin_id:
+            return await call_next(request)
+
+        response = await call_next(request)
+
+        # Skip if the route handler already logged (set by log_admin_action_db())
+        if getattr(request.state, "admin_audit_logged", False):
+            return response
+
+        # Only log successful or client-error responses (2xx/4xx), not 5xx
+        if response.status_code >= 500:
+            return response
+
+        action = _infer_action(method, path)
+        entity_type = _infer_entity_type(path, action)
+        entity_id = _infer_entity_id(path, admin_id)
+
+        # Capture client IP
+        ip_address = _extract_client_ip(request)
+
+        # Fire-and-forget: log the audit entry in background
+        try:
+            from log_sanitizer import log_admin_action_db
+
+            await log_admin_action_db(
+                admin_id=admin_id,
+                action=action,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                details={
+                    "method": method,
+                    "path": path,
+                    "status_code": response.status_code,
+                },
+                ip_address=ip_address,
+            )
+        except Exception as e:
+            logger.warning(
+                "AdminAuditMiddleware: failed to log action %s %s: %s",
+                method, path, e,
+            )
+
+        return response
+
+
+def _extract_admin_id(request: Request) -> str | None:
+    """Extract admin user ID from request.state.user (set by auth dependency).
+
+    Returns None if the user is not authenticated or user data is not present.
+    """
+    user = getattr(request.state, "user", None)
+    if user and isinstance(user, dict):
+        return user.get("id")
+    return None
+
+
+def _extract_client_ip(request: Request) -> str | None:
+    """Extract client IP from X-Forwarded-For or direct connection."""
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return None

--- a/backend/log_sanitizer.py
+++ b/backend/log_sanitizer.py
@@ -563,6 +563,66 @@ def log_admin_action(
     logger.log(level, " ".join(msg_parts))
 
 
+# ============================================================================
+# #1974: Admin Audit Log DB Persistence
+# ============================================================================
+
+
+async def log_admin_action_db(
+    admin_id: str,
+    action: str,
+    entity_type: str,
+    entity_id: str,
+    details: Optional[Dict[str, Any]] = None,
+    ip_address: Optional[str] = None,
+) -> None:
+    """Persist an admin action to the ``admin_audit_log`` table (#1974).
+
+    PII is sanitized via ``sanitize_dict()`` before storage.
+    Failures are logged as warnings but never raised -- audit visibility
+    is always preserved via the existing ``log_admin_action()`` stdout path.
+
+    Args:
+        admin_id: UUID of the admin who performed the action.
+        action: Action identifier (e.g. ``assign_plan``, ``create_user``).
+        entity_type: Type of affected entity (e.g. ``user``, ``cache``,
+            ``feature_flag``, ``reconciliation``).
+        entity_id: ID of the affected entity (UUID, flag name, hash, etc.).
+        details: Optional metadata dict (will be sanitized for PII).
+        ip_address: Optional client IP address.
+    """
+    safe_details: Dict[str, Any] = {}
+    if details:
+        safe_details = sanitize_dict(details)
+
+    row = {
+        "admin_id": admin_id,
+        "action": action,
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "details": safe_details,
+    }
+    if ip_address:
+        row["ip"] = ip_address
+
+    try:
+        from supabase_client import get_supabase, sb_execute
+
+        supabase = get_supabase()
+        await sb_execute(
+            supabase.table("admin_audit_log").insert(row),
+            category="write",
+        )
+    except Exception as e:
+        # Never let a DB write failure suppress the audit event.
+        # The stdout log via log_admin_action() already captured it.
+        logging.getLogger(__name__).warning(
+            "Failed to persist admin audit log to Supabase: %s "
+            "(action=%s, admin=%s, entity=%s/%s)",
+            e, action, admin_id[:8], entity_type, entity_id,
+        )
+
+
 def log_auth_event(
     logger: logging.Logger,
     event: str,

--- a/backend/routes/admin_audit_log.py
+++ b/backend/routes/admin_audit_log.py
@@ -1,0 +1,141 @@
+"""#1974: Admin audit log query endpoint.
+
+Provides a filtered, paginated query interface for the ``admin_audit_log`` table.
+Only users with ``admin:super`` or ``admin:compliance`` role can access this
+endpoint (enforced via ``require_admin_role``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from rbac_granular import require_admin_role
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+# ============================================================================
+# Pydantic models
+# ============================================================================
+
+
+class AuditLogEntry(BaseModel):
+    """Single admin audit log entry."""
+
+    id: str = Field(..., description="Audit log entry UUID")
+    admin_id: str = Field(..., description="Admin user ID")
+    action: str = Field(..., description="Action performed")
+    entity_type: str = Field(..., description="Type of affected entity")
+    entity_id: str = Field(..., description="ID of affected entity")
+    details: dict = Field(default_factory=dict, description="Action details (PII sanitized)")
+    ip: Optional[str] = Field(None, description="Client IP address")
+    created_at: str = Field(..., description="ISO timestamp of the action")
+
+
+class AuditLogResponse(BaseModel):
+    """Paginated audit log response."""
+
+    entries: list[AuditLogEntry] = Field(..., description="List of audit log entries")
+    total: int = Field(..., description="Total matching entries (before pagination)")
+    limit: int = Field(..., description="Page size applied")
+    offset: int = Field(..., description="Offset applied")
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.get("/audit-log", response_model=AuditLogResponse)
+async def get_audit_log(
+    admin: dict = Depends(require_admin_role("admin:compliance")),
+    admin_id: Optional[str] = Query(None, description="Filter by admin user ID"),
+    entity_type: Optional[str] = Query(None, description="Filter by entity type (e.g. user, cache)"),
+    action: Optional[str] = Query(None, description="Filter by action (e.g. assign_plan, create_user)"),
+    from_date: Optional[str] = Query(None, alias="from", description="Start date (ISO 8601)"),
+    to_date: Optional[str] = Query(None, alias="to", description="End date (ISO 8601)"),
+    limit: int = Query(default=50, ge=1, le=200, description="Max results per page"),
+    offset: int = Query(default=0, ge=0, description="Number of results to skip"),
+) -> AuditLogResponse:
+    """Query the admin audit log with optional filters.
+
+    Requires ``admin:compliance`` or ``admin:super`` role.
+    PII in the ``details`` field is sanitized at write time via
+    ``log_sanitizer.sanitize_dict()``.
+
+    **Filters:**
+    - ``admin_id``: Filter by the admin who performed the action.
+    - ``entity_type``: Filter by entity type (e.g. ``user``, ``cache``).
+    - ``action``: Filter by action name (e.g. ``assign_plan``).
+    - ``from`` / ``to``: ISO 8601 date range filter on ``created_at``.
+    - ``limit``: Page size (1-200, default 50).
+    - ``offset``: Pagination offset (default 0).
+    """
+    from supabase_client import get_supabase, sb_execute
+
+    sb = get_supabase()
+
+    # Build query
+    query = sb.table("admin_audit_log").select("*", count="exact")
+
+    if admin_id:
+        query = query.eq("admin_id", admin_id)
+
+    if entity_type:
+        query = query.eq("entity_type", entity_type)
+
+    if action:
+        query = query.eq("action", action)
+
+    if from_date:
+        try:
+            # Validate/parse ISO date
+            datetime.fromisoformat(from_date.replace("Z", "+00:00"))
+            query = query.gte("created_at", from_date)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail="Formato de data 'from' invalido. Use ISO 8601.")
+
+    if to_date:
+        try:
+            datetime.fromisoformat(to_date.replace("Z", "+00:00"))
+            query = query.lte("created_at", to_date)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail="Formato de data 'to' invalido. Use ISO 8601.")
+
+    query = query.order("created_at", desc=True).range(offset, offset + limit - 1)
+
+    try:
+        result = await sb_execute(query, category="read")
+    except Exception as e:
+        logger.error("Failed to query admin_audit_log: %s", e)
+        raise HTTPException(status_code=500, detail="Erro ao consultar log de auditoria.")
+
+    rows = result.data or []
+
+    entries = [
+        AuditLogEntry(
+            id=row["id"],
+            admin_id=row["admin_id"],
+            action=row["action"],
+            entity_type=row["entity_type"],
+            entity_id=row["entity_id"],
+            details=row.get("details", {}),
+            ip=row.get("ip"),
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+    return AuditLogResponse(
+        entries=entries,
+        total=result.count or len(rows),
+        limit=limit,
+        offset=offset,
+    )

--- a/backend/routes/feature_flags.py
+++ b/backend/routes/feature_flags.py
@@ -21,7 +21,7 @@ RBAC Phase 2 (#1954): admin flag management requires ``admin:ops`` role.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
 from pydantic import BaseModel, Field
 
 from admin import require_admin_ops
@@ -35,7 +35,7 @@ from config.features import (
     get_feature_flag,
     reload_feature_flags,
 )
-from log_sanitizer import log_admin_action
+from log_sanitizer import log_admin_action, log_admin_action_db
 from redis_resilience import safe_redis_call
 from schemas.parity import ExperimentsListResponse
 
@@ -458,6 +458,7 @@ async def list_feature_flags(
 
 @router.patch("/{flag_name}", response_model=FeatureFlagUpdateResponse)
 async def update_feature_flag(
+    request: Request,
     body: FeatureFlagUpdateRequest,
     flag_name: str = Path(..., description="Feature flag name from the registry"),
     admin: dict = Depends(require_admin_ops),
@@ -504,6 +505,19 @@ async def update_feature_flag(
             "source": source,
         },
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin["id"],
+        action="update_feature_flag",
+        entity_type="feature_flag",
+        entity_id=flag_name,
+        details={
+            "old_value": str(prev_value),
+            "new_value": str(new_value),
+            "source": source,
+        },
+    )
+    request.state.admin_audit_logged = True
 
     await audit_logger.log(
         event_type="admin.feature_flag_change",
@@ -534,6 +548,7 @@ async def update_feature_flag(
 
 @router.post("/reload", response_model=FeatureFlagReloadResponse)
 async def reload_flags_endpoint(
+    request: Request,
     admin: dict = Depends(require_admin_ops),
 ):
     """Reload all feature flags from environment variables (admin only).
@@ -569,6 +584,18 @@ async def reload_flags_endpoint(
             "flags": current_values,
         },
     )
+    # #1974: Persist to admin_audit_log
+    await log_admin_action_db(
+        admin_id=admin["id"],
+        action="reload_feature_flags",
+        entity_type="feature_flag",
+        entity_id="all",
+        details={
+            "redis_cleared": redis_cleared,
+            "memory_cleared": memory_cleared,
+        },
+    )
+    request.state.admin_audit_logged = True
 
     logger.info(
         "Feature flags fully reloaded: %d Redis + %d memory overrides cleared (by=%s)",

--- a/backend/startup/middleware_setup.py
+++ b/backend/startup/middleware_setup.py
@@ -19,6 +19,7 @@ from middleware import (CorrelationIDMiddleware, SecurityHeadersMiddleware,
                          DeprecationMiddleware, RateLimitMiddleware,
                          APIVersionHeaderMiddleware)
 from seo_404_middleware import SEO404MetricsMiddleware
+from admin_audit_middleware import AdminAuditMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,8 @@ def setup_middleware(app: FastAPI) -> None:
     # Added AFTER tracing middlewares so this sees the final response status; pure response-side
     # logic (no route file changes) — avoids races with concurrent route refactors.
     app.add_middleware(SEO404MetricsMiddleware)
+    # #1974: Admin audit middleware — auto-log POST/PATCH/DELETE to admin_audit_log
+    app.add_middleware(AdminAuditMiddleware)
 
     # DEBT-124: Graceful shutdown drain — reject new requests with 503 during shutdown
     @app.middleware("http")

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -119,6 +119,7 @@ from routes.admin_db_pool import router as admin_db_pool_router
 from routes.csp_report import router as csp_report_router
 from routes.alerts_b2gops import router as alerts_b2gops_router
 from routes.admin_outgoing_webhooks import router as admin_outgoing_webhooks_router
+from routes.admin_audit_log import router as admin_audit_log_router
 _v1_routers = [
     admin_router, subscriptions_router, upgrade_to_lifetime_router,
     features_router, messages_router,
@@ -239,6 +240,8 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(admin_db_pool_router)
     # Issue #1959: Outgoing webhook deliveries — self-prefixed at /v1/admin/webhook-deliveries
     app.include_router(admin_outgoing_webhooks_router)
+    # #1974: Admin audit log — query endpoint at /v1/admin/audit-log
+    app.include_router(admin_audit_log_router)
     # Stripe webhook at root — DEBT-324: single registration only.
     # Removed from _v1_routers above to prevent duplicate at /v1/webhooks/stripe.
     # Stripe Dashboard must be configured with: POST /webhooks/stripe

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -1734,6 +1734,105 @@
         "title": "AtividadeRecenteData",
         "type": "object"
       },
+      "AuditLogEntry": {
+        "description": "Single admin audit log entry.",
+        "properties": {
+          "action": {
+            "description": "Action performed",
+            "title": "Action",
+            "type": "string"
+          },
+          "admin_id": {
+            "description": "Admin user ID",
+            "title": "Admin Id",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "ISO timestamp of the action",
+            "title": "Created At",
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": true,
+            "description": "Action details (PII sanitized)",
+            "title": "Details",
+            "type": "object"
+          },
+          "entity_id": {
+            "description": "ID of affected entity",
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "entity_type": {
+            "description": "Type of affected entity",
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "id": {
+            "description": "Audit log entry UUID",
+            "title": "Id",
+            "type": "string"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Client IP address",
+            "title": "Ip"
+          }
+        },
+        "required": [
+          "id",
+          "admin_id",
+          "action",
+          "entity_type",
+          "entity_id",
+          "created_at"
+        ],
+        "title": "AuditLogEntry",
+        "type": "object"
+      },
+      "AuditLogResponse": {
+        "description": "Paginated audit log response.",
+        "properties": {
+          "entries": {
+            "description": "List of audit log entries",
+            "items": {
+              "$ref": "#/components/schemas/AuditLogEntry"
+            },
+            "title": "Entries",
+            "type": "array"
+          },
+          "limit": {
+            "description": "Page size applied",
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "description": "Offset applied",
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Total matching entries (before pagination)",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "entries",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "AuditLogResponse",
+        "type": "object"
+      },
       "AuthStatusResponse": {
         "properties": {
           "confirmed": {
@@ -22379,6 +22478,162 @@
           }
         ],
         "summary": "Get At Risk Trials",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/v1/admin/audit-log": {
+      "get": {
+        "description": "Query the admin audit log with optional filters.\n\nRequires ``admin:compliance`` or ``admin:super`` role.\nPII in the ``details`` field is sanitized at write time via\n``log_sanitizer.sanitize_dict()``.\n\n**Filters:**\n- ``admin_id``: Filter by the admin who performed the action.\n- ``entity_type``: Filter by entity type (e.g. ``user``, ``cache``).\n- ``action``: Filter by action name (e.g. ``assign_plan``).\n- ``from`` / ``to``: ISO 8601 date range filter on ``created_at``.\n- ``limit``: Page size (1-200, default 50).\n- ``offset``: Pagination offset (default 0).",
+        "operationId": "get_audit_log_v1_admin_audit_log_get",
+        "parameters": [
+          {
+            "description": "Filter by admin user ID",
+            "in": "query",
+            "name": "admin_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by admin user ID",
+              "title": "Admin Id"
+            }
+          },
+          {
+            "description": "Filter by entity type (e.g. user, cache)",
+            "in": "query",
+            "name": "entity_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by entity type (e.g. user, cache)",
+              "title": "Entity Type"
+            }
+          },
+          {
+            "description": "Filter by action (e.g. assign_plan, create_user)",
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by action (e.g. assign_plan, create_user)",
+              "title": "Action"
+            }
+          },
+          {
+            "description": "Start date (ISO 8601)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Start date (ISO 8601)",
+              "title": "From"
+            }
+          },
+          {
+            "description": "End date (ISO 8601)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "End date (ISO 8601)",
+              "title": "To"
+            }
+          },
+          {
+            "description": "Max results per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max results per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of results to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of results to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Audit Log",
         "tags": [
           "admin"
         ]

--- a/backend/tests/test_admin_default.py
+++ b/backend/tests/test_admin_default.py
@@ -115,8 +115,8 @@ class TestAdminUserCreationDefaultPlan:
         assert mock_table.update.called, "Profile should be updated with company info"
 
         # Verify NO subscription was created (free_trial doesn't create subscription)
-        # The insert() method should NOT be called for free_trial plans
-        assert mock_table.insert.call_count == 0, "free_trial should not create a subscription record"
+        # The only insert should be from the admin_audit_log (#1974)
+        assert mock_table.insert.call_count == 1, "free_trial should only create audit log entry, not subscription"
 
     def test_create_user_without_plan_id_and_without_company_minimal_profile(self, admin_client):
         """
@@ -161,8 +161,8 @@ class TestAdminUserCreationDefaultPlan:
         # Since company is None and plan_id == "free_trial", update should NOT happen
         assert mock_table.update.call_count == 0, "Profile should NOT be updated (relying on DB defaults)"
 
-        # Verify NO subscription was created
-        assert mock_table.insert.call_count == 0, "free_trial should not create a subscription record"
+        # Verify NO subscription was created (only audit log entry allowed)
+        assert mock_table.insert.call_count == 1, "free_trial should only create audit log entry, not subscription"
 
     def test_create_user_explicit_free_trial_behaves_same_as_default(self, admin_client):
         """
@@ -201,9 +201,9 @@ class TestAdminUserCreationDefaultPlan:
         assert data["email"] == "explicit@example.com"
         assert data["plan_id"] == "free_trial"
 
-        # Verify behavior is same as default (no update, no subscription)
+        # Verify behavior is same as default (no update, no subscription — only audit log)
         assert mock_table.update.call_count == 0, "Explicit free_trial should not update profile"
-        assert mock_table.insert.call_count == 0, "Explicit free_trial should not create subscription"
+        assert mock_table.insert.call_count == 1, "Explicit free_trial should only create audit log entry, not subscription"
 
     def test_create_user_with_paid_plan_creates_subscription(self, admin_client):
         """
@@ -250,8 +250,8 @@ class TestAdminUserCreationDefaultPlan:
         data = response.json()
         assert data["plan_id"] == "smartlic_pro"
 
-        # Verify subscription WAS created (contrast with free_trial)
-        assert mock_table.insert.call_count == 1, "Paid plan should create a subscription record"
+        # Verify subscription WAS created (1 insert) plus audit log entry (1 insert) = 2 total
+        assert mock_table.insert.call_count == 2, "Paid plan should create subscription (1) + audit log (1)"
 
         # Verify profile WAS updated with plan_type
         update_calls = [call for call in mock_table.update.call_args_list if call[0][0].get("plan_type")]

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -493,6 +493,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/audit-log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Audit Log
+         * @description Query the admin audit log with optional filters.
+         *
+         *     Requires ``admin:compliance`` or ``admin:super`` role.
+         *     PII in the ``details`` field is sanitized at write time via
+         *     ``log_sanitizer.sanitize_dict()``.
+         *
+         *     **Filters:**
+         *     - ``admin_id``: Filter by the admin who performed the action.
+         *     - ``entity_type``: Filter by entity type (e.g. ``user``, ``cache``).
+         *     - ``action``: Filter by action name (e.g. ``assign_plan``).
+         *     - ``from`` / ``to``: ISO 8601 date range filter on ``created_at``.
+         *     - ``limit``: Page size (1-200, default 50).
+         *     - ``offset``: Pagination offset (default 0).
+         */
+        get: operations["get_audit_log_v1_admin_audit_log_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/admin/cache": {
         parameters: {
             query?: never;
@@ -8379,6 +8411,80 @@ export interface components {
              * @default 0
              */
             valor_total_30d: number;
+        };
+        /**
+         * AuditLogEntry
+         * @description Single admin audit log entry.
+         */
+        AuditLogEntry: {
+            /**
+             * Action
+             * @description Action performed
+             */
+            action: string;
+            /**
+             * Admin Id
+             * @description Admin user ID
+             */
+            admin_id: string;
+            /**
+             * Created At
+             * @description ISO timestamp of the action
+             */
+            created_at: string;
+            /**
+             * Details
+             * @description Action details (PII sanitized)
+             */
+            details?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Entity Id
+             * @description ID of affected entity
+             */
+            entity_id: string;
+            /**
+             * Entity Type
+             * @description Type of affected entity
+             */
+            entity_type: string;
+            /**
+             * Id
+             * @description Audit log entry UUID
+             */
+            id: string;
+            /**
+             * Ip
+             * @description Client IP address
+             */
+            ip?: string | null;
+        };
+        /**
+         * AuditLogResponse
+         * @description Paginated audit log response.
+         */
+        AuditLogResponse: {
+            /**
+             * Entries
+             * @description List of audit log entries
+             */
+            entries: components["schemas"]["AuditLogEntry"][];
+            /**
+             * Limit
+             * @description Page size applied
+             */
+            limit: number;
+            /**
+             * Offset
+             * @description Offset applied
+             */
+            offset: number;
+            /**
+             * Total
+             * @description Total matching entries (before pagination)
+             */
+            total: number;
         };
         /** AuthStatusResponse */
         AuthStatusResponse: {
@@ -18141,6 +18247,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_audit_log_v1_admin_audit_log_get: {
+        parameters: {
+            query?: {
+                /** @description Filter by admin user ID */
+                admin_id?: string | null;
+                /** @description Filter by entity type (e.g. user, cache) */
+                entity_type?: string | null;
+                /** @description Filter by action (e.g. assign_plan, create_user) */
+                action?: string | null;
+                /** @description Start date (ISO 8601) */
+                from?: string | null;
+                /** @description End date (ISO 8601) */
+                to?: string | null;
+                /** @description Max results per page */
+                limit?: number;
+                /** @description Number of results to skip */
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuditLogResponse"];
                 };
             };
             /** @description Validation Error */

--- a/supabase/migrations/20260617180000_admin_audit_log.down.sql
+++ b/supabase/migrations/20260617180000_admin_audit_log.down.sql
@@ -1,0 +1,17 @@
+-- Rollback #1974: Admin audit log migration
+
+-- Drop pg_cron job
+SELECT cron.unschedule('cleanup-admin-audit-log');
+
+-- Drop trigger and function
+DROP TRIGGER IF EXISTS trg_prevent_admin_audit_modification ON admin_audit_log;
+DROP FUNCTION IF EXISTS prevent_admin_audit_modification();
+
+-- Drop indexes
+DROP INDEX IF EXISTS idx_admin_audit_log_admin_created;
+DROP INDEX IF EXISTS idx_admin_audit_log_action_created;
+DROP INDEX IF EXISTS idx_admin_audit_log_entity;
+DROP INDEX IF EXISTS idx_admin_audit_log_created;
+
+-- Drop table (cascades to policies)
+DROP TABLE IF EXISTS admin_audit_log;

--- a/supabase/migrations/20260617180000_admin_audit_log.sql
+++ b/supabase/migrations/20260617180000_admin_audit_log.sql
@@ -1,0 +1,100 @@
+-- #1974: Admin audit log — immutable trail for all administrative actions
+-- LGPD/compliance requirement: every admin action must have an auditable trail.
+
+-- ============================================================================
+-- 1. admin_audit_log — immutable audit trail table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS admin_audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    admin_id UUID NOT NULL,
+    action TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    details JSONB DEFAULT '{}'::jsonb,
+    ip INET,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_admin_created
+    ON admin_audit_log(admin_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_action_created
+    ON admin_audit_log(action, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_entity
+    ON admin_audit_log(entity_type, entity_id);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_log_created
+    ON admin_audit_log(created_at DESC);
+
+-- ============================================================================
+-- 2. Row-Level Security (RLS)
+-- ============================================================================
+-- Only admin:super and admin:compliance can SELECT.
+-- INSERT/UPDATE/DELETE are blocked at RLS level (write happens via backend
+-- service_role, which bypasses RLS).
+
+ALTER TABLE admin_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Read-only for compliance/super admins (uses existing has_admin_role function)
+CREATE POLICY "Admin audit log read-only for compliance"
+    ON admin_audit_log FOR SELECT
+    USING (has_admin_role('admin:super') OR has_admin_role('admin:compliance'));
+
+-- Block direct INSERT (backend uses service_role which bypasses RLS)
+CREATE POLICY "Block direct insert"
+    ON admin_audit_log FOR INSERT
+    WITH CHECK (false);
+
+-- Block direct UPDATE
+CREATE POLICY "Block direct update"
+    ON admin_audit_log FOR UPDATE
+    USING (false);
+
+-- Block direct DELETE
+CREATE POLICY "Block direct delete"
+    ON admin_audit_log FOR DELETE
+    USING (false);
+
+-- ============================================================================
+-- 3. Immutability trigger — prevents UPDATE/DELETE at database level
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION prevent_admin_audit_modification()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'admin_audit_log is immutable: UPDATE and DELETE are not allowed (PG code: P0001)';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_prevent_admin_audit_modification
+    BEFORE UPDATE OR DELETE ON admin_audit_log
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_admin_audit_modification();
+
+-- ============================================================================
+-- 4. pg_cron cleanup job — 365-day retention (#1974 AC5)
+-- ============================================================================
+
+SELECT cron.schedule(
+    'cleanup-admin-audit-log',
+    '0 3 * * *',
+    $$DELETE FROM admin_audit_log WHERE created_at < now() - interval '365 days'$$
+);
+
+-- ============================================================================
+-- 5. Comments
+-- ============================================================================
+
+COMMENT ON TABLE admin_audit_log IS '#1974: Immutable audit trail for all admin actions. SELECT only for admin:super and admin:compliance.';
+COMMENT ON COLUMN admin_audit_log.admin_id IS 'UUID of the admin who performed the action';
+COMMENT ON COLUMN admin_audit_log.action IS 'Action identifier (e.g. assign_plan, create_user, invalidate_cache)';
+COMMENT ON COLUMN admin_audit_log.entity_type IS 'Type of affected entity (e.g. user, cache, feature_flag, reconciliation)';
+COMMENT ON COLUMN admin_audit_log.entity_id IS 'ID of the affected entity';
+COMMENT ON COLUMN admin_audit_log.details IS 'Action metadata (PII sanitized before logging via log_sanitizer.sanitize_dict)';
+COMMENT ON COLUMN admin_audit_log.ip IS 'Client IP address of the admin';
+COMMENT ON COLUMN admin_audit_log.created_at IS 'When the action was performed';
+COMMENT ON FUNCTION prevent_admin_audit_modification IS '#1974: Trigger function that raises exception on UPDATE/DELETE to enforce immutability';
+COMMENT ON TRIGGER trg_prevent_admin_audit_modification ON admin_audit_log IS '#1974: Fires before UPDATE/DELETE, raises exception to enforce immutability';


### PR DESCRIPTION
## Summary
Closes #1974

Implementa trilha de auditoria imutável para ações administrativas:
- Tabela `admin_audit_log` com RLS (read-only para admin:super/compliance)
- Trigger `prevent_admin_audit_modification` para imutabilidade
- Middleware automático para requests em `/v1/admin/*`
- Integração com `log_sanitizer.py` (PII masking)
- Retenção 365 dias via pg_cron
- Endpoint `GET /v1/admin/audit-log` com filtros

## Files Changed
- `supabase/migrations/` — tabela + RLS + trigger + pg_cron
- `backend/admin_audit_middleware.py` — intercepta admin requests
- `backend/routes/admin_audit_log.py` — endpoint de consulta
- `backend/log_sanitizer.py` — `log_admin_action_db()`
- `backend/admin.py` — 9 handlers atualizados
- `backend/startup/` — registro de middleware + router

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new admin audit log page/API with filtering (admin, action, entity type, date range) and pagination for compliance and activity tracking.
  * Introduced persistent database audit logging for administrative actions, including user management, password resets, plan/credit updates, cache invalidations, feature flag changes, and reconciliation triggers.
  * Restricted audit log access to authorized compliance admins.
* **Chores**
  * Added automatic audit capture for relevant admin requests, with safe failure handling to avoid disrupting operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->