### PR TITLE
feat: timeline intelligence — feed cronológico de eventos (#2024)

### DIFF
--- a/backend/routes/workspace_timeline.py
+++ b/backend/routes/workspace_timeline.py
@@ -1,0 +1,234 @@
+"""Workspace Timeline routes (B2GOPS-014 / #2024).
+
+Provides endpoints for reading and creating timeline events per edital,
+enabling a chronological feed of events for the workspace.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from auth import require_auth
+from supabase_client import get_supabase, sb_execute
+from schemas.workspace_timeline import (
+    TimelineEventoCreate,
+    TimelineResponse,
+    VALID_TIMELINE_TIPOS,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["workspace-timeline"])
+
+# Only nota_manual and lembrete can be created manually by the user
+MANUAL_CREATION_TIPOS = {"nota_manual", "lembrete"}
+
+# Default pagination
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 200
+
+
+def _row_to_evento(row: dict) -> dict:
+    """Convert a Supabase row to a serializable event dict."""
+    return {
+        "id": row["id"],
+        "edital_id": row["edital_id"],
+        "user_id": row["user_id"],
+        "tipo": row["tipo"],
+        "titulo": row["titulo"],
+        "descricao": row.get("descricao"),
+        "critico": row.get("critico", False),
+        "metadata": row.get("metadata", {}),
+        "created_at": row["created_at"],
+    }
+
+
+@router.get(
+    "/workspace/timeline/{edital_id}",
+    response_model=TimelineResponse,
+    summary="Listar eventos da timeline de um edital",
+    description=(
+        "Retorna eventos cronológicos de um edital em ordem DESC. "
+        "Suporta filtros por tipo_evento, data_inicio, data_fim, critico. "
+        "Paginação via limit (default 50, max 200) e offset."
+    ),
+)
+async def list_timeline_eventos(
+    edital_id: str,
+    tipo_evento: Optional[str] = Query(
+        default=None,
+        description="Filtrar por tipo de evento (ex: publicacao, alteracao)",
+    ),
+    data_inicio: Optional[str] = Query(
+        default=None,
+        description="Filtrar eventos a partir desta data (ISO 8601)",
+    ),
+    data_fim: Optional[str] = Query(
+        default=None,
+        description="Filtrar eventos até esta data (ISO 8601)",
+    ),
+    critico: Optional[bool] = Query(
+        default=None,
+        description="Filtrar apenas eventos críticos",
+    ),
+    limit: int = Query(
+        default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT,
+        description="Número máximo de eventos por página",
+    ),
+    offset: int = Query(
+        default=0, ge=0,
+        description="Offset para paginação",
+    ),
+    user: dict = Depends(require_auth),
+) -> TimelineResponse:
+    """List timeline events for an edital, ordered chronologically DESC."""
+    user_id = user["id"]
+    supabase = get_supabase()
+
+    try:
+        # Build base query for the user-scoped client (RLS handles user_id)
+        query = (
+            supabase.table("workspace_timeline_eventos")
+            .select("*", count="exact")
+            .eq("edital_id", edital_id)
+            .eq("user_id", user_id)
+            .order("created_at", desc=True)
+        )
+
+        # Apply optional filters
+        if tipo_evento:
+            if tipo_evento not in VALID_TIMELINE_TIPOS:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "message": (
+                            f"Tipo de evento inválido: '{tipo_evento}'. "
+                            f"Valores válidos: {sorted(VALID_TIMELINE_TIPOS)}"
+                        ),
+                        "error_code": "invalid_tipo_evento",
+                    },
+                )
+            query = query.eq("tipo", tipo_evento)
+
+        if data_inicio:
+            query = query.gte("created_at", data_inicio)
+
+        if data_fim:
+            query = query.lte("created_at", data_fim)
+
+        if critico is not None:
+            query = query.eq("critico", critico)
+
+        # Execute with pagination
+        query = query.range(offset, offset + limit - 1)
+        result = await sb_execute(query)
+
+        eventos_data = result.data or []
+        total = result.count if hasattr(result, "count") else len(eventos_data)
+
+        eventos = [_row_to_evento(e) for e in eventos_data]
+
+        return TimelineResponse(
+            eventos=eventos,
+            total=total,
+            limit=limit,
+            offset=offset,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "Failed to list timeline eventos for edital=%s user=%s",
+            edital_id, user_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "message": "Erro ao listar eventos da timeline.",
+                "error_code": "timeline_list_error",
+            },
+        ) from exc
+
+
+@router.post(
+    "/workspace/timeline/{edital_id}/evento",
+    status_code=201,
+    summary="Criar evento manual na timeline",
+    description=(
+        "Cria um evento manual na timeline do edital. "
+        "Apenas tipos 'nota_manual' e 'lembrete' são permitidos."
+    ),
+)
+async def create_timeline_evento(
+    edital_id: str,
+    body: TimelineEventoCreate,
+    user: dict = Depends(require_auth),
+) -> dict:
+    """Create a manual timeline event (nota_manual or lembrete)."""
+    user_id = user["id"]
+
+    # Validate tipo — only manual creation tipos are allowed
+    if body.tipo not in MANUAL_CREATION_TIPOS:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": (
+                    f"Tipo '{body.tipo}' não pode ser criado manualmente. "
+                    f"Tipos permitidos: {sorted(MANUAL_CREATION_TIPOS)}"
+                ),
+                "error_code": "tipo_nao_permitido",
+            },
+        )
+
+    supabase = get_supabase()
+
+    # Determine if lembrete is always critico
+    is_critico = body.tipo == "lembrete"
+
+    try:
+        insert_data = {
+            "edital_id": edital_id,
+            "user_id": user_id,
+            "tipo": body.tipo,
+            "titulo": body.titulo,
+            "descricao": body.descricao,
+            "critico": is_critico,
+            "metadata": {},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        query = (
+            supabase.table("workspace_timeline_eventos")
+            .insert(insert_data)
+            .execute()
+        )
+
+        if not query.data:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "message": "Erro ao criar evento na timeline.",
+                    "error_code": "timeline_create_error",
+                },
+            )
+
+        created = query.data[0]
+        return _row_to_evento(created)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "Failed to create timeline evento for edital=%s user=%s",
+            edital_id, user_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "message": "Erro ao criar evento na timeline.",
+                "error_code": "timeline_create_error",
+            },
+        ) from exc

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -20,6 +20,7 @@ from schemas.checkout import *  # noqa: F401,F403
 from schemas.api_keys import *  # noqa: F401,F403
 from schemas.viability import *  # noqa: F401,F403
 from schemas.workspace import *  # noqa: F401,F403
+from schemas.workspace_timeline import *  # noqa: F401,F403
 
 # Re-export private names used by external code
 from schemas.common import (  # noqa: F401

--- a/backend/schemas/workspace_timeline.py
+++ b/backend/schemas/workspace_timeline.py
@@ -1,0 +1,58 @@
+"""Timeline Intelligence (B2GOPS-014) schemas.
+
+Schemas for the workspace timeline feed — chronological events
+for each edital: publicacao, alteracao, impugnacao, esclarecimento,
+resultado, homologacao, nota_manual, lembrete.
+"""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+VALID_TIMELINE_TIPOS = frozenset({
+    "publicacao", "alteracao", "impugnacao", "esclarecimento",
+    "resultado", "homologacao", "nota_manual", "lembrete",
+})
+
+
+class TimelineEventoCreate(BaseModel):
+    """Request body to create a manual timeline event.
+
+    Only 'nota_manual' and 'lembrete' tipos are allowed via user creation.
+    """
+
+    tipo: str = Field(
+        ..., description="Tipo do evento: nota_manual ou lembrete"
+    )
+    titulo: str = Field(
+        ..., min_length=1, max_length=500,
+        description="Título descritivo do evento",
+    )
+    descricao: Optional[str] = Field(
+        default=None, max_length=5000,
+        description="Descrição detalhada do evento (opcional)",
+    )
+
+
+class TimelineEvento(BaseModel):
+    """A single timeline event for an edital."""
+
+    id: str
+    edital_id: str
+    user_id: str
+    tipo: str
+    titulo: str
+    descricao: Optional[str] = None
+    critico: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+
+
+class TimelineResponse(BaseModel):
+    """Paginated timeline event list."""
+
+    eventos: list[TimelineEvento]
+    total: int
+    limit: int
+    offset: int

--- a/backend/startup/routes.py
+++ b/backend/startup/routes.py
@@ -122,6 +122,7 @@ from routes.admin_outgoing_webhooks import router as admin_outgoing_webhooks_rou
 from routes.admin_audit_log import router as admin_audit_log_router
 from routes.admin_rate_limits import router as admin_rate_limits_router
 from routes.workspace import router as workspace_router
+from routes.workspace_timeline import router as workspace_timeline_router
 _v1_routers = [
     admin_router, admin_rate_limits_router, subscriptions_router, upgrade_to_lifetime_router,
     features_router, messages_router,
@@ -192,6 +193,7 @@ _v1_routers = [
     csp_report_router,
     alerts_b2gops_router,
     workspace_router,
+    workspace_timeline_router,
 ]
 def register_routes(app: FastAPI) -> None:
     """Register all application routers onto *app*."""

--- a/backend/tests/snapshots/openapi_schema.json
+++ b/backend/tests/snapshots/openapi_schema.json
@@ -19128,6 +19128,134 @@
         "title": "TimeSeriesDataPoint",
         "type": "object"
       },
+      "TimelineEvento": {
+        "description": "A single timeline event for an edital.",
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "critico": {
+            "default": false,
+            "title": "Critico",
+            "type": "boolean"
+          },
+          "descricao": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Descricao"
+          },
+          "edital_id": {
+            "title": "Edital Id",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          },
+          "tipo": {
+            "title": "Tipo",
+            "type": "string"
+          },
+          "titulo": {
+            "title": "Titulo",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "edital_id",
+          "user_id",
+          "tipo",
+          "titulo",
+          "created_at"
+        ],
+        "title": "TimelineEvento",
+        "type": "object"
+      },
+      "TimelineEventoCreate": {
+        "description": "Request body to create a manual timeline event.\n\nOnly 'nota_manual' and 'lembrete' tipos are allowed via user creation.",
+        "properties": {
+          "descricao": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Descri\u00e7\u00e3o detalhada do evento (opcional)",
+            "title": "Descricao"
+          },
+          "tipo": {
+            "description": "Tipo do evento: nota_manual ou lembrete",
+            "title": "Tipo",
+            "type": "string"
+          },
+          "titulo": {
+            "description": "T\u00edtulo descritivo do evento",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Titulo",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tipo",
+          "titulo"
+        ],
+        "title": "TimelineEventoCreate",
+        "type": "object"
+      },
+      "TimelineResponse": {
+        "description": "Paginated timeline event list.",
+        "properties": {
+          "eventos": {
+            "items": {
+              "$ref": "#/components/schemas/TimelineEvento"
+            },
+            "title": "Eventos",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "eventos",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "TimelineResponse",
+        "type": "object"
+      },
       "TopComprador": {
         "properties": {
           "cnpj": {
@@ -37133,6 +37261,213 @@
         "summary": "Get Workspace Resumo",
         "tags": [
           "workspace"
+        ]
+      }
+    },
+    "/v1/workspace/timeline/{edital_id}": {
+      "get": {
+        "description": "Retorna eventos cronol\u00f3gicos de um edital em ordem DESC. Suporta filtros por tipo_evento, data_inicio, data_fim, critico. Pagina\u00e7\u00e3o via limit (default 50, max 200) e offset.",
+        "operationId": "list_timeline_eventos_v1_workspace_timeline__edital_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "edital_id",
+            "required": true,
+            "schema": {
+              "title": "Edital Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filtrar por tipo de evento (ex: publicacao, alteracao)",
+            "in": "query",
+            "name": "tipo_evento",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filtrar por tipo de evento (ex: publicacao, alteracao)",
+              "title": "Tipo Evento"
+            }
+          },
+          {
+            "description": "Filtrar eventos a partir desta data (ISO 8601)",
+            "in": "query",
+            "name": "data_inicio",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filtrar eventos a partir desta data (ISO 8601)",
+              "title": "Data Inicio"
+            }
+          },
+          {
+            "description": "Filtrar eventos at\u00e9 esta data (ISO 8601)",
+            "in": "query",
+            "name": "data_fim",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filtrar eventos at\u00e9 esta data (ISO 8601)",
+              "title": "Data Fim"
+            }
+          },
+          {
+            "description": "Filtrar apenas eventos cr\u00edticos",
+            "in": "query",
+            "name": "critico",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filtrar apenas eventos cr\u00edticos",
+              "title": "Critico"
+            }
+          },
+          {
+            "description": "N\u00famero m\u00e1ximo de eventos por p\u00e1gina",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "N\u00famero m\u00e1ximo de eventos por p\u00e1gina",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Offset para pagina\u00e7\u00e3o",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Offset para pagina\u00e7\u00e3o",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimelineResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Listar eventos da timeline de um edital",
+        "tags": [
+          "workspace-timeline"
+        ]
+      }
+    },
+    "/v1/workspace/timeline/{edital_id}/evento": {
+      "post": {
+        "description": "Cria um evento manual na timeline do edital. Apenas tipos 'nota_manual' e 'lembrete' s\u00e3o permitidos.",
+        "operationId": "create_timeline_evento_v1_workspace_timeline__edital_id__evento_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "edital_id",
+            "required": true,
+            "schema": {
+              "title": "Edital Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TimelineEventoCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Timeline Evento V1 Workspace Timeline  Edital Id  Evento Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Criar evento manual na timeline",
+        "tags": [
+          "workspace-timeline"
         ]
       }
     },

--- a/frontend/app/api-types.generated.ts
+++ b/frontend/app/api-types.generated.ts
@@ -7592,6 +7592,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/workspace/timeline/{edital_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Listar eventos da timeline de um edital
+         * @description Retorna eventos cronológicos de um edital em ordem DESC. Suporta filtros por tipo_evento, data_inicio, data_fim, critico. Paginação via limit (default 50, max 200) e offset.
+         */
+        get: operations["list_timeline_eventos_v1_workspace_timeline__edital_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/workspace/timeline/{edital_id}/evento": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Criar evento manual na timeline
+         * @description Cria um evento manual na timeline do edital. Apenas tipos 'nota_manual' e 'lembrete' são permitidos.
+         */
+        post: operations["create_timeline_evento_v1_workspace_timeline__edital_id__evento_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/webhooks/stripe": {
         parameters: {
             query?: never;
@@ -16701,6 +16741,72 @@ export interface components {
             searches: number;
             /** Value */
             value: number;
+        };
+        /**
+         * TimelineEvento
+         * @description A single timeline event for an edital.
+         */
+        TimelineEvento: {
+            /** Created At */
+            created_at: string;
+            /**
+             * Critico
+             * @default false
+             */
+            critico: boolean;
+            /** Descricao */
+            descricao?: string | null;
+            /** Edital Id */
+            edital_id: string;
+            /** Id */
+            id: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /** Tipo */
+            tipo: string;
+            /** Titulo */
+            titulo: string;
+            /** User Id */
+            user_id: string;
+        };
+        /**
+         * TimelineEventoCreate
+         * @description Request body to create a manual timeline event.
+         *
+         *     Only 'nota_manual' and 'lembrete' tipos are allowed via user creation.
+         */
+        TimelineEventoCreate: {
+            /**
+             * Descricao
+             * @description Descrição detalhada do evento (opcional)
+             */
+            descricao?: string | null;
+            /**
+             * Tipo
+             * @description Tipo do evento: nota_manual ou lembrete
+             */
+            tipo: string;
+            /**
+             * Titulo
+             * @description Título descritivo do evento
+             */
+            titulo: string;
+        };
+        /**
+         * TimelineResponse
+         * @description Paginated timeline event list.
+         */
+        TimelineResponse: {
+            /** Eventos */
+            eventos: components["schemas"]["TimelineEvento"][];
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Total */
+            total: number;
         };
         /** TopComprador */
         TopComprador: {
@@ -27784,6 +27890,87 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkspaceResumo"];
+                };
+            };
+        };
+    };
+    list_timeline_eventos_v1_workspace_timeline__edital_id__get: {
+        parameters: {
+            query?: {
+                /** @description Filtrar por tipo de evento (ex: publicacao, alteracao) */
+                tipo_evento?: string | null;
+                /** @description Filtrar eventos a partir desta data (ISO 8601) */
+                data_inicio?: string | null;
+                /** @description Filtrar eventos até esta data (ISO 8601) */
+                data_fim?: string | null;
+                /** @description Filtrar apenas eventos críticos */
+                critico?: boolean | null;
+                /** @description Número máximo de eventos por página */
+                limit?: number;
+                /** @description Offset para paginação */
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                edital_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TimelineResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_timeline_evento_v1_workspace_timeline__edital_id__evento_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                edital_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TimelineEventoCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/app/api/workspace/timeline/[edital_id]/evento/route.ts
+++ b/frontend/app/api/workspace/timeline/[edital_id]/evento/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sanitizeProxyError, sanitizeNetworkError } from "../../../../../../lib/proxy-error-handler";
+
+const BACKEND_URL = process.env.BACKEND_URL;
+
+function getAuthHeader(request: NextRequest): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  return authHeader;
+}
+
+async function safeProxyResponse(
+  response: Response,
+  fallbackMessage: string,
+): Promise<NextResponse> {
+  const body = await response.text();
+  const sanitized = sanitizeProxyError(
+    response.status,
+    body,
+    response.headers.get("content-type"),
+  );
+  if (sanitized) return sanitized;
+
+  try {
+    const data = JSON.parse(body);
+    return NextResponse.json(data, { status: response.status });
+  } catch {
+    return NextResponse.json(
+      { message: fallbackMessage },
+      { status: response.status },
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ edital_id: string }> },
+) {
+  if (!BACKEND_URL) {
+    console.error("BACKEND_URL environment variable is not configured");
+    return NextResponse.json({ message: "Serviço temporariamente indisponível" }, { status: 503 });
+  }
+
+  const auth = getAuthHeader(request);
+  if (!auth) {
+    return NextResponse.json({ message: "Autenticação necessária." }, { status: 401 });
+  }
+
+  const { edital_id } = await params;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: auth,
+  };
+
+  const correlationId = request.headers.get("X-Correlation-ID");
+  if (correlationId) {
+    headers["X-Correlation-ID"] = correlationId;
+  }
+
+  try {
+    const body = await request.json();
+    const response = await fetch(
+      `${BACKEND_URL}/v1/workspace/timeline/${edital_id}/evento`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      },
+    );
+    return safeProxyResponse(response, "Erro ao criar evento.");
+  } catch (error) {
+    console.error("[workspace/timeline] Network error:", error instanceof Error ? error.message : error);
+    return sanitizeNetworkError(error);
+  }
+}

--- a/frontend/app/api/workspace/timeline/[edital_id]/route.ts
+++ b/frontend/app/api/workspace/timeline/[edital_id]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sanitizeProxyError, sanitizeNetworkError } from "../../../../../lib/proxy-error-handler";
+
+const BACKEND_URL = process.env.BACKEND_URL;
+
+function getAuthHeader(request: NextRequest): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  return authHeader;
+}
+
+async function safeProxyResponse(
+  response: Response,
+  fallbackMessage: string,
+): Promise<NextResponse> {
+  const body = await response.text();
+  const sanitized = sanitizeProxyError(
+    response.status,
+    body,
+    response.headers.get("content-type"),
+  );
+  if (sanitized) return sanitized;
+
+  try {
+    const data = JSON.parse(body);
+    return NextResponse.json(data, { status: response.status });
+  } catch {
+    return NextResponse.json(
+      { message: fallbackMessage },
+      { status: response.status },
+    );
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ edital_id: string }> },
+) {
+  if (!BACKEND_URL) {
+    console.error("BACKEND_URL environment variable is not configured");
+    return NextResponse.json({ message: "Serviço temporariamente indisponível" }, { status: 503 });
+  }
+
+  const auth = getAuthHeader(request);
+  if (!auth) {
+    return NextResponse.json({ message: "Autenticação necessária." }, { status: 401 });
+  }
+
+  const { edital_id } = await params;
+  const { searchParams } = new URL(request.url);
+  const qs = searchParams.toString();
+
+  const url = `${BACKEND_URL}/v1/workspace/timeline/${edital_id}${qs ? `?${qs}` : ""}`;
+
+  const headers: Record<string, string> = {
+    Authorization: auth,
+  };
+
+  const correlationId = request.headers.get("X-Correlation-ID");
+  if (correlationId) {
+    headers["X-Correlation-ID"] = correlationId;
+  }
+
+  try {
+    const response = await fetch(url, { headers });
+    return safeProxyResponse(response, "Erro ao conectar com servidor.");
+  } catch (error) {
+    console.error("[workspace/timeline] Network error:", error instanceof Error ? error.message : error);
+    return sanitizeNetworkError(error);
+  }
+}

--- a/frontend/app/workspace/timeline/[edital_id]/page.tsx
+++ b/frontend/app/workspace/timeline/[edital_id]/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { TimelineFeed } from "../../../../components/workspace/timeline/TimelineFeed";
+import { PageHeader } from "../../../../components/PageHeader";
+import { ErrorBoundary } from "../../../../components/ErrorBoundary";
+
+export default function TimelinePage() {
+  const params = useParams();
+  const editalId = params.edital_id as string;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-display font-semibold text-[var(--ink)]">
+          Timeline do Edital
+        </h1>
+        <p className="mt-1 text-sm text-[var(--ink-secondary)]">
+          Acompanhe eventos, notas e lembretes deste edital em ordem cronologica.
+        </p>
+      </div>
+
+      <ErrorBoundary>
+        <TimelineFeed editalId={editalId} />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/frontend/components/workspace/timeline/EventoManualForm.tsx
+++ b/frontend/components/workspace/timeline/EventoManualForm.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+
+interface EventoManualFormProps {
+  editalId: string;
+  onCreated: () => void;
+}
+
+export function EventoManualForm({ editalId, onCreated }: EventoManualFormProps) {
+  const [tipo, setTipo] = useState<"nota_manual" | "lembrete">("nota_manual");
+  const [titulo, setTitulo] = useState("");
+  const [descricao, setDescricao] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!titulo.trim()) {
+      setError("O titulo e obrigatorio.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/workspace/timeline/${editalId}/evento`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tipo, titulo: titulo.trim(), descricao: descricao.trim() || undefined }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || "Erro ao criar evento.");
+      }
+
+      setTitulo("");
+      setDescricao("");
+      onCreated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro ao criar evento.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="p-4 rounded-xl border border-[var(--border)] bg-[var(--surface-1)] space-y-3"
+    >
+      <h3 className="text-sm font-semibold text-[var(--ink)]">
+        Adicionar evento
+      </h3>
+
+      {/* Tipo selector */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setTipo("nota_manual")}
+          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+            tipo === "nota_manual"
+              ? "bg-gray-800 text-white"
+              : "bg-[var(--surface-2)] text-[var(--ink-secondary)]"
+          }`}
+        >
+          Nota
+        </button>
+        <button
+          type="button"
+          onClick={() => setTipo("lembrete")}
+          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+            tipo === "lembrete"
+              ? "bg-orange-600 text-white"
+              : "bg-[var(--surface-2)] text-[var(--ink-secondary)]"
+          }`}
+        >
+          Lembrete
+        </button>
+      </div>
+
+      {/* Titulo */}
+      <input
+        type="text"
+        value={titulo}
+        onChange={(e) => setTitulo(e.target.value)}
+        placeholder="Titulo do evento"
+        maxLength={500}
+        className="w-full px-3 py-2 text-sm border rounded-lg bg-white text-[var(--ink)] placeholder:text-[var(--ink-tertiary)]"
+      />
+
+      {/* Descricao */}
+      <textarea
+        value={descricao}
+        onChange={(e) => setDescricao(e.target.value)}
+        placeholder="Descricao (opcional)"
+        maxLength={5000}
+        rows={3}
+        className="w-full px-3 py-2 text-sm border rounded-lg bg-white text-[var(--ink)] placeholder:text-[var(--ink-tertiary)] resize-none"
+      />
+
+      {error && (
+        <p className="text-xs text-red-600">{error}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting || !titulo.trim()}
+        className="w-full px-4 py-2 text-sm font-medium text-white bg-[var(--brand-blue)] rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+      >
+        {submitting ? "Salvando..." : "Adicionar"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/components/workspace/timeline/TimelineEventoCard.tsx
+++ b/frontend/components/workspace/timeline/TimelineEventoCard.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import {
+  FileText,
+  Pencil,
+  AlertTriangle,
+  MessageCircle,
+  Trophy,
+  CheckCircle,
+  FileEdit,
+  Bell,
+} from "lucide-react";
+
+export interface TimelineEvento {
+  id: string;
+  edital_id: string;
+  tipo: string;
+  titulo: string;
+  descricao: string | null;
+  critico: boolean;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+interface TimelineEventoCardProps {
+  evento: TimelineEvento;
+}
+
+const TIPO_CONFIG: Record<
+  string,
+  { icon: React.ReactNode; label: string; color: string; bgColor: string }
+> = {
+  publicacao: {
+    icon: <FileText size={16} />,
+    label: "Publicacao",
+    color: "text-blue-600",
+    bgColor: "bg-blue-100",
+  },
+  alteracao: {
+    icon: <Pencil size={16} />,
+    label: "Alteracao",
+    color: "text-yellow-600",
+    bgColor: "bg-yellow-100",
+  },
+  impugnacao: {
+    icon: <AlertTriangle size={16} />,
+    label: "Impugnacao",
+    color: "text-red-600",
+    bgColor: "bg-red-100",
+  },
+  esclarecimento: {
+    icon: <MessageCircle size={16} />,
+    label: "Esclarecimento",
+    color: "text-purple-600",
+    bgColor: "bg-purple-100",
+  },
+  resultado: {
+    icon: <Trophy size={16} />,
+    label: "Resultado",
+    color: "text-emerald-600",
+    bgColor: "bg-emerald-100",
+  },
+  homologacao: {
+    icon: <CheckCircle size={16} />,
+    label: "Homologacao",
+    color: "text-green-600",
+    bgColor: "bg-green-100",
+  },
+  nota_manual: {
+    icon: <FileEdit size={16} />,
+    label: "Nota",
+    color: "text-gray-600",
+    bgColor: "bg-gray-100",
+  },
+  lembrete: {
+    icon: <Bell size={16} />,
+    label: "Lembrete",
+    color: "text-orange-600",
+    bgColor: "bg-orange-100",
+  },
+};
+
+function formatDate(iso: string): string {
+  try {
+    const date = new Date(iso);
+    return date.toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function TimelineEventoCard({ evento }: TimelineEventoCardProps) {
+  const config = TIPO_CONFIG[evento.tipo] ?? {
+    icon: <FileText size={16} />,
+    label: evento.tipo,
+    color: "text-gray-600",
+    bgColor: "bg-gray-100",
+  };
+
+  return (
+    <div
+      className={`relative flex gap-4 p-4 rounded-xl border transition-colors ${
+        evento.critico
+          ? "border-red-200 bg-red-50/50"
+          : "border-[var(--border)] bg-white"
+      }`}
+      data-testid={`timeline-event-${evento.id}`}
+    >
+      {/* Indicador critico */}
+      {evento.critico && (
+        <div className="absolute -top-2 -right-2">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
+            <AlertTriangle size={12} />
+            Critico
+          </span>
+        </div>
+      )}
+
+      {/* Icone por tipo */}
+      <div
+        className={`flex-shrink-0 w-10 h-10 rounded-full ${config.bgColor} ${config.color} flex items-center justify-center`}
+      >
+        {config.icon}
+      </div>
+
+      {/* Conteudo */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded-full ${config.bgColor} ${config.color}`}
+          >
+            {config.label}
+          </span>
+          <span className="text-xs text-[var(--ink-tertiary)]">
+            {formatDate(evento.created_at)}
+          </span>
+        </div>
+
+        <h4 className="text-sm font-semibold text-[var(--ink)]">
+          {evento.titulo}
+        </h4>
+
+        {evento.descricao && (
+          <p className="mt-1 text-sm text-[var(--ink-secondary)] whitespace-pre-wrap">
+            {evento.descricao}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workspace/timeline/TimelineFeed.tsx
+++ b/frontend/components/workspace/timeline/TimelineFeed.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TimelineEvento, TimelineEventoCard } from "./TimelineEventoCard";
+import { TimelineFiltros } from "./TimelineFiltros";
+import { EventoManualForm } from "./EventoManualForm";
+
+interface TimelineFeedProps {
+  editalId: string;
+}
+
+const LIMIT = 50;
+
+export function TimelineFeed({ editalId }: TimelineFeedProps) {
+  const [eventos, setEventos] = useState<TimelineEvento[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+
+  // Filters
+  const [selectedTipos, setSelectedTipos] = useState<string[]>([]);
+  const [apenasCriticos, setApenasCriticos] = useState(false);
+  const [dataInicio, setDataInicio] = useState("");
+  const [dataFim, setDataFim] = useState("");
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const fetchedRef = useRef(false);
+
+  const buildUrl = useCallback(
+    (offsetVal: number) => {
+      const params = new URLSearchParams();
+      params.set("limit", String(LIMIT));
+      params.set("offset", String(offsetVal));
+
+      if (selectedTipos.length === 1) {
+        params.set("tipo_evento", selectedTipos[0]);
+      }
+      if (apenasCriticos) {
+        params.set("critico", "true");
+      }
+      if (dataInicio) params.set("data_inicio", dataInicio);
+      if (dataFim) params.set("data_fim", dataFim);
+
+      return `/api/workspace/timeline/${editalId}?${params.toString()}`;
+    },
+    [editalId, selectedTipos, apenasCriticos, dataInicio, dataFim],
+  );
+
+  const fetchEventos = useCallback(
+    async (offsetVal: number, append: boolean) => {
+      if (append) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
+      setError(null);
+
+      try {
+        const res = await fetch(buildUrl(offsetVal));
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.message || "Erro ao carregar eventos.");
+        }
+
+        const data = await res.json();
+        const novos = data.eventos ?? [];
+
+        if (append) {
+          setEventos((prev) => [...prev, ...novos]);
+        } else {
+          setEventos(novos);
+        }
+
+        setTotal(data.total ?? 0);
+        setOffset(offsetVal + novos.length);
+        setHasMore(novos.length === LIMIT);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Erro ao carregar eventos.");
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+        fetchedRef.current = true;
+      }
+    },
+    [buildUrl],
+  );
+
+  // Load on mount and when filters change
+  useEffect(() => {
+    setOffset(0);
+    setHasMore(true);
+    fetchedRef.current = false;
+    fetchEventos(0, false);
+  }, [fetchEventos]);
+
+  // Infinite scroll via IntersectionObserver
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore || loading || loadingMore) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting && hasMore && !loadingMore && !loading) {
+          fetchEventos(offset, true);
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loading, loadingMore, offset, fetchEventos]);
+
+  // Refresh handler for EventoManualForm
+  const handleEventoCreated = useCallback(() => {
+    setOffset(0);
+    setHasMore(true);
+    fetchedRef.current = false;
+    fetchEventos(0, false);
+  }, [fetchEventos]);
+
+  return (
+    <div className="space-y-6">
+      {/* Filtros */}
+      <TimelineFiltros
+        selectedTipos={selectedTipos}
+        onToggleTipo={(tipo) =>
+          setSelectedTipos((prev) =>
+            prev.includes(tipo)
+              ? prev.filter((t) => t !== tipo)
+              : [...prev, tipo],
+          )
+        }
+        apenasCriticos={apenasCriticos}
+        onToggleCriticos={() => setApenasCriticos((p) => !p)}
+        dataInicio={dataInicio}
+        onDataInicioChange={setDataInicio}
+        dataFim={dataFim}
+        onDataFimChange={setDataFim}
+      />
+
+      {/* Form de criacao */}
+      <EventoManualForm editalId={editalId} onCreated={handleEventoCreated} />
+
+      {/* Loading state */}
+      {loading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-24 rounded-xl bg-[var(--surface-2)] animate-pulse"
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && !loading && (
+        <div className="p-6 text-center rounded-xl border border-red-200 bg-red-50">
+          <p className="text-sm text-red-700">{error}</p>
+          <button
+            onClick={() => fetchEventos(0, false)}
+            className="mt-3 text-sm text-[var(--brand-blue)] hover:underline"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && eventos.length === 0 && (
+        <div className="p-12 text-center rounded-xl border border-dashed border-[var(--border)]">
+          <p className="text-sm text-[var(--ink-secondary)]">
+            Nenhum evento na timeline ainda.
+          </p>
+          <p className="text-xs text-[var(--ink-tertiary)] mt-1">
+            Adicione notas e lembretes para acompanhar o edital.
+          </p>
+        </div>
+      )}
+
+      {/* Timeline feed */}
+      {eventos.length > 0 && (
+        <div className="space-y-3">
+          {eventos.map((evento) => (
+            <TimelineEventoCard key={evento.id} evento={evento} />
+          ))}
+
+          {/* Infinite scroll sentinel */}
+          <div ref={sentinelRef} className="h-4" />
+
+          {loadingMore && (
+            <div className="flex justify-center py-4">
+              <div className="w-6 h-6 border-2 border-[var(--brand-blue)] border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+
+          {!hasMore && eventos.length > 0 && (
+            <p className="text-center text-xs text-[var(--ink-tertiary)] py-4">
+              Todos os {total} eventos carregados.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/workspace/timeline/TimelineFiltros.tsx
+++ b/frontend/components/workspace/timeline/TimelineFiltros.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { X } from "lucide-react";
+
+const TIPO_OPTIONS = [
+  { value: "publicacao", label: "Publicacao" },
+  { value: "alteracao", label: "Alteracao" },
+  { value: "impugnacao", label: "Impugnacao" },
+  { value: "esclarecimento", label: "Esclarecimento" },
+  { value: "resultado", label: "Resultado" },
+  { value: "homologacao", label: "Homologacao" },
+  { value: "nota_manual", label: "Notas" },
+  { value: "lembrete", label: "Lembretes" },
+];
+
+interface TimelineFiltrosProps {
+  selectedTipos: string[];
+  onToggleTipo: (tipo: string) => void;
+  apenasCriticos: boolean;
+  onToggleCriticos: () => void;
+  dataInicio: string;
+  onDataInicioChange: (val: string) => void;
+  dataFim: string;
+  onDataFimChange: (val: string) => void;
+}
+
+export function TimelineFiltros({
+  selectedTipos,
+  onToggleTipo,
+  apenasCriticos,
+  onToggleCriticos,
+  dataInicio,
+  onDataInicioChange,
+  dataFim,
+  onDataFimChange,
+}: TimelineFiltrosProps) {
+  const hasActiveFilters =
+    selectedTipos.length > 0 || apenasCriticos || dataInicio || dataFim;
+
+  return (
+    <div className="space-y-3">
+      {/* Chips de tipo */}
+      <div className="flex flex-wrap gap-2">
+        {TIPO_OPTIONS.map((opt) => {
+          const isSelected = selectedTipos.includes(opt.value);
+          return (
+            <button
+              key={opt.value}
+              onClick={() => onToggleTipo(opt.value)}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                isSelected
+                  ? "bg-[var(--brand-blue)] text-white"
+                  : "bg-[var(--surface-2)] text-[var(--ink-secondary)] hover:bg-[var(--surface-3)]"
+              }`}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Controles adicionais */}
+      <div className="flex flex-wrap items-center gap-4">
+        {/* Toggle apenas criticos */}
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={apenasCriticos}
+            onChange={onToggleCriticos}
+            className="w-4 h-4 rounded border-gray-300"
+          />
+          <span className="text-sm text-[var(--ink-secondary)]">
+            Apenas criticos
+          </span>
+        </label>
+
+        {/* Date range */}
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-[var(--ink-tertiary)]">De:</label>
+          <input
+            type="date"
+            value={dataInicio}
+            onChange={(e) => onDataInicioChange(e.target.value)}
+            className="px-2 py-1 text-xs border rounded-md bg-[var(--surface-1)] text-[var(--ink)]"
+          />
+          <label className="text-xs text-[var(--ink-tertiary)]">Ate:</label>
+          <input
+            type="date"
+            value={dataFim}
+            onChange={(e) => onDataFimChange(e.target.value)}
+            className="px-2 py-1 text-xs border rounded-md bg-[var(--surface-1)] text-[var(--ink)]"
+          />
+        </div>
+
+        {/* Limpar filtros */}
+        {hasActiveFilters && (
+          <button
+            onClick={() => {
+              selectedTipos.forEach(onToggleTipo);
+              onToggleCriticos();
+              onDataInicioChange("");
+              onDataFimChange("");
+            }}
+            className="text-xs text-[var(--brand-blue)] hover:underline flex items-center gap-1"
+          >
+            <X size={12} />
+            Limpar filtros
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260618012730_workspace_timeline_eventos.down.sql
+++ b/supabase/migrations/20260618012730_workspace_timeline_eventos.down.sql
@@ -1,0 +1,3 @@
+-- B2GOPS-014 (#2024): Rollback workspace_timeline_eventos
+
+DROP TABLE IF EXISTS workspace_timeline_eventos;

--- a/supabase/migrations/20260618012730_workspace_timeline_eventos.sql
+++ b/supabase/migrations/20260618012730_workspace_timeline_eventos.sql
@@ -1,0 +1,67 @@
+-- B2GOPS-014 (#2024): Timeline Intelligence — feed cronológico de eventos do edital
+-- Tabela de eventos de timeline por edital, vinculada ao usuário
+
+-- ============================================================================
+-- workspace_timeline_eventos — eventos cronológicos de cada edital
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS workspace_timeline_eventos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    edital_id TEXT NOT NULL,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    tipo TEXT NOT NULL CHECK (tipo IN (
+        'publicacao', 'alteracao', 'impugnacao', 'esclarecimento',
+        'resultado', 'homologacao', 'nota_manual', 'lembrete'
+    )),
+    titulo TEXT NOT NULL,
+    descricao TEXT,
+    critico BOOLEAN DEFAULT false,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Index para consulta por edital + ordenação cronológica DESC
+CREATE INDEX IF NOT EXISTS idx_timeline_eventos_edital
+    ON workspace_timeline_eventos(edital_id, created_at DESC);
+
+-- Index para consulta por usuário + ordenação cronológica DESC
+CREATE INDEX IF NOT EXISTS idx_timeline_eventos_user
+    ON workspace_timeline_eventos(user_id, created_at DESC);
+
+-- Index para filtro por tipo
+CREATE INDEX IF NOT EXISTS idx_timeline_eventos_tipo
+    ON workspace_timeline_eventos(edital_id, tipo);
+
+-- Index para filtro por crítico
+CREATE INDEX IF NOT EXISTS idx_timeline_eventos_critico
+    ON workspace_timeline_eventos(edital_id, critico)
+    WHERE critico = true;
+
+-- RLS
+ALTER TABLE workspace_timeline_eventos ENABLE ROW LEVEL SECURITY;
+
+-- Política: usuário só vê próprios eventos
+CREATE POLICY "Usuarios veem proprios eventos"
+    ON workspace_timeline_eventos FOR SELECT
+    USING (auth.uid() = user_id);
+
+-- Política: usuário cria próprios eventos
+CREATE POLICY "Usuarios criam proprios eventos"
+    ON workspace_timeline_eventos FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+-- Política: usuário atualiza próprios eventos
+CREATE POLICY "Usuarios atualizam proprios eventos"
+    ON workspace_timeline_eventos FOR UPDATE
+    USING (auth.uid() = user_id);
+
+-- Política: usuário deleta próprios eventos
+CREATE POLICY "Usuarios deletam proprios eventos"
+    ON workspace_timeline_eventos FOR DELETE
+    USING (auth.uid() = user_id);
+
+COMMENT ON TABLE workspace_timeline_eventos IS 'B2GOPS-014: Eventos cronológicos da timeline de um edital';
+COMMENT ON COLUMN workspace_timeline_eventos.tipo IS 'Tipo do evento: publicacao, alteracao, impugnacao, esclarecimento, resultado, homologacao, nota_manual, lembrete';
+COMMENT ON COLUMN workspace_timeline_eventos.edital_id IS 'ID do edital (PNCP ou outro identificador)';
+COMMENT ON COLUMN workspace_timeline_eventos.critico IS 'Se true, evento é destacado como crítico';
+COMMENT ON COLUMN workspace_timeline_eventos.metadata IS 'Metadados adicionais do evento (JSON livre)';


### PR DESCRIPTION
## Resumo

Feed cronológico inteligente que agrega eventos automáticos e manuais para cada edital monitorado.

### O que foi feito

**Backend (2 endpoints):**
| Método | Path | Função |
|--------|------|--------|
| GET | `/v1/workspace/timeline/{edital_id}` | Timeline paginada (limit 50) com filtros |
| POST | `/v1/workspace/timeline/{edital_id}/evento` | Criar nota/lembrete manual |

**DB:**
- `workspace_timeline_eventos`: 8 tipos de evento, 4 índices, RLS
- Migration com paired .down.sql

**Frontend:**
- `/workspace/timeline/[edital_id]`: timeline vertical com scroll infinito
- TimelineFeed, TimelineEventoCard (ícones + cores por tipo), TimelineFiltros, EventoManualForm
- Eventos críticos destacados com badge e cor diferenciada

**Tipos de evento:** 📄 publicação, ✏️ alteração, ⚠️ impugnação, 💬 esclarecimento, 🏆 resultado, ✅ homologação, 📝 nota_manual, 🔔 lembrete

### Escopo reduzido (não incluído)
- Cron job de sincronização automática PNCP (futuro)
- Export PDF/CSV
- Upload de anexos
- Timeline agregada multi-edital

### Validação

- [x] Ruff lint: 0 errors
- [x] Tests: 123 passed, 0 failed
- [x] Migration com .down.sql
- [x] RLS em todas as tabelas

Closes #2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace timeline feed to display chronological events with support for filtering by event type, critical status, and date range.
  * Added ability to create manual timeline events (notes and reminders) with titles and optional descriptions.
  * Added visual timeline event cards showing type indicators, formatted timestamps, and critical status badges for easy event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->