### PR TITLE
fix(pSEO): substituir notFound() por EmptyStateSEO em analise/[hash] (#2043)

### DIFF
--- a/frontend/__tests__/app/analise-hash-no-notfound.test.tsx
+++ b/frontend/__tests__/app/analise-hash-no-notfound.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Issue #2043 (P0-2): analise/[hash] substituir notFound() por EmptyStateSEO.
+ *
+ * Contexto: ISR cacheia 404 → Google desindexa URL. Viola ADR-SEO-001.
+ *
+ * ACs:
+ * - AC4: Backend retorna 404 → página renderiza EmptyStateSEO (HTTP 200)
+ * - AC5: Backend retorna 500 → página renderiza EmptyStateSEO (não throw, não 404)
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const mockNotFound = jest.fn(() => {
+  const err = new Error('NEXT_NOT_FOUND');
+  (err as unknown as { digest: string }).digest = 'NEXT_NOT_FOUND';
+  throw err;
+});
+
+jest.mock('next/navigation', () => ({
+  notFound: mockNotFound,
+}));
+
+jest.mock('@/app/analise/[hash]/AnalysisViewTracker', () => ({
+  AnalysisViewTracker: () => <div data-testid="view-tracker" />,
+}));
+
+jest.mock('@/components/share/ShareButtons', () => ({
+  __esModule: true,
+  default: () => <div data-testid="share-buttons" />,
+}));
+
+jest.mock('@/components/blog/SchemaMarkup', () => ({
+  __esModule: true,
+  default: () => <div data-testid="schema-markup" />,
+}));
+
+const mockAnalysisPayload = {
+  hash: 'abc123def456',
+  bid_id: 'bid-001',
+  bid_title: 'Pregão Eletrônico - Material Hospitalar',
+  bid_orgao: 'Secretaria de Saúde',
+  bid_uf: 'SP',
+  bid_valor: 150000.0,
+  bid_modalidade: 'Pregão',
+  viability_score: 75,
+  viability_level: 'alta',
+  viability_factors: {
+    modalidade: 80,
+    modalidade_label: 'Modalidade adequada',
+    timeline: 70,
+    timeline_label: 'Prazo razoável',
+    value_fit: 75,
+    value_fit_label: 'Valor compatível',
+    geography: 70,
+    geography_label: 'Geograficamente viável',
+  },
+  view_count: 5,
+  created_at: '2026-06-15T10:00:00Z',
+};
+
+global.fetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AnalisePage — Issue #2043 ban notFound() for null/empty payloads', () => {
+  it('AC4: backend retorna 404 → renderiza EmptyStateSEO e NÃO chama notFound()', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    const PageMod = await import('@/app/analise/[hash]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ hash: 'abc123def456' }),
+    });
+    const { getByTestId } = render(element as React.ReactElement);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(getByTestId('empty-state-seo')).toBeTruthy();
+  });
+
+  it('AC5: backend retorna 500 → renderiza EmptyStateSEO e NÃO chama notFound()', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    const PageMod = await import('@/app/analise/[hash]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ hash: 'abc123def456' }),
+    });
+    const { getByTestId } = render(element as React.ReactElement);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(getByTestId('empty-state-seo')).toBeTruthy();
+  });
+
+  it('hash malformado → notFound() AINDA é chamado (preserva 404 para formato inválido)', async () => {
+    const PageMod = await import('@/app/analise/[hash]/page');
+    const Page = PageMod.default;
+
+    // notFound() throws NEXT_NOT_FOUND — verify it was called.
+    // (Jest mock may swallow exception depending on async context.)
+    expect.hasAssertions();
+    try {
+      await Page({ params: Promise.resolve({ hash: 'not-a-valid-hash!!!' }) });
+    } catch {
+      // Expected — hash format is invalid so notFound() was invoked.
+    }
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('payload com dados reais renderiza página completa (não regression)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => mockAnalysisPayload,
+    });
+
+    const PageMod = await import('@/app/analise/[hash]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ hash: 'abc123def456' }),
+    });
+    const { getByTestId, queryByTestId } = render(element as React.ReactElement);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(queryByTestId('empty-state-seo')).toBeNull();
+    expect(getByTestId('view-tracker')).toBeTruthy();
+  });
+
+  it('erro de rede → renderiza EmptyStateSEO e NÃO chama notFound()', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+
+    const PageMod = await import('@/app/analise/[hash]/page');
+    const Page = PageMod.default;
+    const element = await Page({
+      params: Promise.resolve({ hash: 'abc123def456' }),
+    });
+    const { getByTestId } = render(element as React.ReactElement);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(getByTestId('empty-state-seo')).toBeTruthy();
+  });
+});
+
+describe('AnalisePage generateMetadata — robots noindex,follow para null/empty', () => {
+  it('backend retorna 404 → generateMetadata retorna robots.index=false', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    const { generateMetadata } = await import('@/app/analise/[hash]/page');
+    const meta = await generateMetadata({
+      params: Promise.resolve({ hash: 'abc123def456' }),
+    });
+    const robots = meta.robots as { index?: boolean; follow?: boolean } | undefined;
+    expect(robots?.index).toBe(false);
+    expect(robots?.follow).toBe(true);
+  });
+
+  it('backend retorna 500 → generateMetadata retorna robots.index=false', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+
+    const { generateMetadata } = await import('@/app/analise/[hash]/page');
+    const meta = await generateMetadata({
+      params: Promise.resolve({ hash: 'abc123def456' }),
+    });
+    const robots = meta.robots as { index?: boolean; follow?: boolean } | undefined;
+    expect(robots?.index).toBe(false);
+    expect(robots?.follow).toBe(true);
+  });
+});

