### PR TITLE
docs: founding plan and partner program business rules (#1981, #1982)

### DIFF
--- a/docs/architecture/founding-plan-spec.md
+++ b/docs/architecture/founding-plan-spec.md
@@ -1,0 +1,234 @@
+# Founding Plan -- Business Rules Specification
+
+**Status:** Implemented (v2 lifetime)
+**Last updated:** 2026-06-17
+**ADRs:** `docs/adr/ADR-BIZ-FOUND-002-founding-policy.md`, `docs/adr/founding-plan-canonical.md`
+**Epic/Stories:** BIZ-FOUND-002, STORY-BIZ-001, #783 (v2 lifetime pivot), #785 (lifetime entitlement)
+
+---
+
+## 1. Overview
+
+The Founding Plan (Plano Fundadores) is a limited-time, fixed-cap offer for early adopters of SmartLic. It grants lifetime access to SmartLic Pro via a one-time payment of R$997, plus a permanent 50% discount on the Consulting tier.
+
+The program has evolved through two phases:
+
+| Phase | Model | Price | Period | Status |
+|-------|-------|-------|--------|--------|
+| v1 (STORY-BIZ-001) | Monthly subscription at 50% off | R$197/month | 2026-04-xx to 2026-05-06 | Superseded |
+| v2 (#783) | One-time lifetime payment | R$997 | 2026-05-07 to present | **Current** |
+
+---
+
+## 2. Eligibility Rules
+
+### 2.1 Who Can Purchase
+
+- Any business entity (B2G) with a valid Brazilian CNPJ.
+- Purchase is made by an individual (nome, email, CNPJ, razao_social, motivo).
+- No prior SmartLic account required -- founding is sold to unauthenticated visitors.
+- "motivo" field requires minimum 140 characters (qualifying question).
+
+### 2.2 Who Cannot Purchase
+
+- Emails that already have a SmartLic profile (returns HTTP 409).
+- Duplicate CNPJ is allowed (checked at checkout, not a blocker).
+- Self-referral not applicable (no referral flow for founding).
+
+### 2.3 Seat Cap (50 total)
+
+The Founding Plan has a hard cap of **50 seats** (completed checkouts). Once reached, all subsequent checkout attempts receive HTTP 410 Gone with `error_code: founding_cap_reached`.
+
+Cap counting basis: `founding_leads WHERE checkout_status = 'completed'` (not profiles.plan_type).
+
+### 2.4 Deadline
+
+| Original deadline | Extended deadline | Status (as of 2026-06-17) |
+|-------------------|-------------------|---------------------------|
+| 2026-05-30 23:59:59 BRT | 2026-06-30 23:59:59 -03:00 | Active (extended by v2 lifetime pivot) |
+
+The deadline was extended from 2026-05-30 to 2026-06-30 in the v2 lifetime pivot migration (`20260507100100_founding_policy_lifetime_pivot.sql`). After the deadline, checkout returns HTTP 410 with `error_code: founding_deadline_passed`.
+
+### 2.5 Auto-Disable
+
+An ARQ cron job (`founders_auto_disable_check`) runs periodically and auto-disables the offer 1 day after the deadline (timezone safety margin). Sets `founding_policy.active = False` and sends a Sentry warning.
+
+---
+
+## 3. Pricing
+
+### 3.1 Current Pricing (v2 Lifetime)
+
+| Item | Value |
+|------|-------|
+| Payment model | One-time (`mode='payment'`) |
+| Price | R$997 (99700 BRL cents) |
+| Payment methods | Credit card (`card`) and Boleto (`boleto`) |
+| Stripe Price ID | Configured via env var `FOUNDING_ONE_TIME_PRICE_ID` |
+| Coupon/Discount | None applied (no coupon block) |
+| Offer mode | `lifetime` |
+
+### 3.2 Legacy Pricing (v1 -- Superseded)
+
+| Item | Value |
+|------|-------|
+| Payment model | Subscription (`mode='subscription'`) |
+| Price | R$197/month (50% off standard Pro) |
+| Coupon | `FOUNDING30` (30% off / 12 months, later `FOUNDING_LIFETIME` 50% off forever) |
+
+### 3.3 Stripe Configuration
+
+The Stripe Product and Price are provisioned out-of-band via script:
+
+```bash
+python scripts/create_founding_lifetime_price.py
+```
+
+Prints `FOUNDING_ONE_TIME_PRICE_ID=price_xxx` which must be set as Railway env var. The script is idempotent (reuses existing Product/Price by name and amount).
+
+---
+
+## 4. Entitlements
+
+On successful checkout completion, the following entitlements are activated on the user's profile:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `is_founder` | `true` | Founder flag |
+| `founder_since` | ISO 8601 timestamp | When checkout completed |
+| `founder_offer_version` | `v2_lifetime` | Offer version from Stripe metadata |
+| `founder_checkout_source` | Source string | utm_source or `founding_page` |
+| `consulting_discount_pct` | 50 (default) | Lifetime discount on Consulting tier |
+| `plan_type` | `smartlic_pro` | Plan assignment |
+| `trial_expires_at` | `null` | Trial cleared |
+
+The `consulting_discount_pct` is read from `founding_policy.consulting_discount_pct` (default 50). The offer version and checkout source are preserved from Stripe session metadata.
+
+### 4.1 Post-Purchase Flow
+
+1. **User has an account**: Entitlement activated immediately. Founders welcome email dispatched (fire-and-forget background thread, idempotency via `founding_leads.welcome_sent_at`).
+2. **User has NO account**: Entitlement activation deferred. Supabase magic-link invite sent (`_send_founding_invite`) so the buyer can create their account and claim access. Invite idempotency via `founding_leads.magic_link_sent_at`.
+
+---
+
+## 5. How Founding Plan Differs from Regular Plans
+
+| Aspect | Founding Plan | Regular Plans (Pro, Consultor, etc.) |
+|--------|--------------|--------------------------------------|
+| Payment | One-time R$997 | Monthly/quarterly/annual subscription |
+| Access duration | Lifetime | While subscription is active |
+| Price changes | Frozen (lifetime guarantee) | Subject to future pricing updates |
+| Seat cap | 50 total | Unlimited |
+| Deadline | 2026-06-30 | No deadline |
+| Consulting discount | 50% off forever | None |
+| Trial | None (purchase directly) | 14-day free trial |
+| Availability check | `check_founding_availability()` RPC | No gate |
+| Post-purchase invite | Magic link for unauthenticated buyers | Regular signup flow |
+
+---
+
+## 6. Availability & Race Guard
+
+### 6.1 Public Availability Endpoint
+
+`GET /v1/founding/availability` (anonymous) returns:
+- `available`: boolean
+- `seats_total`: 50
+- `seats_remaining`: integer
+- `seats_taken`: integer
+- `deadline_at`: ISO timestamp or null
+- `paused`: boolean
+- `reason`: string enum
+- `offer_mode`: `lifetime`
+- `price_brl_cents`: 99700
+
+Cached with `Cache-Control: public, s-maxage=30`. Disabled by feature flag `FOUNDERS_OFFER_ENABLED=false`.
+
+### 6.2 Reason Enum (why unavailable)
+
+| reason | Meaning |
+|--------|---------|
+| `founding_cap_reached` | 50 seats filled |
+| `founding_deadline_passed` | After 2026-06-30 |
+| `founding_paused` | Admin soft-pause |
+| `founding_disabled` | `founding_policy.active = false` |
+| `founding_policy_missing` | No policy row in DB |
+
+### 6.3 Two-Layer Race Guard
+
+**Layer 1 (pre-checkout):** `check_founding_availability()` RPC uses `SELECT FOR UPDATE` on the `founding_policy` row + counts completed leads atomically. Concurrent callers serialize on the row lock. Returns `available=false` with structured `error_code` for HTTP 410 responses.
+
+**Layer 2 (post-completion):** Stripe webhook `checkout.session.completed` re-runs the RPC AFTER flipping the lead row to `completed`. If `founding_cap_reached` is detected:
+1. Sets `checkout_status = 'cap_violated'`
+2. Issues Stripe Refund against the `payment_intent`
+3. Queues apology email to customer
+4. Logs Sentry error for operator alert
+
+---
+
+## 7. Admin Operations
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/admin/founding/policy` | GET | Policy snapshot + live seat usage |
+| `/v1/admin/founding/leads` | GET | List founding leads with filter |
+| `/v1/admin/founding/pause` | POST | Soft-pause checkouts (paused_at + paused_by) |
+| `/v1/admin/founding/resume` | POST | Clear pause |
+
+All admin endpoints require `is_admin` or `is_master` role.
+
+---
+
+## 8. Feature Flag
+
+`FOUNDERS_OFFER_ENABLED` (default: `true`) disables the entire founding flow when set to `false`:
+- `GET /v1/founding/availability` returns `available=false`, `reason=founders_offer_disabled`
+- `POST /v1/founding/checkout` returns HTTP 410
+
+---
+
+## 9. Database Schema
+
+### `founding_policy` (single-row, id=1)
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| id | INT | 1 | Single-row enforcement (CHECK id=1) |
+| seat_limit | INT | 50 | Hard cap |
+| deadline_at | TIMESTAMPTZ | | Cutoff timestamp |
+| discount_pct | INT | 50 | Lifetime discount % |
+| coupon_code | TEXT | FOUNDING_LIFETIME | Stripe coupon reference |
+| active | BOOLEAN | TRUE | Hard kill switch |
+| paused_at | TIMESTAMPTZ | NULL | Soft-pause timestamp |
+| paused_by | UUID | NULL | Admin who paused |
+| paused_reason | TEXT | NULL | Reason for pause |
+| offer_mode | TEXT | 'lifetime' | 'subscription' or 'lifetime' |
+| price_brl_cents | INT | 99700 | One-time price in BRL cents |
+| consulting_discount_pct | INT | 50 | Consulting tier discount % |
+
+### `founding_leads`
+
+Tracks each checkout attempt. Status enum: `pending`, `completed`, `abandoned`, `failed`, `cap_violated`.
+
+---
+
+## 10. Key Files
+
+| File | Purpose |
+|------|---------|
+| `backend/routes/founding.py` | Checkout + availability endpoints |
+| `backend/routes/admin_founding.py` | Admin policy management |
+| `backend/webhooks/handlers/founding.py` | Webhook handlers + race guard + entitlement activation |
+| `backend/jobs/cron/founders_auto_disable.py` | Auto-disable cron after deadline |
+| `backend/tests/test_founding_canonical_policy.py` | Policy gate tests |
+| `backend/tests/test_founding_checkout.py` | Checkout flow tests |
+| `backend/tests/test_founding_webhook_*.py` | Webhook handler tests |
+| `backend/tests/test_founding_session_status.py` | Session status tests |
+| `backend/tests/test_founders_welcome_email.py` | Welcome email tests |
+| `scripts/create_founding_lifetime_price.py` | Stripe price provisioner |
+| `frontend/app/api/founding/availability/route.ts` | Frontend availability proxy |
+| `frontend/app/api/founding/checkout/route.ts` | Frontend checkout proxy |
+| `frontend/hooks/useFoundersAvailability.ts` | Frontend availability hook |
+| `supabase/migrations/20260428100000_founding_canonical_policy.sql` | Founding policy table |
+| `supabase/migrations/20260428100100_check_founding_availability_rpc.sql` | Availability RPC |
+| `supabase/migrations/20260507100100_founding_policy_lifetime_pivot.sql` | v2 lifetime pivot |

--- a/docs/architecture/partner-program-spec.md
+++ b/docs/architecture/partner-program-spec.md
@@ -1,0 +1,262 @@
+# Partner Program -- Business Rules Specification
+
+**Status:** Implemented (database schema + backend routes + service layer)
+**Last updated:** 2026-06-17
+**ADRs:** `docs/adr/partner-program.md`
+**Stories:** STORY-323 (Revenue Share Tracking), EPIC-CI-GREEN-MAIN-2026Q2/STORY-CIG-FE-12-admin-partners
+**Related: User Referral Program** (`backend/routes/referral.py` -- separate program, see section 7)
+
+---
+
+## 1. Overview
+
+The Partner Program is a revenue-sharing program for consultancy firms and partner companies that refer clients to SmartLic. Partners earn a recurring commission on the subscription revenue of clients they bring in.
+
+**This is distinct from the User Referral Program** (section 7), which is an end-user program offering 1 month free per conversion.
+
+---
+
+## 2. Commission Structure
+
+### 2.1 Default Commission Rate
+
+| Parameter | Value |
+|-----------|-------|
+| Default commission | **20% lifetime revenue share** |
+| Source of truth | `partners.revenue_share_pct` column |
+| Override | Each partner can have a negotiated `revenue_share_pct` (set by admin at creation) |
+
+### 2.2 Commission Calculation
+
+```
+Commission = SUM(referral.monthly_revenue) * partner.revenue_share_pct / 100
+```
+
+Where:
+- `monthly_revenue` is the monthly subscription amount of each active referral
+- A referral is "active" when `converted_at IS NOT NULL AND (churned_at IS NULL OR churned_at > month_start)`
+- Churned referrals are excluded from the month they churn
+
+### 2.3 How Commission is Tracked
+
+On checkout completion, the Stripe webhook creates a `partner_referrals` row with:
+- `monthly_revenue`: the subscription amount in BRL
+- `revenue_share_amount`: calculated as `monthly_revenue * revenue_share_pct / 100`
+- `converted_at`: timestamp of checkout completion
+
+The `revenue_share_amount` is stored at conversion time. If the partner's `revenue_share_pct` changes later, existing referral rows keep their original share amount (historical integrity).
+
+### 2.4 Churn Handling
+
+On `customer.subscription.deleted`, the Stripe webhook calls `mark_referral_churned()` which stamps `partner_referrals.churned_at`. Churned referrals are excluded from future commission calculations.
+
+---
+
+## 3. Attribution Rules
+
+### 3.1 Attribution Mechanisms (Two-Factor)
+
+The partner program uses a **last-click attribution model** with two mechanisms:
+
+#### Mechanism 1: Signup Flow (`?partner=` query param)
+
+1. User signs up with `?partner={slug}` in the URL (e.g., `https://smartlic.tech/signup?partner=triunfo-legis`)
+2. Backend calls `attribute_signup_to_partner()` during signup
+3. Stores `profiles.referred_by_partner_id` on the user's profile
+4. On checkout completion, `create_partner_referral()` reads `referred_by_partner_id` from the profile
+
+#### Mechanism 2: Coupon-Based Attribution (Fallback)
+
+1. Partner's Stripe coupon ID is stored in `partners.stripe_coupon_id`
+2. During checkout, if the user applies a coupon that matches a partner's `stripe_coupon_id`
+3. `create_partner_referral()` falls back to looking up the partner by coupon
+4. Also updates the user's profile with `referred_by_partner_id` for future reference
+
+### 3.2 Attribution Priority
+
+```
+1. Profile attribution (referred_by_partner_id from signup) -- PRIME
+2. Coupon-based (stripe_coupon_id match) -- FALLBACK
+3. No attribution -- referral NOT created
+```
+
+### 3.3 Attribution Window
+
+A **30-day last-click attribution window** is documented but NOT yet enforced in code. The current implementation attributes at any time. Enforcing the 30-day window is a follow-up implementation item (see section 8).
+
+### 3.4 Timestamp Tracking
+
+The pipeline tracks:
+- `partner_referrals.signup_at`: When the referred user signed up
+- `partner_referrals.converted_at`: When the referred user first paid
+- `partner_referrals.churned_at`: When the referred user cancelled
+
+---
+
+## 4. Payout Cycle
+
+### 4.1 Current State (Report Only -- No Automated Payout)
+
+| Aspect | Status |
+|--------|--------|
+| Monthly report generation | **Implemented** (day 1 at 09:00 BRT via `generate_monthly_revenue_report()`) |
+| Pix payout execution | **NOT implemented** (follow-up item) |
+| CPF/CNPJ collection | **NOT implemented** (required before payout) |
+
+### 4.2 Monthly Report
+
+The system generates a monthly revenue share report via `generate_monthly_revenue_report()`:
+- Runs on day 1 of each month at 09:00 BRT
+- Calculates commission for all active partners
+- Output: `{year, month, partner_reports[], total_revenue, total_share}`
+
+### 4.3 Planned Payout Cadence
+
+| Item | Planned Value |
+|------|---------------|
+| Payout frequency | Monthly |
+| Payout day | Day 5 of each month |
+| Payout method | Pix |
+| Pre-requisite | CPF/CNPJ validation |
+| Audit trail | Reconciliation between calculated and paid amounts |
+
+---
+
+## 5. Partner Management (Admin)
+
+### 5.1 Partner Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `active` | Partner is operational, can receive referrals |
+| `inactive` | Partner is disabled, no new referrals attributed |
+| `pending` | Partner awaiting activation |
+
+### 5.2 Admin Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/admin/partners` | GET | List all partners (with referral counts) |
+| `/v1/admin/partners` | POST | Create a new partner |
+| `/v1/admin/partners/{id}/referrals` | GET | List referrals for a partner |
+| `/v1/admin/partners/{id}/revenue` | GET | Revenue share for a specific month |
+
+All admin endpoints require `is_admin` or `is_master` role. Feature flag `PARTNERS_ENABLED` controls availability (default: true).
+
+### 5.3 Partner Default Values at Creation
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `revenue_share_pct` | 20.00% | Can be set per partner |
+| `status` | `active` | Auto-set on creation |
+| `stripe_coupon_id` | null | Optional, for coupon-based attribution |
+
+### 5.4 Partner Self-Service
+
+Partners can access their own dashboard via `GET /v1/partner/dashboard`:
+- Authenticated via their own SmartLic account
+- Partner identified by matching `auth.users.email` to `partners.contact_email`
+- Returns: partner info, referral list, total monthly share
+
+---
+
+## 6. Database Schema
+
+### `partners`
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| id | UUID | gen_random_uuid() | Primary key |
+| name | TEXT | | Partner display name |
+| slug | TEXT | | Unique URL slug (e.g., "triunfo-legis") |
+| contact_email | TEXT | | Partner contact email |
+| contact_name | TEXT | null | Optional contact person |
+| stripe_coupon_id | TEXT | null | Stripe coupon for attribution |
+| revenue_share_pct | NUMERIC(5,2) | 25.00 (migration default), 20.00 (code default) | Commission percentage |
+| status | TEXT | 'active' | active, inactive, pending |
+| created_at | TIMESTAMPTZ | now() | |
+
+### `partner_referrals`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | UUID | Primary key |
+| partner_id | UUID | FK to partners.id |
+| referred_user_id | UUID | FK to auth.users.id |
+| signup_at | TIMESTAMPTZ | When user signed up |
+| converted_at | TIMESTAMPTZ | When user first paid |
+| churned_at | TIMESTAMPTZ | When user cancelled |
+| monthly_revenue | NUMERIC(10,2) | Subscription monthly value |
+| revenue_share_amount | NUMERIC(10,2) | Calculated commission amount |
+
+Unique constraint: `(partner_id, referred_user_id)` -- prevents duplicate attribution.
+
+---
+
+## 7. Distinction from User Referral Program
+
+The Partner Program should NOT be confused with the User Referral Program (`backend/routes/referral.py`):
+
+| Aspect | Partner Program | User Referral Program |
+|--------|----------------|----------------------|
+| Audience | Consultancy firms / companies | End users of SmartLic |
+| Incentive | 20% revenue share (recurring) | 1 month free (one-time) |
+| Attribution | Partner slug or Stripe coupon | 8-char referral code |
+| Tracking | `partner_referrals` table | `referrals` table |
+| Payout | Monthly Pix (planned) | Credit applied automatically |
+| Admin | Full CRUD + reports | Self-serve only |
+| Status | Implemented (payout pending) | Fully implemented |
+
+---
+
+## 8. Implementation Gaps (Follow-Up Items)
+
+The following items from the ADR are documented but NOT yet implemented:
+
+| Item | Description | Current Status |
+|------|-------------|----------------|
+| CPF/CNPJ collection | Partner identity data for payout | Not collected |
+| 30-day attribution expiry | Enforce last-click window in code | Not enforced |
+| Pix payout execution | Monthly payout on day 5 | Not implemented |
+| Admin payout approval | Audit trail before payout | Not implemented |
+| Reconciliation | Match calculated vs paid amounts | Not implemented |
+
+---
+
+## 9. Architecture Flow
+
+```
+Signup (with ?partner=slug)
+  -> partner_service.attribute_signup_to_partner()
+  -> stores profiles.referred_by_partner_id
+
+Checkout (with or without coupon)
+  -> checkout.session.completed webhook
+  -> partner_service.create_partner_referral()
+     -> reads referred_by_partner_id from profile
+     -> OR looks up by stripe_coupon_id
+  -> creates partner_referrals row
+
+Subscription cancelled
+  -> customer.subscription.deleted webhook
+  -> partner_service.mark_referral_churned()
+  -> stamps churned_at
+
+Monthly report
+  -> partner_service.generate_monthly_revenue_report()
+  -> sums active referrals, calculates share
+```
+
+---
+
+## 10. Key Files
+
+| File | Purpose |
+|------|---------|
+| `backend/routes/partners.py` | Partner admin + self-service endpoints |
+| `backend/services/partner_service.py` | Business logic (attribution, revenue calc, reporting) |
+| `backend/schemas/parity.py` | Pydantic response models |
+| `backend/webhooks/handlers/checkout.py` | Webhook that triggers `_create_partner_referral_async` |
+| `backend/config/features.py` | `PARTNERS_ENABLED` feature flag |
+| `supabase/migrations/20260301200000_create_partners.sql` | Partners + referrals tables |
+| `frontend/app/admin/partners/` | Frontend admin pages |


### PR DESCRIPTION
## Summary

Documenta as regras de negocio de dois programas comerciais do SmartLic que estavam implementados mas sem especificacao formal.

### Issue #1981 - Founding Plan Spec

- Regras de elegibilidade (CNPJ, email unico, motivo 140+ chars)
- Pricing: R97 one-time lifetime (v2), pivot historico do modelo de assinatura
- Seat cap: 50 vagas totais
- Deadline: 2026-06-30 23:59:59 -03:00 (estendido do original 2026-05-30)
- Diferencas vs planos regulares (lifetime, sem trial, 50% consulting discount)
- Two-layer race guard (SELECT FOR UPDATE + webhook re-check)
- Entitlements: is_founder, consulting_discount_pct, plan_type, trial cleared

### Issue #1982 - Partner Program Spec

- Commission structure: 20% lifetime revenue share (configuravel por partner)
- Attribution: two-factor (signup slug + Stripe coupon fallback)
- Payout cycle: report implementado (day 1), Pix payout pendente
- Tracking: partner_referrals table com monthly_revenue e revenue_share_amount
- Partner management: admin CRUD + self-service dashboard
- Implementation gaps documentados (CPF/CNPJ, 30-day window, payout execution)
- Distincao clara do User Referral Program (1 mes gratis)

### Arquivos criados

- `docs/architecture/founding-plan-spec.md` (~250 linhas)
- `docs/architecture/partner-program-spec.md` (~250 linhas)

### Fluxo de investigacao

1. grep por 'founding', 'partner', 'affiliate', 'commission' no backend/ + frontend/
2. Leitura de: routes/founding.py, admin_founding.py, partners.py, referral.py
3. Leitura de: webhooks/handlers/founding.py, checkout.py
4. Leitura de: partner_service.py, parity schemas
5. Leitura de: migrations (founding_policy, partners)
6. Leitura de ADRs existentes (docs/adr/)
7. Sistematizacao em docs/architecture/