### PR TITLE
fix(ci): smoke test — usa /observatorio sem trailing slash + curl -L

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -62,14 +62,14 @@ log_skip() { echo -e "  ${YELLOW}SKIP${NC}  $1 — $2"; ((SKIP_COUNT+=1)); }
 
 # (a)-(e) HTTP 200 check
 check_http_200() {
-  local label="$1" url="$2" method="${3:-GET}"
+  local label="$1" url="$2" method="${3:-GET}" extra_flags="${4:-}"
 
   echo "─── ${label} ──────────────────────────────────────"
   echo "${method} ${url}"
 
   local http_code
   http_code=$(curl -s -o /dev/null -w "%{http_code}" -X "${method}" \
-    "${url}" --max-time "${CHECK_TIMEOUT}" 2>&1 || echo "000")
+    ${extra_flags} "${url}" --max-time "${CHECK_TIMEOUT}" 2>&1 || echo "000")
 
   if [ "${http_code}" = "000" ]; then
     log_fail "${label}" "Connection failed (timeout or DNS error)"
@@ -203,9 +203,9 @@ check_http_200 "(b) Readiness probe" "${API_URL}/health/ready"
 # (c) /v1/sectors
 check_http_200 "(c) Public sectors"  "${API_URL}/v1/sectors"
 
-# (d) /observatorio/ (frontend ISR page)
-# Trailing slash required — Next.js redirects /observatorio → /observatorio/ (301)
-check_http_200 "(d) ISR page"        "${FRONTEND_URL}/observatorio/"
+# (d) /observatorio (frontend ISR page)
+# -L follows redirects — resilient to Next.js trailingSlash config changes
+check_http_200 "(d) ISR page"        "${FRONTEND_URL}/observatorio" "GET" "-L"
 
 # (e) /v1/plans
 check_http_200 "(e) Plans"           "${API_URL}/v1/plans"


### PR DESCRIPTION
## Summary

Corrige o smoke test (d) ISR page que falhava com HTTP 308 na produção.

## Root Cause

Produção tem `trailingSlash: false` no Next.js → `/observatorio/` retorna 308 → `/observatorio`. O fix anterior (ad5c1844) assumia `trailingSlash: true` e usava `/observatorio/`.

## Changes

- `scripts/smoke-test.sh`:
  - URL: `/observatorio/` → `/observatorio` (retorna 200 direto)
  - `curl`: adiciona flag `-L` (follow redirects) para resiliência contra mudanças de config
  - `check_http_200`: aceita 4º parâmetro `extra_flags`

## Testing Plan

```bash
SMOKE_TEST_API_URL=https://api.smartlic.tech \
  SMOKE_TEST_FRONTEND_URL=https://smartlic.tech \
  bash scripts/smoke-test.sh
```

Resultado: **5/5 PASS** (era 4/5 com HTTP 308 no ISR page)

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)