### PR TITLE
feat(test): k6 load test scenarios for critical paths (#1968)

### DIFF
--- a/.github/workflows/load-test-schedule.yml
+++ b/.github/workflows/load-test-schedule.yml
@@ -1,0 +1,168 @@
+name: Load Test Schedule
+
+# Issue #1968: Non-blocking weekly load test pipeline.
+#
+# Runs all 4 load test scenarios against staging every Saturday 06:00 UTC.
+# Results are uploaded as artifacts. This workflow is non-blocking
+# (always passes) — thresholds breached are informational only.
+#
+# Manual trigger (workflow_dispatch) available for ad-hoc runs.
+#
+# Secrets needed:
+#   STAGING_BACKEND_URL  — Backend staging URL (e.g. https://smartlic-backend-staging...)
+#   STAGING_FRONTEND_URL — Frontend staging URL (e.g. https://staging.smartlic.tech)
+#   LOAD_TEST_JWTS       — Multi-line secret of JWTs for authenticated scenarios
+
+on:
+  schedule:
+    - cron: '0 6 * * 6'  # Saturday 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      script:
+        description: 'Script to run (search | observatory | pipeline | spike | all)'
+        required: false
+        default: 'all'
+      backend_url:
+        description: 'Backend URL override'
+        required: false
+        default: ''
+      frontend_url:
+        description: 'Frontend URL override'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+env:
+  BACKEND_URL: ${{ github.event.inputs.backend_url || secrets.STAGING_BACKEND_URL || 'http://localhost:8000' }}
+  FRONTEND_URL: ${{ github.event.inputs.frontend_url || secrets.STAGING_FRONTEND_URL || 'http://localhost:3000' }}
+  JWTS_PATH: tests/load/fixtures/jwts.json
+  SCRIPT_FILTER: ${{ github.event.inputs.script || 'all' }}
+  TEST_ID: ${{ github.run_id }}
+
+jobs:
+  load-test:
+    name: k6 Load Tests (${{ github.event.inputs.script || 'all' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup k6
+        uses: grafana/setup-k6-action@v1
+        with:
+          k6-version: 'latest'
+
+      - name: Materialize JWT fixture
+        if: env.SCRIPT_FILTER == 'all' || env.SCRIPT_FILTER == 'search' || env.SCRIPT_FILTER == 'pipeline' || env.SCRIPT_FILTER == 'spike'
+        env:
+          LOAD_TEST_JWTS: ${{ secrets.LOAD_TEST_JWTS }}
+        run: |
+          mkdir -p tests/load/fixtures
+          if [ -n "$LOAD_TEST_JWTS" ]; then
+            python3 <<'PY'
+          import json, os
+          raw = os.environ.get("LOAD_TEST_JWTS", "")
+          tokens = [line.strip() for line in raw.splitlines() if line.strip() and not line.startswith("#")]
+          if tokens:
+              with open("tests/load/fixtures/jwts.json", "w") as f:
+                  json.dump({"tokens": tokens, "_source": "github actions secret"}, f)
+              print(f"Wrote {len(tokens)} JWTs to tests/load/fixtures/jwts.json")
+          else:
+              print("WARN: LOAD_TEST_JWTS contains no valid tokens after stripping comments/blanks")
+              exit(0)
+          PY
+          else
+            echo "WARN: LOAD_TEST_JWTS secret is not set or empty. Auth-required tests will fail with 401."
+            echo "To fix: add LOAD_TEST_JWTS to GitHub Actions secrets (see tests/load/README.md)."
+          fi
+
+      - name: Prepare results directory
+        run: mkdir -p results
+
+      # ---- Scenario 1: Search (50 VUs) ----
+      - name: Run k6 — search-load
+        if: env.SCRIPT_FILTER == 'all' || env.SCRIPT_FILTER == 'search'
+        continue-on-error: true
+        run: |
+          k6 run tests/load/search-load.js \
+            --summary-export=results/search-summary.json \
+            --tag testid=${{ env.TEST_ID }}
+        env:
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+
+      # ---- Scenario 2: Observatory (500 VUs) ----
+      - name: Run k6 — observatory-load
+        if: env.SCRIPT_FILTER == 'all' || env.SCRIPT_FILTER == 'observatory'
+        continue-on-error: true
+        run: |
+          k6 run tests/load/observatory-load.js \
+            --summary-export=results/observatory-summary.json \
+            --tag testid=${{ env.TEST_ID }}
+        env:
+          FRONTEND_URL: ${{ env.FRONTEND_URL }}
+
+      # ---- Scenario 3: Pipeline (20 VUs) ----
+      - name: Run k6 — pipeline-load
+        if: env.SCRIPT_FILTER == 'all' || env.SCRIPT_FILTER == 'pipeline'
+        continue-on-error: true
+        run: |
+          k6 run tests/load/pipeline-load.js \
+            --summary-export=results/pipeline-summary.json \
+            --tag testid=${{ env.TEST_ID }}
+        env:
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+
+      # ---- Scenario 4: Spike (10->200 VUs) ----
+      - name: Run k6 — spike-test
+        if: env.SCRIPT_FILTER == 'all' || env.SCRIPT_FILTER == 'spike'
+        continue-on-error: true
+        run: |
+          k6 run tests/load/spike-test.js \
+            --summary-export=results/spike-summary.json \
+            --tag testid=${{ env.TEST_ID }}
+        env:
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+
+      # ---- Summary ----
+      - name: Generate summary
+        if: always()
+        run: |
+          echo "## Weekly Load Test Results (${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Scenario | Status | p95 | Error Rate | Throughput |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|--------|-----|------------|------------|" >> $GITHUB_STEP_SUMMARY
+
+          for summary in results/*-summary.json; do
+            if [ -f "$summary" ]; then
+              NAME=$(basename "$summary" -summary.json)
+              python3 -c "
+          import json
+          with open('$summary') as f:
+              data = json.load(f)
+          m = data.get('metrics', {})
+          dur = m.get('http_req_duration', {}).get('values', {})
+          failed = m.get('http_req_failed', {}).get('values', {})
+          reqs = m.get('http_reqs', {}).get('values', {})
+          p95 = dur.get('p(95)', 0)
+          err_rate = failed.get('rate', 0) * 100
+          rps = reqs.get('rate', 0)
+          status = 'PASS' if p95 < 5000 and err_rate < 10 else 'WARN'
+          print(f'| {NAME} | {status} | {p95:.0f}ms | {err_rate:.1f}% | {rps:.1f} req/s |')
+          " >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "*Non-blocking: thresholds breached are informational only.*" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results-${{ github.run_id }}
+          path: results/
+          retention-days: 30

--- a/docs/architecture/load-test-2026-06.md
+++ b/docs/architecture/load-test-2026-06.md
@@ -1,0 +1,130 @@
+# Load Test Report — SmartLic (2026-06)
+
+**Issue:** [#1968](https://github.com/tjsasakifln/SmartLic/issues/1968)
+**Ferramenta:** [k6](https://k6.io) (Grafana) — gratuito, open source
+**Scripts:** `tests/load/{search-load,observatory-load,pipeline-load,spike-test}.js`
+
+---
+
+## 1. Resumo dos Cenários
+
+| # | Cenário | VUs | Ramp-up | Sustain | Endpoint | Prioridade |
+|:-:|---------|:---:|:-------:|:-------:|----------|:----------:|
+| 1 | Carga típica de busca | 5 -> 50 | 2 min | 5 min | `POST /buscar` | Critica |
+| 2 | ISR cache — observatorio | 50 -> 500 | 2 min | 5 min | `GET /observatorio/[slug]` | Alta |
+| 3 | Pipeline CRUD | 2 -> 20 | 1 min | 3 min | `POST/PATCH /v1/pipeline` | Alta |
+| 4 | Spike (pico repentino) | 10 -> 200 | 30 s | 1 min | `POST /buscar` | Media |
+
+## 2. Thresholds
+
+| Cenário | p95 | Error Rate | Notas |
+|---------|:---:|:----------:|-------|
+| Search | < 3000 ms | < 2% | Rampa suave, carga esperada |
+| Observatory | < 2000 ms | < 5% | ISR deve servir rapido; 500 VUs testam cache |
+| Pipeline | < 2000 ms | < 5% | CRUD operations, baixo volume |
+| Spike | < 5000 ms | < 10% | Tolerancia maior devido a carga abrupta |
+
+## 3. Resultados (preencher apos execucao)
+
+### 3.1 Search Load
+
+| Metrica | Valor | Threshold | Status |
+|---------|:-----:|:---------:|:------:|
+| p95 latencia | ___ ms | < 3000 ms | :---: |
+| p99 latencia | ___ ms | — | :---: |
+| Error rate | ___ % | < 2% | :---: |
+| Throughput | ___ req/s | — | :---: |
+| VUs maximo | 50 | — | :---: |
+
+### 3.2 Observatory Load
+
+| Metrica | Valor | Threshold | Status |
+|---------|:-----:|:---------:|:------:|
+| p95 latencia | ___ ms | < 2000 ms | :---: |
+| p99 latencia | ___ ms | — | :---: |
+| Error rate | ___ % | < 5% | :---: |
+| Cache hit rate | ___ % | — | :---: |
+| Throughput | ___ req/s | — | :---: |
+| VUs maximo | 500 | — | :---: |
+
+### 3.3 Pipeline Load
+
+| Metrica | Valor | Threshold | Status |
+|---------|:-----:|:---------:|:------:|
+| p95 latencia (create) | ___ ms | < 2000 ms | :---: |
+| p95 latencia (update) | ___ ms | < 2000 ms | :---: |
+| Error rate | ___ % | < 5% | :---: |
+| Throughput | ___ req/s | — | :---: |
+| VUs maximo | 20 | — | :---: |
+
+### 3.4 Spike Test
+
+| Metrica | Valor | Threshold | Status |
+|---------|:-----:|:---------:|:------:|
+| p95 latencia | ___ ms | < 5000 ms | :---: |
+| p99 latencia | ___ ms | — | :---: |
+| Error rate | ___ % | < 10% | :---: |
+| Throughput (pico) | ___ req/s | — | :---: |
+| VUs maximo | 200 | — | :---: |
+| Tempo de recuperacao | ___ s | — | :---: |
+
+## 4. Metricas de Infraestrutura (Pico)
+
+| Recurso | Valor | Notas |
+|---------|:-----:|-------|
+| CPU Railway (backend) | ___ % | Coletar do dashboard Railway |
+| RAM Railway (backend) | ___ MB | Coletar do dashboard Railway |
+| Conexoes DB (Supabase) | ___ | Coletar do dashboard Supabase |
+| Redis hit rate | ___ % | Coletar do Redis INFO |
+| Railway 120s timeout hits | ___ | Verificar logs de 503 |
+
+## 5. Analise
+
+### 5.1 Gargalos Identificados
+
+- _(preencher apos execucao)_
+
+### 5.2 Comportamento sob Carga
+
+- _(preencher apos execucao)_
+
+### 5.3 Memory Leak Check
+
+Comparar p95 da fase inicial vs fase sustentada:
+- Inicio: ___ ms
+- Final: ___ ms
+- Diferenca: ___ % (alerta se > 20%)
+
+## 6. Recomendacoes
+
+- [ ] _(preencher apos execucao)_
+
+## 7. Historico de Execucoes
+
+| Data | Run ID | Resultado | Observacoes |
+|------|:------:|:---------:|-------------|
+| ___ | ___ | ___ | ___ |
+
+---
+
+## Apendice A: Como Executar
+
+```bash
+# Todos os cenarios contra staging
+k6 run tests/load/search-load.js --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+k6 run tests/load/observatory-load.js --env FRONTEND_URL=https://staging.smartlic.tech
+k6 run tests/load/pipeline-load.js --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+k6 run tests/load/spike-test.js --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+
+# Smoke test (validacao rapida)
+k6 run tests/load/search-load.js --env SMOKE=1 --vus 1 --duration 10s
+```
+
+## Apendice B: Configuracao
+
+Ver `tests/load/config.json` para thresholds compartilhados e
+`tests/load/fixtures/jwts.json.example` para template de fixture JWT.
+
+---
+
+_Ultima atualizacao: 2026-06-17_

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -22,25 +22,61 @@ docker pull grafana/k6
 
 | Script | Objetivo | Duração | VUs Máx |
 |--------|----------|:---:|:---:|
-| `k6-search-load.js` | Load test progressivo | ~17 min | 500 |
-| `k6-stress-test.js` | Stress test + breaking point | ~36 min | 500 |
+| `k6-search-load.js` | Load test progressivo (legado) | ~17 min | 500 |
+| `k6-stress-test.js` | Stress test + breaking point (legado) | ~36 min | 500 |
+| `buscar.k6.js` | Load test — POST /buscar com arrival-rate | ~5.5 min | 50 RPS |
+| `dashboard.k6.js` | Load test — GET /analytics | ~5.5 min | 100 RPS |
+| `sse.k6.js` | Load test — SSE /buscar-progress | 5 min | 50 conexões |
+| `search-load.js` | Load test — POST /buscar (50 VUs, rampa 5→50) | ~7.5 min | 50 |
+| `observatory-load.js` | Load test — ISR /observatorio/[slug] (500 VUs) | ~7.5 min | 500 |
+| `pipeline-load.js` | Load test — POST/PATCH /v1/pipeline (20 VUs) | ~4.5 min | 20 |
+| `spike-test.js` | Spike test — 10→200 VUs em 30s | ~2.5 min | 200 |
 
 ## 3. Como Executar
 
-### 3.1 Load Test (Staging)
+### 3.1 Scripts Legados
 
 ```bash
 k6 run tests/load/k6-search-load.js
 BASE_URL=https://localhost:8000 k6 run tests/load/k6-search-load.js
 ```
 
-### 3.2 Stress Test (Staging)
+### 3.2 Scripts Modernos (JWT fixtures)
 
 ```bash
-k6 run tests/load/k6-stress-test.js
+# Garanta que tests/load/fixtures/jwts.json existe (ver jwts.json.example)
+k6 run tests/load/search-load.js --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+k6 run tests/load/pipeline-load.js --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+k6 run tests/load/spike-test.js --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+
+# Frontend ISR
+k6 run tests/load/observatory-load.js --env FRONTEND_URL=https://staging.smartlic.tech
 ```
 
-### 3.3 Modo CI (Leve)
+### 3.3 Smoke Test (Validação Rápida)
+
+Todos os scripts modernos suportam modo SMOKE:
+
+```bash
+k6 run tests/load/search-load.js --env SMOKE=1 --vus 1 --duration 10s
+k6 run tests/load/observatory-load.js --env SMOKE=1 --vus 1 --duration 10s
+k6 run tests/load/pipeline-load.js --env SMOKE=1 --vus 1 --duration 10s
+k6 run tests/load/spike-test.js --env SMOKE=1 --vus 1 --duration 10s
+```
+
+### 3.4 CI Tagging
+
+```bash
+k6 run tests/load/search-load.js --tag testid=$(date +%F)
+```
+
+### 3.5 Auth via AUTH_TOKEN (alternativa)
+
+```bash
+k6 run tests/load/search-load.js --env AUTH_TOKEN=<seu-jwt-aqui>
+```
+
+### 3.6 Modo CI (Leve)
 
 ```bash
 k6 run --duration 2m --vus 10 tests/load/k6-search-load.js
@@ -79,11 +115,21 @@ k6 run --duration 2m --vus 10 tests/load/k6-search-load.js
 
 ## 7. CI Semanal
 
-Workflow `.github/workflows/load-test-weekly.yml`:
+### Workflow Legado
+
+`.github/workflows/load-test-weekly.yml`:
 - Domingo 03:00 UTC
 - 10 VUs, 2 minutos
 - Target: staging
 - Falha se p95 > 3s ou error rate > 10%
+
+### Workflow Issue #1968
+
+`.github/workflows/load-test-schedule.yml`:
+- Sabado 06:00 UTC
+- Todos os 4 cenários (search, observatory, pipeline, spike)
+- Non-blocking (thresholds breached são informativos, não bloqueiam)
+- Resultados exportados como artifact (30 dias de retencao)
 
 ## 8. Referências
 

--- a/tests/load/config.json
+++ b/tests/load/config.json
@@ -1,0 +1,33 @@
+{
+  "base_url": "http://localhost:8000",
+  "frontend_url": "http://localhost:3000",
+  "thresholds": {
+    "search": {
+      "p95_ms": 3000,
+      "error_rate": 0.02,
+      "vus": 50,
+      "duration": "7m30s"
+    },
+    "observatory": {
+      "p95_ms": 2000,
+      "error_rate": 0.05,
+      "vus": 500,
+      "duration": "7m30s"
+    },
+    "pipeline": {
+      "p95_ms": 2000,
+      "error_rate": 0.05,
+      "vus": 20,
+      "duration": "4m30s"
+    },
+    "spike": {
+      "p95_ms": 5000,
+      "error_rate": 0.10,
+      "vus": 200,
+      "duration": "2m30s"
+    }
+  },
+  "think_time_seconds": 1,
+  "timeout_seconds": 30,
+  "jwts_path": "./fixtures/jwts.json"
+}

--- a/tests/load/observatory-load.js
+++ b/tests/load/observatory-load.js
@@ -1,0 +1,150 @@
+/**
+ * Issue #1968: k6 load test — cenário 2: 500 usuários simultâneos em /observatorio/[slug]
+ *
+ * Testa páginas ISR (Incremental Static Regeneration) do observatório setorial.
+ * O objetivo é validar a eficácia do cache: ISR deve servir páginas em <500ms
+ * após o primeiro hit, mesmo sob 500 VUs concorrentes.
+ *
+ * Profile:
+ *   - Ramp-up   : 2 min (50 -> 500 VUs)
+ *   - Sustain   : 5 min at 500 VUs
+ *   - Ramp-down : 30 s (500 -> 0 VUs)
+ *
+ * Thresholds:
+ *   - http_req_duration p(95) < 2000 ms
+ *   - http_req_failed   rate  < 5%
+ *
+ * Run local:
+ *   k6 run tests/load/observatory-load.js \
+ *     --env FRONTEND_URL=http://localhost:3000
+ *
+ * Smoke:
+ *   k6 run tests/load/observatory-load.js --env SMOKE=1 --vus 1 --duration 10s
+ *
+ * CI:
+ *   k6 run tests/load/observatory-load.js \
+ *     --env FRONTEND_URL=https://smartlic.tech \
+ *     --tag testid=$(date +%F)
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const FRONTEND_URL = __ENV.FRONTEND_URL || __ENV.BASE_URL || 'http://localhost:3000';
+const SMOKE = __ENV.SMOKE === '1' || __ENV.SMOKE === 'true';
+
+// Custom metrics
+// Note: k6 automatically computes all percentiles (p50/p90/p95/p99) from a single Trend metric.
+const obsErrors = new Rate('obs_errors');
+const obsLatency = new Trend('obs_latency_ms', true);
+const obsCacheHit = new Rate('obs_cache_hit');
+
+/**
+ * Lista de slugs do observatório setorial.
+ * Cada slug corresponde a uma página ISR: /observatorio/{slug}
+ * A diversidade de slugs garante que o teste não acerte apenas uma página em cache.
+ */
+const SLUGS = [
+  'construcao-civil',
+  'tecnologia-da-informacao',
+  'saude',
+  'educacao',
+  'limpeza-e-conservacao',
+  'vigilancia-e-seguranca',
+  'transporte',
+  'alimentacao',
+  'obras',
+  'consultoria',
+  'energia',
+  'meio-ambiente',
+  'seguros',
+  'comunicacao',
+  'servicos-financeiros',
+  'seguranca-do-trabalho',
+  'juridico',
+  'engenharia',
+  'logistica',
+  'publicidade',
+];
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export const options = SMOKE
+  ? {
+      vus: 1,
+      duration: '10s',
+      thresholds: {
+        http_req_failed: ['rate<0.5'], // smoke is permissive
+      },
+    }
+  : {
+      scenarios: {
+        observatory: {
+          executor: 'ramping-vus',
+          startVUs: 50,
+          stages: [
+            { target: 500, duration: '2m' },   // ramp-up: 50 -> 500 VUs
+            { target: 500, duration: '5m' },   // sustain: 500 VUs
+            { target: 0, duration: '30s' },    // ramp-down
+          ],
+          gracefulRampDown: '30s',
+        },
+      },
+      thresholds: {
+        http_req_duration: ['p(95)<2000'],
+        http_req_failed: ['rate<0.05'],
+        obs_errors: ['rate<0.05'],
+      },
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pickSlug() {
+  return SLUGS[Math.floor(Math.random() * SLUGS.length)];
+}
+
+// ---------------------------------------------------------------------------
+// Default VU function
+// ---------------------------------------------------------------------------
+
+export default function () {
+  const slug = pickSlug();
+  const url = `${FRONTEND_URL}/observatorio/${slug}`;
+  const params = {
+    headers: {
+      'Cache-Control': 'no-cache',
+    },
+    tags: { endpoint: 'observatorio', slug: slug, testid: __ENV.TEST_ID || 'local' },
+    timeout: '15s',
+  };
+
+  const res = http.get(url, params);
+
+  obsLatency.add(res.timings.duration);
+
+  // Heuristic for cache hit detection
+  // Next.js ISR returns X-Cache or x-cache header (e.g. "HIT", "MISS", "STALE")
+  const cacheHeader = (res.headers['X-Cache'] || res.headers['x-cache'] || '').toLowerCase();
+  obsCacheHit.add(cacheHeader.includes('hit') || cacheHeader.includes('stale'));
+
+  const ok = check(res, {
+    'status is 200': (r) => r.status === 200,
+    'has html body': (r) => r.body && r.body.length > 1000,
+    'response time < 5s': (r) => r.timings.duration < 5000,
+  });
+
+  obsErrors.add(!ok);
+
+  if (SMOKE) {
+    sleep(1);
+  }
+}

--- a/tests/load/pipeline-load.js
+++ b/tests/load/pipeline-load.js
@@ -1,0 +1,286 @@
+/**
+ * Issue #1968: k6 load test — cenário 3: 20 usuários simultâneos em /v1/pipeline
+ *
+ * Profile:
+ *   - Ramp-up   : 1 min (2 -> 20 VUs)
+ *   - Sustain   : 3 min at 20 VUs
+ *   - Ramp-down : 30 s (20 -> 0 VUs)
+ *
+ * Operações:
+ *   - POST /v1/pipeline  (criar item no pipeline) — ~60% das requisições
+ *   - PATCH /v1/pipeline/{id} (atualizar status) — ~40% das requisições
+ *
+ * Cada VU mantém seu próprio conjunto de IDs criados, evitando contenção.
+ *
+ * Thresholds:
+ *   - http_req_duration p(95) < 2000 ms
+ *   - http_req_failed   rate  < 5%
+ *
+ * Auth: JWTs loaded from tests/load/fixtures/jwts.json.
+ *
+ * Run local:
+ *   k6 run tests/load/pipeline-load.js \
+ *     --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+ *
+ * Smoke:
+ *   k6 run tests/load/pipeline-load.js --env SMOKE=1 --vus 1 --duration 10s
+ *
+ * CI:
+ *   k6 run tests/load/pipeline-load.js \
+ *     --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app \
+ *     --tag testid=$(date +%F)
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Rate, Trend } from 'k6/metrics';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BACKEND_URL = __ENV.BACKEND_URL || __ENV.BASE_URL || 'http://localhost:8000';
+const JWTS_PATH = __ENV.JWTS_PATH || './fixtures/jwts.json';
+const SMOKE = __ENV.SMOKE === '1' || __ENV.SMOKE === 'true';
+
+// Custom metrics
+// Note: pipeline_create_latency and pipeline_update_latency are separate Trends
+// for CREATE vs UPDATE breakdown; k6 computes percentiles automatically.
+const pipelineErrors = new Rate('pipeline_errors');
+const pipelineLatency = new Trend('pipeline_latency_ms', true);
+const pipelineCreateLatency = new Trend('pipeline_create_latency_ms', true);
+const pipelineUpdateLatency = new Trend('pipeline_update_latency_ms', true);
+
+// ---------------------------------------------------------------------------
+// JWT fixture loading
+// ---------------------------------------------------------------------------
+
+const jwts = new SharedArray('jwts', function () {
+  try {
+    // eslint-disable-next-line no-undef
+    const raw = open(JWTS_PATH);
+    const parsed = JSON.parse(raw);
+    const tokens = Array.isArray(parsed.tokens) ? parsed.tokens : [];
+    if (tokens.length === 0) {
+      throw new Error('no tokens in fixture');
+    }
+    return tokens;
+  } catch (err) {
+    if (!SMOKE) {
+      throw new Error(
+        `Failed to load JWTs from ${JWTS_PATH}: ${err.message}. ` +
+          `See tests/load/README.md for how to generate the fixture.`
+      );
+    }
+    return ['smoke-placeholder-jwt'];
+  }
+});
+
+// Statuses for PATCH updates
+const STATUSES = [
+  'em_andamento',
+  'analise_viabilidade',
+  'proposta_enviada',
+  'vencido',
+  'ganho',
+];
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export const options = SMOKE
+  ? {
+      vus: 1,
+      duration: '10s',
+      thresholds: {
+        http_req_failed: ['rate<0.5'],
+      },
+    }
+  : {
+      scenarios: {
+        pipeline: {
+          executor: 'ramping-vus',
+          startVUs: 2,
+          stages: [
+            { target: 20, duration: '1m' },   // ramp-up: 2 -> 20 VUs
+            { target: 20, duration: '3m' },   // sustain: 20 VUs
+            { target: 0, duration: '30s' },   // ramp-down
+          ],
+          gracefulRampDown: '30s',
+        },
+      },
+      thresholds: {
+        http_req_duration: ['p(95)<2000'],
+        http_req_failed: ['rate<0.05'],
+        pipeline_errors: ['rate<0.05'],
+      },
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function recentDateRange() {
+  const today = new Date();
+  const end = today.toISOString().slice(0, 10);
+  const start = new Date(today.getTime() - 10 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  return { data_inicial: start, data_final: end };
+}
+
+function pickToken() {
+  const token = jwts[Math.floor(Math.random() * jwts.length)];
+  if (__ENV.AUTH_TOKEN) return __ENV.AUTH_TOKEN;
+  return token;
+}
+
+// Per-VU storage for created pipeline IDs (each VU has its own list)
+// This avoids cross-VU race conditions on PATCH operations.
+const createdIds = [];
+
+// ---------------------------------------------------------------------------
+// Default VU function
+// ---------------------------------------------------------------------------
+
+export default function () {
+  const token = pickToken();
+  const baseHeaders = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+
+  // Decide operation: 60% CREATE, 40% UPDATE (only if we have IDs)
+  const shouldPatch = createdIds.length > 0 && Math.random() < 0.4;
+
+  if (shouldPatch) {
+    // ---- PATCH: update pipeline item status ----
+    const id = createdIds[Math.floor(Math.random() * createdIds.length)];
+    const status = STATUSES[Math.floor(Math.random() * STATUSES.length)];
+    const url = `${BACKEND_URL}/v1/pipeline/${id}`;
+    const payload = JSON.stringify({ status });
+
+    const patchParams = {
+      headers: baseHeaders,
+      tags: { endpoint: 'pipeline_update', testid: __ENV.TEST_ID || 'local' },
+      timeout: '10s',
+    };
+
+    const start = Date.now();
+    const res = http.patch(url, payload, patchParams);
+    const elapsed = Date.now() - start;
+
+    pipelineUpdateLatency.add(elapsed);
+    pipelineLatency.add(elapsed);
+
+    const ok = check(res, {
+      'PATCH pipeline status is 200': (r) => r.status === 200,
+      'PATCH pipeline has body': (r) => r.body && r.body.length > 0,
+    });
+
+    pipelineErrors.add(!ok);
+  } else {
+    // ---- POST: create pipeline item ----
+    // First do a quick search to find a real bid ID for the pipeline item.
+    // This makes the test more realistic — users add actual bids to their pipeline.
+    const { data_inicial, data_final } = recentDateRange();
+    const searchPayload = JSON.stringify({
+      ufs: ['SP'],
+      data_inicial,
+      data_final,
+      setor_id: 'construcao_civil',
+      modo_busca: 'abertas',
+      pagina: 1,
+      itens_por_pagina: 5,
+    });
+
+    const searchRes = http.post(`${BACKEND_URL}/buscar`, searchPayload, {
+      headers: baseHeaders,
+      timeout: '15s',
+    });
+
+    if (searchRes.status !== 200 && searchRes.status !== 202) {
+      // Search failure is not a pipeline error — fall through to fallback creation below
+      // (bidId stays null, which triggers the fallback path)
+    }
+
+    // Extract a bid ID from search results
+    let bidId = null;
+    try {
+      const body = JSON.parse(searchRes.body);
+      const items = body.resultados || body.itens || body.data || body.items || [];
+      if (items.length > 0) {
+        bidId = items[0].id || items[0].licitacao_id || items[0].processo_id || items[0].external_id;
+      }
+    } catch (e) {
+      // JSON parse errors are acceptable under load
+    }
+
+    let pipelineUrl;
+    let payload;
+
+    if (bidId) {
+      // Real bid found — add to pipeline
+      pipelineUrl = `${BACKEND_URL}/v1/pipeline`;
+      payload = JSON.stringify({
+        licitacao_id: bidId,
+        status: 'em_andamento',
+        observacoes: 'Adicionado por load test k6',
+      });
+    } else {
+      // Fallback: create pipeline item with explicit data
+      pipelineUrl = `${BACKEND_URL}/v1/pipeline`;
+      payload = JSON.stringify({
+        titulo: `Pipeline Load Test VU ${__VU} - ${Date.now()}`,
+        orgao: 'Orgao Teste',
+        uf: 'SP',
+        setor: 'construcao_civil',
+        status: 'em_andamento',
+        observacoes: 'Criado por load test k6',
+      });
+    }
+
+    const postParams = {
+      headers: baseHeaders,
+      tags: { endpoint: 'pipeline_create', testid: __ENV.TEST_ID || 'local' },
+      timeout: '10s',
+    };
+
+    const start = Date.now();
+    const res = http.post(pipelineUrl, payload, postParams);
+    const elapsed = Date.now() - start;
+
+    pipelineCreateLatency.add(elapsed);
+    pipelineLatency.add(elapsed);
+
+    const ok = check(res, {
+      'POST pipeline status is 200 or 201': (r) => r.status === 200 || r.status === 201,
+      'POST pipeline has body': (r) => r.body && r.body.length > 0,
+    });
+
+    pipelineErrors.add(!ok);
+
+    // Store the created ID for future PATCH operations
+    if (ok) {
+      try {
+        const body = JSON.parse(res.body);
+        const newId = body.id || body.pipeline_id;
+        if (newId) {
+          createdIds.push(newId);
+          // Keep the list bounded to avoid unbounded growth
+          if (createdIds.length > 50) {
+            createdIds.shift();
+          }
+        }
+      } catch (e) {
+        // ignore parse errors
+      }
+    }
+  }
+
+  if (SMOKE) {
+    sleep(1);
+  }
+}

--- a/tests/load/search-load.js
+++ b/tests/load/search-load.js
@@ -1,0 +1,173 @@
+/**
+ * Issue #1968: k6 load test — cenário 1: 50 usuários simultâneos em /buscar
+ *
+ * Profile:
+ *   - Ramp-up   : 2 min (5 -> 50 VUs)
+ *   - Sustain   : 5 min at 50 VUs
+ *   - Ramp-down : 30 s (50 -> 0 VUs)
+ *
+ * Thresholds:
+ *   - http_req_duration p(95) < 3000 ms
+ *   - http_req_failed   rate  < 2%
+ *
+ * Auth: JWTs loaded from tests/load/fixtures/jwts.json (path overridable
+ *       via JWTS_PATH env var).
+ *
+ * Run local:
+ *   k6 run tests/load/search-load.js \
+ *     --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+ *
+ * Smoke:
+ *   k6 run tests/load/search-load.js --env SMOKE=1 --vus 1 --duration 10s
+ *
+ * CI:
+ *   k6 run tests/load/search-load.js \
+ *     --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app \
+ *     --tag testid=$(date +%F)
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Rate, Trend } from 'k6/metrics';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BACKEND_URL = __ENV.BACKEND_URL || __ENV.BASE_URL || 'http://localhost:8000';
+const JWTS_PATH = __ENV.JWTS_PATH || './fixtures/jwts.json';
+const SMOKE = __ENV.SMOKE === '1' || __ENV.SMOKE === 'true';
+
+// Custom metrics
+// Note: k6 automatically computes all percentiles (p50/p90/p95/p99) from a single Trend metric.
+const searchErrors = new Rate('search_errors');
+const searchLatency = new Trend('search_latency_ms', true);
+
+// ---------------------------------------------------------------------------
+// JWT fixture loading (SharedArray keeps it out of per-VU memory)
+// ---------------------------------------------------------------------------
+
+const jwts = new SharedArray('jwts', function () {
+  try {
+    // eslint-disable-next-line no-undef
+    const raw = open(JWTS_PATH);
+    const parsed = JSON.parse(raw);
+    const tokens = Array.isArray(parsed.tokens) ? parsed.tokens : [];
+    if (tokens.length === 0) {
+      throw new Error('no tokens in fixture');
+    }
+    return tokens;
+  } catch (err) {
+    if (!SMOKE) {
+      throw new Error(
+        `Failed to load JWTs from ${JWTS_PATH}: ${err.message}. ` +
+          `See tests/load/README.md for how to generate the fixture.`
+      );
+    }
+    return ['smoke-placeholder-jwt'];
+  }
+});
+
+// Search payload variants to diversify the load
+const SEARCH_PAYLOADS = [
+  { ufs: ['SP', 'RJ'],           setor_id: 'construcao_civil',           modo_busca: 'abertas', pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['MG'],                 setor_id: 'tecnologia_da_informacao',   modo_busca: 'abertas', pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['SP', 'MG', 'RJ'],     setor_id: 'saude',                      modo_busca: 'todas',   pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['SP'],                 setor_id: 'educacao',                   modo_busca: 'abertas', pagina: 1, itens_por_pagina: 10 },
+  { ufs: ['RS', 'SC', 'PR'],     setor_id: 'limpeza_e_conservacao',      modo_busca: 'todas',   pagina: 2, itens_por_pagina: 20 },
+  { ufs: ['BA', 'PE'],           setor_id: 'saude',                      modo_busca: 'abertas', pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['SP', 'RJ', 'MG', 'RS'], setor_id: 'vigilancia_e_seguranca',  modo_busca: 'todas',   pagina: 1, itens_por_pagina: 10 },
+];
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export const options = SMOKE
+  ? {
+      vus: 1,
+      duration: '10s',
+      thresholds: {
+        http_req_failed: ['rate<0.5'], // smoke is permissive
+      },
+    }
+  : {
+      scenarios: {
+        search: {
+          executor: 'ramping-vus',
+          startVUs: 5,
+          stages: [
+            { target: 50, duration: '2m' },   // ramp-up: 5 -> 50 VUs
+            { target: 50, duration: '5m' },   // sustain: 50 VUs
+            { target: 0, duration: '30s' },   // ramp-down
+          ],
+          gracefulRampDown: '30s',
+        },
+      },
+      thresholds: {
+        http_req_duration: ['p(95)<3000'],
+        http_req_failed: ['rate<0.02'],
+        search_errors: ['rate<0.02'],
+      },
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a 10-day window ending today in YYYY-MM-DD (UTC-safe).
+ */
+function recentDateRange() {
+  const today = new Date();
+  const end = today.toISOString().slice(0, 10);
+  const start = new Date(today.getTime() - 10 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  return { data_inicial: start, data_final: end };
+}
+
+function buildPayload() {
+  const base = SEARCH_PAYLOADS[Math.floor(Math.random() * SEARCH_PAYLOADS.length)];
+  const { data_inicial, data_final } = recentDateRange();
+  return JSON.stringify({ ...base, data_inicial, data_final });
+}
+
+function pickToken() {
+  const token = jwts[Math.floor(Math.random() * jwts.length)];
+  if (__ENV.AUTH_TOKEN) return __ENV.AUTH_TOKEN;
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Default VU function
+// ---------------------------------------------------------------------------
+
+export default function () {
+  const token = pickToken();
+  const payload = buildPayload();
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    tags: { endpoint: 'search', testid: __ENV.TEST_ID || 'local' },
+    timeout: '30s',
+  };
+
+  const res = http.post(`${BACKEND_URL}/buscar`, payload, params);
+
+  searchLatency.add(res.timings.duration);
+
+  const ok = check(res, {
+    'status is 200 or 202': (r) => r.status === 200 || r.status === 202,
+    'has response body': (r) => r.body && r.body.length > 0,
+  });
+
+  searchErrors.add(!ok);
+
+  if (SMOKE) {
+    sleep(1);
+  }
+}

--- a/tests/load/spike-test.js
+++ b/tests/load/spike-test.js
@@ -1,0 +1,168 @@
+/**
+ * Issue #1968: k6 load test — cenário 4: spike test (10 -> 200 VUs em 30s)
+ *
+ * Simula um pico repentino de tráfego (ex: notificação de edital relevante,
+ * campanha de marketing, matéria em veículo de grande imprensa).
+ *
+ * Profile:
+ *   - Ramp-up   : 30 s (10 -> 200 VUs) — spike agressivo
+ *   - Sustain   : 1 min at 200 VUs
+ *   - Ramp-down : 1 min (200 -> 0 VUs) — recuperação
+ *
+ * Endpoint: POST /buscar (operação mais pesada do sistema)
+ *
+ * Thresholds (mais permissivos devido ao spike):
+ *   - http_req_duration p(95) < 5000 ms
+ *   - http_req_failed   rate  < 10%
+ *
+ * Auth: JWTs loaded from tests/load/fixtures/jwts.json.
+ *
+ * Run local:
+ *   k6 run tests/load/spike-test.js \
+ *     --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app
+ *
+ * Smoke:
+ *   k6 run tests/load/spike-test.js --env SMOKE=1 --vus 1 --duration 10s
+ *
+ * CI:
+ *   k6 run tests/load/spike-test.js \
+ *     --env BACKEND_URL=https://smartlic-backend-staging.up.railway.app \
+ *     --tag testid=$(date +%F)
+ */
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Rate, Trend } from 'k6/metrics';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BACKEND_URL = __ENV.BACKEND_URL || __ENV.BASE_URL || 'http://localhost:8000';
+const JWTS_PATH = __ENV.JWTS_PATH || './fixtures/jwts.json';
+const SMOKE = __ENV.SMOKE === '1' || __ENV.SMOKE === 'true';
+
+// Custom metrics
+// Note: k6 automatically computes all percentiles (p50/p90/p95/p99) from a single Trend metric.
+const spikeErrors = new Rate('spike_errors');
+const spikeLatency = new Trend('spike_latency_ms', true);
+
+// ---------------------------------------------------------------------------
+// JWT fixture loading
+// ---------------------------------------------------------------------------
+
+const jwts = new SharedArray('jwts', function () {
+  try {
+    // eslint-disable-next-line no-undef
+    const raw = open(JWTS_PATH);
+    const parsed = JSON.parse(raw);
+    const tokens = Array.isArray(parsed.tokens) ? parsed.tokens : [];
+    if (tokens.length === 0) {
+      throw new Error('no tokens in fixture');
+    }
+    return tokens;
+  } catch (err) {
+    if (!SMOKE) {
+      throw new Error(
+        `Failed to load JWTs from ${JWTS_PATH}: ${err.message}. ` +
+          `See tests/load/README.md for how to generate the fixture.`
+      );
+    }
+    return ['smoke-placeholder-jwt'];
+  }
+});
+
+// Search payloads for /buscar
+const SEARCH_PAYLOADS = [
+  { ufs: ['SP', 'RJ'],           setor_id: 'construcao_civil',           modo_busca: 'abertas', pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['MG'],                 setor_id: 'tecnologia_da_informacao',   modo_busca: 'abertas', pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['SP', 'MG', 'RJ'],     setor_id: 'saude',                      modo_busca: 'todas',   pagina: 1, itens_por_pagina: 20 },
+  { ufs: ['SP'],                 setor_id: 'educacao',                   modo_busca: 'abertas', pagina: 1, itens_por_pagina: 10 },
+  { ufs: ['RS', 'SC', 'PR'],     setor_id: 'limpeza_e_conservacao',      modo_busca: 'todas',   pagina: 1, itens_por_pagina: 20 },
+];
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export const options = SMOKE
+  ? {
+      vus: 1,
+      duration: '10s',
+      thresholds: {
+        http_req_failed: ['rate<0.5'],
+      },
+    }
+  : {
+      scenarios: {
+        spike: {
+          executor: 'ramping-vus',
+          startVUs: 10,
+          stages: [
+            { target: 200, duration: '30s' },   // spike: 10 -> 200 VUs em 30s
+            { target: 200, duration: '1m' },    // sustain: pico por 1 min
+            { target: 0, duration: '1m' },      // ramp-down: recuperação
+          ],
+          gracefulRampDown: '30s',
+        },
+      },
+      thresholds: {
+        http_req_duration: ['p(95)<5000'],
+        http_req_failed: ['rate<0.10'],
+        spike_errors: ['rate<0.10'],
+      },
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function recentDateRange() {
+  const today = new Date();
+  const end = today.toISOString().slice(0, 10);
+  const start = new Date(today.getTime() - 10 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  return { data_inicial: start, data_final: end };
+}
+
+function buildPayload() {
+  const base = SEARCH_PAYLOADS[Math.floor(Math.random() * SEARCH_PAYLOADS.length)];
+  const { data_inicial, data_final } = recentDateRange();
+  return JSON.stringify({ ...base, data_inicial, data_final });
+}
+
+function pickToken() {
+  const token = jwts[Math.floor(Math.random() * jwts.length)];
+  if (__ENV.AUTH_TOKEN) return __ENV.AUTH_TOKEN;
+  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Default VU function
+// ---------------------------------------------------------------------------
+
+export default function () {
+  const token = pickToken();
+  const payload = buildPayload();
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    tags: { endpoint: 'spike', testid: __ENV.TEST_ID || 'local' },
+    timeout: '30s',
+  };
+
+  const res = http.post(`${BACKEND_URL}/buscar`, payload, params);
+
+  spikeLatency.add(res.timings.duration);
+
+  const ok = check(res, {
+    'status is 200 or 202': (r) => r.status === 200 || r.status === 202,
+    'has response body': (r) => r.body && r.body.length > 0,
+  });
+
+  spikeErrors.add(!ok);
+}


### PR DESCRIPTION
## Summary
Closes #1968

Scripts de load test com Grafana k6 para fluxos críticos:
- `/buscar`: 50 usuários simultâneos (rampa 5→50, sustain 5min)
- `/observatorio/[slug]`: 500 usuários (ISR cache test)
- `/v1/pipeline`: 20 usuários CRUD
- Spike test: 10→200 usuários em 30s
- CI workflow semanal non-blocking (Sábado 06:00 UTC)
- Documentação em `docs/architecture/load-test-2026-06.md`

## Files Changed
- `tests/load/` — 4 scripts k6 + config
- `.github/workflows/load-test-schedule.yml` — CI semanal
- `docs/architecture/load-test-2026-06.md` — template de resultados

🤖 Generated with [Claude Code](https://claude.com/claude-code)