### PR TITLE
fix(oauth): Google Sheets OAuth — corrige prefixo /v1 ausente nas rotas proxy

### DIFF
--- a/backend/routes/auth_oauth.py
+++ b/backend/routes/auth_oauth.py
@@ -35,6 +35,16 @@ router = APIRouter(prefix="/api/auth", tags=["oauth"])
 # Frontend URL for redirects
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
 
+# Backend public URL — prefer explicit BACKEND_URL, fallback to Railway service URL
+_backend_url_raw = os.getenv("BACKEND_URL")
+if not _backend_url_raw:
+    _railway_backend = os.getenv("RAILWAY_SERVICE_BIDIQ_BACKEND_URL")
+    if _railway_backend:
+        _backend_url_raw = f"https://{_railway_backend}"
+    else:
+        _backend_url_raw = "http://localhost:8000"
+BACKEND_URL = _backend_url_raw
+
 # STORY-210 AC13: In-memory OAuth nonce store with TTL
 # Key: nonce string, Value: (user_id, redirect_path, created_at)
 _OAUTH_NONCE_TTL = 600  # 10 minutes
@@ -110,9 +120,8 @@ async def google_oauth_initiate(
         → Redirects to https://accounts.google.com/o/oauth2/auth?...
     """
     try:
-        # Build redirect URI
-        backend_url = os.getenv("BACKEND_URL", "http://localhost:8000")
-        redirect_uri = f"{backend_url}/api/auth/google/callback"
+        # Build redirect URI using configured BACKEND_URL
+        redirect_uri = f"{BACKEND_URL}/v1/api/auth/google/callback"
 
         # STORY-210 AC13: Validate redirect path against whitelist
         if redirect not in _ALLOWED_REDIRECT_PATHS:
@@ -192,8 +201,7 @@ async def google_oauth_callback(
         user_id, redirect_path = nonce_result
 
         # Build redirect URI (must match authorization request)
-        backend_url = os.getenv("BACKEND_URL", "http://localhost:8000")
-        redirect_uri = f"{backend_url}/api/auth/google/callback"
+        redirect_uri = f"{BACKEND_URL}/v1/api/auth/google/callback"
 
         # Exchange code for tokens
         tokens = await exchange_code_for_tokens(code, redirect_uri)

--- a/frontend/__tests__/api/auth-google-oauth.test.ts
+++ b/frontend/__tests__/api/auth-google-oauth.test.ts
@@ -208,7 +208,7 @@ describe("GET /api/auth/google/callback", () => {
     const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
     expect(fetchUrl).toContain("code=4%2Fauth-code");
     expect(fetchUrl).toContain("state=nonce123");
-    expect(fetchUrl).toContain("test-backend:8000/api/auth/google/callback");
+    expect(fetchUrl).toContain("test-backend:8000/v1/api/auth/google/callback");
   });
 
   it("forwards error param when user denies OAuth", async () => {

--- a/frontend/app/api/auth/google/callback/route.ts
+++ b/frontend/app/api/auth/google/callback/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
   });
 
   try {
-    const backendCallbackUrl = `${backendUrl}/api/auth/google/callback?${params.toString()}`;
+    const backendCallbackUrl = `${backendUrl}/v1/api/auth/google/callback?${params.toString()}`;
     const response = await fetch(backendCallbackUrl, {
       method: "GET",
       redirect: "manual", // Capture the 302 — don't follow it server-side

--- a/frontend/app/api/auth/google/route.ts
+++ b/frontend/app/api/auth/google/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const backendOAuthUrl = `${backendUrl}/api/auth/google?redirect=${encodeURIComponent(redirect)}`;
+    const backendOAuthUrl = `${backendUrl}/v1/api/auth/google?redirect=${encodeURIComponent(redirect)}`;
     const response = await fetch(backendOAuthUrl, {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },

--- a/frontend/app/buscar/page.tsx
+++ b/frontend/app/buscar/page.tsx
@@ -34,10 +34,42 @@ import { RestoredResultsBanner } from "./components/RestoredResultsBanner";
 import { clearNewBidsBadge } from "../../components/NewBidsNotificationBadge";
 import { setClarityTag } from "../components/ClarityAnalytics";
 import { tagOnboardingStep } from "../../lib/analytics/clarity_onboarding";
+import { toast } from "sonner";
 
 function HomePageContent() {
   const orch = useSearchOrchestration();
   const searchParams = useSearchParams();
+
+  // STORY-361: Handle OAuth query params (google_oauth=success, error=oauth_*)
+  useEffect(() => {
+    const oauthSuccess = searchParams.get("google_oauth");
+    const oauthError = searchParams.get("error");
+    if (oauthSuccess === "success") {
+      toast.success("Google Sheets conectado com sucesso!", {
+        description: "Agora você pode exportar seus resultados.",
+        duration: 5000,
+      });
+      const url = new URL(window.location.href);
+      url.searchParams.delete("google_oauth");
+      window.history.replaceState({}, "", url.toString());
+    } else if (oauthError?.startsWith("oauth_")) {
+      const messages: Record<string, string> = {
+        oauth_init_failed: "Falha ao iniciar autenticação com Google. Tente novamente.",
+        oauth_network_error: "Erro de conexão com o servidor. Verifique sua internet.",
+        oauth_denied: "Autorização do Google negada. Para exportar, é necessário permitir o acesso.",
+        oauth_failed: "Falha na autenticação com Google. Tente novamente.",
+        oauth_callback_failed: "Erro ao finalizar autenticação. Tente novamente.",
+        missing_code: "Resposta inválida do Google. Tente novamente.",
+        invalid_state: "Sessão expirada. Tente autorizar novamente.",
+      };
+      const msg = messages[oauthError] || `Erro de autenticação (${oauthError}). Tente novamente.`;
+      toast.error("Erro no Google Sheets", { description: msg, duration: 6000 });
+      const url = new URL(window.location.href);
+      url.searchParams.delete("error");
+      url.searchParams.delete("detail");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, []); // Run once on mount
 
   // CONV-INST-005: fire first_analysis_done tag only once per session
   const firstAnalysisDoneRef = useRef(false);


### PR DESCRIPTION
## Context

Hotfix para corrigir prefixo `/v1` ausente nas rotas proxy OAuth do Google Sheets. As rotas de exportação (`/api/export/google-sheets`) já usavam o prefixo `/v1` corretamente, mas as rotas OAuth criadas posteriormente (STORY-361) não incluíam o prefixo, causando HTTP 404 do backend e redirecionamento para `/buscar?error=oauth_init_failed`.

## Root Cause

Frontend OAuth proxy routes (STORY-361) chamavam o backend **sem** o prefixo `/v1`, resultando em HTTP 404 do backend. O frontend proxy interpretava o 404 (não-3xx) como falha e redirecionava o usuário para `/buscar?error=oauth_init_failed`.

### Fluxo quebrado:
1. Usuário clica "Exportar para Google Sheets" → backend retorna 401 (não autorizado)
2. Frontend redireciona para `/api/auth/google?redirect=/buscar` (proxy Next.js)
3. Proxy chama `{BACKEND_URL}/api/auth/google` → **404** (rota real é `/v1/api/auth/google`)
4. Proxy vê non-3xx → redireciona para `/buscar?error=oauth_init_failed`
5. Usuário vê URL com erro mas sem mensagem amigável

### Por que o export_sheets proxy funciona?
O proxy de export (`/api/export/google-sheets/route.ts`) já usa `/v1/api/export/google-sheets` corretamente. Apenas os proxies OAuth (criados depois, em STORY-361) faltavam o prefixo.

## Changes

| Arquivo | Mudança |
|---------|---------|
| `frontend/app/api/auth/google/route.ts` | `/api/auth/google` → `/v1/api/auth/google` |
| `frontend/app/api/auth/google/callback/route.ts` | `/api/auth/google/callback` → `/v1/api/auth/google/callback` |
| `backend/routes/auth_oauth.py` | `redirect_uri` usa `/v1/` + fallback robusto para `BACKEND_URL` (Railway `RAILWAY_SERVICE_BIDIQ_BACKEND_URL`) |
| `frontend/app/buscar/page.tsx` | Toast amigável para `?error=oauth_*` e `?google_oauth=success` |
| `frontend/__tests__/api/auth-google-oauth.test.ts` | URL esperada atualizada com `/v1` |

## Verification

- Backend: 36/36 tests pass (`test_oauth.py` + `test_routes_export_sheets.py`)
- Frontend: 13/13 tests pass (`auth-google-oauth.test.ts`)
- Frontend TypeScript: `tsc --noEmit` zero errors
- Full backend suite: 2601 pass, 1 pre-existing failure (gunicorn logging, não relacionado)

## Additional: Railway env vars needed

Para o fluxo OAuth funcionar em produção, verificar se estas env vars estão configuradas no Railway backend:
- `BACKEND_URL=https://api.smartlic.tech` (ou o fallback para `RAILWAY_SERVICE_BIDIQ_BACKEND_URL` cobre)
- `GOOGLE_OAUTH_CLIENT_ID` e `GOOGLE_OAUTH_CLIENT_SECRET` (credenciais OAuth do Google Cloud Console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)