### PR TITLE
fix(ci): smoke test — usa /observatorio/ com trailing slash para evitar HTTP 301

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -13,7 +13,7 @@
 #   (a) GET  /health/live      → 200 (liveness)
 #   (b) GET  /health/ready     → 200 (readiness)
 #   (c) GET  /v1/sectors       → 200 (public sectors)
-#   (d) GET  /observatorio     → 200 (frontend ISR page)
+#   (d) GET  /observatorio/    → 200 (frontend ISR page)
 #   (e) GET  /v1/plans         → 200 (plans)
 #   (f) Redis ping             → PONG (if redis-cli or python3+redis available)
 #   (g) Supabase connect       → OK (if supabase CLI available)
@@ -203,8 +203,9 @@ check_http_200 "(b) Readiness probe" "${API_URL}/health/ready"
 # (c) /v1/sectors
 check_http_200 "(c) Public sectors"  "${API_URL}/v1/sectors"
 
-# (d) /observatorio (frontend ISR page)
-check_http_200 "(d) ISR page"        "${FRONTEND_URL}/observatorio"
+# (d) /observatorio/ (frontend ISR page)
+# Trailing slash required — Next.js redirects /observatorio → /observatorio/ (301)
+check_http_200 "(d) ISR page"        "${FRONTEND_URL}/observatorio/"
 
 # (e) /v1/plans
 check_http_200 "(e) Plans"           "${API_URL}/v1/plans"


### PR DESCRIPTION
## Summary

Production Smoke Tests failing on main after recent merges. Root cause: ISR page check uses `/observatorio` without trailing slash — Next.js redirects to `/observatorio/` with HTTP 301.

## Root Cause

O check (d) ISR page usa `/observatorio` sem trailing slash. Next.js redireciona para `/observatorio/` com HTTP 301. O `check_http_200` considera qualquer código fora de 2xx como FAIL.

## Efeito cascata

1. Attempt 1: ISR page FAIL (301) → triggera retry
2. Attempt 2: backend já sob carga, alguns endpoints retornam HTTP 000 (timeout) → deploy marcado DEGRADED

## Fix

- `/observatorio` → `/observatorio/` (trailing slash)
- Atualizado comentário no header do script

## Evidence

CI log 2026-06-18T00:38Z:
- Attempt 1: 4 PASS, 1 FAIL ((d) ISR page HTTP 301)
- Attempt 2: 2 PASS, 3 FAIL ((b) readiness timeout, (d) ISR 301, (e) plans timeout)

Com fix, attempt 1 passa nos 5 checks HTTP → sem retry → sem falha cascata.

Closes: Production Smoke Tests failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)