--- a/frontend/app/analise/[hash]/page.tsx
+++ b/frontend/app/analise/[hash]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ssgLimitedFetch } from '@/lib/concurrency';
+import EmptyStateSEO from '@/components/seo/EmptyStateSEO';
 import { AnalysisViewTracker } from './AnalysisViewTracker';
 import ShareButtons from '@/components/share/ShareButtons';
 import SchemaMarkup from '@/components/blog/SchemaMarkup';
@@ -72,8 +73,13 @@ export async function generateMetadata({
   params: Promise<{ hash: string }>;
 }): Promise<Metadata> {
   const { hash } = await params;
-  const data = await fetchAnalysis(hash);
-  if (!data) return { title: 'Análise não encontrada' };
+  let data: SharedAnalysis | null = null;
+  try {
+    data = await fetchAnalysis(hash);
+  } catch {
+    // 5xx transient → noindex, follow; ISR retries at next revalidation
+  }
+  if (!data) return { title: 'Análise não encontrada', robots: { index: false, follow: true } };
 
   const levelLabel = data.viability_level === 'alta' ? 'ALTA' : data.viability_level === 'media' ? 'MÉDIA' : 'BAIXA';
   const setor = data.bid_modalidade || data.bid_uf || 'licitações';
@@ -133,8 +139,30 @@ export default async function AnalisePage({
   params: Promise<{ hash: string }>;
 }) {
   const { hash } = await params;
-  const data = await fetchAnalysis(hash);
-  if (!data) notFound();
+
+  // ADR-SEO-001: hash malformed → true 404 (no backend call needed)
+  if (!/^[A-Za-z0-9_-]{8,64}$/.test(hash)) {
+    notFound(); // adr-seo-001-allow: hash format invalid — true 404
+  }
+
+  let data: SharedAnalysis | null = null;
+  try {
+    data = await fetchAnalysis(hash);
+  } catch {
+    // 5xx transient → render EmptyStateSEO; ISR retries at next revalidation
+  }
+
+  // ADR-SEO-001: data absence → EmptyStateSEO (not notFound) to prevent ISR-cached 404s
+  if (!data) {
+    return (
+      <EmptyStateSEO
+        title="Análise não encontrada"
+        description="Análise não encontrada ou ainda sendo processada. Tente novamente mais tarde."
+        ctaHref="/"
+        ctaLabel="Página inicial"
+      />
+    );
+  }
 
   const levelLabel = data.viability_level === 'alta' ? 'ALTA' : data.viability_level === 'media' ? 'MÉDIA' : 'BAIXA';
   const levelColor =


### PR DESCRIPTION
## Summary

Substitui notFound() por EmptyStateSEO em analise/[hash]/page.tsx.
Elimina Estrategia C (notFound on null data) conforme ADR-SEO-001.

## O que muda

- Dados nulos/404/5xx -> renderiza EmptyStateSEO (HTTP 200) com robots: noindex, follow
- Hash malformado -> mantem notFound() com marcador adr-seo-001-allow
- Adiciona validacao de formato do hash via regex
- Adiciona try-catch em generateMetadata e AnalisePage para capturar 5xx

## ACs

- [x] AC1: Substituir notFound() por EmptyStateSEO
- [x] AC2: Metadata robots noindex,follow quando !data
- [x] AC3: Manter notFound() apenas para hash malformado com marcador
- [x] AC4: Teste backend 404 -> EmptyStateSEO (HTTP 200)
- [x] AC5: Teste backend 500 -> EmptyStateSEO
- [x] AC6: CI gate compativel (marcador presente)

Closes #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes & Tests

* **Bug Fixes**
  * Improved handling when analysis data is unavailable—now displays a fallback empty state instead of a 404 error for valid hashes.
  * Enhanced SEO metadata handling for missing data scenarios.
  * Added validation to distinguish between invalid hash formats (404) and valid hashes with missing data.

* **Tests**
  * Added comprehensive test coverage for data retrieval and display edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->