### PR TITLE
fix(ci): add --max-time 90 and --connect-timeout 30 to smoke test curl commands (#2018)

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Liveness probe
         run: |
           echo "=== GET /health/live ==="
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BACKEND_URL}/health/live" 2>&1 || echo "000")
+          HTTP_CODE=$(curl -s --max-time 90 --connect-timeout 30 -o /dev/null -w "%{http_code}" "${BACKEND_URL}/health/live" 2>&1 || echo "000")
           echo "HTTP $HTTP_CODE"
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::error::Liveness probe failed (HTTP $HTTP_CODE)"
@@ -57,7 +57,7 @@ jobs:
       - name: Readiness probe
         run: |
           echo "=== GET /health/ready ==="
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BACKEND_URL}/health/ready" 2>&1 || echo "000")
+          HTTP_CODE=$(curl -s --max-time 90 --connect-timeout 30 -o /dev/null -w "%{http_code}" "${BACKEND_URL}/health/ready" 2>&1 || echo "000")
           echo "HTTP $HTTP_CODE"
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::warning::Readiness probe returned HTTP $HTTP_CODE (may be degraded, not blocking)"
@@ -66,7 +66,7 @@ jobs:
       - name: OpenAPI schema accessible
         run: |
           echo "=== GET /openapi.json ==="
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BACKEND_URL}/openapi.json" 2>&1 || echo "000")
+          HTTP_CODE=$(curl -s --max-time 90 --connect-timeout 30 -o /dev/null -w "%{http_code}" "${BACKEND_URL}/openapi.json" 2>&1 || echo "000")
           echo "HTTP $HTTP_CODE"
           if [ "$HTTP_CODE" != "200" ]; then
             echo "::error::OpenAPI schema not accessible (HTTP $HTTP_CODE)"
@@ -76,7 +76,7 @@ jobs:
       - name: POST buscar endpoint — not returning 5xx
         run: |
           echo "=== POST /v1/buscar (smoke) ==="
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+          HTTP_CODE=$(curl -s --max-time 90 --connect-timeout 30 -o /dev/null -w "%{http_code}" -X POST \
             "${BACKEND_URL}/v1/buscar" \
             -H "Content-Type: application/json" \
             -d '{"ufs":["SP"],"data_inicial":"2026-01-20","data_final":"2026-01-27"}' \


### PR DESCRIPTION
## Summary

Adiciona `--max-time 90` e `--connect-timeout 30` aos 4 comandos `curl` no workflow de smoke test (`.github/workflows/smoke-tests.yml`).

## Problem

O smoke test #2018 falhou porque o backend estava temporariamente lento durante a recalculação do `indice_municipal` (360s bloqueando o event loop). Os comandos curl não tinham timeout explícito, então ficaram pendurados até o Railway matar a conexão em ~120s. Isso resultou no HTTP code malformado `200000` (HTTP 200 parcial + curl error concatenado).

## Fix

- `--max-time 90`: força timeout do curl antes do Railway proxy kill (120s), produzindo HTTP 000 limpo
- `--connect-timeout 30`: evita espera longa em falha de DNS/TCP

## Changes

4 comandos curl afetados (liveness probe, readiness probe, OpenAPI schema, POST /v1/buscar).

## Related

Closes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved post-deployment smoke test reliability with hardened HTTP checks and timeout controls. Enhanced health verification for liveness probe, readiness probe, and API accessibility checks to strengthen service health verification during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->