### PR TITLE
fix(backend): hotfix — link Ver Edital usa URL do PNCP em vez de ComprasNet

### DIFF
--- a/backend/clients/pncp/sync_client.py
+++ b/backend/clients/pncp/sync_client.py
@@ -525,6 +525,11 @@ class PNCPClient:
         item["municipio"] = unidade.get("municipioNome", "")
         item["nomeOrgao"] = orgao.get("razaoSocial", "") or unidade.get("nomeUnidade", "")
         item["codigoCompra"] = item.get("numeroControlePNCP", "")
+        # HOTFIX 2026-06-17: Flatten orgaoEntidade.cnpj → cnpjOrgao for PNCP link fallback.
+        # _build_pncp_link and excel.py need cnpjOrgao at top level to construct
+        # https://pncp.gov.br/app/editais/{cnpj}/{ano}/{seq} when linkSistemaOrigem
+        # is missing or points to ComprasNet.
+        item["cnpjOrgao"] = orgao.get("cnpj", "")
 
         # Preserve link fields (already in root level from API)
         # CRIT-FLT-008: linkSistemaOrigem is the primary link (86% populated).

--- a/backend/excel.py
+++ b/backend/excel.py
@@ -212,41 +212,56 @@ def create_excel(licitacoes: list[dict], paywall_preview: bool = False, total_be
         ws.cell(row=row_idx, column=10, value=sanitize_for_excel(lic.get("situacaoCompraNome")))
 
         # K: Link (hyperlink)
-        # CRIT-FLT-008: linkSistemaOrigem (86% populated) > linkProcessoEletronico (0% — dead field) > fallback PNCP
-        link = lic.get("linkSistemaOrigem") or lic.get("linkProcessoEletronico")
+        # HOTFIX 2026-06-17: PNCP API's linkSistemaOrigem points to ComprasNet
+        # (cnetmobile.estaleiro.serpro.gov.br), NOT pncp.gov.br. ComprasNet links
+        # often fail or require auth. We now prioritize constructing the PNCP URL
+        # from structured fields.
+        # Priority: numeroControlePNCP > cnpjOrgao/anoCompra/sequencialCompra >
+        # linkSistemaOrigem > linkProcessoEletronico
+        link = None
 
-        # Fallback: construir URL do PNCP a partir do numeroControlePNCP
+        # Priority 1: Construir URL do PNCP a partir do numeroControlePNCP
         # Formato numeroControlePNCP: {CNPJ}-{TIPO}-{SEQUENCIAL}/{ANO}
         # Formato URL PNCP: /editais/{CNPJ}/{ANO}/{SEQUENCIAL_SEM_ZEROS}
-        if not link:
-            numero_controle = lic.get("numeroControlePNCP", "")
-            if numero_controle:
-                try:
-                    # Parse: "67366310000103-1-000189/2025" -> cnpj=67366310000103, ano=2025, seq=189
-                    partes = numero_controle.split("/")
-                    if len(partes) != 2:
-                        raise ValueError("Formato inválido: esperado 'xxx/ano'")
-
+        numero_controle = lic.get("numeroControlePNCP", "")
+        q_fallback = None  # last-resort search URL when parsing fails
+        if numero_controle:
+            try:
+                # Parse: "67366310000103-1-000189/2025" -> cnpj=67366310000103, ano=2025, seq=189
+                partes = numero_controle.split("/")
+                if len(partes) == 2:
                     ano = partes[1]
                     cnpj_tipo_seq = partes[0].split("-")
 
-                    if len(cnpj_tipo_seq) < 3:
-                        raise ValueError("Formato inválido: esperado 'cnpj-tipo-seq'")
+                    if len(cnpj_tipo_seq) >= 3:
+                        cnpj = cnpj_tipo_seq[0]
+                        sequencial = cnpj_tipo_seq[2].lstrip("0")
 
-                    cnpj = cnpj_tipo_seq[0]
-                    sequencial = cnpj_tipo_seq[2].lstrip("0")
+                        if cnpj and ano and sequencial:
+                            link = f"https://pncp.gov.br/app/editais/{cnpj}/{ano}/{sequencial}"
+                if not link:
+                    q_fallback = f"https://pncp.gov.br/app/editais?q={numero_controle}"
+            except (IndexError, AttributeError, ValueError):
+                q_fallback = f"https://pncp.gov.br/app/editais?q={numero_controle}"
 
-                    if cnpj and ano and sequencial:
-                        link = f"https://pncp.gov.br/app/editais/{cnpj}/{ano}/{sequencial}"
-                    else:
-                        raise ValueError("Componentes vazios após parsing")
+        # Priority 2: Construir URL do PNCP a partir de cnpjOrgao/anoCompra/sequencialCompra
+        if not link:
+            cnpj = lic.get("cnpjOrgao", "")
+            ano = lic.get("anoCompra", "")
+            seq = lic.get("sequencialCompra", "")
+            if cnpj and ano and seq:
+                link = f"https://pncp.gov.br/app/editais/{cnpj}/{ano}/{seq}"
 
-                except (IndexError, AttributeError, ValueError):
-                    # Se parsing falhar, usar busca genérica
-                    link = f"https://pncp.gov.br/app/editais?q={numero_controle}"
+        # Priority 3: Fallback para linkSistemaOrigem (pode apontar para ComprasNet)
+        if not link:
+            link = lic.get("linkSistemaOrigem")
+
+        # Priority 4: Fallback para linkProcessoEletronico
+        if not link:
+            link = lic.get("linkProcessoEletronico")
 
         link_cell = ws.cell(row=row_idx, column=11, value="Abrir")
-        link_cell.hyperlink = link or "https://pncp.gov.br/app/editais"
+        link_cell.hyperlink = link or q_fallback or "https://pncp.gov.br/app/editais"
         link_cell.font = Font(color="0563C1", underline="single")
 
         # Aplicar bordas e alinhamento em todas as células da linha

--- a/backend/pipeline/helpers.py
+++ b/backend/pipeline/helpers.py
@@ -35,34 +35,51 @@ def _sanitize_item_valor(valor) -> float | None:
 def _build_pncp_link(lic: dict) -> str | None:
     """Build PNCP link from bid data.
 
-    Priority: linkSistemaOrigem > linkProcessoEletronico > constructed URL
-    from numeroControlePNCP > cnpjOrgao/anoCompra/sequencialCompra.
+    Priority: constructed PNCP URL from numeroControlePNCP >
+    cnpjOrgao/anoCompra/sequencialCompra > linkSistemaOrigem >
+    linkProcessoEletronico.
+
+    HOTFIX 2026-06-17: PNCP API's linkSistemaOrigem points to ComprasNet
+    (cnetmobile.estaleiro.serpro.gov.br), NOT pncp.gov.br. ComprasNet links
+    often fail or require auth. We now prioritize constructing the PNCP URL
+    from structured fields, falling back to linkSistemaOrigem only when
+    we cannot build a PNCP URL.
+
     Returns None when no link can be constructed.
     """
-    link = lic.get("linkSistemaOrigem") or lic.get("linkProcessoEletronico")
+    link = None
 
-    if not link:
-        numero_controle = lic.get("numeroControlePNCP", "")
-        if numero_controle:
-            try:
-                partes = numero_controle.split("/")
-                if len(partes) == 2:
-                    ano = partes[1]
-                    cnpj_tipo_seq = partes[0].split("-")
-                    if len(cnpj_tipo_seq) >= 3:
-                        cnpj = cnpj_tipo_seq[0]
-                        sequencial = cnpj_tipo_seq[2].lstrip("0")
-                        if cnpj and ano and sequencial:
-                            link = f"https://pncp.gov.br/app/editais/{cnpj}/{ano}/{sequencial}"
-            except Exception as e:
-                logger.debug(f"PNCP link extraction failed for {numero_controle}: {e}")
+    # Priority 1: Construct PNCP URL from numeroControlePNCP
+    numero_controle = lic.get("numeroControlePNCP", "")
+    if numero_controle:
+        try:
+            partes = numero_controle.split("/")
+            if len(partes) == 2:
+                ano = partes[1]
+                cnpj_tipo_seq = partes[0].split("-")
+                if len(cnpj_tipo_seq) >= 3:
+                    cnpj = cnpj_tipo_seq[0]
+                    sequencial = cnpj_tipo_seq[2].lstrip("0")
+                    if cnpj and ano and sequencial:
+                        link = f"https://pncp.gov.br/app/editais/{cnpj}/{ano}/{sequencial}"
+        except Exception as e:
+            logger.debug(f"PNCP link extraction failed for {numero_controle}: {e}")
 
+    # Priority 2: Construct PNCP URL from cnpjOrgao/anoCompra/sequencialCompra
     if not link:
         cnpj = lic.get("cnpjOrgao", "")
         ano = lic.get("anoCompra", "")
         seq = lic.get("sequencialCompra", "")
         if cnpj and ano and seq:
             link = f"https://pncp.gov.br/app/editais/{cnpj}/{ano}/{seq}"
+
+    # Priority 3: Fallback to linkSistemaOrigem (may point to ComprasNet or other sources)
+    if not link:
+        link = lic.get("linkSistemaOrigem")
+
+    # Priority 4: Fallback to linkProcessoEletronico
+    if not link:
+        link = lic.get("linkProcessoEletronico")
 
     return link or None
 

--- a/backend/tests/test_excel.py
+++ b/backend/tests/test_excel.py
@@ -136,9 +136,10 @@ class TestCreateExcel:
             # Verificar formatação de moeda
             assert "R$" in ws["F2"].number_format
 
-            # Verificar hyperlink (coluna K) - agora usando linkSistemaOrigem
+            # Verificar hyperlink (coluna K) - HOTFIX 2026-06-17: PNCP URL from
+            # numeroControlePNCP takes priority over linkSistemaOrigem (ComprasNet)
             assert ws["K2"].value == "Abrir"
-            assert ws["K2"].hyperlink.target == "https://sistema.compras.gov.br/edital/12345"
+            assert ws["K2"].hyperlink.target == "https://pncp.gov.br/app/editais/12345678000100/2024/123"
             assert ws["K2"].font.color.rgb == "000563C1"  # Azul (openpyxl ARGB format)
             assert ws["K2"].font.underline == "single"
 
@@ -207,7 +208,8 @@ class TestCreateExcel:
         assert ws["I2"].value is None
 
     def test_create_excel_with_link_sistema_origem(self):
-        """Deve usar linkSistemaOrigem quando disponível (prioridade 1)."""
+        """HOTFIX 2026-06-17: PNCP URL from numeroControlePNCP takes priority
+        over linkSistemaOrigem (which points to ComprasNet, not PNCP)."""
         licitacao = {
             "numeroControlePNCP": "12345678000100-1-000001/2025",
             "linkSistemaOrigem": "https://sistema.compras.gov.br/edital/123",
@@ -219,11 +221,12 @@ class TestCreateExcel:
         with open_workbook(buffer) as wb:
             ws = wb["Licitações Uniformes"]
 
-        # Deve usar linkSistemaOrigem (prioridade)
-        assert ws["K2"].hyperlink.target == "https://sistema.compras.gov.br/edital/123"
+        # PNCP URL from numeroControlePNCP wins (priority 1)
+        assert ws["K2"].hyperlink.target == "https://pncp.gov.br/app/editais/12345678000100/2025/1"
 
     def test_create_excel_with_link_processo_eletronico(self):
-        """Deve usar linkProcessoEletronico quando linkSistemaOrigem não existe (prioridade 2)."""
+        """HOTFIX 2026-06-17: PNCP URL from numeroControlePNCP takes priority
+        over linkProcessoEletronico."""
         licitacao = {
             "numeroControlePNCP": "12345678000100-1-000001/2025",
             "linkProcessoEletronico": "https://processo.gov.br/456",
@@ -234,8 +237,8 @@ class TestCreateExcel:
         with open_workbook(buffer) as wb:
             ws = wb["Licitações Uniformes"]
 
-        # Deve usar linkProcessoEletronico (segunda prioridade)
-        assert ws["K2"].hyperlink.target == "https://processo.gov.br/456"
+        # PNCP URL from numeroControlePNCP wins (priority 1)
+        assert ws["K2"].hyperlink.target == "https://pncp.gov.br/app/editais/12345678000100/2025/1"
 
     def test_create_excel_with_fallback_link(self):
         """Deve gerar link padrão PNCP parseando numeroControlePNCP quando nenhum link específico existe."""

--- a/backend/tests/test_search_pipeline_generate_persist.py
+++ b/backend/tests/test_search_pipeline_generate_persist.py
@@ -147,21 +147,23 @@ class TestBuildPncpLink:
     """Tests for _build_pncp_link helper function."""
 
     def test_returns_link_sistema_origem_when_present(self):
-        """linkSistemaOrigem has highest priority."""
+        """HOTFIX 2026-06-17: PNCP URL from numeroControlePNCP now takes priority
+        over linkSistemaOrigem (which points to ComprasNet, not PNCP)."""
         lic = {
             "linkSistemaOrigem": "https://compras.gov.br/123",
             "linkProcessoEletronico": "https://outro.gov.br/456",
             "numeroControlePNCP": "12345678000100-1-00001/2026",
         }
-        assert _build_pncp_link(lic) == "https://compras.gov.br/123"
+        assert _build_pncp_link(lic) == "https://pncp.gov.br/app/editais/12345678000100/2026/1"
 
     def test_falls_back_to_link_processo_eletronico(self):
-        """When linkSistemaOrigem is absent, uses linkProcessoEletronico."""
+        """HOTFIX 2026-06-17: PNCP URL from numeroControlePNCP now takes priority
+        over linkProcessoEletronico."""
         lic = {
             "linkProcessoEletronico": "https://processo.gov.br/456",
             "numeroControlePNCP": "12345678000100-1-00001/2026",
         }
-        assert _build_pncp_link(lic) == "https://processo.gov.br/456"
+        assert _build_pncp_link(lic) == "https://pncp.gov.br/app/editais/12345678000100/2026/1"
 
     def test_constructs_url_from_numero_controle(self):
         """When no direct links, constructs URL from numeroControlePNCP."""
@@ -256,7 +258,8 @@ class TestConvertToLicitacaoItems:
     """Tests for _convert_to_licitacao_items helper function."""
 
     def test_basic_conversion(self):
-        """Converts a dict with all fields to a LicitacaoItem."""
+        """HOTFIX 2026-06-17: PNCP URL from numeroControlePNCP takes priority
+        over linkSistemaOrigem (ComprasNet)."""
         lic = make_licitacao()
         result = _convert_to_licitacao_items([lic])
         assert len(result) == 1
@@ -267,7 +270,7 @@ class TestConvertToLicitacaoItems:
         assert item.orgao == "Prefeitura Municipal de Florianopolis"
         assert item.uf == "SC"
         assert item.valor == 50000.0
-        assert item.link == "https://pncp.gov.br/app/editais/123"
+        assert item.link == "https://pncp.gov.br/app/editais/12345678000100/2026/1"
 
     def test_missing_optional_fields(self):
         """Handles missing optional fields with graceful defaults.

--- a/backend/tests/test_ux400_link_fallback.py
+++ b/backend/tests/test_ux400_link_fallback.py
@@ -52,7 +52,8 @@ class TestBuildPncpLink:
         assert result == "https://pncp.gov.br/app/editais/99999999000100/2025/3"
 
     def test_prefers_link_sistema_origem_over_fallbacks(self):
-        """linkSistemaOrigem takes priority over all fallbacks."""
+        """HOTFIX 2026-06-17: PNCP URL from numeroControlePNCP now takes priority
+        over linkSistemaOrigem (which points to ComprasNet, not PNCP)."""
         lic = {
             "linkSistemaOrigem": "https://original.com/edital",
             "numeroControlePNCP": "11111111000100-1-000001/2026",
@@ -60,7 +61,8 @@ class TestBuildPncpLink:
             "anoCompra": "2026",
             "sequencialCompra": "1",
         }
-        assert _build_pncp_link(lic) == "https://original.com/edital"
+        # Priority 1 (numeroControlePNCP) wins over priority 3 (linkSistemaOrigem)
+        assert _build_pncp_link(lic) == "https://pncp.gov.br/app/editais/11111111000100/2026/1"
 
     def test_prefers_numero_controle_over_cnpj_fields(self):
         """numeroControlePNCP takes priority over cnpjOrgao/anoCompra/sequencialCompra."""


### PR DESCRIPTION
## Context

Hotfix urgente para o link "Ver Edital" nos resultados de busca e na planilha Excel. O link estava apontando para o ComprasNet (cnetmobile.estaleiro.serpro.gov.br) em vez do PNCP (pncp.gov.br), causando falhas de acesso e exigência de autenticação desnecessária. A correção inverte a prioridade de construção do URL para usar o `numeroControlePNCP` como fonte primária.

## Problema

Ao clicar em "Ver Edital" nos resultados de busca (e nos links da planilha Excel), o usuário era enviado para o **ComprasNet** (`cnetmobile.estaleiro.serpro.gov.br`), que frequentemente falha ou exige autenticação, exibindo:

> Ocorreu um problema ao buscar os dados. Por favor tente mais tarde.

## Causa Raiz

O campo `linkSistemaOrigem` retornado pela API do PNCP aponta para URLs do ComprasNet, NÃO para `pncp.gov.br`. O código usava `linkSistemaOrigem` como **prioridade 1** na construção do link, enviando o usuário para o sistema errado.

## Solução

Inverteu-se a prioridade em `_build_pncp_link()` (helpers.py) e `excel.py`:

| Prioridade | Fonte | URL |
|---|---|---|
| 1 (nova) | `numeroControlePNCP` | `https://pncp.gov.br/app/editais/{CNPJ}/{ANO}/{SEQ}` |
| 2 (nova) | `cnpjOrgao/anoCompra/sequencialCompra` | `https://pncp.gov.br/app/editais/{CNPJ}/{ANO}/{SEQ}` |
| 3 (fallback) | `linkSistemaOrigem` | URL original (ComprasNet) |
| 4 (fallback) | `linkProcessoEletronico` | URL original |

Também adicionou extração de `cnpjOrgao` de `orgaoEntidade.cnpj` no `_normalize_item()`.

## Arquivos Alterados

- `backend/pipeline/helpers.py` — nova prioridade no `_build_pncp_link()`
- `backend/excel.py` — mesma correção na coluna K (hyperlink)
- `backend/clients/pncp/sync_client.py` — extrai `cnpjOrgao` de `orgaoEntidade.cnpj`
- Testes atualizados para refletir nova prioridade

## Testes

67/67 passando (test_ux400_link_fallback.py + test_excel.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved PNCP link resolution in Excel exports by prioritizing structured procurement data when source links are unavailable or unreliable
  * Enhanced link fallback strategy to automatically construct valid PNCP URLs from bid information when direct links are missing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->